### PR TITLE
Sort resolutions by size

### DIFF
--- a/src/guiengine/widgets/dynamic_ribbon_widget.cpp
+++ b/src/guiengine/widgets/dynamic_ribbon_widget.cpp
@@ -518,6 +518,7 @@ void DynamicRibbonWidget::clearItems()
     m_scroll_offset = 0;
     m_max_label_width = 0;
 }
+
 // -----------------------------------------------------------------------------
 void DynamicRibbonWidget::elementRemoved()
 {

--- a/src/guiengine/widgets/dynamic_ribbon_widget.hpp
+++ b/src/guiengine/widgets/dynamic_ribbon_widget.hpp
@@ -22,6 +22,8 @@
 
 #include <irrString.h>
 
+#include <algorithm>
+
 #include "guiengine/widget.hpp"
 #include "guiengine/widgets/ribbon_widget.hpp"
 #include "utils/leak_check.hpp"
@@ -236,6 +238,13 @@ namespace GUIEngine
         /** Clears all items added through 'addItem'. You can then add new items with 'addItem' and call
             'updateItemDisplay' to update the display. */
         void clearItems();
+
+        /** Sort the list of items with a given comparator. */
+        template<typename Compare>
+        void sortItems(Compare comp)
+        {
+            std::sort(m_items.begin(), m_items.end(), comp);
+        }
 
         /**
           * \brief Register a listener to be notified of selection changes within the ribbon.

--- a/src/states_screens/options_screen_video.cpp
+++ b/src/states_screens/options_screen_video.cpp
@@ -126,6 +126,23 @@ void OptionsScreenVideo::loadedFromFile()
 
 // ----------------------------------------------------------------------------
 
+struct SortResolutions
+{
+    bool operator()(GUIEngine::ItemDescription i1, GUIEngine::ItemDescription i2)
+    {
+        int w1 = -1, w2 = -1, h1 = -1, h2 = -1;
+        if (sscanf(i1.m_code_name.c_str(), "%ix%i", &w1, &h1) != 2 || w1 == -1 || h1 == -1 ||
+            sscanf(i2.m_code_name.c_str(), "%ix%i", &w2, &h2) != 2 || w2 == -1 || h2 == -1)
+        {
+            Log::error("OptionsScreenVideo", "Failed to decode resolution %s or %s",
+                i1.m_code_name.c_str(), i2.m_code_name.c_str());
+            return false;
+        }
+        return w1 < w2 || (w1 == w2 && h1 < h2);
+    }
+} sortResolutions;
+// ----------------------------------------------------------------------------
+
 void OptionsScreenVideo::init()
 {
     Screen::init();
@@ -306,6 +323,9 @@ void OptionsScreenVideo::init()
         {
             res->addItem(L"1024\u00D7768", "1024x768", "/gui/screen43.png");
         }
+
+        // Sort resolutions by size
+        res->sortItems(sortResolutions);
 
     } // end if not inited
 

--- a/src/states_screens/options_screen_video.cpp
+++ b/src/states_screens/options_screen_video.cpp
@@ -103,6 +103,33 @@ static GFXPreset GFX_PRESETS[] =
 
 static const int  GFX_LEVEL_AMOUNT = 5;
 
+struct Resolution
+{
+    int width, height;
+
+    Resolution()
+    {
+        width = 0;
+        height = 0;
+    }
+
+    Resolution(int w, int h)
+    {
+        width = w;
+        height = h;
+    }
+
+    bool operator< (Resolution r) const
+    {
+        return width < r.width || (width == r.width && height < r.height);
+    }
+
+    float getRatio() const
+    {
+        return (float) width / height;
+    }
+};
+
 // ----------------------------------------------------------------------------
 
 OptionsScreenVideo::OptionsScreenVideo() : Screen("options_video.stkgui")
@@ -124,23 +151,6 @@ void OptionsScreenVideo::loadedFromFile()
 
 }   // loadedFromFile
 
-// ----------------------------------------------------------------------------
-
-struct SortResolutions
-{
-    bool operator()(GUIEngine::ItemDescription i1, GUIEngine::ItemDescription i2)
-    {
-        int w1 = -1, w2 = -1, h1 = -1, h2 = -1;
-        if (sscanf(i1.m_code_name.c_str(), "%ix%i", &w1, &h1) != 2 || w1 == -1 || h1 == -1 ||
-            sscanf(i2.m_code_name.c_str(), "%ix%i", &w2, &h2) != 2 || w2 == -1 || h2 == -1)
-        {
-            Log::error("OptionsScreenVideo", "Failed to decode resolution %s or %s",
-                i1.m_code_name.c_str(), i2.m_code_name.c_str());
-            return false;
-        }
-        return w1 < w2 || (w1 == w2 && h1 < h2);
-    }
-} sortResolutions;
 // ----------------------------------------------------------------------------
 
 void OptionsScreenVideo::init()
@@ -193,6 +203,9 @@ void OptionsScreenVideo::init()
                                                 irr_driver->getVideoModes();
         const int amount = (int)modes.size();
 
+        std::vector<Resolution> resolutions;
+        Resolution r;
+
         bool found_config_res = false;
 
         // for some odd reason, irrlicht sometimes fails to report the good
@@ -207,40 +220,95 @@ void OptionsScreenVideo::init()
 
         for (int n=0; n<amount; n++)
         {
-            const int w = modes[n].getWidth();
-            const int h = modes[n].getHeight();
-            const float ratio = (float)w / h;
+            r.width  = modes[n].getWidth();
+            r.height = modes[n].getHeight();
+            resolutions.push_back(r);
 
-            if (w == UserConfigParams::m_width &&
-                h == UserConfigParams::m_height)
+            if (r.width  == UserConfigParams::m_width &&
+                r.height == UserConfigParams::m_height)
             {
                 found_config_res = true;
             }
 
-            if (w == 800 && h == 600)
-            {
 #ifdef DEBUG
+            if (r.width == 800 && r.height == 600)
+            {
                 found_800_600 = true;
-#else
-                continue;
-#endif
             }
-            else if (w == 1024 && h == 640)
+            else
+#endif
+            if (r.width == 1024 && r.height == 640)
+            // This becomes an 'else if' when DEBUG is defined
             {
                 found_1024_640 = true;
             }
-            else if (w == 1024 && h == 768)
+            else if (r.width == 1024 && r.height == 768)
             {
                 found_1024_768 = true;
             }
+        }
 
+        if (!found_config_res)
+        {
+            r.width  = UserConfigParams::m_width;
+            r.height = UserConfigParams::m_height;
+            resolutions.push_back(r);
+
+#ifdef DEBUG
+            if (r.width == 800 && r.height == 600)
+            {
+                found_800_600 = true;
+            }
+            else
+#endif
+            if (r.width == 1024 && r.height == 640)
+            // This becomes an 'else if' when DEBUG is defined
+            {
+                found_1024_640 = true;
+            }
+            else if (r.width == 1024 && r.height == 768)
+            {
+                found_1024_768 = true;
+            }
+        } // next found resolution
+
+        // Add default resolutions that were not found by irrlicht
+#ifdef DEBUG
+        if (!found_800_600)
+        {
+            r.width  = 800;
+            r.height = 600;
+            resolutions.push_back(r);
+        }
+#endif
+        if (!found_1024_640)
+        {
+            r.width  = 1024;
+            r.height = 640;
+            resolutions.push_back(r);
+        }
+        if (!found_1024_768)
+        {
+            r.width  = 1024;
+            r.height = 768;
+            resolutions.push_back(r);
+        }
+
+        // Sort resolutions by size
+        std::sort(resolutions.begin(), resolutions.end());
+
+        // Add resolutions list
+        for(std::vector<Resolution>::iterator it = resolutions.begin();
+            it != resolutions.end(); it++)
+        {
+            const float ratio = it->getRatio();
             char name[32];
-            sprintf( name, "%ix%i", w, h );
+            sprintf(name, "%ix%i", it->width, it->height);
 
             core::stringw label;
-            label += w;
+            label += it->width;
             label += L"\u00D7";
-            label += h;
+            label += it->height;
 
 #define ABOUT_EQUAL(a , b) (fabsf( a - b ) < 0.01)
 
@@ -259,74 +327,7 @@ void OptionsScreenVideo::init()
             else
                 res->addItem(label, name, "/gui/screen_other.png");
 #undef ABOUT_EQUAL
-        } // next resolution
-
-        if (!found_config_res)
-        {
-            const int w = UserConfigParams::m_width;
-            const int h = UserConfigParams::m_height;
-            const float ratio = (float)w / h;
-
-            if (w == 800 && h == 600)
-            {
-#ifdef DEBUG
-                found_800_600 = true;
-#endif
-            }
-            else if (w == 1024 && h == 640)
-            {
-                found_1024_640 = true;
-            }
-            else if (w == 1024 && h == 768)
-            {
-                found_1024_768 = true;
-            }
-
-            char name[32];
-            sprintf( name, "%ix%i", w, h );
-
-            core::stringw label;
-            label += w;
-            label += L"\u00D7";
-            label += h;
-
-#define ABOUT_EQUAL(a , b) (fabsf( a - b ) < 0.01)
-
-            if      (ABOUT_EQUAL( ratio, (5.0f/4.0f)   ))
-                res->addItem(label, name, "/gui/screen54.png");
-            else if (ABOUT_EQUAL( ratio, (4.0f/3.0f)   ))
-                res->addItem(label, name, "/gui/screen43.png");
-            else if (ABOUT_EQUAL( ratio, (16.0f/10.0f) ))
-                res->addItem(label, name, "/gui/screen1610.png");
-            else if (ABOUT_EQUAL( ratio, (5.0f/3.0f)   ))
-                res->addItem(label, name, "/gui/screen53.png");
-            else if (ABOUT_EQUAL( ratio, (3.0f/2.0f)   ))
-                res->addItem(label, name, "/gui/screen32.png");
-            else if (ABOUT_EQUAL( ratio, (16.0f/9.0f)   ))
-                res->addItem(label, name, "/gui/screen169.png");
-            else
-                res->addItem(label, name, "/gui/screen_other.png");
-#undef ABOUT_EQUAL
-        }
-
-#ifdef DEBUG
-        if (!found_800_600)
-        {
-            res->addItem(L"800\u00D7600", "800x600", "/gui/screen43.png");
-        }
-#endif
-        if (!found_1024_640)
-        {
-            res->addItem(L"1024\u00D7640", "1024x640", "/gui/screen1610.png");
-        }
-        if (!found_1024_768)
-        {
-            res->addItem(L"1024\u00D7768", "1024x768", "/gui/screen43.png");
-        }
-
-        // Sort resolutions by size
-        res->sortItems(sortResolutions);
-
+        } // add next resolution
     } // end if not inited
 
     res->updateItemDisplay();


### PR DESCRIPTION
With this change, the resolutions in the options screen are sorted by their size, so the greatest resolution is on the right and the lowest on the left.