### PR TITLE
Set correct volume for last lap music

### DIFF
--- a/src/audio/music.hpp
+++ b/src/audio/music.hpp
@@ -35,7 +35,6 @@ public:
     virtual bool pauseMusic  ()                            = 0;
     virtual bool resumeMusic ()                            = 0;
     virtual void setVolume   (float volume)                = 0;
-    virtual void updateFading(float percent)               = 0;
     virtual void updateFaster(float percent, float pitch)  = 0;
     virtual void update      ()                            = 0;
     virtual bool isPlaying   ()                            = 0;

--- a/src/audio/music_dummy.hpp
+++ b/src/audio/music_dummy.hpp
@@ -35,7 +35,6 @@ public:
     virtual bool pauseMusic  ()                            { return true; }
     virtual bool resumeMusic ()                            { return true; }
     virtual void setVolume   (float volume)                {}
-    virtual void updateFading(float percent)               {}
     virtual void updateFaster(float percent, float pitch)  {}
     virtual void update      ()                            {}
     virtual bool isPlaying   ()                            { return false; }

--- a/src/audio/music_information.cpp
+++ b/src/audio/music_information.cpp
@@ -223,8 +223,8 @@ void MusicInformation::update(float dt)
             return;
         }
         float fraction=m_time_since_faster/m_faster_time;
-        m_normal_music->updateFading(1-fraction);
-        m_fast_music->updateFading(fraction);
+        m_normal_music->setVolume(1-fraction);
+        m_fast_music->setVolume(fraction);
         break;
                        }
     case SOUND_FASTER: {
@@ -322,6 +322,7 @@ void MusicInformation::switchToFastMusic()
     {
         m_mode = SOUND_FADING;
         m_fast_music->playMusic();
+        m_fast_music->setVolume(0);
     }
     else
     {

--- a/src/audio/music_ogg.cpp
+++ b/src/audio/music_ogg.cpp
@@ -258,13 +258,6 @@ void MusicOggStream::setVolume(float volume)
 }   // setVolume
 
 //-----------------------------------------------------------------------------
-void MusicOggStream::updateFading(float percent)
-{
-    alSourcef(m_soundSource,AL_GAIN,percent);
-    update();
-}   // updateFading
-
-//-----------------------------------------------------------------------------
 void MusicOggStream::updateFaster(float percent, float max_pitch)
 {
     alSourcef(m_soundSource,AL_PITCH,1+max_pitch*percent);

--- a/src/audio/music_ogg.hpp
+++ b/src/audio/music_ogg.hpp
@@ -51,7 +51,6 @@ public:
     virtual ~MusicOggStream();
 
     virtual void update();
-    virtual void updateFading(float percent);
     virtual void updateFaster(float percent, float max_pitch);
 
     virtual bool load(const std::string& filename);

--- a/src/audio/sfx_manager.cpp
+++ b/src/audio/sfx_manager.cpp
@@ -873,7 +873,7 @@ void SFXManager::positionListener(const Vec3 &position, const Vec3 &front,
 void SFXManager::reallyPositionListenerNow()
 {
 #if HAVE_OGGVORBIS
-    if (!UserConfigParams::m_sfx || !m_initialized) return;
+    if (!sfxAllowed()) return;
 
     m_listener_position.lock();
     {
@@ -925,5 +925,4 @@ SFXBase* SFXManager::quickSound(const std::string &sound_type)
         return (*sound).second;
     }
 }   // quickSound
-
 


### PR DESCRIPTION
This patch removes the updateFading method because it doesn't do the right thing. `updateFading` sets an absolute volume but the fading last lap music should have a relative volume compared to the maximum. That's exactly what `setVolume` does so I used that instead.

The last lap music works for me with this patch, but probably (I'm not sure) samuncle's and 
Odd0002's issues aren't related to this.