### PR TITLE
Fix some issues with RTL languages

### DIFF
--- a/src/achievements/achievement.cpp
+++ b/src/achievements/achievement.cpp
@@ -200,7 +200,7 @@ void Achievement::check()
     {
         //show achievement
         core::stringw s = _("Completed achievement \"%s\".", 
-                            m_achievement_info->getName().c_str());
+                            m_achievement_info->getName());
         MessageQueue::add(MessageQueue::MT_ACHIEVEMENT, s);
 
         // Sends a confirmation to the server that an achievement has been

--- a/src/challenges/challenge_data.cpp
+++ b/src/challenges/challenge_data.cpp
@@ -483,8 +483,7 @@ const irr::core::stringw
             // shouldn't happen but let's avoid crashes as much as possible...
             if (track == NULL) return irr::core::stringw( L"????" );
 
-            return _("New track '%s' now available",
-                     core::stringw(track->getName()));
+            return _("New track '%s' now available", track->getName());
             break;
         }
         case UNLOCK_MODE:
@@ -513,8 +512,7 @@ const irr::core::stringw
             // shouldn't happen but let's avoid crashes as much as possible...
             if (kp == NULL) return irr::core::stringw( L"????" );
 
-            return _("New kart '%s' now available",
-                      core::stringw(kp->getName()));
+            return _("New kart '%s' now available", kp->getName());
         }
         default:
             assert(false);

--- a/src/graphics/irr_driver.cpp
+++ b/src/graphics/irr_driver.cpp
@@ -1745,15 +1745,13 @@ video::SColorf IrrDriver::getAmbientLight() const
 void IrrDriver::displayFPS()
 {
     gui::IGUIFont* font = GUIEngine::getSmallFont();
+    core::rect<s32> position;
 
-    if(UserConfigParams::m_artist_debug_mode)
-    {
-        GL32_draw2DRectangle(video::SColor(150, 96, 74, 196),core::rect< s32 >(75,0,1100,40),NULL);
-    }
+    if (UserConfigParams::m_artist_debug_mode)
+        position = core::rect<s32>(75, 0, 1100, 40);
     else
-    {
-        GL32_draw2DRectangle(video::SColor(150, 96, 74, 196),core::rect< s32 >(75,0,900,40),NULL);
-    }
+        position = core::rect<s32>(75, 0, 900, 40);
+    GL32_draw2DRectangle(video::SColor(150, 96, 74, 196), position, NULL);
     // We will let pass some time to let things settle before trusting FPS counter
     // even if we also ignore fps = 1, which tends to happen in first checks
     const int NO_TRUST_COUNT = 200;
@@ -1805,7 +1803,7 @@ void IrrDriver::displayFPS()
 
     if (UserConfigParams::m_artist_debug_mode)
     {
-        fpsString = StringUtils::insertValues(_("FPS: %d/%d/%d  - PolyCount: %d Solid, %d Shadows - LightDist : %d"),
+        fpsString = _("FPS: %d/%d/%d  - PolyCount: %d Solid, %d Shadows - LightDist : %d",
             min, fps, max, poly_count[SOLID_NORMAL_AND_DEPTH_PASS], poly_count[SHADOW_PASS], m_last_light_bucket_distance);
         poly_count[SOLID_NORMAL_AND_DEPTH_PASS] = 0;
         poly_count[SHADOW_PASS] = 0;
@@ -1814,11 +1812,11 @@ void IrrDriver::displayFPS()
         object_count[TRANSPARENT_PASS] = 0;
     }
     else
-        fpsString = StringUtils::insertValues(_("FPS: %d/%d/%d - %d KTris"), min, fps, max, (int)roundf(kilotris));
+        fpsString = _("FPS: %d/%d/%d - %d KTris", min, fps, max, (int)roundf(kilotris));
 
     static video::SColor fpsColor = video::SColor(255, 0, 0, 0);
 
-    font->draw( fpsString.c_str(), core::rect< s32 >(100,0,400,50), fpsColor, false );
+    font->draw( fpsString.c_str(), position, fpsColor, false );
 }   // updateFPS
 
 // ----------------------------------------------------------------------------

--- a/src/graphics/stk_text_billboard.cpp
+++ b/src/graphics/stk_text_billboard.cpp
@@ -46,7 +46,8 @@ void STKTextBillboard::updateAbsolutePosition()
 
 scene::IMesh* STKTextBillboard::getTextMesh(core::stringw text, gui::ScalableFont* font)
 {
-    font->doDraw(text, core::rect<s32>(0, 0, 1000, 1000), video::SColor(255,255,255,255),
+    core::dimension2du size = font->getDimension(text.c_str());
+    font->doDraw(text, core::rect<s32>(0, 0, size.Width, size.Height), video::SColor(255,255,255,255),
         false, false, NULL, this);
 
     const float scale = 0.018f;

--- a/src/input/input_manager.cpp
+++ b/src/input/input_manager.cpp
@@ -749,7 +749,7 @@ void InputManager::dispatchInput(Input::InputType type, int deviceID,
                         // is not associated to any player
                         GUIEngine::showMessage(
                             _("Ignoring '%s', you needed to join earlier to play!",
-                            irr::core::stringw(gp->getName().c_str()).c_str())      );
+                            core::stringw(gp->getName().c_str())));
                     }
                 }
                 return;

--- a/src/modes/world.cpp
+++ b/src/modes/world.cpp
@@ -1145,7 +1145,7 @@ void World::eliminateKart(int kart_id, bool notify_of_elimination)
                                        2.0f);
             else
                 m_race_gui->addMessage(_("'%s' has been eliminated.",
-                                       core::stringw(kart->getName())),
+                                       kart->getName()),
                                        camera->getKart(),
                                        2.0f);
         }  // for i < number of cameras

--- a/src/states_screens/dialogs/select_challenge.cpp
+++ b/src/states_screens/dialogs/select_challenge.cpp
@@ -131,13 +131,13 @@ SelectChallengeDialog::SelectChallengeDialog(const float percentWidth,
     if (c->getData()->isGrandPrix())
     {
         const GrandPrixData* gp = grand_prix_manager->getGrandPrix(c->getData()->getGPId());
-        getWidget<LabelWidget>("title")->setText( gp->getName(), true );
+        getWidget<LabelWidget>("title")->setText(translations->fribidize(gp->getName()), true);
     }
     else
     {
         const core::stringw track_name =
             track_manager->getTrack(c->getData()->getTrackId())->getName();
-        getWidget<LabelWidget>("title")->setText( track_name, true );
+        getWidget<LabelWidget>("title")->setText(translations->fribidize(track_name), true);
     }
 
     LabelWidget* typeLbl = getWidget<LabelWidget>("race_type_val");

--- a/src/states_screens/edit_gp_screen.cpp
+++ b/src/states_screens/edit_gp_screen.cpp
@@ -155,7 +155,7 @@ void EditGPScreen::init()
     {
         LabelWidget* header = getWidget<LabelWidget>("title");
         assert(header != NULL);
-        header->setText(m_gp->getName(), true);
+        header->setText(translations->fribidize(m_gp->getName()), true);
 
         IconButtonWidget* button = getWidget<IconButtonWidget>("save");
         assert(button != NULL);
@@ -281,7 +281,8 @@ void EditGPScreen::setModified(const bool modified)
 
     LabelWidget* header = getWidget<LabelWidget>("title");
     assert(header != NULL);
-    header->setText(m_gp->getName() + (modified ? L" (+)" : L""), true);
+    //I18N: Indicate that the grand prix is modified and not saved
+    header->setText(modified ? _(L"%s (+)", m_gp->getName()) : L"", true);
 
     enableButtons();
 }

--- a/src/states_screens/edit_track_screen.cpp
+++ b/src/states_screens/edit_track_screen.cpp
@@ -223,7 +223,7 @@ void EditTrackScreen::selectTrack(const std::string& id)
     if (m_track != NULL)
     {
         tracks->setSelection(m_track->getIdent(), PLAYER_ID_GAME_MASTER, true);
-        selected_track->setText(m_track->getName(), true);
+        selected_track->setText(translations->fribidize(m_track->getName()), true);
 
         laps->setValue(m_laps);
 

--- a/src/states_screens/gp_info_screen.cpp
+++ b/src/states_screens/gp_info_screen.cpp
@@ -215,11 +215,11 @@ void GPInfoScreen::init()
         m_gp.createRandomGP(m_num_tracks_spinner->getValue(),
                             m_group_name, getReverse(), true);
 
-        getWidget<LabelWidget>("name")->setText(m_gp.getName(), false);
+        getWidget<LabelWidget>("name")->setText(translations->fribidize(m_gp.getName()), false);
     }
     else
     {
-        getWidget<LabelWidget>("name")->setText(m_gp.getName(), false);
+        getWidget<LabelWidget>("name")->setText(translations->fribidize(m_gp.getName()), false);
         m_gp.checkConsistency();
     }
 

--- a/src/states_screens/grand_prix_editor_screen.cpp
+++ b/src/states_screens/grand_prix_editor_screen.cpp
@@ -168,7 +168,7 @@ void GrandPrixEditorScreen::setSelection (const GrandPrixData* gpdata)
     else
     {
         m_selection = grand_prix_manager->editGrandPrix(gpdata->getId());
-        gpname_widget->setText (gpdata->getName(), true);
+        gpname_widget->setText(translations->fribidize(gpdata->getName()), true);
         gplist_widget->setSelection(m_selection->getId(), PLAYER_ID_GAME_MASTER, true);
         loadTrackList (gpdata->getId());
     }

--- a/src/states_screens/race_gui_overworld.cpp
+++ b/src/states_screens/race_gui_overworld.cpp
@@ -490,7 +490,7 @@ void RaceGUIOverworld::drawGlobalMiniMap()
                 }
 
                 gui::ScalableFont* font = GUIEngine::getTitleFont();
-                font->draw(gp->getName(), pos, video::SColor(255,255,255,255),
+                font->draw(translations->fribidize(gp->getName()), pos, video::SColor(255,255,255,255),
                            false, true /* vcenter */, NULL);
 
                 core::rect<s32> pos(15,
@@ -515,7 +515,8 @@ void RaceGUIOverworld::drawGlobalMiniMap()
                 }
 
                 gui::ScalableFont* font = GUIEngine::getTitleFont();
-                font->draw(track->getName(), pos, video::SColor(255,255,255,255),
+                font->draw(translations->fribidize(track->getName()),
+                           pos, video::SColor(255, 255, 255, 255),
                            false, true /* vcenter */, NULL);
             }
 

--- a/src/states_screens/race_gui_overworld.cpp
+++ b/src/states_screens/race_gui_overworld.cpp
@@ -435,7 +435,7 @@ void RaceGUIOverworld::drawGlobalMiniMap()
     // ---- Draw nearby challenge if any
     core::rect<s32> pos(15,
                         10,
-                        15 + irr_driver->getActualScreenSize().Width/2,
+                        irr_driver->getActualScreenSize().Width - 200,
                         10 + GUIEngine::getTitleFontHeight());
 
     m_close_to_a_challenge = false;
@@ -493,13 +493,12 @@ void RaceGUIOverworld::drawGlobalMiniMap()
                 font->draw(translations->fribidize(gp->getName()), pos, video::SColor(255,255,255,255),
                            false, true /* vcenter */, NULL);
 
-                core::rect<s32> pos(15,
-                                    20 + GUIEngine::getTitleFontHeight(),
-                                    15 + irr_driver->getActualScreenSize().Width/2,
-                                    20 + 2*GUIEngine::getTitleFontHeight());
+                core::rect<s32> pos2(pos);
+                pos2.UpperLeftCorner.Y += 10 + GUIEngine::getTitleFontHeight();
+                pos2.LowerRightCorner.Y += 10 + GUIEngine::getTitleFontHeight();
 
                 //just below GP name
-                font->draw(_("Type: Grand Prix"), pos, video::SColor(255,255,255,255),
+                font->draw(_("Type: Grand Prix"), pos2, video::SColor(255,255,255,255),
                            false, true /* vcenter */, NULL);
             }
             else

--- a/src/states_screens/track_info_screen.cpp
+++ b/src/states_screens/track_info_screen.cpp
@@ -100,7 +100,7 @@ void TrackInfoScreen::init()
     const bool has_laps       = race_manager->modeHasLaps();
     const bool has_highscores = race_manager->modeHasHighscores();
 
-    getWidget<LabelWidget>("name")->setText(m_track->getName(), false);
+    getWidget<LabelWidget>("name")->setText(translations->fribidize(m_track->getName()), false);
 
     //I18N: when showing who is the author of track '%s'
     //I18N: (place %s where the name of the author should appear)

--- a/src/tracks/track.cpp
+++ b/src/tracks/track.cpp
@@ -182,7 +182,7 @@ bool Track::operator<(const Track &other) const
     \note this is the LTR name, invoke fribidi as needed. */
 core::stringw Track::getName() const
 {
-    core::stringw translated = translations->w_gettext(m_name.c_str());
+    core::stringw translated = _LTR(m_name.c_str());
     int index = translated.find("|");
     if(index>-1)
     {

--- a/src/utils/translation.cpp
+++ b/src/utils/translation.cpp
@@ -47,6 +47,8 @@
 
 // set to 1 to debug i18n
 #define TRANSLATE_VERBOSE 0
+// Define TEST_BIDI to force right-to-left style for all languages
+//#define TEST_BIDI
 
 using namespace tinygettext;
 
@@ -274,6 +276,9 @@ Translations::Translations() //: m_dictionary_manager("UTF-16")
             break;
         }
     }
+#ifdef TEST_BIDI
+    m_rtl = true;
+#endif
 }   // Translations
 
 // ----------------------------------------------------------------------------
@@ -298,6 +303,12 @@ const wchar_t* Translations::fribidize(const wchar_t* in_ptr)
             for (std::size_t i = 0; i <= length; i++)
                 fribidiInput[i] = in_ptr[i];
         }
+#ifdef TEST_BIDI
+        FriBidiChar *tmp = fribidiInput;
+        fribidiInput = new FriBidiChar[++length + 1];
+        std::memcpy(fribidiInput + 1, tmp, length * sizeof(FriBidiChar));
+        fribidiInput[0] = L'\u202E';
+#endif
 
         // Assume right to left as start direction.
 #if FRIBIDI_MINOR_VERSION==10
@@ -319,6 +330,11 @@ const wchar_t* Translations::fribidize(const wchar_t* in_ptr)
               /* gint   *position_V_to_L_list */ NULL,
               /* gint8  *embedding_level_list */ NULL
                                                                );
+#ifdef TEST_BIDI
+        delete[] fribidiInput;
+        fribidiInput = tmp;
+#endif
+
         if (sizeof(wchar_t) != sizeof(FriBidiChar))
             delete[] fribidiInput;
 

--- a/src/utils/translation.cpp
+++ b/src/utils/translation.cpp
@@ -295,7 +295,6 @@ const wchar_t* Translations::fribidize(const wchar_t* in_ptr)
             // is technically incorrect, all characters we use/support fit
             // in 16 bits, which is what irrlicht supports atm).
             fribidiInput = new FriBidiChar[length + 1];
-            std::memset(fribidiInput, 0, (length + 1) * sizeof(FriBidiChar));
             for (std::size_t i = 0; i <= length; i++)
                 fribidiInput[i] = in_ptr[i];
         }
@@ -320,7 +319,8 @@ const wchar_t* Translations::fribidize(const wchar_t* in_ptr)
               /* gint   *position_V_to_L_list */ NULL,
               /* gint8  *embedding_level_list */ NULL
                                                                );
-        delete[] fribidiInput;
+        if (sizeof(wchar_t) != sizeof(FriBidiChar))
+            delete[] fribidiInput;
 
         if (!result)
         {


### PR DESCRIPTION
I fixed some issues with RTL languages and removed some unnecessary code.
There were some missing `fribidize` invocations and I changed the position the track/gp-name to the right side of the screen to avoid issues with long names.

There's a new debug option to force text to be right-to-left in `translations.cpp`.

Edit: I forgot to mention that this pull request depends on the changes I made in  #2057 (Allocate memory dynamically in fribidize).