### PR TITLE
Added SFX to nitro

### DIFF
--- a/src/karts/kart.cpp
+++ b/src/karts/kart.cpp
@@ -1715,7 +1715,7 @@ void Kart::updateNitro(float dt)
     bool increase_speed = (m_controls.m_nitro && isOnGround());
     if (!increase_speed && m_min_nitro_time <= 0.0f)
     {
-        if(m_nitro_sound->getStatus()==SFXBase::SFX_PLAYING)
+        if(m_nitro_sound->getStatus() == SFXBase::SFX_PLAYING)
             m_nitro_sound->stop();
         return;
     }
@@ -1724,7 +1724,7 @@ void Kart::updateNitro(float dt)
                           m_difficulty->getNitroConsumption();
     if (m_collected_energy < 0)
     {
-        if(m_nitro_sound->getStatus()==SFXBase::SFX_PLAYING)
+        if(m_nitro_sound->getStatus() == SFXBase::SFX_PLAYING)
             m_nitro_sound->stop();
         m_collected_energy = 0;
         return;
@@ -1732,7 +1732,7 @@ void Kart::updateNitro(float dt)
 
     if (increase_speed)
     {
-        if(m_nitro_sound->getStatus()!=SFXBase::SFX_PLAYING)
+        if(m_nitro_sound->getStatus() != SFXBase::SFX_PLAYING)
             m_nitro_sound->play();
         m_max_speed->increaseMaxSpeed(MaxSpeed::MS_INCREASE_NITRO,
                                      m_kart_properties->getNitroMaxSpeedIncrease() *
@@ -1746,7 +1746,7 @@ void Kart::updateNitro(float dt)
     }
     else
     {
-        if(m_nitro_sound->getStatus()==SFXBase::SFX_PLAYING)
+        if(m_nitro_sound->getStatus() == SFXBase::SFX_PLAYING)
             m_nitro_sound->stop();
     }
 }   // updateNitro

--- a/src/karts/kart.hpp
+++ b/src/karts/kart.hpp
@@ -149,7 +149,7 @@ private:
 
     /** True if fire button was pushed and not released */
     bool         m_fire_clicked;
-    
+
     /** Counter which is used for displaying wrong way message after a delay */
     float        m_wrongway_counter;
 
@@ -200,6 +200,7 @@ private:
     SFXBase      *m_engine_sound;
     SFXBase      *m_crash_sound;
     SFXBase      *m_terrain_sound;
+    SFXBase      *m_nitro_sound;
     /** A pointer to the previous terrain sound needs to be saved so that an
      *  'older' sfx can be finished and an abrupt end of the sfx is avoided. */
     SFXBase      *m_previous_terrain_sound;


### PR DESCRIPTION
https://github.com/supertuxkart/stk-code/issues/2182
I added some SFX to nitro. Beside the changes in the code, some changes have to be done in stk_assets :
- adding http://www.bigsoundbank.com/dl.php?ext=ogg&id=0851 in stk-assets/sfx/ and renaming it nitro.ogg
- adding the following line to stk-assets/sfx/sfx.xml :   
 `<sfx filename="nitro.ogg"            volume="3.0" positional="true" rolloff="0.5" />`

The result can be seen here : https://youtu.be/fU1IYIvejnw?t=46s