### PR TITLE
Fix focus cycling with text boxes

### DIFF
--- a/src/guiengine/widgets/text_box_widget.cpp
+++ b/src/guiengine/widgets/text_box_widget.cpp
@@ -101,7 +101,7 @@ void TextBoxWidget::add()
     //                                               true /* border */, m_parent, getNewID());
     m_id = m_element->getID();
     m_element->setTabOrder(m_id);
-    m_element->setTabGroup(false);
+    m_element->setTabGroup(true);
     m_element->setTabStop(true);
 }
 


### PR DESCRIPTION
This fixes the issue that the wrong text box is focused. I don't know why this fix works and it may not be the right approach but it works (at least in the cases where I tested it)...
