### PR TITLE
Fix clang build, freeing memory too early

### DIFF
--- a/src/modes/linear_world.cpp
+++ b/src/modes/linear_world.cpp
@@ -352,11 +352,11 @@ void LinearWorld::newLap(unsigned int kart_index)
 
         // Store the temporary string because clang would mess this up
         // (remove the stringw before the wchar_t* is used).
-        core::stringw css = kart->getName();
+        core::stringw kartName = kart->getName();
 
         //I18N: as in "fastest lap: 60 seconds by Wilber"
         irr::core::stringw m_fastest_lap_message =
-            _C("fastest_lap", "%s by %s", s.c_str(), css.c_str());
+            _C("fastest_lap", "%s by %s", s.c_str(), kartName);
 
         m_race_gui->addMessage(m_fastest_lap_message, NULL,
                                3.0f, video::SColor(255, 255, 255, 255), false);

--- a/src/modes/linear_world.cpp
+++ b/src/modes/linear_world.cpp
@@ -350,10 +350,13 @@ void LinearWorld::newLap(unsigned int kart_index)
 
         std::string s = StringUtils::timeToString(time_per_lap);
 
-        irr::core::stringw m_fastest_lap_message;
+        // Store the temporary string because clang would mess this up
+        // (remove the stringw before the wchar_t* is used).
+        core::stringw css = kart->getName();
+
         //I18N: as in "fastest lap: 60 seconds by Wilber"
-        m_fastest_lap_message += _C("fastest_lap", "%s by %s", s.c_str(),
-                                    core::stringw(kart->getName()));
+        irr::core::stringw m_fastest_lap_message =
+            _C("fastest_lap", "%s by %s", s.c_str(), css.c_str());
 
         m_race_gui->addMessage(m_fastest_lap_message, NULL,
                                3.0f, video::SColor(255, 255, 255, 255), false);


### PR DESCRIPTION
Only the top half of the last lap message was displayed when SuperTuxKart was compiled with clang (version 3.5.1), the bottom half was an empty string. @hiker found out that clang deletes the string too fast, so caching it as a local variable fixes that problem.