### PR TITLE
Improvements for the first person camera

### DIFF
--- a/src/graphics/camera.cpp
+++ b/src/graphics/camera.cpp
@@ -489,6 +489,7 @@ void Camera::update(float dt)
         // - the kart should not be visible, but it works)
         m_camera->setNearValue(27.0);
     }
+    // Update the first person camera
     else if (UserConfigParams::m_camera_debug == 3)
     {
         core::vector3df direction(m_camera->getTarget() - m_camera->getPosition());

--- a/src/graphics/camera.hpp
+++ b/src/graphics/camera.hpp
@@ -113,6 +113,10 @@ private:
     /** Smooth acceleration with the first person camera. */
     bool m_smooth;
 
+    /** Attache the first person camera to a kart.
+        That means moving the kart also moves the camera. */
+    bool m_attached;
+
     /** The speed at which the up-vector rotates, only used for the first person camera. */
     float m_angular_velocity;
 
@@ -137,6 +141,15 @@ private:
 
     /** The up vector the camera should have, only used for the first person camera. */
     core::vector3df m_target_up_vector;
+
+    /** Save the local position if the first person camera is attached to the kart. */
+    core::vector3df m_local_position;
+
+    /** Save the local direction if the first person camera is attached to the kart. */
+    core::vector3df m_local_direction;
+
+    /** Save the local up vector if the first person camera is attached to the kart. */
+    core::vector3df m_local_up;
 
     /** List of all cameras. */
     static std::vector<Camera*> m_all_cameras;
@@ -270,12 +283,24 @@ public:
     AbstractKart* getKart() { return m_kart; }
 
     // ------------------------------------------------------------------------
+    /** Applies mouse movement to the first person camera. */
+    void applyMouseMovement (float x, float y);
+
+    // ------------------------------------------------------------------------
     /** Sets if the first person camera should be moved smooth. */
     void setSmoothMovement (bool value) { m_smooth = value; }
 
     // ------------------------------------------------------------------------
     /** If the first person camera should be moved smooth. */
     bool getSmoothMovement () { return m_smooth; }
+
+    // ------------------------------------------------------------------------
+    /** Sets if the first person camera should be moved with the kart. */
+    void setAttachedFpsCam (bool value) { m_attached = value; }
+
+    // ------------------------------------------------------------------------
+    /** If the first person camera should be moved with the kart. */
+    bool getAttachedFpsCam () { return m_attached; }
 
     // ------------------------------------------------------------------------
     /** Sets the angular velocity for this camera. */

--- a/src/input/input_manager.cpp
+++ b/src/input/input_manager.cpp
@@ -985,27 +985,7 @@ EventPropagation InputManager::input(const SEvent& event)
                    (diff_x + diff_y) < 100 && (diff_x + diff_y) > -100)
                 {
                     // Rotate camera
-                    core::vector3df up(cam->getUpVector());
-                    core::vector3df direction(cam->getDirection());
-                    core::vector3df side(direction.crossProduct(up));
-                    direction.normalize();
-                    up.normalize();
-                    core::quaternion quat;
-                    quat.fromAngleAxis(mouse_x, up);
-
-                    core::quaternion quat_y;
-                    quat_y.fromAngleAxis(mouse_y, side);
-                    quat *= quat_y;
-
-                    direction = quat * direction;
-                    cam->setDirection(direction);
-                    side = direction.crossProduct(up);
-
-                    // Compute new up vector
-                    /*up = side.crossProduct(direction);
-                    up.normalize();
-                    // Don't do that because it looks ugly and is bad to handle ;)
-                    cam->setUpVector(up);*/
+                    cam->applyMouseMovement(mouse_x, mouse_y);
 
                     // Reset mouse position to the middle of the screen when
                     // the mouse is far away

--- a/src/input/input_manager.cpp
+++ b/src/input/input_manager.cpp
@@ -67,8 +67,7 @@ using GUIEngine::EVENT_BLOCK;
 /** Initialise input
  */
 InputManager::InputManager() : m_mode(BOOTSTRAP),
-                               m_mouse_val_x(-1), m_mouse_val_y(-1),
-                               m_mouse_reset(0)
+                               m_mouse_val_x(-1), m_mouse_val_y(-1)
 {
     m_device_manager = new DeviceManager();
     m_device_manager->initialize();
@@ -977,11 +976,13 @@ EventPropagation InputManager::input(const SEvent& event)
                     UserConfigParams::m_fpscam_direction_speed;
                 float mouse_y = ((float) diff_y) *
                     -UserConfigParams::m_fpscam_direction_speed;
+
                 // No movement the first time it's used
                 // At the moment there's also a hard limit because the mouse
                 // gets reset to the middle of the screen and sometimes there
                 // are more events fired than expected.
-                if (m_mouse_val_x != -1 && m_mouse_reset <= 0)
+                if (m_mouse_val_x != -1 &&
+                   (diff_x + diff_y) < 100 && (diff_x + diff_y) > -100)
                 {
                     // Rotate camera
                     core::vector3df up(cam->getUpVector());
@@ -1016,8 +1017,6 @@ EventPropagation InputManager::input(const SEvent& event)
                         irr_driver->getDevice()->getCursorControl()->setPosition(mid_x, mid_y);
                         m_mouse_val_x = mid_x;
                         m_mouse_val_y = mid_y;
-                        // Ignore the next 2 movements
-                        m_mouse_reset = 2;
                     }
                     else
                     {
@@ -1029,7 +1028,6 @@ EventPropagation InputManager::input(const SEvent& event)
                 {
                     m_mouse_val_x = event.MouseInput.X;
                     m_mouse_val_y = event.MouseInput.Y;
-                    --m_mouse_reset;
                 }
                 return EVENT_BLOCK;
             }

--- a/src/input/input_manager.hpp
+++ b/src/input/input_manager.hpp
@@ -67,10 +67,6 @@ private:
     * makes the mouse behave like an analog axis on a gamepad/joystick.
     */
     int m_mouse_val_x, m_mouse_val_y;
-    /** To detect mouse events that are not caused by the user but by resetting
-        the mouse position to the center of the screen.
-        If it's not 0, the movement is ignored and the value is decreased. */
-    int m_mouse_reset;
 
     void   dispatchInput(Input::InputType, int deviceID, int btnID,
                          Input::AxisDirection direction, int value);

--- a/src/utils/debug.cpp
+++ b/src/utils/debug.cpp
@@ -97,6 +97,7 @@ enum DebugMenuCommand
     DEBUG_GUI_CAM_WHEEL,
     DEBUG_GUI_CAM_NORMAL,
     DEBUG_GUI_CAM_SMOOTH,
+    DEBUG_GUI_CAM_ATTACH,
     DEBUG_HIDE_KARTS,
     DEBUG_THROTTLE_FPS,
     DEBUG_VISUAL_VALUES,
@@ -260,6 +261,7 @@ bool onEvent(const SEvent &event)
             sub->addItem(L"First person view", DEBUG_GUI_CAM_FREE);
             sub->addItem(L"Normal view", DEBUG_GUI_CAM_NORMAL);
             sub->addItem(L"Toggle smooth camera", DEBUG_GUI_CAM_SMOOTH);
+            sub->addItem(L"Attach fps camera to kart", DEBUG_GUI_CAM_ATTACH);
 
             mnu->addItem(L"Adjust values", DEBUG_VISUAL_VALUES);
 
@@ -538,6 +540,11 @@ bool onEvent(const SEvent &event)
                 {
                     Camera *cam = Camera::getActiveCamera();
                     cam->setSmoothMovement(!cam->getSmoothMovement());
+                }
+                else if (cmdID == DEBUG_GUI_CAM_ATTACH)
+                {
+                    Camera *cam = Camera::getActiveCamera();
+                    cam->setAttachedFpsCam(!cam->getAttachedFpsCam());
                 }
                 else if (cmdID == DEBUG_PRINT_START_POS)
                 {


### PR DESCRIPTION
This pull request contains two improvements/changes for the fps camera:
* I changed the way, how the mouse position is handled: There is now a limit for the movement per event, that works better than ignoring a number of events.
* I added a new "mode" for the first person camera, that attaches it to a kart. That allows to drive a kart from a different (fixed) position than normal.