### PR TITLE
Fix sending of 'client-quit' request on quit. Also fix abortable requests.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1094,7 +1094,7 @@ void initRest()
 
     if (!track_manager->getTrack(UserConfigParams::m_last_track))
         UserConfigParams::m_last_track.revertToDefaults();
-        
+
     race_manager->setTrack(UserConfigParams::m_last_track);
 
 }   // initRest
@@ -1134,7 +1134,7 @@ void askForInternetPermission()
         }   // onCancel
     };   // ConfirmServer
 
-    GUIEngine::ModalDialog *dialog = 
+    GUIEngine::ModalDialog *dialog =
     new MessageDialog(_("SuperTuxKart may connect to a server "
         "to download add-ons and notify you of updates. We also collect "
         "anonymous hardware statistics to help with the development of STK. "
@@ -1201,7 +1201,7 @@ int main(int argc, char *argv[] )
         material_manager->addSharedMaterial(
                    file_manager->getAsset(FileManager::FONT,"materials.xml"));
         file_manager->popTextureSearchPath();
-        
+
         GUIEngine::addLoadingIcon( irr_driver->getTexture(FileManager::GUI,
                                                           "options_video.png"));
         kart_properties_manager -> loadAllKarts    ();
@@ -1462,7 +1462,6 @@ static void cleanSuperTuxKart()
 
     if(Online::RequestManager::isRunning())
         Online::RequestManager::get()->stopNetworkThread();
-
     SFXManager::get()->stopThread();
     irr_driver->updateConfigIfRelevant();
     AchievementsManager::destroy();

--- a/src/online/http_request.cpp
+++ b/src/online/http_request.cpp
@@ -361,11 +361,9 @@ namespace Online
     {
         HTTPRequest *request = (HTTPRequest *)clientp;
 
-        RequestManager* request_manager = RequestManager::get();
-
         // Check if we are asked to abort the download. If so, signal this
         // back to libcurl by returning a non-zero status.
-        if ((request_manager->getAbort() || request->isCancelled()) &&
+        if ((RequestManager::get()->getAbort() || request->isCancelled()) &&
              request->isAbortable()                                     )
         {
             // Indicates to abort the current download, which means that this

--- a/src/online/request.cpp
+++ b/src/online/request.cpp
@@ -61,13 +61,13 @@ namespace Online
     {
         assert(isBusy());
         // Abort as early as possible if abort is requested
-        if(RequestManager::get()->getAbort()) return;
+        if (RequestManager::get()->getAbort() && isAbortable()) return;
         prepareOperation();
-        if(RequestManager::get()->getAbort()) return;
+        if (RequestManager::get()->getAbort() && isAbortable()) return;
         operation();
-        if(RequestManager::get()->getAbort()) return;
+        if (RequestManager::get()->getAbort() && isAbortable()) return;
         setExecuted();
-        if(RequestManager::get()->getAbort()) return;
+        if (RequestManager::get()->getAbort() && isAbortable()) return;
         afterOperation();
     }   // execute
 

--- a/src/online/request_manager.cpp
+++ b/src/online/request_manager.cpp
@@ -63,7 +63,7 @@ namespace Online
     }   // isRunning
     // ------------------------------------------------------------------------
     /** Constructor. It only initialised values, it does not start the actual
-     *  thread. 
+     *  thread.
      */
     RequestManager::RequestManager()
     {

--- a/src/online/request_manager.hpp
+++ b/src/online/request_manager.hpp
@@ -122,7 +122,7 @@ namespace Online
                         >  m_request_queue;
 
             /** The list of pointers to all requests that are already executed
-             *  by the networking thread, but still need to be processed by the 
+             *  by the networking thread, but still need to be processed by the
              *  main thread. */
             Synchronised< std::queue<Online::Request*> >    m_result_queue;
 
@@ -133,7 +133,7 @@ namespace Online
 
             RequestManager(); //const std::string &url
             ~RequestManager();
-            
+
             static RequestManager * m_request_manager;
 
         public:
@@ -159,12 +159,12 @@ namespace Online
             void startNetworkThread();
             void stopNetworkThread();
 
-            bool getAbort(){ return m_abort.getAtomic(); }
+            bool getAbort() { return m_abort.getAtomic(); }
             void update(float dt);
 
             // ----------------------------------------------------------------
             /** Sets the interval with which poll requests are send to the
-             *  server. This can happen from the news manager (i.e. info 
+             *  server. This can happen from the news manager (i.e. info
              *  contained in the news.xml file), or a poll request. */
             void setMenuPollingInterval(float polling_interval)
             {
@@ -172,7 +172,7 @@ namespace Online
             }   // setPollingInterval
             // ----------------------------------------------------------------
             /** Sets the interval with which poll requests are send to the
-             *  server. This can happen from the news manager (i.e. info 
+             *  server. This can happen from the news manager (i.e. info
              *  contained in the news.xml file), or a poll request. */
             void setGamePollingInterval(float polling_interval)
             {


### PR DESCRIPTION
When executing a request there was no check to see if is abortable, only the request manager was consulted in this regard, ignoring the option to the individual requests.