### PR TITLE
Fix two little glitches in intro and outro scenes

### DIFF
--- a/src/modes/cutscene_world.cpp
+++ b/src/modes/cutscene_world.cpp
@@ -514,15 +514,22 @@ void CutsceneWorld::enterRaceOverState()
                  race_manager->getTrackName() == "introcutscene2")
         {
             PlayerProfile *player = PlayerManager::getCurrentPlayer();
-            race_manager->exitRace();
-            StateManager::get()->resetAndGoToScreen(MainMenuScreen::getInstance());
-
-            player->setFirstTime(false);
-            PlayerManager::get()->save();
-            KartSelectionScreen* s = OfflineKartSelectionScreen::getInstance();
-            s->setMultiplayer(false);
-            s->setGoToOverworldNext();
-            s->push();
+            if (player->isFirstTime())
+            {
+                race_manager->exitRace();
+                StateManager::get()->resetAndGoToScreen(MainMenuScreen::getInstance());
+                player->setFirstTime(false);
+                PlayerManager::get()->save();
+                KartSelectionScreen* s = OfflineKartSelectionScreen::getInstance();
+                s->setMultiplayer(false);
+                s->setGoToOverworldNext();
+                s->push();
+            } else
+            {
+                race_manager->exitRace();
+                StateManager::get()->resetAndGoToScreen(MainMenuScreen::getInstance());
+                OverWorld::enterOverWorld();
+            }
         }
         // TODO: remove hardcoded knowledge of cutscenes, replace with scripting probably
         else if (m_parts.size() == 1 && m_parts[0] == "featunlocked")


### PR DESCRIPTION
- I wasn't able leave the intro screen when starting it from the main menu screen, as it doesn't seem to hurt anything, I removed the `if`-statement.
- When exiting the outro scene, the credit screen was loaded two times so you had to press ESC twice to exit it.
