### PR TITLE
Fix two issues related to the addon server

### DIFF
--- a/src/addons/addons_manager.cpp
+++ b/src/addons/addons_manager.cpp
@@ -583,13 +583,19 @@ bool AddonsManager::uninstall(const Addon &addon)
  */
 void AddonsManager::saveInstalled()
 {
-    //Put the addons in the xml file
-    //Manually because the irrlicht xml writer doesn't seem finished, FIXME ?
+    // Put the addons in the xml file
+    // Manually because the irrlicht xml writer doesn't seem finished, FIXME ?
     std::ofstream xml_installed(m_file_installed.c_str());
 
-    //write the header of the xml file
+    // Write the header of the xml file
     xml_installed << "<?xml version=\"1.0\"?>" << std::endl;
-    xml_installed << "<addons  xmlns='http://stkaddons.net/'>"
+
+    // Get server address from config
+    std::string server = UserConfigParams::m_server_addons;
+    // Find the third slash (end of the domain)
+    std::string::size_type index = server.find('/');
+    index = server.find('/', index + 2) + 1; // Omit one slash
+    xml_installed << "<addons  xmlns='" << server.substr(0, index) << "'>"
                     << std::endl;
 
     for(unsigned int i = 0; i < m_addons_list.getData().size(); i++)

--- a/src/config/hardware_stats.cpp
+++ b/src/config/hardware_stats.cpp
@@ -313,9 +313,6 @@ void reportHardwareStats()
 
     std::string vendor, renderer, full_version;
     irr_driver->getOpenGLData(&vendor, &renderer, &full_version);
-    json.add("GL_VENDOR",   vendor          );
-    json.add("GL_RENDERER", renderer        );
-    json.add("GL_VERSION",  full_version    );
     json.add("gfx_drv_ver", "OpenGL "+vendor);
 
     std::string card_name = vendor;


### PR DESCRIPTION
This are two commits of #1907:
* leyyin found out that some stats were sent in `reportHardwareStats()` and in `getGLLimits(&json)`. Completing the getGLLimits method will introduce the same problem with e. g. GL_SHADING_LANGUAGE_VERSION
* The addon-server which is written into the addons_installed.xml now gets extracted from the UserConfig