### PR TITLE
fix video options dialog

### DIFF
--- a/src/states_screens/dialogs/custom_video_settings.cpp
+++ b/src/states_screens/dialogs/custom_video_settings.cpp
@@ -109,11 +109,11 @@ GUIEngine::EventPropagation CustomVideoSettingsDialog::processEvent(const std::s
 
         UserConfigParams::m_dof =
             advanced_pipeline && getWidget<CheckBoxWidget>("dof")->getState();
-        
+
         UserConfigParams::m_motionblur      =
             advanced_pipeline && getWidget<CheckBoxWidget>("motionblur")->getState();
-        
-        if (advanced_pipeline && getWidget<CheckBoxWidget>("ubo")->getState())
+
+        if (advanced_pipeline)
         {
             UserConfigParams::m_shadows =
                 getWidget<SpinnerWidget>("shadows")->getValue();


### PR DESCRIPTION
fixes the following crash:

```
Program received signal SIGSEGV, Segmentation fault.
0x00000000008e00ae in GUIEngine::CheckBoxWidget::getState (this=0x0) at /home/konsti/stk/src/guiengine/widgets/check_box_widget.hpp:51
51 bool getState() const { return m_state; }
(gdb) bt
#0 0x00000000008e00ae in GUIEngine::CheckBoxWidget::getState (this=0x0) at /home/konsti/stk/src/guiengine/widgets/check_box_widget.hpp:51
#1 0x0000000000b4d5e9 in CustomVideoSettingsDialog::processEvent (this=0xf5e1df0, eventSource=...) at /home/konsti/stk/src/states_screens/dialogs/custom_video_settings.cpp:116
#2 0x00000000008d12ca in GUIEngine::EventHandler::onWidgetActivated (this=0x3ca19f0, w=0xf622e80, playerID=0) at /home/konsti/stk/src/guiengine/event_handler.cpp:525
#3 0x00000000008d168a in GUIEngine::EventHandler::onGUIEvent (this=0x3ca19f0, event=...) at /home/konsti/stk/src/guiengine/event_handler.cpp:597
#4 0x00000000008d058b in GUIEngine::EventHandler::OnEvent (this=0x3ca19f0, event=...) at /home/konsti/stk/src/guiengine/event_handler.cpp:149
#5 0x0000000000d8ff82 in OnEvent (event=..., this=0xf5e2830) at /home/konsti/stk/lib/irrlicht/include/IGUIElement.h:524
#6 irr::gui::CGUIModalScreen::OnEvent (this=0xf5e2830, event=...) at /home/konsti/stk/lib/irrlicht/source/Irrlicht/CGUIModalScreen.cpp:141
#7 0x0000000000e7c2ca in OnEvent (event=..., this=0xf5e1fb0) at /home/konsti/stk/lib/irrlicht/include/IGUIElement.h:524
#8 irr::gui::CGUIWindow::OnEvent (this=0xf5e1fb0, event=...) at /home/konsti/stk/lib/irrlicht/source/Irrlicht/CGUIWindow.cpp:217
#9 0x0000000000ea773d in irr::gui::CGUIButton::OnEvent (this=0xf625140, event=...) at /home/konsti/stk/lib/irrlicht/source/Irrlicht/CGUIButton.cpp:215
#10 0x0000000000d53e19 in irr::gui::CGUIEnvironment::postEventFromUser (this=0x180b020, event=...) at /home/konsti/stk/lib/irrlicht/source/Irrlicht/CGUIEnvironment.cpp:570
#11 0x0000000000cd6709 in irr::CIrrDeviceStub::postEventFromUser (this=0x1622180, event=...) at /home/konsti/stk/lib/irrlicht/source/Irrlicht/CIrrDeviceStub.cpp:220
#12 0x0000000000ccd891 in irr::CIrrDeviceLinux::run (this=0x1622180) at /home/konsti/stk/lib/irrlicht/source/Irrlicht/CIrrDeviceLinux.cpp:1214
#13 0x00000000009b074d in IrrDriver::update (this=0x1621b40, dt=0,0280000009) at /home/konsti/stk/src/graphics/irr_driver.cpp:1966
#14 0x0000000000a8e73c in MainLoop::run (this=0x3d60c90) at /home/konsti/stk/src/main_loop.cpp:153
#15 0x0000000000a64607 in main (argc=1, argv=0x7fffffffde08) at /home/konsti/stk/src/main.cpp:1369
(gdb) bt full
#0 0x00000000008e00ae in GUIEngine::CheckBoxWidget::getState (this=0x0) at /home/konsti/stk/src/guiengine/widgets/check_box_widget.hpp:51
No locals.
#1 0x0000000000b4d5e9 in CustomVideoSettingsDialog::processEvent (this=0xf5e1df0, eventSource=...) at /home/konsti/stk/src/states_screens/dialogs/custom_video_settings.cpp:116
advanced_pipeline = true
#2 0x00000000008d12ca in GUIEngine::EventHandler::onWidgetActivated (this=0x3ca19f0, w=0xf622e80, playerID=0) at /home/konsti/stk/src/guiengine/event_handler.cpp:525
parent = 0x0
__PRETTY_FUNCTION__ = "GUIEngine::EventPropagation GUIEngine::EventHandler::onWidgetActivated(GUIEngine::Widget*, int)"
#3 0x00000000008d168a in GUIEngine::EventHandler::onGUIEvent (this=0x3ca19f0, event=...) at /home/konsti/stk/src/guiengine/event_handler.cpp:597
w = 0xf622e80
id = 125
__PRETTY_FUNCTION__ = "GUIEngine::EventPropagation GUIEngine::EventHandler::onGUIEvent(const irr::SEvent&)"
#4 0x00000000008d058b in GUIEngine::EventHandler::OnEvent (this=0x3ca19f0, event=...) at /home/konsti/stk/src/guiengine/event_handler.cpp:149
No locals.
#5 0x0000000000d8ff82 in OnEvent (event=..., this=0xf5e2830) at /home/konsti/stk/lib/irrlicht/include/IGUIElement.h:524
No locals.
#6 irr::gui::CGUIModalScreen::OnEvent (this=0xf5e2830, event=...) at /home/konsti/stk/lib/irrlicht/source/Irrlicht/CGUIModalScreen.cpp:141
No locals.
#7 0x0000000000e7c2ca in OnEvent (event=..., this=0xf5e1fb0) at /home/konsti/stk/lib/irrlicht/include/IGUIElement.h:524
No locals.
#8 irr::gui::CGUIWindow::OnEvent (this=0xf5e1fb0, event=...) at /home/konsti/stk/lib/irrlicht/source/Irrlicht/CGUIWindow.cpp:217
No locals.
#9 0x0000000000ea773d in irr::gui::CGUIButton::OnEvent (this=0xf625140, event=...) at /home/konsti/stk/lib/irrlicht/source/Irrlicht/CGUIButton.cpp:215
newEvent = {EventType = irr::EET_GUI_EVENT, {GUIEvent = {Caller = 0xf625140, Element = 0x0, EventType = irr::gui::EGET_BUTTON_CLICKED}, MouseInput = {X = 258101568, Y = 0, Wheel = 0, Shift = false, Control = false, ButtonStates = 5,
Event = irr::EMIE_LMOUSE_PRESSED_DOWN}, KeyInput = {Char = 258101568 L'\xf625140', Key = 0, PressedDown = false, Shift = false, Control = false}, JoystickEvent = {ButtonStates = 258101568, Axis = {0, 0, 0, 0, 0, 0, 5, 0 <repeats 11 times>, -10160, -1,
32767, 0, 8576, 354, 0, 0, 8576, 354, 0, 0, -13088, 912}, POV = 0, Joystick = 0 '\000'}, LogEvent = {Text = 0xf625140 "`i \001", Level = irr::ELL_DEBUG}, UserEvent = {UserData1 = 258101568, UserData2 = 0}}}
wasPressed = true
#10 0x0000000000d53e19 in irr::gui::CGUIEnvironment::postEventFromUser (this=0x180b020, event=...) at /home/konsti/stk/lib/irrlicht/source/Irrlicht/CGUIEnvironment.cpp:570
No locals.
#11 0x0000000000cd6709 in irr::CIrrDeviceStub::postEventFromUser (this=0x1622180, event=...) at /home/konsti/stk/lib/irrlicht/source/Irrlicht/CIrrDeviceStub.cpp:220
absorbed = <optimized out>
inputReceiver = <optimized out>
#12 0x0000000000ccd891 in irr::CIrrDeviceLinux::run (this=0x1622180) at /home/konsti/stk/lib/irrlicht/source/Irrlicht/CIrrDeviceLinux.cpp:1214
event = {type = 5, xany = {type = 5, serial = 6511, send_event = 0, display = 0x1623740, window = 65011714}, xkey = {type = 5, serial = 6511, send_event = 0, display = 0x1623740, window = 65011714, root = 145, subwindow = 0, time = 1063403, x = 647, y = 656,
x_root = 974, y_root = 754, state = 272, keycode = 1, same_screen = 1}, xbutton = {type = 5, serial = 6511, send_event = 0, display = 0x1623740, window = 65011714, root = 145, subwindow = 0, time = 1063403, x = 647, y = 656, x_root = 974, y_root = 754,
state = 272, button = 1, same_screen = 1}, xmotion = {type = 5, serial = 6511, send_event = 0, display = 0x1623740, window = 65011714, root = 145, subwindow = 0, time = 1063403, x = 647, y = 656, x_root = 974, y_root = 754, state = 272, is_hint = 1 '\001',
same_screen = 1}, xcrossing = {type = 5, serial = 6511, send_event = 0, display = 0x1623740, window = 65011714, root = 145, subwindow = 0, time = 1063403, x = 647, y = 656, x_root = 974, y_root = 754, mode = 272, detail = 1, same_screen = 1, focus = 15,
state = 0}, xfocus = {type = 5, serial = 6511, send_event = 0, display = 0x1623740, window = 65011714, mode = 145, detail = 0}, xexpose = {type = 5, serial = 6511, send_event = 0, display = 0x1623740, window = 65011714, x = 145, y = 0, width = 0,
height = 0, count = 1063403}, xgraphicsexpose = {type = 5, serial = 6511, send_event = 0, display = 0x1623740, drawable = 65011714, x = 145, y = 0, width = 0, height = 0, count = 1063403, major_code = 0, minor_code = 647}, xnoexpose = {type = 5,
serial = 6511, send_event = 0, display = 0x1623740, drawable = 65011714, major_code = 145, minor_code = 0}, xvisibility = {type = 5, serial = 6511, send_event = 0, display = 0x1623740, window = 65011714, state = 145}, xcreatewindow = {type = 5,
serial = 6511, send_event = 0, display = 0x1623740, parent = 65011714, window = 145, x = 0, y = 0, width = 1063403, height = 0, border_width = 647, override_redirect = 656}, xdestroywindow = {type = 5, serial = 6511, send_event = 0, display = 0x1623740,
event = 65011714, window = 145}, xunmap = {type = 5, serial = 6511, send_event = 0, display = 0x1623740, event = 65011714, window = 145, from_configure = 0}, xmap = {type = 5, serial = 6511, send_event = 0, display = 0x1623740, event = 65011714,
window = 145, override_redirect = 0}, xmaprequest = {type = 5, serial = 6511, send_event = 0, display = 0x1623740, parent = 65011714, window = 145}, xreparent = {type = 5, serial = 6511, send_event = 0, display = 0x1623740, event = 65011714, window = 145,
parent = 0, x = 1063403, y = 0, override_redirect = 647}, xconfigure = {type = 5, serial = 6511, send_event = 0, display = 0x1623740, event = 65011714, window = 145, x = 0, y = 0, width = 1063403, height = 0, border_width = 647, above = 3238405342158,
override_redirect = 272}, xgravity = {type = 5, serial = 6511, send_event = 0, display = 0x1623740, event = 65011714, window = 145, x = 0, y = 0}, xresizerequest = {type = 5, serial = 6511, send_event = 0, display = 0x1623740, window = 65011714,
width = 145, height = 0}, xconfigurerequest = {type = 5, serial = 6511, send_event = 0, display = 0x1623740, parent = 65011714, window = 145, x = 0, y = 0, width = 1063403, height = 0, border_width = 647, above = 3238405342158, detail = 272,
value_mask = 64424509441}, xcirculate = {type = 5, serial = 6511, send_event = 0, display = 0x1623740, event = 65011714, window = 145, place = 0}, xcirculaterequest = {type = 5, serial = 6511, send_event = 0, display = 0x1623740, parent = 65011714,
window = 145, place = 0}, xproperty = {type = 5, serial = 6511, send_event = 0, display = 0x1623740, window = 65011714, atom = 145, time = 0, state = 1063403}, xselectionclear = {type = 5, serial = 6511, send_event = 0, display = 0x1623740,
window = 65011714, selection = 145, time = 0}, xselectionrequest = {type = 5, serial = 6511, send_event = 0, display = 0x1623740, owner = 65011714, requestor = 145, selection = 0, target = 1063403, property = 2817498546823, time = 3238405342158},
---Type <return> to continue, or q <return> to quit---
xselection = {type = 5, serial = 6511, send_event = 0, display = 0x1623740, requestor = 65011714, selection = 145, target = 0, property = 1063403, time = 2817498546823}, xcolormap = {type = 5, serial = 6511, send_event = 0, display = 0x1623740,
window = 65011714, colormap = 145, c_new = 0, state = 0}, xclient = {type = 5, serial = 6511, send_event = 0, display = 0x1623740, window = 65011714, message_type = 145, format = 0, data = {
b = "\353\071\020\000\000\000\000\000\207\002\000\000\220\002\000\000\316\003\000", s = {14827, 16, 0, 0, 647, 0, 656, 0, 974, 0}, l = {1063403, 2817498546823, 3238405342158, 4294967568, 64424509441}}}, xmapping = {type = 5, serial = 6511, send_event = 0,
display = 0x1623740, window = 65011714, request = 145, first_keycode = 0, count = 0}, xerror = {type = 5, display = 0x196f, resourceid = 0, serial = 23213888, error_code = 2 '\002', request_code = 0 '\000', minor_code = 224 '\340'}, xkeymap = {type = 5,
serial = 6511, send_event = 0, display = 0x1623740, window = 65011714, key_vector = "\221", '\000' <repeats 15 times>, "\353\071\020\000\000\000\000\000\207\002\000\000\220\002\000"}, xgeneric = {type = 5, serial = 6511, send_event = 0, display = 0x1623740,
extension = 65011714, evtype = 0}, xcookie = {type = 5, serial = 6511, send_event = 0, display = 0x1623740, extension = 65011714, evtype = 0, cookie = 145, data = 0x0}, pad = {140733193388037, 6511, 0, 23213888, 65011714, 145, 0, 1063403, 2817498546823,
3238405342158, 4294967568, 64424509441, 0, 8589934593, 17179869184, 0, 979252543488, 0, 0, 0, 0, 0, 0, 0}}
irrevent = {EventType = irr::EET_MOUSE_INPUT_EVENT, {GUIEvent = {Caller = 0x29000000287, Element = 0x7ffcffffd978, EventType = irr::gui::EGET_ELEMENT_FOCUS_LOST}, MouseInput = {X = 647, Y = 656, Wheel = -nan(0x7fd978), Shift = false, Control = false,
ButtonStates = 0, Event = irr::EMIE_LMOUSE_LEFT_UP}, KeyInput = {Char = 647 L'ʇ', Key = 656, PressedDown = false, Shift = false, Control = false}, JoystickEvent = {ButtonStates = 647, Axis = {656, 0, -9864, -1, 32764, 0, 0, 0, 3, 0, 9777, 0, -32768, -1,
4, 0, 0, 0, 1, 0, 0, 0, 56, 0, 0, 0, 9745, 0, -32768, -1, 4, 0}, POV = 0, Joystick = 0 '\000'}, LogEvent = {Text = 0x29000000287 <error: Cannot access memory at address 0x29000000287>, Level = 4294957432}, UserEvent = {UserData1 = 647, UserData2 = 656}}}
#13 0x00000000009b074d in IrrDriver::update (this=0x1621b40, dt=0,0280000009) at /home/konsti/stk/src/graphics/irr_driver.cpp:1966
world = 0x402e276000000000
#14 0x0000000000a8e73c in MainLoop::run (this=0x3d60c90) at /home/konsti/stk/src/main_loop.cpp:153
dt = 0,0280000009
device = 0x1622180
#15 0x0000000000a64607 in main (argc=1, argv=0x7fffffffde08) at /home/konsti/stk/src/main.cpp:1369
s = {static npos = <optimized out>, _M_dataplus = {<std::allocator<char>> = {<__gnu_cxx::new_allocator<char>> = {<No data fields>}, <No data fields>}, _M_p = 0x7ffff691e3f8 <std::string::_Rep::_S_empty_rep_storage+24> ""}}
materials_file = {static npos = <optimized out>, _M_dataplus = {<std::allocator<char>> = {<__gnu_cxx::new_allocator<char>> = {<No data fields>}, <No data fields>}, _M_p = 0xd243248 "../data/models/materials.xml"}}
important_message = {array = 0xec5d930 L"", allocated = 1, used = 1, allocator = {_vptr.irrAllocator = 0xf87d50 <vtable for irr::core::irrAllocator<wchar_t>+16>}}
```
