### PR TITLE
Fix #2164 : Resized max length of mail address up to 254 chars

### DIFF
--- a/data/po/supertuxkart.pot
+++ b/data/po/supertuxkart.pot
@@ -1067,7 +1067,7 @@ msgid "Email"
 msgstr ""
 
 #: src/states_screens/register_screen.cpp:292
-msgid "Email has to be between 4 and 50 characters long!"
+msgid "Email has to be between 5 and 254 characters long!"
 msgstr ""
 
 #: src/states_screens/register_screen.cpp:298

--- a/src/states_screens/register_screen.cpp
+++ b/src/states_screens/register_screen.cpp
@@ -287,9 +287,9 @@ void RegisterScreen::doRegister()
     {
         m_info_widget->setText(_("Password has to be between 8 and 30 characters long!"), false);
     }
-    else if (email.size() < 4 || email.size() > 50)
+    else if (email.size() < 5 || email.size() > 254)
     {
-        m_info_widget->setText(_("Email has to be between 4 and 50 characters long!"), false);
+        m_info_widget->setText(_("Email has to be between 5 and 254 characters long!"), false);
     }
     else if (  email.find(L"@")== -1 || email.find(L".")== -1 ||
               (email.findLast(L'.') - email.findLast(L'@') <= 2 ) ||


### PR DESCRIPTION
Also, i raised the min value to 5 since as i explained in the issue thread, we might want to be ready for a 1 character tld.