### PR TITLE
Allow configurable fonts file names in stk-config

### DIFF
--- a/data/stk_config.xml
+++ b/data/stk_config.xml
@@ -749,4 +749,21 @@
          </heavy>
      </kart-type>
   </general-kart-defaults>
+
+  <!-- Here are the default fonts file names for STK.
+
+  Please DO NOT report bugs if there're crashes when using your custom font.
+  This usually happen because the character map of the font is not in unicode mode
+  (let's take Chinese for example, some fonts of it store the characters in BIG5 mode,
+  which leads to crash with STK), but the fonts are to blame, what's the point of not
+  using industry standard nowadays...
+  -->
+  <font default="Ubuntu-R.ttf"
+        default_fallback="FreeSans.ttf"
+        cjk="wqy-microhei.ttf"
+        ar="NotoNaskhArabicUI-Bold.ttf"
+        bold="Ubuntu-B.ttf"
+        bold_fallback="FreeSansBold.ttf"
+        digit="SigmarOne.otf" />
+
 </config>

--- a/src/config/stk_config.cpp
+++ b/src/config/stk_config.cpp
@@ -385,6 +385,17 @@ void STKConfig::getAllData(const XMLNode * root)
 
     }
 
+    if(const XMLNode *font_node = root->getNode("font"))
+    {
+        font_node->get("default",          &m_font_default         );
+        font_node->get("default_fallback", &m_font_default_fallback);
+        font_node->get("cjk",              &m_font_cjk             );
+        font_node->get("ar",               &m_font_ar              );
+        font_node->get("bold",             &m_font_bold            );
+        font_node->get("bold_fallback",    &m_font_bold_fallback   );
+        font_node->get("digit",            &m_font_digit           );
+    }
+
     // Get the default KartProperties
     // ------------------------------
     const XMLNode *node = root -> getNode("general-kart-defaults");

--- a/src/config/stk_config.hpp
+++ b/src/config/stk_config.hpp
@@ -160,6 +160,15 @@ public:
     /** The field of view for 1, 2, 3, 4 player split screen. */
     float m_camera_fov[4];
 
+    /** File names of the default fonts in STK. */
+    std::string m_font_default;
+    std::string m_font_default_fallback;
+    std::string m_font_cjk;
+    std::string m_font_ar;
+    std::string m_font_bold;
+    std::string m_font_bold_fallback;
+    std::string m_font_digit;
+
 private:
     /** True if stk_config has been loaded. This is necessary if the
      *  --stk-config command line parameter has been specified to avoid

--- a/src/guiengine/ft_environment.cpp
+++ b/src/guiengine/ft_environment.cpp
@@ -19,6 +19,7 @@
 #include "guiengine/ft_environment.hpp"
 #include "io/file_manager.hpp"
 #include "utils/log.hpp"
+#include "config/stk_config.hpp"
 
 #include <algorithm>
 
@@ -70,31 +71,31 @@ void FTEnvironment::checkError(FT_Error err, const irr::core::stringc desc)
 void FTEnvironment::loadFont()
 {
     checkError(FT_New_Face(m_ft_lib, (file_manager->getAssetChecked
-                                (FileManager::TTF, "Ubuntu-R.ttf", true)).c_str(),
+                                (FileManager::TTF, stk_config->m_font_default.c_str(), true)).c_str(),
                                 0, &m_ft_face[F_DEFAULT]), "loading F_DEFAULT");
 
     checkError(FT_New_Face(m_ft_lib, (file_manager->getAssetChecked
-                                (FileManager::TTF, "FreeSans.ttf",true)).c_str(),
+                                (FileManager::TTF, stk_config->m_font_default_fallback.c_str(), true)).c_str(),
                                 0, &m_ft_face[F_DEFAULT_FALLBACK]), "loading F_DEFAULT_FALLBACK");
 
     checkError(FT_New_Face(m_ft_lib, (file_manager->getAssetChecked
-                                (FileManager::TTF, "wqy-microhei.ttf",true)).c_str(),
+                                (FileManager::TTF, stk_config->m_font_cjk.c_str(), true)).c_str(),
                                  0, &m_ft_face[F_CJK]), "loading F_CJK");
 
     checkError(FT_New_Face(m_ft_lib, (file_manager->getAssetChecked
-                                (FileManager::TTF, "NotoNaskhArabicUI-Bold.ttf",true)).c_str(),
+                                (FileManager::TTF, stk_config->m_font_ar.c_str(), true)).c_str(),
                                  0, &m_ft_face[F_AR]), "loading F_AR");
 
     checkError(FT_New_Face(m_ft_lib, (file_manager->getAssetChecked
-                                (FileManager::TTF, "Ubuntu-B.ttf", true)).c_str(),
+                                (FileManager::TTF, stk_config->m_font_bold.c_str(), true)).c_str(),
                                 0, &m_ft_face[F_BOLD]), "loading F_BOLD");
 
     checkError(FT_New_Face(m_ft_lib, (file_manager->getAssetChecked
-                                (FileManager::TTF, "FreeSansBold.ttf", true)).c_str(),
+                                (FileManager::TTF, stk_config->m_font_bold_fallback.c_str(), true)).c_str(),
                                 0, &m_ft_face[F_BOLD_FALLBACK]), "loading F_BOLD_FALLBACK");
 
     checkError(FT_New_Face(m_ft_lib, (file_manager->getAssetChecked
-                                (FileManager::TTF, "SigmarOne.otf",true)).c_str(),
+                                (FileManager::TTF, stk_config->m_font_digit.c_str(),true)).c_str(),
                                  0, &m_ft_face[F_DIGIT]), "loading F_DIGIT");
 
     //Set charmap

--- a/src/guiengine/scalable_font.cpp
+++ b/src/guiengine/scalable_font.cpp
@@ -23,11 +23,6 @@
 #include "io/file_manager.hpp"
 #include "utils/translation.hpp"
 
-#include <IAttributes.h>
-#include <IGUIEnvironment.h>
-#include <IGUISpriteBank.h>
-#include <IVideoDriver.h>
-
 #include <clocale>
 #include <cmath>
 #include <cwctype>
@@ -310,7 +305,7 @@ bool ScalableFont::loadTTF()
 
     m_glyph_max_height = curr_maxheight;
 
-    for(wchar_t c='0'; c<='9'; c++)
+    for(wchar_t c = '0'; c <= '9'; c++)
     {
         SFontArea a = getAreaFromCharacter(c, NULL);
         m_max_digit_area.width     = a.width;
@@ -815,7 +810,7 @@ void ScalableFont::doDraw(const core::stringw& text,
 
     if (m_type == T_NORMAL || T_BOLD) //lazy load char, have to do this again
     {                                 //because some text isn't drawn with getDimension
-        for (u32 i = 0; i<text_size; i++)
+        for (u32 i = 0; i < text_size; i++)
         {
             wchar_t c = text[i];
             if (c == L'\r' ||  c == L'\n' || c == L' ' || c < 32) continue;
@@ -842,7 +837,7 @@ void ScalableFont::doDraw(const core::stringw& text,
         }
     }
 
-    for (u32 i = 0; i<text_size; i++)
+    for (u32 i = 0; i < text_size; i++)
     {
         wchar_t c = text[i];
 

--- a/src/guiengine/scalable_font.hpp
+++ b/src/guiengine/scalable_font.hpp
@@ -22,15 +22,6 @@
 #include "guiengine/ft_environment.hpp"
 #include "utils/leak_check.hpp"
 
-#include "IrrCompileConfig.h"
-#include "IGUIFontBitmap.h"
-#include "irrString.h"
-#include "irrMap.h"
-#include "IXMLReader.h"
-#include "IReadFile.h"
-#include "irrArray.h"
-
-
 #include <map>
 #include <string>
 #include <set>


### PR DESCRIPTION
Extract from my old freetype issue:

2.Change title font color according to skin
As they are color-able now, it would be good to make them match the skin.

3.Configurable font for experts?
Allowing overwritten the default font config, ie custom font, can be done on command line side.

![](https://cloud.githubusercontent.com/assets/3252341/10303703/1cc2f4a4-6c48-11e5-880e-3a2055882c1c.png)

-----
Now I finished no.3, which @leyyin suggests, by not (and shouldn't anyway) hard-coding font file names in source. I warned users too about the risks of changing font themselves already.

I also remove some unused header and coding style fixing in scalable_font src (NOT tested in windows).

I think I should be able to handle no.2 too (if stk devs think it's good idea to make a "smart" title font color, like the screenshot), I can implement that in this custom_font branch, and keep this PR open.