### PR TITLE
Add default precision qualifier in fragment shaders

### DIFF
--- a/src/graphics/shader.cpp
+++ b/src/graphics/shader.cpp
@@ -65,6 +65,11 @@ GLuint ShaderBase::loadShader(const std::string &file, unsigned type)
     
     std::ostringstream code;
     code << "#version " << CVS->getGLSLVersion()<<"\n";
+    
+    //shader compilation fails with some drivers if there is no precision qualifier
+    if (type == GL_FRAGMENT_SHADER)
+        code << "precision mediump float;\n";
+        
     if (CVS->isAMDVertexShaderLayerUsable())
         code << "#extension GL_AMD_vertex_shader_layer : enable\n";
     if (CVS->isAZDOEnabled())


### PR DESCRIPTION
I tried to fix shader compilation with some drivers:
http://forum.freegamedev.net/viewtopic.php?f=17&t=6600

I don't know if it will work since I can't reproduce the issue described in this topic. According to GLSL specification, precision qualifer are useless with OpenGL (they only have an effect with OpenGL ES), so this PR should not break anything, at worse it is useless.