### PR TITLE
Readme and Install.md improvments

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
-#SuperTuxKart Installation Instructions
+# SuperTuxKart Installation Instructions
 
-Note : If you obtained this source code from github, you also need to download the game assets from sourceforge using SVN.
+Note: If you obtained this source code from Github, you also need to download the game assets from Sourceforge using SVN.
 
 `svn checkout https://svn.code.sf.net/p/supertuxkart/code/stk-assets stk-assets`
 
@@ -8,7 +8,7 @@ Place the `stk-assets` folder next to the source root `stk-code` folder.
 See <http://supertuxkart.sourceforge.net/Source_control> for more information
 
 
-##Building STK on Linux
+## Building STK on Linux
 
 First, make sure that you have the following packages installed:
 
@@ -50,14 +50,18 @@ make VERBOSE=1 -j2
 
 To create a debug version of STK, use:
 
-`cmake .. -DCMAKE_BUILD_TYPE=Debug`
+```
+cmake .. -DCMAKE_BUILD_TYPE=Debug
+```
 
 To test the compilation, supertuxkart can be run from the build
 directory by ./bin/supertuxkart 
 
 To install the file, as root execute:
 
-`make install`
+```
+make install
+```
 
 The default install location is `/usr/local`, i.e. the data files will
 be written to `/usr/local/share/games/supertuxkart`, the executable
@@ -66,9 +70,9 @@ location, specify `CMAKE_INSTALL_PREFIX` when running cmake, e.g.:
 `cmake .. -DCMAKE_INSTALL_PREFIX=/opt/stk`
 
   
-##Building STK on OS X
+## Building STK on OS X
 See <http://supertuxkart.sourceforge.net/Building_and_packaging_on_OSX>
 
 
-##Building STK on Windows
+## Building STK on Windows
 See <http://supertuxkart.sourceforge.net/How_to_build_the_Windows_version>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#SuperTuxKart
+# SuperTuxKart
 [![Build Status](https://travis-ci.org/supertuxkart/stk-code.png?branch=master)](https://travis-ci.org/supertuxkart/stk-code)
 
 SuperTuxKart is a free kart racing game. It is focusing on fun and
@@ -15,7 +15,7 @@ Hope you enjoy the game.
 -- The SuperTuxKart development team.
 
 
-##Hardware Requirements
+## Hardware Requirements
 * You need a 3D graphics card. (NVIDIA GeForce 8xxx and higher, ATI Radeon HD 4xxx and higher or Intel HD 3000 and higher)
 * You should have a CPU that's running at 1GHz or better.
 * You'll need at least 512 MB of free VRAM (video memory).
@@ -23,9 +23,9 @@ Hope you enjoy the game.
 * Ideally, you want a joystick with at least 6 buttons.
 
 
-##Compiling SuperTuxKart
+## Compiling SuperTuxKart
 
-###Windows
+### Windows
 1. Install VS 2013 (or later). The free express versions work fine.
 2. Download and install a source package - either a released package or from our [git/svn repositories](http://supertuxkart.sourceforge.net/Source_control)
 3. Download the latest dependency package depdendencies_for_0.8.2.zip from [here](https://sourceforge.net/projects/supertuxkart/files/SuperTuxKart%20Dependencies/Windows/). Unzip it in the root directory, so that the dependencies directory is next to the src and data directory (if you are updating from a previous dependency package, you can delete the .dll files in the root directory, they are not needed anymore).
@@ -38,24 +38,24 @@ Hope you enjoy the game.
 Compilation with cygwin is not officially supported, but
 this has been done (check with the forum for details).
 
-###Mac OS X
+### Mac OS X
 The latest information about compilation on Mac are on our wiki:
 <http://supertuxkart.sourceforge.net/Building_and_packaging_on_OSX>
 The Xcode project file is in `/src/ide/Xcode/`, but it still 
 requires that all dependencies are installed as explained on the wiki.
 
-###UNIX
-See `INSTALL` for details.
+### UNIX
+See [`INSTALL.md`](INSTALL.md) for details.
 
 
-##License
+## License
 This software is released under the GNU General Public License (GPL) which
-can be found in the file `LICENSE` in the same directory as this file.
+can be found in the file [`COPYING`](/COPYING) in the same directory as this file.
 Information about the licenses for artwork are contained in 
 `data/licenses`.
 
 
-##3D coordinates
+## 3D coordinates
 A reminder for those looking at the code and 3d models:
 
 STK    : X right, Y up,       Z forwards


### PR DESCRIPTION
* added space after `#` headline
* corrected file names of files I could find
* linked to files

However one thing I could not fix was this sentence:
"Information about the licenses for artwork are contained in 
`data/licenses`."

The mentioned file or dir does not exist (anymore) and I could not find any other file, which would fit there.