### PR TITLE
User conf dir versioned naming appears to be wrong

### DIFF
--- a/src/io/file_manager.cpp
+++ b/src/io/file_manager.cpp
@@ -824,7 +824,7 @@ void FileManager::checkAndCreateConfigDir()
     if(m_user_config_dir.size()>0 && *m_user_config_dir.rbegin()!='/')
         m_user_config_dir += "/";
 
-    m_user_config_dir +="0.8.2/";
+    m_user_config_dir +="0.9/";
     if(!checkAndCreateDirectoryP(m_user_config_dir))
     {
         Log::warn("FileManager", "Can not  create config dir '%s', "


### PR DESCRIPTION
Confdir name is versioned and seems to be outdated.
Maybe an automatic naming (using macros) would be more robust.