### PR TITLE
Reset the scroll offset when clearing a dynamic ribbon widget

### DIFF
--- a/src/guiengine/widgets/dynamic_ribbon_widget.cpp
+++ b/src/guiengine/widgets/dynamic_ribbon_widget.cpp
@@ -491,6 +491,7 @@ void DynamicRibbonWidget::clearItems()
 {
     m_items.clear();
     m_animated_contents = false;
+    m_scroll_offset = 0;
 }
 // -----------------------------------------------------------------------------
 void DynamicRibbonWidget::elementRemoved()


### PR DESCRIPTION
This prevents some odd behaviour in the GP editor when changing the currently selected GP, and probably in some other places too.
