### PR TITLE
Highscores update

### DIFF
--- a/src/states_screens/track_info_screen.cpp
+++ b/src/states_screens/track_info_screen.cpp
@@ -194,6 +194,8 @@ void TrackInfoScreen::init()
     RibbonWidget* bt_start = getWidget<GUIEngine::RibbonWidget>("buttons");
     bt_start->setFocusForPlayer(PLAYER_ID_GAME_MASTER);
 
+    updateHighScores();
+
 }   // init
 
 // ----------------------------------------------------------------------------
@@ -322,6 +324,7 @@ void TrackInfoScreen::eventCallback(Widget* widget, const std::string& name,
         const int num_ai = m_ai_kart_spinner->getValue();
         race_manager->setNumKarts( race_manager->getNumLocalPlayers() + num_ai );
         UserConfigParams::m_num_karts = race_manager->getNumLocalPlayers() + num_ai;
+        updateHighScores();
     }
 }   // eventCallback
 


### PR DESCRIPTION
On track_info_screen high scores were not visible or updated (after entering or after changing number of ai).
Now they are updated on init() or after click on ai-spinner.