### PR TITLE
Fix memory leak on early exit(0) in handleCmdLinePreliminary()

### DIFF
--- a/src/config/stk_config.cpp
+++ b/src/config/stk_config.cpp
@@ -39,6 +39,7 @@ float STKConfig::UNDEFINED = -99.9f;
 STKConfig::STKConfig()
 {
     m_has_been_loaded         = false;
+    m_title_music             = NULL;
     m_default_kart_properties = new KartProperties();
 }   // STKConfig
 //-----------------------------------------------------------------------------
@@ -46,7 +47,9 @@ STKConfig::~STKConfig()
 {
     if(m_title_music)
         delete m_title_music;
-    delete m_default_kart_properties;
+
+    if(m_default_kart_properties)
+        delete m_default_kart_properties;
 }   // ~STKConfig
 
 //-----------------------------------------------------------------------------

--- a/src/config/stk_config.hpp
+++ b/src/config/stk_config.hpp
@@ -137,8 +137,7 @@ public:
     std::vector<int> m_score_increase;
 
     /** Filename of the title music to play.*/
-    MusicInformation
-         *m_title_music;
+    MusicInformation *m_title_music;
 
     /** Minimum time between consecutive saved tranform events.  */
     float m_replay_dt;

--- a/src/graphics/irr_driver.cpp
+++ b/src/graphics/irr_driver.cpp
@@ -106,6 +106,7 @@ IrrDriver::IrrDriver()
     m_request_screenshot  = false;
     m_shaders             = NULL;
     m_rtts                = NULL;
+    m_post_processing     = NULL;
     m_wind                = new Wind();
     m_mipviz = m_wireframe = m_normals = m_ssaoviz = \
         m_lightviz = m_shadowviz = m_distortviz = 0;
@@ -124,7 +125,11 @@ IrrDriver::~IrrDriver()
     // instead we just decrease the ref count here. When the material
     // is deleted, it will trigger the actual deletion of
     // PostProcessing when decreasing the refcount of its callback object.
-    m_post_processing->drop();
+    if(m_post_processing)
+    {
+        // check if we createad the OpenGL device by calling initDevice()
+        m_post_processing->drop();
+    }
     assert(m_device != NULL);
 
     m_device->drop();

--- a/src/io/file_manager.cpp
+++ b/src/io/file_manager.cpp
@@ -490,9 +490,12 @@ void FileManager::pushTextureSearchPath(const std::string& path)
  */
 void FileManager::popTextureSearchPath()
 {
-    std::string dir = m_texture_search_path.back();
-    m_texture_search_path.pop_back();
-    m_file_system->removeFileArchive(createAbsoluteFilename(dir));
+    if(!m_texture_search_path.empty())
+    {
+        std::string dir = m_texture_search_path.back();
+        m_texture_search_path.pop_back();
+        m_file_system->removeFileArchive(createAbsoluteFilename(dir));
+    }
 }   // popTextureSearchPath
 
 //-----------------------------------------------------------------------------
@@ -500,10 +503,24 @@ void FileManager::popTextureSearchPath()
  */
 void FileManager::popModelSearchPath()
 {
-    std::string dir = m_model_search_path.back();
-    m_model_search_path.pop_back();
-    m_file_system->removeFileArchive(createAbsoluteFilename(dir));
+    if(!m_model_search_path.empty())
+    {
+        std::string dir = m_model_search_path.back();
+        m_model_search_path.pop_back();
+        m_file_system->removeFileArchive(createAbsoluteFilename(dir));
+    }
 }   // popModelSearchPath
+
+// ------------------------------------------------------------------------
+/** Removes the last added directory from the music search path.
+ */
+void FileManager::popMusicSearchPath()
+{
+    if(!m_music_search_path.empty())
+    {
+        m_music_search_path.pop_back();
+    }
+}
 
 //-----------------------------------------------------------------------------
 /** Tries to find the specified file in any of the given search paths.

--- a/src/io/file_manager.hpp
+++ b/src/io/file_manager.hpp
@@ -132,9 +132,10 @@ public:
 
 
     void       pushTextureSearchPath(const std::string& path);
-    void       pushModelSearchPath  (const std::string& path);
-    void       popTextureSearchPath ();
-    void       popModelSearchPath   ();
+    void       pushModelSearchPath(const std::string& path);
+    void       popTextureSearchPath();
+    void       popModelSearchPath();
+    void       popMusicSearchPath();
     void       redirectOutput();
     // ------------------------------------------------------------------------
     /** Adds a directory to the music search path (or stack).
@@ -143,10 +144,7 @@ public:
     {
         m_music_search_path.push_back(path);
     }   // pushMusicSearchPath
-    // ------------------------------------------------------------------------
-    /** Removes the last added directory from the music search path.
-     */
-    void popMusicSearchPath() {m_music_search_path.pop_back(); }
+
     // ------------------------------------------------------------------------
     /** Returns true if the specified file exists.
      */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -201,6 +201,7 @@
 #include "utils/translation.hpp"
 
 static void cleanSuperTuxKart();
+static void cleanUserConfig();
 
 // ============================================================================
 //                        gamepad visualisation screen
@@ -462,10 +463,10 @@ void cmdLineHelp()
  */
 int handleCmdLinePreliminary()
 {
-    if(CommandLine::has("--help") || CommandLine::has("--help") ||
-       CommandLine::has("-h"))
+    if(CommandLine::has("--help") || CommandLine::has("-h"))
     {
         cmdLineHelp();
+        cleanUserConfig();
         exit(0);
     }
 
@@ -478,6 +479,7 @@ int handleCmdLinePreliminary()
                           IRRLICHT_VERSION_MAJOR , IRRLICHT_VERSION_MINOR,
                           IRRLICHT_VERSION_REVISION, IRRLICHT_SDK_VERSION );
         Log::info("main", "==============================");
+        cleanUserConfig();
         exit(0);
     }
 
@@ -1213,8 +1215,10 @@ int main(int argc, char *argv[] )
         // If the server has been created (--server option), this will do nothing (just a warning):
         NetworkManager::getInstance<ClientNetworkManager>();
         if (NetworkManager::getInstance()->isServer())
+        {
             ServerNetworkManager::getInstance()->setMaxPlayers(
                     UserConfigParams::m_server_max_players);
+        }
         NetworkManager::getInstance()->run();
         if (NetworkManager::getInstance()->isServer())
         {
@@ -1443,15 +1447,24 @@ static void cleanSuperTuxKart()
     if(sfx_manager)             delete sfx_manager;
     if(music_manager)           delete music_manager;
     delete ParticleKindManager::get();
-    if(stk_config)              delete stk_config;
-    if(user_config)             delete user_config;
     PlayerManager::destroy();
     if(unlock_manager)          delete unlock_manager;
-    if(translations)            delete translations;
-    if(file_manager)            delete file_manager;
-    if(irr_driver)              delete irr_driver;
+
+    cleanUserConfig();
 
     StateManager::deallocate();
     GUIEngine::EventHandler::deallocate();
 }   // cleanSuperTuxKart
 
+//=============================================================================
+/**
+ * Frees all the memory of initUserConfig()
+ */
+static void cleanUserConfig()
+{
+    if(stk_config)              delete stk_config;
+    if(translations)            delete translations;
+    if(user_config)             delete user_config;
+    if(file_manager)            delete file_manager;
+    if(irr_driver)              delete irr_driver;
+}


### PR DESCRIPTION
The check was performed with valgrind.
