### PR TITLE
Fixed bug #1056 Addons search last updated option text is cropped

### DIFF
--- a/data/gui/addons_screen.stkgui
+++ b/data/gui/addons_screen.stkgui
@@ -10,10 +10,10 @@
     
     <box id="filter_box" width="97%" height="75" layout="vertical-row" align="center">
         <div x="0" y="0" width="98%" height="100%" layout="horizontal-row" align="center">
-            <textbox id="filter_name" proportion="9" align="center" />
+            <textbox id="filter_name" proportion="7" align="center" />
             <spacer width="10" />
             <label text="Updated" align="center" I18N="In addons screen, in the filtering bar, to enable a filter that will show only recently updated items"/>
-            <spinner id="filter_date" proportion="5" align="center" min_value="0" wrap_around="true"/>
+            <spinner id="filter_date" proportion="8" align="center" min_value="0" wrap_around="true"/>
             <label text="Rating >=" align="center" I18N="In addons screen, in the filtering bar, to enable a filter that will show only recently items with good rating"/>
             <spinner id="filter_rating" proportion="3" align="center" min_value="0" wrap_around="true"/>
             <icon-button id="filter_search" height="100%" icon="gui/search.png"/>


### PR DESCRIPTION
changed addons_screen.stkgui to ensure the filterdate spinner had adequate space.

Signed-off-by: Sachith Hasaranga Seneviratne sachith500@gmail.com
