### PR TITLE
Fix SuperTux difficulty button state not updating correctly

### DIFF
--- a/src/states_screens/race_setup_screen.cpp
+++ b/src/states_screens/race_setup_screen.cpp
@@ -281,15 +281,23 @@ void RaceSetupScreen::init()
             break;
     }
 
-    if (PlayerManager::getCurrentPlayer()->isLocked("difficulty_best"))
     {
         RibbonWidget* w = getWidget<RibbonWidget>("difficulty");
         assert(w != NULL);
 
         int index = w->findItemNamed("best");
         Widget* hardestWidget = &w->getChildren()[index];
-        hardestWidget->setBadge(LOCKED_BADGE);
-        hardestWidget->setActive(false);
+
+        if (PlayerManager::getCurrentPlayer()->isLocked("difficulty_best"))
+        {
+            hardestWidget->setBadge(LOCKED_BADGE);
+            hardestWidget->setActive(false);
+        }
+        else
+        {
+            hardestWidget->unsetBadge(LOCKED_BADGE);
+            hardestWidget->setActive(true);
+        }
     }
 }   // init
 


### PR DESCRIPTION
If the race setup screen is entered while the SuperTux difficulty is unavailable (locked), the SuperTux difficulty button will retain its locked badge and inactive state forever -- that is even if said difficulty becomes available (e.g. by changing the current user).