### PR TITLE
fix cleaning of transparent meshes and close #1522

### DIFF
--- a/src/graphics/stkanimatedmesh.cpp
+++ b/src/graphics/stkanimatedmesh.cpp
@@ -46,6 +46,8 @@ void STKAnimatedMesh::cleanGLMeshes()
     GLmeshes.clear();
     for (unsigned i = 0; i < MAT_COUNT; i++)
         MeshSolidMaterial[i].clearWithoutDeleting();
+    for (unsigned i = 0; i < TM_COUNT; i++)
+        TransparentMesh[i].clearWithoutDeleting();
 }
 
 void STKAnimatedMesh::setMesh(scene::IAnimatedMesh* mesh)


### PR DESCRIPTION
Thanks to vlj who pointed me to STKAnimatedMesh::cleanGLMeshes() I finally fixed #1522. The problem was that every new bubblegum shield added a new transparent mesh which wasn't cleaned properly after removing the shield.
