### PR TITLE
Bugfix for 1118

### DIFF
--- a/src/states_screens/race_gui.cpp
+++ b/src/states_screens/race_gui.cpp
@@ -170,7 +170,10 @@ void RaceGUI::renderGlobal(float dt)
 
     if (!m_is_tutorial)
     {
-        drawGlobalTimer();
+        //stop displaying timer as soon as race is over
+        if (world->getPhase()<WorldStatus::DELAY_FINISH_PHASE)
+           drawGlobalTimer();
+        
         if(world->getPhase() == WorldStatus::GO_PHASE ||
            world->getPhase() == WorldStatus::MUSIC_PHASE)
         {


### PR DESCRIPTION
Hide countdown as soon as race ends to prevent the drawGlobalTimer() method in race_gui from checking for failed challenges.

https://sourceforge.net/apps/trac/supertuxkart/ticket/1118

Signed-off-by: Sachith Hasaranga Seneviratne sachith500@gmail.com
