### PR TITLE
Some improvements to the GP editor

### DIFF
--- a/data/gui/gpeditor.stkgui
+++ b/data/gui/gpeditor.stkgui
@@ -15,7 +15,10 @@
                 child_height="120" keep_selection="true" />
         </box>
 
-        <spacer height="10" />
+        <!-- Populated dynamically at runtime -->
+        <tabs width="100%" height="30" id="gpgroups"> </tabs>
+
+        <spacer height="20" />
 
         <box proportion="2" width="100%" layout="vertical-row">
             <label id="gpname" text_align="center" width="100%"

--- a/src/race/grand_prix_data.hpp
+++ b/src/race/grand_prix_data.hpp
@@ -60,6 +60,9 @@ private:
     /** Wether the user can edit this grand prix or not */
     bool m_editable;
 
+    /** ID of the group to which this GP belongs. */
+    std::string m_group;
+
     /** In the last GP Fort Magma can not be used untill the final challenge.
      *  In order to provide still 5 tracks/GP, the last GP is only using 4
      *  tracks in story mode, but once nolok is unlocked Fort Magma becomes
@@ -83,6 +86,10 @@ public:
 #if (defined(WIN32) || defined(_WIN32)) && !defined(__MINGW32__)
 #  pragma warning(disable:4290)
 #endif
+    static const char* STANDARD_GP_GROUP_ID;
+    static const char* USER_GP_GROUP_ID;
+    static const char* ADDON_GP_GROUP_ID;
+
     /** Load the GrandPrixData from the given filename */
     GrandPrixData(const std::string& filename);
 
@@ -141,6 +148,10 @@ public:
     // ------------------------------------------------------------------------
     /** Returns the filename of the grand prix xml file. */
     const std::string& getFilename() const { return m_filename;           }
+
+    // ------------------------------------------------------------------------
+    /** Returns the group. */
+    const std::string& getGroup() const { return m_group;                 }
 };   // GrandPrixData
 
 #endif

--- a/src/race/grand_prix_manager.cpp
+++ b/src/race/grand_prix_manager.cpp
@@ -34,6 +34,10 @@ const char* GrandPrixManager::SUFFIX = ".grandprix";
 // ----------------------------------------------------------------------------
 GrandPrixManager::GrandPrixManager()
 {
+    m_groups.push_back(GrandPrixData::STANDARD_GP_GROUP_ID);
+    m_groups.push_back(GrandPrixData::USER_GP_GROUP_ID);
+    m_groups.push_back(GrandPrixData::ADDON_GP_GROUP_ID);
+
     loadFiles();
 }   // GrandPrixManager
 
@@ -174,6 +178,12 @@ void GrandPrixManager::checkConsistency()
         }
     }
 }   // checkConsistency
+
+// ----------------------------------------------------------------------------
+const std::vector<std::string>& GrandPrixManager::getAllGroups() const
+{
+    return m_groups;
+}
 
 // ----------------------------------------------------------------------------
 GrandPrixData* GrandPrixManager::createNewGP(const irr::core::stringw& newName)

--- a/src/race/grand_prix_manager.hpp
+++ b/src/race/grand_prix_manager.hpp
@@ -34,6 +34,7 @@ private:
     static const char* SUFFIX;
 
     std::vector<GrandPrixData*> m_gp_data;
+    std::vector<std::string>    m_groups;
 
     /** Load all the grands prix from the 3 directories known */
     void loadFiles();
@@ -54,6 +55,8 @@ public:
     unsigned int   getNumberOfGrandPrix()    const { return m_gp_data.size(); }
     bool existsName(const irr::core::stringw& name) const;
     void           checkConsistency();
+
+    const std::vector<std::string>& getAllGroups() const;
 
     // Methods for the gp editor
     GrandPrixData* editGrandPrix(const std::string& s) const;

--- a/src/states_screens/grand_prix_editor_screen.cpp
+++ b/src/states_screens/grand_prix_editor_screen.cpp
@@ -39,10 +39,36 @@ using namespace irr::core;
 
 DEFINE_SCREEN_SINGLETON( GrandPrixEditorScreen );
 
+const char* GrandPrixEditorScreen::ALL_GP_GROUP_ID = "all";
+
 // -----------------------------------------------------------------------------
 GrandPrixEditorScreen::GrandPrixEditorScreen()
     : Screen("gpeditor.stkgui"), m_selection(NULL)
 {
+}
+
+// -----------------------------------------------------------------------------
+void GrandPrixEditorScreen::beforeAddingWidget()
+{
+    RibbonWidget* tabs = getWidget<RibbonWidget>("gpgroups");
+    assert (tabs != NULL);
+
+    const std::vector<std::string>& groups = grand_prix_manager->getAllGroups();
+    if (groups.size() > 1)
+    {
+        tabs->clearAllChildren();
+        tabs->addTextChild(_("All"), ALL_GP_GROUP_ID);
+        for (unsigned int i = 0; i < groups.size(); i++)
+            tabs->addTextChild(_(groups[i].c_str()), groups[i]);
+    }
+
+#define FOR_GETTEXT_ONLY(x)
+    //I18N: Grand Prix group name
+    FOR_GETTEXT_ONLY( _("standard") )
+    //I18N: Grand Prix group name
+    FOR_GETTEXT_ONLY( _("user defined") )
+    //I18N: Grand Prix group name
+    FOR_GETTEXT_ONLY( _("Add-Ons") )
 }
 
 // -----------------------------------------------------------------------------
@@ -54,13 +80,20 @@ void GrandPrixEditorScreen::loadedFromFile()
 // -----------------------------------------------------------------------------
 void GrandPrixEditorScreen::eventCallback(Widget* widget, const std::string& name, const int playerID)
 {
-    DynamicRibbonWidget* gplist_widget = getWidget<DynamicRibbonWidget>("gplist");
-    assert (gplist_widget != NULL);
-    std::string selected = gplist_widget->getSelectionIDString(PLAYER_ID_GAME_MASTER);
-    if (!selected.empty())
-        setSelection (grand_prix_manager->getGrandPrix(selected));
-
-    if (name == "menu")
+    if (name == "gplist")
+    {
+        DynamicRibbonWidget* gplist_widget = getWidget<DynamicRibbonWidget>("gplist");
+        assert (gplist_widget != NULL);
+        std::string selected = gplist_widget->getSelectionIDString(PLAYER_ID_GAME_MASTER);
+        if (!selected.empty())
+        {
+            if (m_selection != NULL && selected == m_selection->getId() && m_selection->isEditable())
+                showEditScreen(m_selection);
+            else
+                setSelection (grand_prix_manager->getGrandPrix(selected));
+        }
+    }
+    else if (name == "menu")
     {
         RibbonWidget* menu = getWidget<RibbonWidget>("menu");
         assert(menu != NULL);
@@ -70,52 +103,39 @@ void GrandPrixEditorScreen::eventCallback(Widget* widget, const std::string& nam
         {
             new EnterGPNameDialog(this, 0.5f, 0.4f);
         }
-        else if (m_action == "edit")
+        else if (m_action == "edit" && m_selection != NULL)
         {
-            if (m_selection->isEditable())
-            {
-                showEditScreen(m_selection);
-            }
-            else
-            {
-                new MessageDialog(
-                    _("You can't edit the '%s' grand prix.\nYou might want to copy it first",
-                        m_selection->getName().c_str()),
-                    MessageDialog::MESSAGE_DIALOG_OK, NULL, false);
-            }
+            showEditScreen(m_selection);
         }
-        else if (m_action == "remove")
+        else if (m_action == "remove" && m_selection != NULL)
         {
-            if (m_selection->isEditable())
-            {
-                new MessageDialog(
-                    _("Are you sure you want to remove '%s'?", m_selection->getName().c_str()),
-                    MessageDialog::MESSAGE_DIALOG_CONFIRM,
-                    this, false);
-            }
-            else
-            {
-                new MessageDialog(
-                    _("You can't remove '%s'.", m_selection->getName().c_str()),
-                    MessageDialog::MESSAGE_DIALOG_OK, NULL, false);
-            }
+            new MessageDialog(
+                _("Are you sure you want to remove '%s'?", m_selection->getName().c_str()),
+                MessageDialog::MESSAGE_DIALOG_CONFIRM,
+                this, false);
         }
-        else if (m_action == "rename")
+        else if (m_action == "rename" && m_selection != NULL)
         {
-            if (m_selection->isEditable())
-            {
-                new EnterGPNameDialog(this, 0.5f, 0.4f);
-            }
-            else
-            {
-                new MessageDialog(
-                    _("You can't rename '%s'.", m_selection->getName().c_str()),
-                    MessageDialog::MESSAGE_DIALOG_OK, NULL, false);
-            }
+            new EnterGPNameDialog(this, 0.5f, 0.4f);
+        }
+    }
+    else if (name == "gpgroups")
+    {
+        RibbonWidget* tabs = getWidget<RibbonWidget>("gpgroups");
+        assert(tabs != NULL);
+
+        std::string group = tabs->getSelectionIDString(PLAYER_ID_GAME_MASTER);
+        if (m_gpgroup != group)
+        {
+            m_gpgroup = group;
+            loadGPList();
+            setSelection(NULL);
         }
     }
     else if (name == "back")
     {
+        m_gpgroup = "";
+        setSelection(NULL);
         StateManager::get()->escapePressed();
     }
 }
@@ -123,27 +143,15 @@ void GrandPrixEditorScreen::eventCallback(Widget* widget, const std::string& nam
 // -----------------------------------------------------------------------------
 void GrandPrixEditorScreen::init()
 {
-    if (grand_prix_manager->getNumberOfGrandPrix() > 0)
-    {
-        if (m_selection == NULL)
-        {
-            loadGPList();
-            setSelection (grand_prix_manager->getGrandPrix(0));
-        }
-        else
-        {
-            std::string id = m_selection->getId();
-            grand_prix_manager->reload();
-            loadGPList();
-            m_selection = grand_prix_manager->editGrandPrix(id);
-            m_selection->reload();
-            setSelection (m_selection);
-        }
-    }
+    RibbonWidget* tabs = getWidget<RibbonWidget>("gpgroups");
+    assert (tabs != NULL);
+    if (m_gpgroup.empty())
+        tabs->select ("all", PLAYER_ID_GAME_MASTER);
     else
-    {
-        loadGPList();
-    }
+        tabs->select (m_gpgroup, PLAYER_ID_GAME_MASTER);
+
+    loadGPList();
+    setSelection(m_selection);
 }
 
 // -----------------------------------------------------------------------------
@@ -153,11 +161,25 @@ void GrandPrixEditorScreen::setSelection (const GrandPrixData* gpdata)
     assert(gpname_widget != NULL);
     DynamicRibbonWidget* gplist_widget = getWidget<DynamicRibbonWidget>("gplist");
     assert (gplist_widget != NULL);
+    DynamicRibbonWidget* tracks_widget = getWidget<DynamicRibbonWidget>("tracks");
+    assert(tracks_widget != NULL);
 
-    m_selection = grand_prix_manager->editGrandPrix(gpdata->getId());
-    gpname_widget->setText (gpdata->getName(), true);
-    gplist_widget->setSelection(m_selection->getId(), PLAYER_ID_GAME_MASTER, true);
-    loadTrackList (gpdata->getId());
+    if (gpdata == NULL)
+    {
+        m_selection = NULL;
+        gpname_widget->setText (L"Please select a Grand Prix", true);
+        tracks_widget->clearItems();
+        tracks_widget->updateItemDisplay();
+    }
+    else
+    {
+        m_selection = grand_prix_manager->editGrandPrix(gpdata->getId());
+        gpname_widget->setText (gpdata->getName(), true);
+        gplist_widget->setSelection(m_selection->getId(), PLAYER_ID_GAME_MASTER, true);
+        loadTrackList (gpdata->getId());
+    }
+
+    enableButtons();
 }
 
 // -----------------------------------------------------------------------------
@@ -219,9 +241,16 @@ void GrandPrixEditorScreen::loadGPList()
             Track* track = track_manager->getTrack(tracks[t]);
             sshot_files.push_back(track->getScreenshotFile());
         }
+        if (sshot_files.empty())
+            sshot_files.push_back(file_manager->getAsset(FileManager::GUI,"main_help.png"));
 
-        gplist_widget->addAnimatedItem(translations->fribidize(gp->getName()), gp->getId(),
-            sshot_files, 2.0f, 0, IconButtonWidget::ICON_PATH_TYPE_ABSOLUTE );
+        if (m_gpgroup.empty() || m_gpgroup == ALL_GP_GROUP_ID || m_gpgroup == gp->getGroup())
+        {
+            gplist_widget->addAnimatedItem(
+                translations->fribidize(gp->getName()),
+                gp->getId(), sshot_files, 2.0f, 0,
+                IconButtonWidget::ICON_PATH_TYPE_ABSOLUTE );
+        }
     }
 
     gplist_widget->updateItemDisplay();
@@ -237,13 +266,44 @@ void GrandPrixEditorScreen::showEditScreen(GrandPrixData* gp)
 }
 
 // -----------------------------------------------------------------------------
+void GrandPrixEditorScreen::enableButtons()
+{
+    IconButtonWidget* copy_button = getWidget<IconButtonWidget>("copy");
+    IconButtonWidget* edit_button = getWidget<IconButtonWidget>("edit");
+    IconButtonWidget* remove_button = getWidget<IconButtonWidget>("remove");
+    IconButtonWidget* rename_button = getWidget<IconButtonWidget>("rename");
+    assert(copy_button != NULL);
+    assert(edit_button != NULL);
+    assert(remove_button != NULL);
+    assert(rename_button != NULL);
+
+    if (m_selection != NULL && m_selection->getNumberOfTracks() > 0)
+        copy_button->setActivated();
+    else
+        copy_button->setDeactivated();
+
+    if (m_selection != NULL && m_selection->isEditable())
+    {
+        edit_button->setActivated();
+        remove_button->setActivated();
+        rename_button->setActivated();
+    }
+    else
+    {
+        edit_button->setDeactivated();
+        remove_button->setDeactivated();
+        rename_button->setDeactivated();
+    }
+}
+
+// -----------------------------------------------------------------------------
 void GrandPrixEditorScreen::onNewGPWithName(const stringw& newName)
 {
-    if (m_action == "copy")
+    if (m_action == "copy" && m_selection != NULL)
     {
         setSelection(grand_prix_manager->copy(m_selection->getId(), newName));
     }
-    else if (m_action == "rename")
+    else if (m_action == "rename" && m_selection != NULL)
     {
         m_selection->setName(newName);
         m_selection->writeToFile();
@@ -254,14 +314,14 @@ void GrandPrixEditorScreen::onNewGPWithName(const stringw& newName)
     }
 
     loadGPList();
-    if (m_action != "rename")
+    if (m_action != "rename" && m_selection != NULL)
         showEditScreen(m_selection);
 }
 
 // -----------------------------------------------------------------------------
 void GrandPrixEditorScreen::onConfirm()
 {
-    if (m_action == "remove")
+    if (m_action == "remove" && m_selection != NULL)
     {
         grand_prix_manager->remove(m_selection->getId());
         loadGPList();

--- a/src/states_screens/grand_prix_editor_screen.hpp
+++ b/src/states_screens/grand_prix_editor_screen.hpp
@@ -45,14 +45,21 @@ class GrandPrixEditorScreen :
     void loadGPList();
     void loadTrackList(const std::string& gpname);
     void showEditScreen(GrandPrixData* gp);
+    void enableButtons();
 
     void onNewGPWithName(const irr::core::stringw& newName);
     void onConfirm();
 
     GrandPrixData*   m_selection;
     std::string      m_action;
+    std::string      m_gpgroup;
 
 public:
+
+    static const char* ALL_GP_GROUP_ID;
+
+    /** \brief implement callback from parent class GUIEngine::Screen */
+    virtual void beforeAddingWidget() OVERRIDE;
 
     /** \brief implement callback from parent class GUIEngine::Screen */
     virtual void loadedFromFile() OVERRIDE;

--- a/src/states_screens/tracks_screen.cpp
+++ b/src/states_screens/tracks_screen.cpp
@@ -185,6 +185,10 @@ void TracksScreen::init()
         const GrandPrixData* gp = grand_prix_manager->getGrandPrix(n);
         const std::vector<std::string> tracks = gp->getTrackNames(true);
 
+        //Skip epmpty GPs
+        if (gp->getNumberOfTracks()==0)
+            continue;
+
         std::vector<std::string> screenshots;
         for (unsigned int t=0; t<tracks.size(); t++)
         {


### PR DESCRIPTION
```
- now the GPs are classified by group, just like tracks: standard, user defined and add-ons
- allow empty GPs to be loaded by the GP manager, so that they can appear
  on the GP editor (but not on the track selection screen)
- enable/disable buttons on the main screen depending on the selected GP
- some minor bug corrections
```
