### PR TITLE
Ticket #1148

### DIFF
--- a/src/states_screens/feature_unlocked.cpp
+++ b/src/states_screens/feature_unlocked.cpp
@@ -171,16 +171,16 @@ void FeatureUnlockedCutScene::addTrophy(RaceManager::Difficulty difficulty)
     switch (difficulty)
     {
         case RaceManager::DIFFICULTY_EASY:
-            msg = _("You completed the easy challenge! This trophy is worth %i points",
-                    CHALLENGE_POINTS[RaceManager::DIFFICULTY_EASY]);
+            msg = _("You completed the easy challenge! Points earned on this level: %i/%i",
+                    CHALLENGE_POINTS[RaceManager::DIFFICULTY_EASY], CHALLENGE_POINTS[RaceManager::DIFFICULTY_HARD]);
             break;
         case RaceManager::DIFFICULTY_MEDIUM:
-            msg = _("You completed the intermediate challenge! This trophy is worth %i points",
-                    CHALLENGE_POINTS[RaceManager::DIFFICULTY_MEDIUM]);
+            msg = _("You completed the intermediate challenge! Points earned on this level: %i/%i",
+                    CHALLENGE_POINTS[RaceManager::DIFFICULTY_MEDIUM], CHALLENGE_POINTS[RaceManager::DIFFICULTY_HARD]);
             break;
         case RaceManager::DIFFICULTY_HARD:
-            msg = _("You completed the difficult challenge! This trophy is worth %i points",
-                    CHALLENGE_POINTS[RaceManager::DIFFICULTY_HARD]);
+            msg = _("You completed the difficult challenge! Points earned on this level: %i/%i",
+                    CHALLENGE_POINTS[RaceManager::DIFFICULTY_HARD], CHALLENGE_POINTS[RaceManager::DIFFICULTY_HARD]);
             break;
         default:
             assert(false);


### PR DESCRIPTION
Quote from the bug tracker: "Quite a few people were confused that when you complete a medium challenge after completing it at easy, or completing it hard after completing it at medium, you only get one point. The text on screen says "this trophy is worth X points", perhaps we should make it say something like "this trophy is worth X more point that your preview trophy for the same challenge""

I think displaying the possible maximum amount of points for each level encourages improvement. It also implies that the points do not accumulate. For example, you don't get two trophies' points for completing the novice challenge and then the intermediate challenge, rather you get one trophy that was worth more than the previous.
