### PR TITLE
Fix glVertexAttribDivisor redefinition warning

### DIFF
--- a/src/graphics/gl_headers.hpp
+++ b/src/graphics/gl_headers.hpp
@@ -13,6 +13,9 @@ extern "C" {
 #    include <OpenGL/gl3.h>
 #    define OGL32CTX
 #    ifdef GL_ARB_instanced_arrays
+#        ifdef glVertexAttribDivisor
+#            undef glVertexAttribDivisor
+#        endif
 #        define glVertexAttribDivisor glVertexAttribDivisorARB
 #    endif
 #    ifndef GL_TEXTURE_SWIZZLE_RGBA


### PR DESCRIPTION
This fixes this warning:

supertuxkart/stk-code/src/graphics/gl_headers.hpp:16:17: warning: 
      'glVertexAttribDivisor' macro redefined
#        define glVertexAttribDivisor glVertexAttribDivisorARB
                ^
supertuxkart/stk-code/lib/glew/include/GL/glew.h:2382:9: note: 
      previous definition is here
#define glVertexAttribDivisor GLEW_GET_FUN(__glewVertexAttribDivisor)
        ^