### PR TITLE
Fix issues with the new "reverse grand prix" feature and user defined GPs

### DIFF
--- a/src/race/grand_prix_data.cpp
+++ b/src/race/grand_prix_data.cpp
@@ -158,14 +158,20 @@ void GrandPrixData::changeReverse(const GrandPrixData::GPReverseType use_reverse
     for (unsigned int i = 0; i < m_tracks.size(); i++)
     {
         if (use_reverse == GP_NO_REVERSE)
+        {
             m_reversed[i] = false;
+        }
+        else if (use_reverse == GP_ALL_REVERSE) // all reversed
+        {
+            m_reversed[i] = track_manager->getTrack(m_tracks[i])->reverseAvailable();
+        }
         else if (use_reverse == GP_RANDOM_REVERSE)
+        {
             if (track_manager->getTrack(m_tracks[i])->reverseAvailable())
                 m_reversed[i] = (rand() % 2 != 0);
             else
                 m_reversed[i] = false;
-        else // all reversed
-            m_reversed[i] = track_manager->getTrack(m_tracks[i])->reverseAvailable();
+        }
     }   // for i < m_tracks.size()
 }   // changeReverse
 

--- a/src/race/grand_prix_data.hpp
+++ b/src/race/grand_prix_data.hpp
@@ -90,7 +90,8 @@ public:
     {
         GP_NO_REVERSE = 0,
         GP_ALL_REVERSE = 1,
-        GP_RANDOM_REVERSE = 2
+        GP_RANDOM_REVERSE = 2,
+        GP_DEFAULT_REVERSE = 3
     };   // GPReverseType
 
 public:

--- a/src/states_screens/gp_info_screen.cpp
+++ b/src/states_screens/gp_info_screen.cpp
@@ -71,8 +71,9 @@ void GPInfoScreen::loadedFromFile()
     // (since the groups can change if addons are added/deleted).
     m_group_spinner      = getWidget<SpinnerWidget>("group-spinner");
     m_reverse_spinner    = getWidget<SpinnerWidget>("reverse-spinner");
-    m_reverse_spinner->addLabel(_("No"));
-    m_reverse_spinner->addLabel(_("Yes"));
+    m_reverse_spinner->addLabel(_("Default"));
+    m_reverse_spinner->addLabel(_("None"));
+    m_reverse_spinner->addLabel(_("All"));
     m_reverse_spinner->addLabel(_("Random"));
     m_reverse_spinner->setValue(0);
 
@@ -108,13 +109,14 @@ GrandPrixData::GPReverseType GPInfoScreen::getReverse() const
 {
     switch (m_reverse_spinner->getValue())
     {
-    case 0: return GrandPrixData::GP_NO_REVERSE;     break;
-    case 1: return GrandPrixData::GP_ALL_REVERSE;    break;
-    case 2: return GrandPrixData::GP_RANDOM_REVERSE; break;
-    default: assert(false); 
+    case 0: return GrandPrixData::GP_DEFAULT_REVERSE; break;
+    case 1: return GrandPrixData::GP_NO_REVERSE;      break;
+    case 2: return GrandPrixData::GP_ALL_REVERSE;     break;
+    case 3: return GrandPrixData::GP_RANDOM_REVERSE;  break;
+    default: assert(false);
     }   // switch
     // Avoid compiler warning
-    return GrandPrixData::GP_NO_REVERSE;
+    return GrandPrixData::GP_DEFAULT_REVERSE;
 }   // getReverse
 // ----------------------------------------------------------------------------
 void GPInfoScreen::beforeAddingWidget()
@@ -296,6 +298,7 @@ void GPInfoScreen::eventCallback(Widget *, const std::string &name,
             // Normal GP: start/continue a saved GP
             int n = getWidget<SpinnerWidget>("ai-spinner")->getValue();
 
+            m_gp.changeReverse(getReverse());
             race_manager->setNumKarts(race_manager->getNumLocalPlayers() + n);
             race_manager->startGP(m_gp, false, (name == "continue"));
         }
@@ -325,10 +328,6 @@ void GPInfoScreen::eventCallback(Widget *, const std::string &name,
     {
         m_gp.changeTrackNumber(m_num_tracks_spinner->getValue(), m_group_name);
         addTracks();
-    }
-    else if (name=="reverse-spinner")
-    {
-        m_gp.changeReverse(getReverse());
     }
     else if(name=="back")
     {


### PR DESCRIPTION
There is a new feature that allows the user to run a grand prix in reverse mode, no reverse mode, or random reverse. It's a nice feature, but unfortunately clashes with the possibility of the user being able to define its own grand prix with some tracks in reverse and some in normal mode. But the solution is simple: adding a fourth option (default), which leaves the reversibility of the tracks in the grand prix untouched.

I have also changed the names in the spinner. "All" and "None" instead of "Yes" and "No", which I think are more clear and less prone to confusion.
