### PR TITLE
Check size of window; don't assume it equals requested size

### DIFF
--- a/src/states_screens/cutscene_gui.cpp
+++ b/src/states_screens/cutscene_gui.cpp
@@ -16,10 +16,10 @@
 //  along with this program; if not, write to the Free Software
 //  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
-#include "config/user_config.hpp"
 #include "guiengine/engine.hpp"
 #include "guiengine/scalable_font.hpp"
 #include "graphics/2dutils.hpp"
+#include "graphics/irr_driver.hpp"
 #include "states_screens/cutscene_gui.hpp"
 
 // -----------------------------------------------------------------------------
@@ -40,21 +40,23 @@ CutsceneGUI::~CutsceneGUI()
 
 void CutsceneGUI::renderGlobal(float dt)
 {
+    core::dimension2d<u32> screen_size = irr_driver->getActualScreenSize();
+
     if (m_fade_level > 0.0f)
     {
         GL32_draw2DRectangle(
                                 video::SColor((int)(m_fade_level*255), 0,0,0),
                                 core::rect<s32>(0, 0,
-                                                UserConfigParams::m_width,
-                                                UserConfigParams::m_height));
+                                                screen_size.Width,
+                                                screen_size.Height));
     }
 
     if (m_subtitle.size() > 0)
     {
-        core::rect<s32> r(0, UserConfigParams::m_height - GUIEngine::getFontHeight()*2,
-                          UserConfigParams::m_width, UserConfigParams::m_height);
+        core::rect<s32> r(0, screen_size.Height - GUIEngine::getFontHeight()*2,
+                          screen_size.Width, screen_size.Height);
 
-        if (GUIEngine::getFont()->getDimension(m_subtitle.c_str()).Width > (unsigned int)UserConfigParams::m_width)
+        if (GUIEngine::getFont()->getDimension(m_subtitle.c_str()).Width > screen_size.Width)
         {
             GUIEngine::getSmallFont()->draw(m_subtitle, r,
                                             video::SColor(255,255,255,255), true, true, NULL);


### PR DESCRIPTION
Some window managers don't honour window size requests. If the window is bigger than requested, only the top left corner of cutscenes will fade.