### PR TITLE
Re-prioritize SUPERTUXKART_DATADIR build option

### DIFF
--- a/src/io/file_manager.cpp
+++ b/src/io/file_manager.cpp
@@ -160,6 +160,10 @@ FileManager::FileManager()
 #ifdef __APPLE__
     else if( macSetBundlePathIfRelevant( root_dir ) ) { root_dir = root_dir + "data/"; }
 #endif
+#ifdef SUPERTUXKART_DATADIR
+    else if (m_file_system->existFile(SUPERTUXKART_DATADIR"/data"))
+        root_dir = SUPERTUXKART_DATADIR"/data/";
+#endif
     else if(m_file_system->existFile("data"))
         root_dir = "data/" ;
     else if(m_file_system->existFile("../data"))
@@ -179,14 +183,7 @@ FileManager::FileManager()
     }
     else
     {
-#ifdef SUPERTUXKART_DATADIR
-        root_dir = SUPERTUXKART_DATADIR"/data/";
-        if(root_dir.size()==0 || root_dir[root_dir.size()-1]!='/')
-            root_dir+='/';
-
-#else
         root_dir = "/usr/local/share/games/supertuxkart/";
-#endif
     }
 
     addRootDirs(root_dir);


### PR DESCRIPTION
This is a draft proposal for fixing #2073, and I have not tested it at all.

Before, when selecting the directory containing the data files, STK checked whether some paths such as `../../data` existed before considering the `SUPERTUXKART_DATADIR` build option. This commit makes the build option take priority over those checks, although it remains lower priority than the `SUPERTUXKART_DATADIR` environment variable.

Now, when `SUPERTUXKART_DATADIR` is defined to the correct value during compilation, the existence of an empty `/data` directory (when the actual data files are in e.g. `/usr/share/supertuxkart/data`) does not cause STK to crash on startup.