### PR TITLE
Fixed bug 1067

### DIFF
--- a/src/states_screens/arenas_screen.cpp
+++ b/src/states_screens/arenas_screen.cpp
@@ -105,7 +105,8 @@ void ArenasScreen::beforeAddingWidget()
 
     DynamicRibbonWidget* tracks_widget = this->getWidget<DynamicRibbonWidget>("tracks");
     assert( tracks_widget != NULL );
-    tracks_widget->setItemCountHint(num_of_arenas); //set the item hint to that number to prevent weird formatting
+    tracks_widget->setItemCountHint(num_of_arenas + 1); 
+    //set the item hint to that number to prevent weird formatting + 1 is for the random track
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
void ArenasScreen::beforeAddingWidget() wasn't accounting for the extra space required for the random track.
This was causing the ribbon widget in soccer mode to get drawn incorrectly.

Signed-off-by: Sachith Hasaranga Seneviratne sachith500@gmail.com
