### PR TITLE
Don’t sort strings alphabetically (again)

### DIFF
--- a/data/po/update_pot.sh
+++ b/data/po/update_pot.sh
@@ -52,7 +52,7 @@ xgettext  -j  -d supertuxkart --keyword=_ --keyword=N_ --keyword=_LTR \
                                --package-name=supertuxkart
 
 # Angelscript files (xgettext doesn't support AS so pretend it's c++)
-xgettext  -j  -d supertuxkart -s --keyword="translate" --add-comments="I18N:" \
+xgettext  -j  -d supertuxkart --keyword="translate" --add-comments="I18N:" \
                                -p ./data/po -o supertuxkart.pot $ANGELSCRIPT_FILE_LIST \
                                --package-name=supertuxkart --language=c++
 


### PR DESCRIPTION
This patch changes the string extraction so that strings aren’t sorted alphabetically. This makes the translators’ work *much* easier. (For more information, see previous pull request #2188, which was applied, but whose effect was accidently removed by a later commit.)