### PR TITLE
Remove virtual function, fixes #2248

### DIFF
--- a/src/states_screens/race_result_gui.hpp
+++ b/src/states_screens/race_result_gui.hpp
@@ -249,9 +249,6 @@ public:
                             bool important=true,
                             bool big_font=false) { }
 
-    /** Should not be called anymore. */
-    virtual void clearAllMessages() {assert(false); }
-
     void nextPhase();
 
     /** Show no highscore */


### PR DESCRIPTION
That way, the base class func is being called which does some proper things.