### PR TITLE
Add light effect when skidding

### DIFF
--- a/src/karts/kart.cpp
+++ b/src/karts/kart.cpp
@@ -2756,24 +2756,8 @@ void Kart::setOnScreenText(const wchar_t *text)
 
 void Kart::activateSkidLight(unsigned int level)
 {
-    if (level > 0)
-    {
-        if (level == 1)
-        {
-            m_skidding_light_1->setVisible(true);
-            m_skidding_light_2->setVisible(false);
-        }
-        else
-        {
-            m_skidding_light_2->setVisible(true);
-            m_skidding_light_1->setVisible(false);
-        }
-    }
-    else
-    {
-        m_skidding_light_1->setVisible(false);
-        m_skidding_light_2->setVisible(false);
-    }
+    m_skidding_light_1->setVisible(level == 1);
+    m_skidding_light_2->setVisible(level > 1);
 }
 
 /* EOF */

--- a/src/karts/kart.cpp
+++ b/src/karts/kart.cpp
@@ -132,6 +132,8 @@ Kart::Kart (const std::string& ident, unsigned int world_kart_id,
     m_fire_clicked         = 0;
     m_wrongway_counter     = 0;
     m_nitro_light          = NULL;
+    m_skidding_light_1     = NULL;
+    m_skidding_light_2     = NULL;
     m_type                 = RaceManager::KT_AI;
 
     m_view_blocked_by_plunger = 0;
@@ -2393,10 +2395,23 @@ void Kart::loadData(RaceManager::KartType type, bool is_animated_model)
     bool always_animated = (type == RaceManager::KT_PLAYER && race_manager->getNumPlayers() == 1);
     m_node = m_kart_model->attachModel(is_animated_model, always_animated);
 
+    // Create nitro light
     m_nitro_light = irr_driver->addLight(core::vector3df(0.0f, 0.5f, m_kart_model->getLength()*-0.5f - 0.05f),
-        0.6f /* force */, 5.0f /* radius */, 0.0f, 0.4f, 1.0f, false, m_node);
+        0.4f /* force */, 5.0f /* radius */, 0.0f, 0.4f, 1.0f, false, m_node);
     m_nitro_light->setVisible(false);
     m_nitro_light->setName( ("nitro emitter (" + getIdent() + ")").c_str() );
+
+    // Create skidding lights
+    // For the first skidding level
+    m_skidding_light_1 = irr_driver->addLight(core::vector3df(0.0f, 0.1f, m_kart_model->getLength()*-0.5f - 0.05f),
+        0.3f /* force */, 3.0f /* radius */, 1.0f, 0.6f, 0.0f, false, m_node);
+    m_skidding_light_1->setVisible(false);
+    m_skidding_light_1->setName( ("skidding emitter 1 (" + getIdent() + ")").c_str() );
+    // For the second skidding level
+    m_skidding_light_2 = irr_driver->addLight(core::vector3df(0.0f, 0.1f, m_kart_model->getLength()*-0.5f - 0.05f),
+        0.4f /* force */, 4.0f /* radius */, 1.0f, 0.0f, 0.0f, false, m_node);
+    m_skidding_light_2->setVisible(false);
+    m_skidding_light_2->setName( ("skidding emitter 2 (" + getIdent() + ")").c_str() );
 
 #ifdef DEBUG
     m_node->setName( (getIdent()+"(lod-node)").c_str() );
@@ -2738,5 +2753,27 @@ void Kart::setOnScreenText(const wchar_t *text)
     // It has one reference to the parent, and will get deleted
     // when the parent is deleted.
 }   // setOnScreenText
+
+void Kart::activateSkidLight(unsigned int level)
+{
+    if (level > 0)
+    {
+        if (level == 1)
+        {
+            m_skidding_light_1->setVisible(true);
+            m_skidding_light_2->setVisible(false);
+        }
+        else
+        {
+            m_skidding_light_2->setVisible(true);
+            m_skidding_light_1->setVisible(false);
+        }
+    }
+    else
+    {
+        m_skidding_light_1->setVisible(false);
+        m_skidding_light_2->setVisible(false);
+    }
+}
 
 /* EOF */

--- a/src/karts/kart.hpp
+++ b/src/karts/kart.hpp
@@ -222,7 +222,13 @@ private:
     /** To prevent using nitro in too short bursts */
     float         m_min_nitro_time;
 
+    /** A light that's shown when the kart uses nitro. */
     scene::ISceneNode* m_nitro_light;
+
+    /** Lights that are shown when the kart is skidding. */
+    scene::ISceneNode* m_skidding_light_1;
+    /** A light that's shown on the second skid-level with another color. */
+    scene::ISceneNode* m_skidding_light_2;
 
     void          updatePhysics(float dt);
     void          handleMaterialSFX(const Material *material);
@@ -250,8 +256,8 @@ public:
     virtual bool   isInRest         () const;
     virtual void   applyEngineForce (float force);
 
-    virtual void flyUp();
-    virtual void flyDown();
+    virtual void   flyUp();
+    virtual void   flyDown();
 
     virtual void   startEngineSFX   ();
     virtual void   adjustSpeed      (float f);
@@ -448,6 +454,8 @@ public:
     /** Counter which is used for displaying wrong way message after a delay */
     float getWrongwayCounter() { return m_wrongway_counter; }
     void setWrongwayCounter(float counter) { m_wrongway_counter = counter; }
+
+    void activateSkidLight(unsigned int level);
 };   // Kart
 
 

--- a/src/karts/skidding.cpp
+++ b/src/karts/skidding.cpp
@@ -77,6 +77,7 @@ void Skidding::reset()
     m_jump_speed          = 0.0f;
     m_kart->getKartGFX()->setCreationRateAbsolute(KartGFX::KGFX_SKIDL, 0);
     m_kart->getKartGFX()->setCreationRateAbsolute(KartGFX::KGFX_SKIDR, 0);
+    m_kart->activateSkidLight(0);
     m_kart->getControls().m_skid = KartControl::SC_NONE;
     
     btVector3 rot(0, 0, 0);
@@ -392,6 +393,7 @@ void Skidding::update(float dt, bool is_on_ground,
             {
                 m_skid_bonus_ready = true;
                 m_kart->getKartGFX()->setSkidLevel(level);
+                m_kart->activateSkidLight(level);
             }
             // If player stops skidding, trigger bonus, and change state to
             // SKID_SHOW_GFX_*
@@ -445,6 +447,7 @@ void Skidding::update(float dt, bool is_on_ground,
                   ->setCreationRateAbsolute(KartGFX::KGFX_SKIDL, 0);
             m_kart->getKartGFX()
                   ->setCreationRateAbsolute(KartGFX::KGFX_SKIDR, 0);
+            m_kart->activateSkidLight(0);
             m_skid_state = SKID_NONE;
         }
     }   // switch


### PR DESCRIPTION
I added two lights when skidding, one yellow for the first level and one red for the second.
This implements the idea that Arthur-D mentioned in #1724.