### PR TITLE
Fix compiler warning about shift count being bigger than size of type

### DIFF
--- a/src/network/network_string.hpp
+++ b/src/network/network_string.hpp
@@ -167,7 +167,8 @@ class NetworkString
             T result = 0;
             while(a--)
             {
-                result <<= 8; // offset one byte
+                result <<= 7; // offset one byte
+                result <<= 1;
                 result += ((uint8_t)(m_string[pos+n-1-a]) & 0xff); // add the data to result
             }
             return result;
@@ -212,7 +213,8 @@ class NetworkString
             T result = 0;
             while(a--)
             {
-                result <<= 8; // offset one byte
+                result <<= 7; // offset one byte
+                result <<= 1;
                 result += ((uint8_t)(m_string[pos+n-1-a]) & 0xff); // add the data
             }
             remove(pos,n);


### PR DESCRIPTION
/stk-code/src/network/network_string.hpp:170:24: warning: shift count >= width of
      type [-Wshift-count-overflow]