### PR TITLE
Offers the possibility to look backward during the start phase. #2232

### DIFF
--- a/src/karts/controller/player_controller.cpp
+++ b/src/karts/controller/player_controller.cpp
@@ -326,8 +326,8 @@ void PlayerController::update(float dt)
     // if automatic reverse camera is active
     if (m_camera->getMode() != Camera::CM_FINAL)
     {
-        if (m_controls->m_look_back || (UserConfigParams::m_reverse_look_threshold>0 &&
-            m_kart->getSpeed()<-UserConfigParams::m_reverse_look_threshold))
+        if (m_controls->m_look_back || (UserConfigParams::m_reverse_look_threshold > 0 &&
+            m_kart->getSpeed() < -UserConfigParams::m_reverse_look_threshold))
         {
             m_camera->setMode(Camera::CM_REVERSE);
         }

--- a/src/karts/controller/player_controller.cpp
+++ b/src/karts/controller/player_controller.cpp
@@ -321,6 +321,24 @@ void PlayerController::update(float dt)
     if (!history->replayHistory())
         steer(dt, m_steer_val);
 
+
+    // look backward when the player requests or
+    // if automatic reverse camera is active
+    if (m_camera->getMode() != Camera::CM_FINAL)
+    {
+        if (m_controls->m_look_back || (UserConfigParams::m_reverse_look_threshold>0 &&
+            m_kart->getSpeed()<-UserConfigParams::m_reverse_look_threshold))
+        {
+            m_camera->setMode(Camera::CM_REVERSE);
+        }
+        else
+        {
+            if (m_camera->getMode() == Camera::CM_REVERSE)
+                m_camera->setMode(Camera::CM_NORMAL);
+        }
+    }
+
+
     if (World::getWorld()->isStartPhase())
     {
         if (m_controls->m_accel || m_controls->m_brake ||
@@ -358,21 +376,7 @@ void PlayerController::update(float dt)
         return;
     }
 
-    // look backward when the player requests or
-    // if automatic reverse camera is active
-    if (m_camera->getMode() != Camera::CM_FINAL)
-    {
-        if (m_controls->m_look_back || (UserConfigParams::m_reverse_look_threshold>0 &&
-            m_kart->getSpeed()<-UserConfigParams::m_reverse_look_threshold))
-        {
-            m_camera->setMode(Camera::CM_REVERSE);
-        }
-        else
-        {
-            if (m_camera->getMode() == Camera::CM_REVERSE)
-                m_camera->setMode(Camera::CM_NORMAL);
-        }
-    }
+
 
     // We can't restrict rescue to fulfil isOnGround() (which would be more like
     // MK), since e.g. in the City track it is possible for the kart to end


### PR DESCRIPTION
https://github.com/supertuxkart/stk-code/issues/2232

Moving the camera "manager" before the penalty time check allows the player to look backward during the countdown.