### PR TITLE
Add logging for API requests that are not successful.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@ src/html
 *~
 *.swp
 
+# Ignore QtCreator project file
+CMakeLists.txt.user
+
 packets_log.txt
 history.dat
 README.dependencies

--- a/src/online/xml_request.cpp
+++ b/src/online/xml_request.cpp
@@ -71,6 +71,11 @@ namespace Online
         {
             m_success = (rec_success == "yes");
             m_xml_data->get("info", &m_info);
+
+            if (!m_success)
+            {
+                Log::debug("XMLRequest::afterOperation", "Request returned error: %ls", m_info.c_str());
+            }
         }
         else
         {


### PR DESCRIPTION
Ideally this should be properly done for each API call and to check if it was a success.
But for now, this works as well, it's very useful for development purposes, especially for me :).