### PR TITLE
Fix move on unitialised values in displayFPS

### DIFF
--- a/src/graphics/irr_driver.cpp
+++ b/src/graphics/irr_driver.cpp
@@ -99,7 +99,7 @@ const int MIN_SUPPORTED_WIDTH  = 800;
  *  So we create a dummy device here to begin with, which is then later (once
  *  the real device exists) changed in initDevice().
  */
-IrrDriver::IrrDriver()
+IrrDriver::IrrDriver() : object_count{}
 {
     m_resolution_changing = RES_CHANGE_NONE;
     m_phase               = SOLID_NORMAL_AND_DEPTH_PASS;

--- a/src/graphics/irr_driver.hpp
+++ b/src/graphics/irr_driver.hpp
@@ -338,7 +338,7 @@ private:
     bool                 m_distortviz;
     /** Performance stats */
     unsigned             m_last_light_bucket_distance;
-    unsigned             object_count[PASS_COUNT] = {};
+    unsigned             object_count[PASS_COUNT];
     u32                  m_renderpass;
     u32                  m_lensflare_query;
     bool                 m_query_issued;


### PR DESCRIPTION
The check was performed with valgrind.
