### PR TITLE
Fix music and sound when starting with -R and add brackets to a calculation

### DIFF
--- a/src/karts/kart.cpp
+++ b/src/karts/kart.cpp
@@ -2522,8 +2522,8 @@ void Kart::updateGraphics(float dt, const Vec3& offset_xyz,
     {
         // fabs(speed) is important, otherwise the negative number will
         // become a huge unsigned number in the particle scene node!
-        float f = fabsf(getSpeed())/m_kart_properties->getMaxSpeed() *
-                  m_difficulty->getMaxSpeed();
+        float f = fabsf(getSpeed())/(m_kart_properties->getMaxSpeed() *
+                  m_difficulty->getMaxSpeed());
         // The speed of the kart can be higher (due to powerups) than
         // the normal maximum speed of the kart.
         if(f>1.0f) f = 1.0f;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1052,7 +1052,7 @@ void initRest()
     Online::RequestManager::get()->startNetworkThread();
     NewsManager::get();   // this will create the news manager
 
-    music_manager           = new MusicManager();
+    music_manager = new MusicManager();
     SFXManager::create();
     // The order here can be important, e.g. KartPropertiesManager needs
     // defaultKartProperties, which are defined in stk_config.
@@ -1238,7 +1238,7 @@ int main(int argc, char *argv[] )
             material_manager->addSharedMaterial(materials_file);
         }
         Referee::init();
-        powerup_manager         -> loadAllPowerups ();
+        powerup_manager->loadAllPowerups();
         ItemManager::loadDefaultItemMeshes();
 
         GUIEngine::addLoadingIcon( irr_driver->getTexture(FileManager::GUI,

--- a/src/modes/world_status.cpp
+++ b/src/modes/world_status.cpp
@@ -56,7 +56,22 @@ void WorldStatus::reset()
     m_auxiliary_timer = 0.0f;
     // Using SETUP_PHASE will play the track into sfx first, and has no
     // other side effects.
-    m_phase           = UserConfigParams::m_race_now ? RACE_PHASE : SETUP_PHASE;
+    m_phase           = UserConfigParams::m_race_now ? MUSIC_PHASE : SETUP_PHASE;
+
+    if (UserConfigParams::m_race_now)
+    {
+        // Setup music and sound
+        if (World::getWorld()->getWeather() != NULL)
+            World::getWorld()->getWeather()->playSound();
+
+        // Starting the music here doesn't work so it's done in the MUSIC_PHASE
+        World::getWorld()->getTrack()->startMusic();
+
+        // Start engines
+        for (unsigned int i = 0; i < World::getWorld()->getNumKarts(); i++)
+            World::getWorld()->getKart(i)->startEngineSFX();
+    }
+
     m_previous_phase  = UNDEFINED_PHASE;
     // Just in case that the game is reset during the intro phase
     m_track_intro_sound->stop();
@@ -140,7 +155,7 @@ void WorldStatus::update(const float dt)
 
             if (World::getWorld()->getWeather() != NULL)
             {
-                 World::getWorld()->getWeather()->playSound();
+                World::getWorld()->getWeather()->playSound();
             }
 
             return;
@@ -254,6 +269,12 @@ void WorldStatus::update(const float dt)
 
             break;
         case MUSIC_PHASE:
+            // Start the music here when starting fast
+            if (UserConfigParams::m_race_now)
+            {
+                music_manager->startMusic(music_manager->getCurrentMusic());
+                UserConfigParams::m_race_now = false;
+            }
             // how long to display the 'music' message
             if (m_auxiliary_timer>stk_config->m_music_credit_time)
             {

--- a/src/modes/world_status.cpp
+++ b/src/modes/world_status.cpp
@@ -58,14 +58,12 @@ void WorldStatus::reset()
     // other side effects.
     m_phase           = UserConfigParams::m_race_now ? MUSIC_PHASE : SETUP_PHASE;
 
+    // Parts of the initialisation-phase are skipped so do it here
     if (UserConfigParams::m_race_now)
     {
         // Setup music and sound
         if (World::getWorld()->getWeather() != NULL)
             World::getWorld()->getWeather()->playSound();
-
-        // Starting the music here doesn't work so it's done in the MUSIC_PHASE
-        World::getWorld()->getTrack()->startMusic();
 
         // Start engines
         for (unsigned int i = 0; i < World::getWorld()->getNumKarts(); i++)
@@ -80,6 +78,9 @@ void WorldStatus::reset()
 
     if (device->getTimer()->isStopped())
         device->getTimer()->start();
+
+    // Set the right music
+    World::getWorld()->getTrack()->startMusic();
 }   // reset
 
 //-----------------------------------------------------------------------------
@@ -227,8 +228,6 @@ void WorldStatus::update(const float dt)
                 {
                     m_start_sound->play();
                 }
-
-                World::getWorld()->getTrack()->startMusic();
 
                 // event
                 onGo();


### PR DESCRIPTION
* I must have forgotten to add brackets there. It shouldn't have much impact, but it still looks better with brackets
* The bigger part of this pull request starts sound and music when stk is started with '-R' and the ready-set-go-phase is skipped. I can do most of the initialization in the `reset()` function but starting the music there doesn't work so I moved it to the `MUSIC_PHASE` which also adds the music author at the bottom of the screen. The only functional change I made is setting `m_race_now` to false after that's done, so if another race is started afterwards the read-set-go-phase isn't skipped.