### PR TITLE
Don’t sort strings alphabetically (makes the translators’ work much easier)

### DIFF
--- a/data/po/update_pot.sh
+++ b/data/po/update_pot.sh
@@ -37,13 +37,13 @@ echo "---------------------------"
 echo "    Generating .pot file..."
 
 # XML Files
-xgettext  -d supertuxkart -s --keyword=_ --add-comments="I18N:" \
+xgettext  -d supertuxkart --keyword=_ --add-comments="I18N:" \
                                -p ./data/po -o supertuxkart.pot \
                                --no-location --from-code=UTF-8 ./data/po/gui_strings.h \
                                --package-name=supertuxkart
 
 # C++ Files
-xgettext  -j  -d supertuxkart -s --keyword=_ --keyword=N_ --keyword=_LTR \
+xgettext  -j  -d supertuxkart --keyword=_ --keyword=N_ --keyword=_LTR \
                                --keyword=_C:1c,2 --keyword=_P:1,2 \
                                --keyword=_CP:1c,2,3 --add-comments="I18N:" \
                                -p ./data/po -o supertuxkart.pot $CPP_FILE_LIST \


### PR DESCRIPTION
Here’s a patch to remove the sorting of the strings for translation. Currently, they’re sorted alphabetically, which makes translation more difficult and error-prone, since one can’t see the strings in proper context (e.g., the strings ‘Ready!’, ‘Set!’ and ‘Go!’ appear in completely different parts of the translation file). After applying the patch, the strings will appear in ‘natural’ order, i.e., in the source code order.