### PR TITLE
fixing crash when running with asan

### DIFF
--- a/src/io/file_manager.cpp
+++ b/src/io/file_manager.cpp
@@ -422,7 +422,7 @@ XMLNode *FileManager::createXMLTreeFromString(const std::string & content)
     {
         char *b = new char[content.size()];
         memcpy(b, content.c_str(), content.size());
-        io::IReadFile * ireadfile = m_file_system->createMemoryReadFile(b, strlen(b), "tempfile", true);
+        io::IReadFile * ireadfile = m_file_system->createMemoryReadFile(b, content.size(), "tempfile", true);
         io::IXMLReader * reader = m_file_system->createXMLReader(ireadfile);
         XMLNode* node = new XMLNode(reader);
         reader->drop();
@@ -791,7 +791,7 @@ void FileManager::checkAndCreateConfigDir()
         {
             m_user_config_dir  = getenv("HOME");
             checkAndCreateDirectory(m_user_config_dir);
-            
+
             m_user_config_dir += "/.config";
             if(!checkAndCreateDirectory(m_user_config_dir))
             {


### PR DESCRIPTION
Without this change it crashes with

```
    #1 0x969cf7 in FileManager::createXMLTreeFromString(std::string const&) /home/konsti/stk/src/io/file_manager.cpp:425
    #2 0xae32d8 in Online::XMLRequest::afterOperation() /home/konsti/stk/src/online/xml_request.cpp:60
    #3 0xadb537 in Online::Request::execute() /home/konsti/stk/src/online/request.cpp:71
    #4 0xae84d2 in Online::RequestManager::mainLoop(void*) /home/konsti/stk/src/online/request_manager.cpp:223
    #5 0x7fad03c78b97 (/usr/lib/x86_64-linux-gnu/libasan.so.0+0x18b97)
    #6 0x7fad03a4a181 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x8181)
    #7 0x7fad0181afbc (/lib/x86_64-linux-gnu/libc.so.6+0xfafbc)
0x601a000dc97f is located 0 bytes to the right of 143-byte region [0x601a000dc8f0,0x601a000dc97f)
```
