### PR TITLE
Make note spinner values of addons search bar readable in low resolution

### DIFF
--- a/data/gui/addons_screen.stkgui
+++ b/data/gui/addons_screen.stkgui
@@ -14,7 +14,7 @@
                 <label text="Updated" align="center" I18N="In addons screen, in the filtering bar, to enable a filter that will show only recently updated items"/>
                 <spinner id="filter_date" proportion="8" align="center" min_value="0" wrap_around="true"/>
                 <label text="Rating >=" align="center" I18N="In addons screen, in the filtering bar, to enable a filter that will show only items with good rating"/>
-                <spinner id="filter_rating" proportion="3" align="center" min_value="0" wrap_around="true"/>
+                <spinner id="filter_rating" proportion="5" align="center" min_value="0" wrap_around="true"/>
                 <icon-button id="filter_search" height="100%" icon="gui/search.png"/>
             </div>
         </box>


### PR DESCRIPTION
As the title says, here's how it currently looks like on low resolutions like 800x600. (1024x768 is also a problem). I changed the proportion and now it looks great on low resolutions and still looks great on high resolutions.

![cantsee](https://cloud.githubusercontent.com/assets/9955284/5622225/f3908f5e-950d-11e4-9fa1-bae29c46e668.png)

