### PR TITLE
Some improvements to the GP editor

### DIFF
--- a/data/gui/gpeditor.stkgui
+++ b/data/gui/gpeditor.stkgui
@@ -15,7 +15,10 @@
                 child_height="120" keep_selection="true" />
         </box>
 
-        <spacer height="10" />
+        <!-- Populated dynamically at runtime -->
+        <tabs width="100%" height="30" id="gpgroups"> </tabs>
+
+        <spacer height="20" />
 
         <box proportion="2" width="100%" layout="vertical-row">
             <label id="gpname" text_align="center" width="100%"

--- a/src/race/grand_prix_data.hpp
+++ b/src/race/grand_prix_data.hpp
@@ -36,6 +36,17 @@ class Track;
   */
 class GrandPrixData
 {
+public:
+    /** Used to classify GPs into groups */
+    enum GPGroupType
+    {
+        GP_NONE = 0,      ///< No group
+        GP_STANDARD,      ///< Standard GP, included with the game
+        GP_USER_DEFINED,  ///< Created by the user
+        GP_ADDONS,        ///< Add-on GP
+        GP_GROUP_COUNT    ///< Number of groups
+    };   // GPGroupType
+
 private:
     /** The name of the grand prix. */
     irr::core::stringw m_name;
@@ -59,6 +70,9 @@ private:
 
     /** Wether the user can edit this grand prix or not */
     bool m_editable;
+
+    /** Group to which this GP belongs. */
+    enum GPGroupType m_group;
 
     /** In the last GP Fort Magma can not be used untill the final challenge.
      *  In order to provide still 5 tracks/GP, the last GP is only using 4
@@ -84,7 +98,7 @@ public:
 #  pragma warning(disable:4290)
 #endif
     /** Load the GrandPrixData from the given filename */
-    GrandPrixData(const std::string& filename);
+    GrandPrixData(const std::string& filename, enum GPGroupType group);
 
     /** Needed for simple creation of an instance of GrandPrixData */
     GrandPrixData() {};
@@ -103,6 +117,7 @@ public:
     void setName(const irr::core::stringw& name);
     void setFilename(const std::string& filename);
     void setEditable(const bool editable);
+    void setGroup(const enum GPGroupType group);
     /** Load the grand prix from the file set by the constructor or the grand
      * prix editor */
     void reload();
@@ -141,6 +156,10 @@ public:
     // ------------------------------------------------------------------------
     /** Returns the filename of the grand prix xml file. */
     const std::string& getFilename() const { return m_filename;           }
+
+    // ------------------------------------------------------------------------
+    /** Returns the group. */
+    enum GPGroupType getGroup()      const { return m_group;              }
 };   // GrandPrixData
 
 #endif

--- a/src/race/grand_prix_manager.cpp
+++ b/src/race/grand_prix_manager.cpp
@@ -20,11 +20,11 @@
 
 #include "config/user_config.hpp"
 #include "io/file_manager.hpp"
-#include "race/grand_prix_data.hpp"
 #include "utils/string_utils.hpp"
 
 #include <algorithm>
 #include <set>
+#include <utility>
 #include <sstream>
 
 GrandPrixManager *grand_prix_manager = NULL;
@@ -47,44 +47,47 @@ GrandPrixManager::~GrandPrixManager()
 // ----------------------------------------------------------------------------
 void GrandPrixManager::loadFiles()
 {
+    // Add the directories to a set to avoid duplicates
     std::set<std::string> dirs;
+    std::string dir;
 
-    // Add all the directories to a set to avoid duplicates
-    dirs.insert(file_manager->getAsset(FileManager::GRANDPRIX, ""));
-    dirs.insert(file_manager->getGPDir());
-    dirs.insert(UserConfigParams::m_additional_gp_directory);
+    //Standard GPs
+    loadDir(file_manager->getAsset(FileManager::GRANDPRIX, ""), GrandPrixData::GP_STANDARD);
 
-    for (std::set<std::string>::const_iterator it  = dirs.begin();
-                                               it != dirs.end  (); ++it)
-    {
-        std::string dir = *it;
-        if (!dir.empty() && dir[dir.size() - 1] == '/')
-            loadDir(dir);
-    }
+    //User defined GPs
+    dir = file_manager->getGPDir();
+    if (!dir.empty() && dir[dir.size() - 1] == '/' && dirs.count(dir) == 0)
+        loadDir(dir, GrandPrixData::GP_USER_DEFINED);
+
+    //Add-on GPs
+    dir = UserConfigParams::m_additional_gp_directory;
+    if (!dir.empty() && dir[dir.size() - 1] == '/' && dirs.count(dir) == 0)
+        loadDir(dir, GrandPrixData::GP_ADDONS);
 }   // loadFiles
 
 // ----------------------------------------------------------------------------
-void GrandPrixManager::loadDir(const std::string& dir)
+void GrandPrixManager::loadDir(const std::string& dir, enum GrandPrixData::GPGroupType group)
 {
     Log::info("GrandPrixManager",
               "Loading Grand Prix files from %s", dir.c_str());
     assert(!dir.empty() && dir[dir.size() - 1] == '/');
 
-    // Findout which grand prix are available and load them
+    // Find out which grand prix are available and load them
     std::set<std::string> result;
     file_manager->listFiles(result, dir);
-    for(std::set<std::string>::iterator i  = result.begin();
-                                        i != result.end(); i++)
+    for(std::set<std::string>::iterator i = result.begin(); i != result.end(); i++)
+    {
         if (StringUtils::hasSuffix(*i, SUFFIX))
-            load(dir + *i);
+            load(dir + *i, group);
+    }
 }   // loadDir
 
 // ----------------------------------------------------------------------------
-void GrandPrixManager::load(const std::string& filename)
+void GrandPrixManager::load(const std::string& filename, enum GrandPrixData::GPGroupType group)
 {
     try
     {
-        GrandPrixData* gp = new GrandPrixData(filename);
+        GrandPrixData* gp = new GrandPrixData(filename, group);
         m_gp_data.push_back(gp);
         Log::debug("GrandPrixManager",
                    "Grand Prix '%s' loaded from %s",
@@ -188,6 +191,7 @@ GrandPrixData* GrandPrixManager::createNewGP(const irr::core::stringw& newName)
     gp->setName(newName);
     gp->setFilename(file_manager->getGPDir() + newID + SUFFIX);
     gp->setEditable(true);
+    gp->setGroup(GrandPrixData::GP_USER_DEFINED);
     gp->writeToFile();
     m_gp_data.push_back(gp);
 

--- a/src/race/grand_prix_manager.hpp
+++ b/src/race/grand_prix_manager.hpp
@@ -19,6 +19,8 @@
 #ifndef HEADER_GRAND_PRIX_MANAGER_HPP
 #define HEADER_GRAND_PRIX_MANAGER_HPP
 
+#include "race/grand_prix_data.hpp"
+
 #include <vector>
 #include <string>
 
@@ -38,9 +40,9 @@ private:
     /** Load all the grands prix from the 3 directories known */
     void loadFiles();
     /** Load all the grands prix in one directory */
-    void loadDir(const std::string& dir);
+    void loadDir(const std::string& dir, enum GrandPrixData::GPGroupType group);
     /** Load a grand prix and add it to m_gp_data*/
-    void load(const std::string &filename);
+    void load(const std::string &filename, enum GrandPrixData::GPGroupType group);
 
     /** Generates a new unique indentifier for a user defined grand prix */
     std::string generateId();

--- a/src/states_screens/edit_gp_screen.cpp
+++ b/src/states_screens/edit_gp_screen.cpp
@@ -187,6 +187,7 @@ void EditGPScreen::init()
         loadList(m_selected);
         m_action.clear();
     }
+    enableButtons();
 }
 
 // -----------------------------------------------------------------------------
@@ -213,7 +214,10 @@ void EditGPScreen::onCancel()
 {
     ModalDialog::dismiss();
     if (m_action == "back")
+    {
+        m_gp->reload(); // Discard changes
         back();
+    }
 }
 
 // -----------------------------------------------------------------------------
@@ -231,8 +235,14 @@ void EditGPScreen::loadList(const int selected)
 
         Track* t = track_manager->getTrack(m_gp->getTrackId(i));
         assert(t != NULL);
+
         video::ITexture* screenShot = irr_driver->getTexture(t->getScreenshotFile());
-        assert(screenShot != NULL);
+        if (screenShot == NULL)
+        {
+            screenShot = irr_driver->getTexture(
+                file_manager->getAsset(FileManager::GUI, "main_help.png"));
+        }
+        assert (screenShot != NULL);
         m_icons.push_back(m_icon_bank->addTextureAsSprite(screenShot));
 
         row.push_back(GUIEngine::ListWidget::ListCell(
@@ -264,15 +274,19 @@ void EditGPScreen::setModified(const bool modified)
         save_button->setActivated();
     else
         save_button->setDeactivated();
+
+    LabelWidget* header = getWidget<LabelWidget>("title");
+    assert(header != NULL);
+    header->setText(m_gp->getName() + (modified ? L" (+)" : L""), true);
+
+    enableButtons();
 }
 
 // -----------------------------------------------------------------------------
 void EditGPScreen::setSelected(const int selected)
 {
-    assert(getWidget<IconButtonWidget>("up") != NULL);
-    assert(getWidget<IconButtonWidget>("down") != NULL);
-
     m_selected = selected;
+    enableButtons();
 }
 
 // -----------------------------------------------------------------------------
@@ -326,4 +340,39 @@ bool EditGPScreen::canMoveUp() const
 bool EditGPScreen::canMoveDown() const
 {
     return (0 <= m_selected && m_selected < m_list->getItemCount() - 1);
+}
+
+// -----------------------------------------------------------------------------
+void EditGPScreen::enableButtons()
+{
+    IconButtonWidget* up_button = getWidget<IconButtonWidget>("up");
+    IconButtonWidget* down_button = getWidget<IconButtonWidget>("down");
+    IconButtonWidget* edit_button = getWidget<IconButtonWidget>("edit");
+    IconButtonWidget* remove_button = getWidget<IconButtonWidget>("remove");
+    assert(up_button != NULL);
+    assert(down_button != NULL);
+    assert(edit_button != NULL);
+    assert(remove_button != NULL);
+
+    if (m_selected >= 0 && m_list->getItemCount() > 1)
+    {
+        up_button->setActivated();
+        down_button->setActivated();
+    }
+    else
+    {
+        up_button->setDeactivated();
+        down_button->setDeactivated();
+    }
+
+    if (m_selected >= 0)
+    {
+        edit_button->setActivated();
+        remove_button->setActivated();
+    }
+    else
+    {
+        edit_button->setDeactivated();
+        remove_button->setDeactivated();
+    }
 }

--- a/src/states_screens/edit_gp_screen.hpp
+++ b/src/states_screens/edit_gp_screen.hpp
@@ -56,6 +56,8 @@ class EditGPScreen :
     bool canMoveUp() const;
     bool canMoveDown() const;
 
+    void enableButtons();
+
     GrandPrixData*                     m_gp;
     GUIEngine::ListWidget*             m_list;
     irr::gui::STKModifiedSpriteBank*   m_icon_bank;

--- a/src/states_screens/grand_prix_editor_screen.hpp
+++ b/src/states_screens/grand_prix_editor_screen.hpp
@@ -19,6 +19,7 @@
 #define HEADER_GRAND_PRIX_EDITOR_SCREEN_HPP
 
 #include "guiengine/screen.hpp"
+#include "race/grand_prix_data.hpp"
 #include "states_screens/dialogs/enter_gp_name_dialog.hpp"
 #include "states_screens/dialogs/message_dialog.hpp"
 
@@ -45,14 +46,21 @@ class GrandPrixEditorScreen :
     void loadGPList();
     void loadTrackList(const std::string& gpname);
     void showEditScreen(GrandPrixData* gp);
+    void enableButtons();
 
     void onNewGPWithName(const irr::core::stringw& newName);
     void onConfirm();
 
-    GrandPrixData*   m_selection;
-    std::string      m_action;
+    static const wchar_t* getGroupName(enum GrandPrixData::GPGroupType group);
+
+    GrandPrixData*                  m_selection;
+    std::string                     m_action;
+    enum GrandPrixData::GPGroupType m_gpgroup;
 
 public:
+
+    /** \brief implement callback from parent class GUIEngine::Screen */
+    virtual void beforeAddingWidget() OVERRIDE;
 
     /** \brief implement callback from parent class GUIEngine::Screen */
     virtual void loadedFromFile() OVERRIDE;

--- a/src/states_screens/tracks_screen.cpp
+++ b/src/states_screens/tracks_screen.cpp
@@ -185,6 +185,10 @@ void TracksScreen::init()
         const GrandPrixData* gp = grand_prix_manager->getGrandPrix(n);
         const std::vector<std::string> tracks = gp->getTrackNames(true);
 
+        //Skip epmpty GPs
+        if (gp->getNumberOfTracks()==0)
+            continue;
+
         std::vector<std::string> screenshots;
         for (unsigned int t=0; t<tracks.size(); t++)
         {


### PR DESCRIPTION
Second try, this one includes the suggestions made by konstin to the first one.
    - GP are now classified into groups, just like tracks: standard, user defined, and add-ons
    - allow empty GPs to be loaded by the GP manager, so that they can appear
      on the GP editor (but not on the track selection screen)
    - enable/disable buttons depending on the available options
    - provide some feedback after pushing the "save" button
    - some minor bug corrections and improvements
