### PR TITLE
Fix transparency of fallback characters

### DIFF
--- a/data/shaders/colortexturedquad.frag
+++ b/data/shaders/colortexturedquad.frag
@@ -7,5 +7,5 @@ out vec4 FragColor;
 void main()
 {
 	vec4 res = texture(tex, uv);
-	FragColor = vec4(res.xyz * col.xyz, res.a);
+	FragColor = res * col;
 }

--- a/src/guiengine/scalable_font.cpp
+++ b/src/guiengine/scalable_font.cpp
@@ -668,9 +668,9 @@ void ScalableFont::doDraw(const core::stringw& text,
         if (fallback[n])
         {
             // TODO: don't hardcode colors?
-            static video::SColor orange(color.getAlpha(), 255, 100, 0);
-            static video::SColor yellow(color.getAlpha(), 255, 220, 15);
-            video::SColor title_colors[] = {yellow, orange, orange, yellow};
+            video::SColor orange(color.getAlpha(), 255, 100, 0);
+            video::SColor yellow(color.getAlpha(), 255, 220, 15);
+            video::SColor title_colors[] = {orange, yellow, orange, yellow};
 
             if (charCollector != NULL)
             {


### PR DESCRIPTION
This patch fixes transparency of fallback characters in title fonts.
The brackets in the credit screen didn't fade out and in which was caused by the shader that didn't respect transparency (I hope this isn't expected behaviour)
and the colors that didn't change because they were static.

Additionally I changed the order of yellow and orange, so it fades from yellow to orange now.