### PR TITLE
Check for libbluetooth on Unix platforms.

### DIFF
--- a/lib/wiiuse/CMakeLists.txt
+++ b/lib/wiiuse/CMakeLists.txt
@@ -2,6 +2,16 @@
 
 cmake_minimum_required(VERSION 2.8.1)
 
+# libbluetooth is required on Unix platforms
+if(UNIX)
+    include(FindPkgConfig)
+    pkg_check_modules(BLUETOOTH bluez)
+    if(NOT BLUETOOTH_FOUND)
+        message(FATAL_ERROR "Bluetooth library not found. "
+            "Either install libbluetooth or disable wiiuse support with -DUSE_WIIUSE=0")
+    endif()
+endif()
+
 set(WIIUSE_SOURCES
     classic.c
     dynamics.c


### PR DESCRIPTION
As mentioned in bug #1251, CMake doesn't check for `libbluetooth` even though some of the source files reference `bluetooth/bluetooth.h`. This commit adds an additional check that will display a fatal error on Unix platforms when the library is not present and `wiiuse` is being built.
