### PR TITLE
Fix some translation and bidi issues

### DIFF
--- a/src/achievements/achievement_info.hpp
+++ b/src/achievements/achievement_info.hpp
@@ -113,7 +113,7 @@ public:
     irr::core::stringw getDescription() const { return _(m_description.c_str()); }
     // ------------------------------------------------------------------------
     /** Returns the name of this achievement. */
-    irr::core::stringw getName() const { return _(m_name.c_str()); }
+    irr::core::stringw getName() const { return _LTR(m_name.c_str()); }
     // ------------------------------------------------------------------------
     bool needsResetAfterRace() const { return m_reset_type == AFTER_RACE; }
     // ------------------------------------------------------------------------

--- a/src/guiengine/widgets/bubble_widget.cpp
+++ b/src/guiengine/widgets/bubble_widget.cpp
@@ -74,7 +74,7 @@ void BubbleWidget::replaceText()
     EGUI_ALIGNMENT align = EGUIA_UPPERLEFT;
     if      (m_properties[PROP_TEXT_ALIGN] == "center") align = EGUIA_CENTER;
     else if (m_properties[PROP_TEXT_ALIGN] == "right")  align = EGUIA_LOWERRIGHT;
-    else if (translations->isRTLLanguage())             align = EGUIA_LOWERRIGHT;
+    else if (translations->isRTLText(message))          align = EGUIA_LOWERRIGHT;
 
     EGUI_ALIGNMENT valign = EGUIA_CENTER ; //TODO: make label v-align configurable through XML file?
 
@@ -90,7 +90,7 @@ void BubbleWidget::replaceText()
         m_expanded_size.LowerRightCorner.Y += additionalNeededSize/2 + 10;
 
         // reduce text to fit in the available space if it's too long
-        if (translations->isRTLLanguage())
+        if (translations->isRTLText(message))
         {
             while (text_height > m_shrinked_size.getHeight() && message.size() > 10)
             {

--- a/src/guiengine/widgets/player_kart_widget.cpp
+++ b/src/guiengine/widgets/player_kart_widget.cpp
@@ -344,6 +344,7 @@ void PlayerKartWidget::add()
         name = m_associated_player->getProfile()->getName();
     if (m_associated_user)
         name = m_associated_user->getUserName();
+    core::stringw label = translations->fribidize(name);
 
     if (m_parent_screen->m_multiplayer)
     {
@@ -357,21 +358,21 @@ void PlayerKartWidget::add()
             {
                 // I18N: 'handicapped' indicates that per-player handicaps are
                 //       activated for this kart (i.e. it will drive slower)
-                label = _("%s (handicapped)", label);
+                label = _("%s (handicapped)", name);
                 m_player_ident_spinner->addLabel(label);
             }
         }
 
         // select the right player profile in the spinner
-        m_player_ident_spinner->setValue(name);
+        m_player_ident_spinner->setValue(label);
     }
     else
     {
-        m_player_ident_spinner->addLabel(name);
+        m_player_ident_spinner->addLabel(label);
         m_player_ident_spinner->setVisible(false);
     }
 
-    assert(m_player_ident_spinner->getStringValue() == name);
+    assert(m_player_ident_spinner->getStringValue() == label);
 }   // add
 
 // ------------------------------------------------------------------------

--- a/src/race/grand_prix_data.hpp
+++ b/src/race/grand_prix_data.hpp
@@ -148,7 +148,7 @@ public:
     // ------------------------------------------------------------------------
     /** @return the (potentially translated) user-visible name of the Grand
      *  Prix (apply fribidi as needed) */
-    irr::core::stringw getName()      const { return _LTR(m_name.c_str());   }
+    irr::core::stringw getName()      const { return m_editable ? m_name.c_str() : _LTR(m_name.c_str());   }
 
     // ------------------------------------------------------------------------
     /** @return the internal indentifier of the Grand Prix (not translated) */

--- a/src/states_screens/grand_prix_editor_screen.cpp
+++ b/src/states_screens/grand_prix_editor_screen.cpp
@@ -161,7 +161,7 @@ void GrandPrixEditorScreen::setSelection (const GrandPrixData* gpdata)
     if (gpdata == NULL)
     {
         m_selection = NULL;
-        gpname_widget->setText (L"Please select a Grand Prix", true);
+        gpname_widget->setText (_("Please select a Grand Prix"), true);
         tracks_widget->clearItems();
         tracks_widget->updateItemDisplay();
     }

--- a/src/states_screens/online_profile_achievements.cpp
+++ b/src/states_screens/online_profile_achievements.cpp
@@ -107,7 +107,7 @@ void BaseOnlineProfileAchievements::init()
             const Achievement *a = it->second;
             if(a->getInfo()->isSecret() && !a->isAchieved())
                 continue;
-            ListWidget::ListCell title(a->getInfo()->getName(), -1, 2);
+            ListWidget::ListCell title(translations->fribidize(a->getInfo()->getName()), -1, 2);
             ListWidget::ListCell progress(a->getProgressAsString(), -1, 1);
             row.push_back(title);
             row.push_back(progress);

--- a/src/utils/translation.cpp
+++ b/src/utils/translation.cpp
@@ -25,6 +25,7 @@
 
 #include "utils/translation.hpp"
 
+#include <algorithm>
 #include <assert.h>
 #include <locale.h>
 #include <stdio.h>

--- a/src/utils/translation.cpp
+++ b/src/utils/translation.cpp
@@ -147,9 +147,10 @@ FriBidiChar* toFribidiChar(const wchar_t* str)
     // Prepend a character that forces RTL style
     FriBidiChar *tmp = result;
     result = new FriBidiChar[++length + 1];
-    std::memcpy(result + 1, tmp, length * sizeof(FriBidiChar));
+    memcpy(result + 1, tmp, length * sizeof(FriBidiChar));
     result[0] = L'\u202E';
-    freeFribidiChar(tmp);
+    if (sizeof(wchar_t) != sizeof(FriBidiChar))
+        delete[] tmp;
 #endif
 
     return result;

--- a/src/utils/translation.hpp
+++ b/src/utils/translation.hpp
@@ -70,6 +70,9 @@ public:
     const std::vector<std::string>* getLanguageList() const;
 
     std::string        getCurrentLanguageName();
+
+private:
+    irr::core::stringw fribidizeLine(const irr::core::stringw &str);
 };   // Translations
 
 


### PR DESCRIPTION
I hope I didn't mix up too many unrelated changes here. There are some little changes that
- fix #2125,
- the second part of #2132 (“Please select a Grand Prix”),
- the achievement display (@GreenLunar mentioned it in #1815),
- use isRTLText instead of isRTLLanguage in the BubbleWidget (if text is untranslated) and
- I partially fixed the TEST_BIDI debug option (it's still not working when you try to choose a kart in multiplayer).

The bigger change (fae12f3) is to fix a bidi issue in the multiplayer KartSelection screen where a multiline string (with `\n`) should be displayed. That caused issues with fribidi so now the text is splitted into lines before it gets fribidized.

Update: TEST_BIDI works in the multiplayer kart-selection screen now