### PR TITLE
Support plural translations. Fixes #1852.

### DIFF
--- a/data/po/update_pot.sh
+++ b/data/po/update_pot.sh
@@ -38,7 +38,8 @@ echo "    Generating .pot file..."
 
 # C++ Files
 xgettext    -d supertuxkart -s --keyword=_ --keyword=N_ --keyword=_LTR \
-                               --keyword=_C:1c,2 --add-comments="I18N:" \
+                               --keyword=_C:1c,2 --keyword=_P:1,2 \
+                               --keyword=_CP:1c,2,3 --add-comments="I18N:" \
                                -p ./data/po -o supertuxkart.pot $CPP_FILE_LIST \
                                --package-name=supertuxkart
 

--- a/src/online/online_player_profile.cpp
+++ b/src/online/online_player_profile.cpp
@@ -403,8 +403,10 @@ namespace Online
                     }
                     else if(to_notify.size() > 3)
                     {
-                        message = _("%d friends are now online.",
-                                    (int)to_notify.size());
+                        //I18N: Only used for count > 3
+                        message = _P("%d friend is now online.",
+                                     "%d friends are now online.",
+                                     (int)to_notify.size());
                     }
                     MessageQueue::add(MessageQueue::MT_FRIEND, message);
                 }

--- a/src/tinygettext/plural_forms.cpp
+++ b/src/tinygettext/plural_forms.cpp
@@ -42,6 +42,7 @@ unsigned int plural3_sk(int n) { return static_cast<unsigned int>( (n==1) ? 0 : 
 unsigned int plural3_pl(int n) { return static_cast<unsigned int>(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2); }
 unsigned int plural3_sl(int n) { return static_cast<unsigned int>(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3); }
 unsigned int plural4_ar(int n) { return static_cast<unsigned int>( n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : 3 ); }
+unsigned int plural4_gd(int n) { return static_cast<unsigned int>( n==1 || n==11) ? 0 : (n==2 || n==12) ? 1 : (n > 2 && n < 20) ? 2 : 3; }
 
 typedef std::map<std::string, class PluralForms> tPluralForms;
 
@@ -67,6 +68,7 @@ PluralForms::from_string(const std::string& str)
     plural_forms["Plural-Forms:nplurals=3;plural=(n%100==1?0:n%100==2?1:n%100==3||n%100==4?2:3);"] = PluralForms(3, plural3_sl);
 
     plural_forms["Plural-Forms:nplurals=4;plural=n==1?0:n==2?1:n>=3&&n<=10?2:3;"]=PluralForms(4, plural4_ar);
+    plural_forms["Plural-Forms:nplurals=4;plural=(n==1||n==11)?0:(n==2||n==12)?1:(n>2&&n<20)?2:3;"]=PluralForms(4, plural4_gd);
   }
 
   // Remove spaces from string before lookup

--- a/src/utils/translation.cpp
+++ b/src/utils/translation.cpp
@@ -352,10 +352,10 @@ const wchar_t* Translations::fribidize(const wchar_t* in_ptr)
 }
 
 /**
-  * \param original Message to translate
-  * \param context  Optional, can be set to differentiate 2 strings that are identical
-  *                 in English but could be different in other languages
-  */
+ * \param original Message to translate
+ * \param context  Optional, can be set to differentiate 2 strings that are identical
+ *                 in English but could be different in other languages
+ */
 const wchar_t* Translations::w_gettext(const wchar_t* original, const char* context)
 {
     return w_gettext( wide_to_utf8(original), context );
@@ -403,6 +403,40 @@ const wchar_t* Translations::w_gettext(const char* original, const char* context
     return out_ptr;
 }
 
+/**
+ * \param singular Message to translate in singular form
+ * \param plural   Message to translate in plural form (can be the same as the singular form)
+ * \param num      Count used to obtain the correct plural form.
+ * \param context  Optional, can be set to differentiate 2 strings that are identical
+ *                 in English but could be different in other languages
+ */
+const wchar_t* Translations::w_ngettext(const wchar_t* singular, const wchar_t* plural, int num, const char* context)
+{
+    return w_ngettext( wide_to_utf8(singular), wide_to_utf8(plural), num, context);
+}
+
+/**
+ * \param singular Message to translate in singular form
+ * \param plural   Message to translate in plural form (can be the same as the singular form)
+ * \param num      Count used to obtain the correct plural form.
+ * \param context  Optional, can be set to differentiate 2 strings that are identical
+ *                 in English but could be different in other languages
+ */
+const wchar_t* Translations::w_ngettext(const char* singular, const char* plural, int num, const char* context)
+{
+    const std::string& res = (context == NULL ?
+                              m_dictionary.translate_plural(singular, plural, num) :
+                              m_dictionary.translate_ctxt_plural(context, singular, plural, num));
+
+    wchar_t* out_ptr = utf8_to_wide(res.c_str());
+    if (REMOVE_BOM) out_ptr++;
+
+#if TRANSLATE_VERBOSE
+    std::wcout << L"  translation : " << out_ptr << std::endl;
+#endif
+
+    return out_ptr;
+}
 
 
 bool Translations::isRTLLanguage() const

--- a/src/utils/translation.hpp
+++ b/src/utils/translation.hpp
@@ -29,6 +29,8 @@
 #  define _(String, ...)        (translations->fribidize(StringUtils::insertValues(translations->w_gettext(String), ##__VA_ARGS__)))
 #undef _C
 #  define _C(Ctx, String, ...)  (translations->fribidize(StringUtils::insertValues(translations->w_gettext(String, Ctx), ##__VA_ARGS__)))
+#  define _P(Singular, Plural, Num, ...) (translations->fribidize(StringUtils::insertValues(translations->w_ngettext(Singular, Plural, Num), Num, ##__VA_ARGS__)))
+#  define _CP(Ctx, Singular, Plural, Num, ...) (translations->fribidize(StringUtils::insertValues(translations->w_ngettext(Singular, Plural, Num, Ctx), Num, ##__VA_ARGS__)))
 #  define _LTR(String, ...)     (StringUtils::insertValues(translations->w_gettext(String), ##__VA_ARGS__))
 #  define gettext_noop(String)  (String)
 #  define N_(String)            (gettext_noop (String))
@@ -53,6 +55,9 @@ public:
 
     const wchar_t     *w_gettext(const wchar_t* original, const char* context=NULL);
     const wchar_t     *w_gettext(const char* original, const char* context=NULL);
+
+    const wchar_t     *w_ngettext(const wchar_t* singular, const wchar_t* plural, int num, const char* context=NULL);
+    const wchar_t     *w_ngettext(const char* singular, const char* plural, int num, const char* context=NULL);
 
     bool               isRTLLanguage() const;
     const wchar_t*     fribidize(const wchar_t* in_ptr);


### PR DESCRIPTION
Support plural translations by implementing a variant of ngettext with slightly different parameters (similar to the gettext() variant).

Also add Gaelic plural forms to tinygettext. (from https://github.com/leper/tinygettext/commit/d3cc412ab1d645d97c603991caf7fb9669224fcf)