### PR TITLE
A few extensions and fixes for the first person camera

### DIFF
--- a/src/input/input_manager.cpp
+++ b/src/input/input_manager.cpp
@@ -206,6 +206,28 @@ void InputManager::handleStaticAction(int key, int value)
             cam->setLinearVelocity(vel);
             break;
         }
+        case KEY_KEY_R:
+        {
+            if (!world || !UserConfigParams::m_artist_debug_mode ||
+                UserConfigParams::m_camera_debug != 3) break;
+
+            Camera *cam = Camera::getActiveCamera();
+            core::vector3df vel(cam->getLinearVelocity());
+            vel.Y = value ? cam->getMaximumVelocity() : 0;
+            cam->setLinearVelocity(vel);
+            break;
+        }
+        case KEY_KEY_F:
+        {
+            if (!world || !UserConfigParams::m_artist_debug_mode ||
+                UserConfigParams::m_camera_debug != 3) break;
+
+            Camera *cam = Camera::getActiveCamera();
+            core::vector3df vel(cam->getLinearVelocity());
+            vel.Y = value ? -cam->getMaximumVelocity() : 0;
+            cam->setLinearVelocity(vel);
+            break;
+        }
         // Rotating the first person camera
         case KEY_KEY_Q:
         {

--- a/src/utils/debug.cpp
+++ b/src/utils/debug.cpp
@@ -520,6 +520,10 @@ bool onEvent(const SEvent &event)
                 {
                     UserConfigParams::m_camera_debug = 3;
                     irr_driver->getDevice()->getCursorControl()->setVisible(false);
+                    // Reset camera rotation
+                    Camera *cam = Camera::getActiveCamera();
+                    cam->setDirection(vector3df(0, 0, 1));
+                    cam->setUpVector(vector3df(0, 1, 0));
                 }
                 else if (cmdID == DEBUG_GUI_CAM_NORMAL)
                 {


### PR DESCRIPTION
 * The camera can be moved up and down with the `r` and `f` key
 * The rotation is reset when the fps camera gets activated (fixes #2040)
 * The rotation code changed a bit, the camera shouldn't be stuck at high angles anymore (like mentioned in #2040)