### PR TITLE
Fix debug build on GCC 5.3.0

### DIFF
--- a/lib/bullet/src/BulletCollision/CollisionDispatch/btCollisionObject.h
+++ b/lib/bullet/src/BulletCollision/CollisionDispatch/btCollisionObject.h
@@ -16,19 +16,7 @@ subject to the following restrictions:
 #ifndef BT_COLLISION_OBJECT_H
 #define BT_COLLISION_OBJECT_H
 
-#if defined(WIN32) && !defined(__CYGWIN__) && !defined(__MINGW32__) && _MSC_VER < 1800
-#  undef isnan
-#  define isnan _isnan
-#  define isinf(x) (!_finite(x))
-#else
-#  include <math.h>
-#endif
-
-#if defined(__MINGW32__) && __cplusplus >= 201103
-	#include <cmath>
-	using std::isinf;
-	using std::isnan;
-#endif
+#include <cmath>
 
 #include "LinearMath/btTransform.h"
 
@@ -308,12 +296,12 @@ public:
 
 	void	setWorldTransform(const btTransform& worldTrans)
 	{
-        btAssert(!isnan(worldTrans.getOrigin().getX()));
-        btAssert(!isnan(worldTrans.getOrigin().getY()));
-        btAssert(!isnan(worldTrans.getOrigin().getZ()));
-        btAssert(!isinf(worldTrans.getOrigin().getX()));
-        btAssert(!isinf(worldTrans.getOrigin().getY()));
-        btAssert(!isinf(worldTrans.getOrigin().getZ()));
+        btAssert(!std::isnan(worldTrans.getOrigin().getX()));
+        btAssert(!std::isnan(worldTrans.getOrigin().getY()));
+        btAssert(!std::isnan(worldTrans.getOrigin().getZ()));
+        btAssert(!std::isinf(worldTrans.getOrigin().getX()));
+        btAssert(!std::isinf(worldTrans.getOrigin().getY()));
+        btAssert(!std::isinf(worldTrans.getOrigin().getZ()));
 		m_worldTransform = worldTrans;
 	}
 

--- a/lib/bullet/src/BulletDynamics/Dynamics/btRigidBody.cpp
+++ b/lib/bullet/src/BulletDynamics/Dynamics/btRigidBody.cpp
@@ -133,9 +133,9 @@ void	btRigidBody::getAabb(btVector3& aabbMin,btVector3& aabbMax) const
 
 void btRigidBody::setGravity(const btVector3& acceleration) 
 {
-    btAssert(!isnan(acceleration.getX()));
-    btAssert(!isnan(acceleration.getY()));
-    btAssert(!isnan(acceleration.getZ()));
+    btAssert(!std::isnan(acceleration.getX()));
+    btAssert(!std::isnan(acceleration.getY()));
+    btAssert(!std::isnan(acceleration.getZ()));
 	if (m_inverseMass != btScalar(0.0))
 	{
 		m_gravity = acceleration * (btScalar(1.0) / m_inverseMass);
@@ -150,8 +150,8 @@ void btRigidBody::setGravity(const btVector3& acceleration)
 
 void btRigidBody::setDamping(btScalar lin_damping, btScalar ang_damping)
 {
-    btAssert(!isnan(lin_damping));
-    btAssert(!isnan(ang_damping));
+    btAssert(!std::isnan(lin_damping));
+    btAssert(!std::isnan(ang_damping));
 	m_linearDamping = btClamped(lin_damping, (btScalar)btScalar(0.0), (btScalar)btScalar(1.0));
 	m_angularDamping = btClamped(ang_damping, (btScalar)btScalar(0.0), (btScalar)btScalar(1.0));
 }
@@ -290,13 +290,13 @@ btQuaternion btRigidBody::getOrientation() const
 	
 void btRigidBody::setCenterOfMassTransform(const btTransform& xform)
 {
-    btAssert(!isnan(xform.getOrigin().getX()));
-    btAssert(!isnan(xform.getOrigin().getY()));
-    btAssert(!isnan(xform.getOrigin().getZ()));
-    btAssert(!isnan(xform.getRotation().getX()));
-    btAssert(!isnan(xform.getRotation().getY()));
-    btAssert(!isnan(xform.getRotation().getZ()));
-    btAssert(!isnan(xform.getRotation().getW()));
+    btAssert(!std::isnan(xform.getOrigin().getX()));
+    btAssert(!std::isnan(xform.getOrigin().getY()));
+    btAssert(!std::isnan(xform.getOrigin().getZ()));
+    btAssert(!std::isnan(xform.getRotation().getX()));
+    btAssert(!std::isnan(xform.getRotation().getY()));
+    btAssert(!std::isnan(xform.getRotation().getZ()));
+    btAssert(!std::isnan(xform.getRotation().getW()));
 
 	if (isStaticOrKinematicObject())
 	{

--- a/lib/bullet/src/BulletDynamics/Dynamics/btRigidBody.h
+++ b/lib/bullet/src/BulletDynamics/Dynamics/btRigidBody.h
@@ -21,15 +21,7 @@ subject to the following restrictions:
 #include "BulletCollision/BroadphaseCollision/btBroadphaseProxy.h"
 #include "BulletCollision/CollisionDispatch/btCollisionObject.h"
 
-#if defined(WIN32) && !defined(__CYGWIN__) && !defined(__MINGW32__)
-#  define isnan _isnan
-#endif
-#include <math.h>
-
-#if defined(__MINGW32__) && __cplusplus >= 201103
-	#include <cmath>
-	using std::isnan;
-#endif
+#include <cmath>
 
 class btCollisionShape;
 class btMotionState;
@@ -263,9 +255,9 @@ public:
 	}
 	void setLinearFactor(const btVector3& linearFactor)
 	{
-        btAssert(!isnan(linearFactor.getX()));
-        btAssert(!isnan(linearFactor.getY()));
-        btAssert(!isnan(linearFactor.getZ()));
+        btAssert(!std::isnan(linearFactor.getX()));
+        btAssert(!std::isnan(linearFactor.getY()));
+        btAssert(!std::isnan(linearFactor.getZ()));
 		m_linearFactor = linearFactor;
 		m_invMass = m_linearFactor*m_inverseMass;
 	}
@@ -280,9 +272,9 @@ public:
 
 	void			applyCentralForce(const btVector3& force)
 	{
-        btAssert(!isnan(force.getX()));
-        btAssert(!isnan(force.getY()));
-        btAssert(!isnan(force.getZ()));
+        btAssert(!std::isnan(force.getX()));
+        btAssert(!std::isnan(force.getY()));
+        btAssert(!std::isnan(force.getZ()));
 		m_totalForce += force*m_linearFactor;
 	}
 
@@ -303,9 +295,9 @@ public:
 
 	void	setInvInertiaDiagLocal(const btVector3& diagInvInertia)
 	{
-        btAssert(!isnan(diagInvInertia.getX()));
-        btAssert(!isnan(diagInvInertia.getY()));
-        btAssert(!isnan(diagInvInertia.getZ()));
+        btAssert(!std::isnan(diagInvInertia.getX()));
+        btAssert(!std::isnan(diagInvInertia.getY()));
+        btAssert(!std::isnan(diagInvInertia.getZ()));
 		m_invInertiaLocal = diagInvInertia;
 	}
 
@@ -317,48 +309,48 @@ public:
 
 	void	applyTorque(const btVector3& torque)
 	{
-        btAssert(!isnan(torque.getX()));
-        btAssert(!isnan(torque.getY()));
-        btAssert(!isnan(torque.getZ()));
+        btAssert(!std::isnan(torque.getX()));
+        btAssert(!std::isnan(torque.getY()));
+        btAssert(!std::isnan(torque.getZ()));
 		m_totalTorque += torque*m_angularFactor;
 	}
 
 	void	applyForce(const btVector3& force, const btVector3& rel_pos)
 	{
-        btAssert(!isnan(force.getX()));
-        btAssert(!isnan(force.getY()));
-        btAssert(!isnan(force.getZ()));
-        btAssert(!isnan(rel_pos.getX()));
-        btAssert(!isnan(rel_pos.getY()));
-        btAssert(!isnan(rel_pos.getZ()));
+        btAssert(!std::isnan(force.getX()));
+        btAssert(!std::isnan(force.getY()));
+        btAssert(!std::isnan(force.getZ()));
+        btAssert(!std::isnan(rel_pos.getX()));
+        btAssert(!std::isnan(rel_pos.getY()));
+        btAssert(!std::isnan(rel_pos.getZ()));
 		applyCentralForce(force);
 		applyTorque(rel_pos.cross(force*m_linearFactor));
 	}
 
 	void applyCentralImpulse(const btVector3& impulse)
 	{
-        btAssert(!isnan(impulse.getX()));
-        btAssert(!isnan(impulse.getY()));
-        btAssert(!isnan(impulse.getZ()));
+        btAssert(!std::isnan(impulse.getX()));
+        btAssert(!std::isnan(impulse.getY()));
+        btAssert(!std::isnan(impulse.getZ()));
 		m_linearVelocity += impulse *m_linearFactor * m_inverseMass;
 	}
 
   	void applyTorqueImpulse(const btVector3& torque)
 	{
-            btAssert(!isnan(torque.getX()));
-            btAssert(!isnan(torque.getY()));
-            btAssert(!isnan(torque.getZ()));
+            btAssert(!std::isnan(torque.getX()));
+            btAssert(!std::isnan(torque.getY()));
+            btAssert(!std::isnan(torque.getZ()));
 			m_angularVelocity += m_invInertiaTensorWorld * torque * m_angularFactor;
 	}
 
 	void applyImpulse(const btVector3& impulse, const btVector3& rel_pos)
 	{
-        btAssert(!isnan(impulse.getX()));
-        btAssert(!isnan(impulse.getY()));
-        btAssert(!isnan(impulse.getZ()));
-        btAssert(!isnan(rel_pos.getX()));
-        btAssert(!isnan(rel_pos.getY()));
-        btAssert(!isnan(rel_pos.getZ()));
+        btAssert(!std::isnan(impulse.getX()));
+        btAssert(!std::isnan(impulse.getY()));
+        btAssert(!std::isnan(impulse.getZ()));
+        btAssert(!std::isnan(rel_pos.getX()));
+        btAssert(!std::isnan(rel_pos.getY()));
+        btAssert(!std::isnan(rel_pos.getZ()));
 		if (m_inverseMass != btScalar(0.))
 		{
 			applyCentralImpulse(impulse);
@@ -395,17 +387,17 @@ public:
 
 	inline void setLinearVelocity(const btVector3& lin_vel)
 	{
-        btAssert(!isnan(lin_vel.getX()));
-        btAssert(!isnan(lin_vel.getY()));
-        btAssert(!isnan(lin_vel.getZ()));
+        btAssert(!std::isnan(lin_vel.getX()));
+        btAssert(!std::isnan(lin_vel.getY()));
+        btAssert(!std::isnan(lin_vel.getZ()));
 		m_linearVelocity = lin_vel;
 	}
 
 	inline void setAngularVelocity(const btVector3& ang_vel)
 	{
-        btAssert(!isnan(ang_vel.getX()));
-        btAssert(!isnan(ang_vel.getY()));
-        btAssert(!isnan(ang_vel.getZ()));
+        btAssert(!std::isnan(ang_vel.getX()));
+        btAssert(!std::isnan(ang_vel.getY()));
+        btAssert(!std::isnan(ang_vel.getZ()));
 		m_angularVelocity = ang_vel;
 	}
 
@@ -635,10 +627,10 @@ public:
 	{
 		if (m_inverseMass)
 		{
-            btAssert(!isnan(impulseMagnitude));
-            btAssert(!isnan(linearComponent.getX()));
-            btAssert(!isnan(linearComponent.getY()));
-            btAssert(!isnan(linearComponent.getZ()));
+            btAssert(!std::isnan(impulseMagnitude));
+            btAssert(!std::isnan(linearComponent.getX()));
+            btAssert(!std::isnan(linearComponent.getY()));
+            btAssert(!std::isnan(linearComponent.getZ()));
 			m_deltaLinearVelocity += linearComponent*impulseMagnitude;
 			m_deltaAngularVelocity += angularComponent*(impulseMagnitude*m_angularFactor);
 		}

--- a/src/animations/animation_base.cpp
+++ b/src/animations/animation_base.cpp
@@ -24,7 +24,7 @@
 #include "utils/vs.hpp"
 
 #include <algorithm>
-#include <math.h>
+#include <cmath>
 
 
 AnimationBase::AnimationBase(const XMLNode &node)
@@ -93,13 +93,13 @@ void AnimationBase::reset()
  */
 void AnimationBase::update(float dt, Vec3 *xyz, Vec3 *hpr, Vec3 *scale)
 {
-    assert(!isnan(m_current_time));
+    assert(!std::isnan(m_current_time));
 
     // Don't do anything if the animation is disabled
     if(!m_playing) return;
     m_current_time += dt;
 
-    assert(!isnan(m_current_time));
+    assert(!std::isnan(m_current_time));
 
     for_var_in (Ipo*, curr, m_all_ipos)
     {

--- a/src/animations/ipo.cpp
+++ b/src/animations/ipo.cpp
@@ -24,7 +24,7 @@
 
 #include <string.h>
 #include <algorithm>
-#include <math.h>
+#include <cmath>
 
 const std::string Ipo::m_all_channel_names[IPO_MAX] =
                 {"LocX", "LocY", "LocZ", "LocXYZ",
@@ -444,7 +444,7 @@ void Ipo::reset()
  */
 void Ipo::update(float time, Vec3 *xyz, Vec3 *hpr,Vec3 *scale)
 {
-    assert(!isnan(time));
+    assert(!std::isnan(time));
     switch(m_ipo_data->m_channel)
     {
     case Ipo::IPO_LOCX   : if(xyz)   xyz  ->setX(get(time, 0)); break;
@@ -478,7 +478,7 @@ void Ipo::update(float time, Vec3 *xyz, Vec3 *hpr,Vec3 *scale)
  */
 float Ipo::get(float time, unsigned int index) const
 {
-    assert(!isnan(time));
+    assert(!std::isnan(time));
 
     // Avoid crash in case that only one point is given for this IPO.
     if(m_next_n==0)
@@ -496,6 +496,6 @@ float Ipo::get(float time, unsigned int index) const
          time >=m_ipo_data->m_points[m_next_n].getW())
         m_next_n++;
     float rval = m_ipo_data->get(time, index, m_next_n-1);
-    assert(!isnan(rval));
+    assert(!std::isnan(rval));
     return rval;
 }   // get

--- a/src/animations/three_d_animation.cpp
+++ b/src/animations/three_d_animation.cpp
@@ -56,9 +56,9 @@ ThreeDAnimation::ThreeDAnimation(const XMLNode &node, TrackObject* object) : Ani
                         object->getInitRotation() );
     m_hpr = object->getInitRotation();
 
-    assert(!isnan(m_hpr.getX()));
-    assert(!isnan(m_hpr.getY()));
-    assert(!isnan(m_hpr.getZ()));
+    assert(!std::isnan(m_hpr.getX()));
+    assert(!std::isnan(m_hpr.getY()));
+    assert(!std::isnan(m_hpr.getZ()));
 }   // ThreeDAnimation
 
 // ----------------------------------------------------------------------------
@@ -94,9 +94,9 @@ void ThreeDAnimation::update(float dt)
         core::matrix4 m;
         m.makeIdentity();
         core::matrix4 mx;
-        assert(!isnan(m_hpr.getX()));
-        assert(!isnan(m_hpr.getY()));
-        assert(!isnan(m_hpr.getZ()));
+        assert(!std::isnan(m_hpr.getX()));
+        assert(!std::isnan(m_hpr.getY()));
+        assert(!std::isnan(m_hpr.getZ()));
         mx.setRotationDegrees(core::vector3df(m_hpr.getX(), 0, 0));
         core::matrix4 my;
         my.setRotationDegrees(core::vector3df(0, m_hpr.getY(), 0));

--- a/src/audio/sfx_openal.cpp
+++ b/src/audio/sfx_openal.cpp
@@ -34,7 +34,7 @@
 #endif
 
 #include <assert.h>
-#include <math.h>
+#include <cmath>
 #include <stdio.h>
 #include <string>
 
@@ -147,7 +147,7 @@ void SFXOpenAL::updatePlayingSFX(float dt)
 void SFXOpenAL::setSpeed(float factor)
 {
     //if(m_status!=SFX_PLAYING || !SFXManager::get()->sfxAllowed()) return;
-    assert(!isnan(factor));
+    assert(!std::isnan(factor));
     SFXManager::get()->queue(SFXManager::SFX_SPEED, this, factor);
 }   // setSpeed
 
@@ -186,7 +186,7 @@ void SFXOpenAL::reallySetSpeed(float factor)
 void SFXOpenAL::setVolume(float volume)
 {
     if(m_status==SFX_UNKNOWN || !SFXManager::get()->sfxAllowed()) return;
-    assert(!isnan(volume)) ;
+    assert(!std::isnan(volume)) ;
     SFXManager::get()->queue(SFXManager::SFX_VOLUME, this, volume);
 }   // setVolume
 

--- a/src/graphics/camera.cpp
+++ b/src/graphics/camera.cpp
@@ -19,7 +19,7 @@
 
 #include "graphics/camera.hpp"
 
-#include <math.h>
+#include <cmath>
 
 #include "audio/sfx_manager.hpp"
 #include "config/user_config.hpp"
@@ -353,9 +353,9 @@ void Camera::setInitialTransform()
     m_camera->setRotation( core::vector3df( 0.0f, 0.0f, 0.0f ) );
     m_camera->setFOV(m_fov);
 
-    assert(!isnan(m_camera->getPosition().X));
-    assert(!isnan(m_camera->getPosition().Y));
-    assert(!isnan(m_camera->getPosition().Z));
+    assert(!std::isnan(m_camera->getPosition().X));
+    assert(!std::isnan(m_camera->getPosition().Y));
+    assert(!std::isnan(m_camera->getPosition().Z));
 }   // setInitialTransform
 
 //-----------------------------------------------------------------------------
@@ -429,9 +429,9 @@ void Camera::smoothMoveCamera(float dt)
         m_camera->setPosition(current_position);
     m_camera->setTarget(current_target);//set new target
 
-    assert(!isnan(m_camera->getPosition().X));
-    assert(!isnan(m_camera->getPosition().Y));
-    assert(!isnan(m_camera->getPosition().Z));
+    assert(!std::isnan(m_camera->getPosition().X));
+    assert(!std::isnan(m_camera->getPosition().Y));
+    assert(!std::isnan(m_camera->getPosition().Z));
 
 }   // smoothMoveCamera
 

--- a/src/graphics/material.cpp
+++ b/src/graphics/material.cpp
@@ -682,15 +682,15 @@ void Material::setSFXSpeed(SFXBase *sfx, float speed, bool should_be_paused) con
     }
     if (speed > m_sfx_max_speed)
     {
-        assert(!isnan(m_sfx_max_speed));
+        assert(!std::isnan(m_sfx_max_speed));
         sfx->setSpeed(m_sfx_max_pitch);
         return;
     }
 
-    assert(!isnan(speed));
+    assert(!std::isnan(speed));
 
     float f = m_sfx_pitch_per_speed*(speed-m_sfx_min_speed) + m_sfx_min_pitch;
-    assert(!isnan(f));
+    assert(!std::isnan(f));
     sfx->setSpeed(f);
 }   // setSFXSpeed
 

--- a/src/items/flyable.cpp
+++ b/src/items/flyable.cpp
@@ -112,8 +112,8 @@ void Flyable::createPhysics(float forw_offset, const Vec3 &velocity,
     // Apply offset
     btTransform offset_transform;
     offset_transform.setIdentity();
-    assert(!isnan(m_average_height));
-    assert(!isnan(forw_offset));
+    assert(!std::isnan(m_average_height));
+    assert(!std::isnan(forw_offset));
     offset_transform.setOrigin(Vec3(0,m_average_height,forw_offset));
 
     // turn around
@@ -142,16 +142,16 @@ void Flyable::createPhysics(float forw_offset, const Vec3 &velocity,
     {
 #ifdef DEBUG
         // Just to get some additional information if the assert is triggered
-        if(isnan(v.getX()) || isnan(v.getY()) || isnan(v.getZ()))
+        if(std::isnan(v.getX()) || std::isnan(v.getY()) || std::isnan(v.getZ()))
         {
             Log::debug("[Flyable]", "vel %f %f %f v %f %f %f",
                         velocity.getX(),velocity.getY(),velocity.getZ(),
                         v.getX(),v.getY(),v.getZ());
         }
 #endif
-        assert(!isnan(v.getX()));
-        assert(!isnan(v.getY()));
-        assert(!isnan(v.getZ()));
+        assert(!std::isnan(v.getX()));
+        assert(!std::isnan(v.getY()));
+        assert(!std::isnan(v.getZ()));
         m_body->setLinearVelocity(v);
         if(!rotates) m_body->setAngularFactor(0.0f);   // prevent rotations
     }
@@ -379,9 +379,9 @@ bool Flyable::updateAndDelete(float dt)
     // But since we couldn't reproduce the problem, and the epsilon used
     // here does not hurt, I'll leave it in.
     float eps = 0.1f;
-    assert(!isnan(xyz.getX()));
-    assert(!isnan(xyz.getY()));
-    assert(!isnan(xyz.getZ()));
+    assert(!std::isnan(xyz.getX()));
+    assert(!std::isnan(xyz.getY()));
+    assert(!std::isnan(xyz.getZ()));
     if(xyz[0]<(*min)[0]+eps || xyz[2]<(*min)[2]+eps || xyz[1]<(*min)[1]+eps ||
        xyz[0]>(*max)[0]-eps || xyz[2]>(*max)[2]-eps || xyz[1]>(*max)[1]-eps   )
     {
@@ -406,16 +406,16 @@ bool Flyable::updateAndDelete(float dt)
         float delta = m_average_height - std::max(std::min(hat, m_max_height),
                                                   m_min_height);
         Vec3 v = getVelocity();
-        assert(!isnan(v.getX()));
-        assert(!isnan(v.getX()));
-        assert(!isnan(v.getX()));
+        assert(!std::isnan(v.getX()));
+        assert(!std::isnan(v.getX()));
+        assert(!std::isnan(v.getX()));
         float heading = atan2f(v.getX(), v.getZ());
-        assert(!isnan(heading));
+        assert(!std::isnan(heading));
         float pitch   = getTerrainPitch(heading);
         float vel_up = m_force_updown*(delta);
         if (hat < m_max_height) // take into account pitch of surface
             vel_up += v.length_2d()*tanf(pitch);
-        assert(!isnan(vel_up));
+        assert(!std::isnan(vel_up));
         v.setY(vel_up);
         setVelocity(v);
     }   // if m_adjust_up_velocity

--- a/src/items/rubber_ball.cpp
+++ b/src/items/rubber_ball.cpp
@@ -435,9 +435,9 @@ void RubberBall::moveTowardsTarget(Vec3 *next_xyz, float dt)
         next_xyz->setZ(getXYZ().getZ() + old_2d.Y*dt*m_speed);
     }   // if fabsf(angle) > m_st_target_angle_max*dt
 
-    assert(!isnan((*next_xyz)[0]));
-    assert(!isnan((*next_xyz)[1]));
-    assert(!isnan((*next_xyz)[2]));
+    assert(!std::isnan((*next_xyz)[0]));
+    assert(!std::isnan((*next_xyz)[1]));
+    assert(!std::isnan((*next_xyz)[2]));
 }   // moveTowardsTarget
 
 // ----------------------------------------------------------------------------
@@ -474,9 +474,9 @@ void RubberBall::interpolate(Vec3 *next_xyz, float dt)
                       + (-  m_control_points[0] +  m_control_points[2])*m_t
                       +   2*m_control_points[1]                              );
                       
-    assert(!isnan((*next_xyz)[0]));
-    assert(!isnan((*next_xyz)[1]));
-    assert(!isnan((*next_xyz)[2]));
+    assert(!std::isnan((*next_xyz)[0]));
+    assert(!std::isnan((*next_xyz)[1]));
+    assert(!std::isnan((*next_xyz)[2]));
 }   // interpolate
 
 // ----------------------------------------------------------------------------

--- a/src/karts/controller/skidding_ai.cpp
+++ b/src/karts/controller/skidding_ai.cpp
@@ -52,7 +52,7 @@
    using namespace irr;
 #endif
 
-#include <math.h>
+#include <cmath>
 #include <cstdlib>
 #include <ctime>
 #include <cstdio>
@@ -2167,9 +2167,9 @@ void SkiddingAI::handleCurve()
 
     determineTurnRadius(xyz, tangent, last_xyz,
                         &m_curve_center, &m_current_curve_radius);
-    assert(!isnan(m_curve_center.getX()));
-    assert(!isnan(m_curve_center.getY()));
-    assert(!isnan(m_curve_center.getZ()));
+    assert(!std::isnan(m_curve_center.getX()));
+    assert(!std::isnan(m_curve_center.getY()));
+    assert(!std::isnan(m_curve_center.getZ()));
 
 #undef ADJUST_TURN_RADIUS_TO_AVOID_CRASH_INTO_TRACK
 #ifdef ADJUST_TURN_RADIUS_TO_AVOID_CRASH_INTO_TRACK

--- a/src/karts/kart.cpp
+++ b/src/karts/kart.cpp
@@ -84,12 +84,6 @@
 #  pragma warning(disable:4355)
 #endif
 
-#if defined(WIN32) && !defined(__CYGWIN__)  && !defined(__MINGW32__)
-#  define isnan _isnan
-#else
-#  include <math.h>
-#endif
-
 /** The kart constructor.
  *  \param ident  The identifier for the kart model to use.
  *  \param position The position (or rank) for this kart (between 1 and
@@ -1038,20 +1032,20 @@ float Kart::getStartupBoost() const
 float Kart::getActualWheelForce()
 {
     float add_force = m_max_speed->getCurrentAdditionalEngineForce();
-    assert(!isnan(add_force));
+    assert(!std::isnan(add_force));
     const std::vector<float>& gear_ratio=m_kart_properties->getGearSwitchRatio();
     for(unsigned int i=0; i<gear_ratio.size(); i++)
     {
         if(m_speed <= m_kart_properties->getEngineMaxSpeed() * gear_ratio[i])
         {
-            assert(!isnan(m_kart_properties->getEnginePower()));
-            assert(!isnan(m_kart_properties->getGearPowerIncrease()[i]));
+            assert(!std::isnan(m_kart_properties->getEnginePower()));
+            assert(!std::isnan(m_kart_properties->getGearPowerIncrease()[i]));
             return m_kart_properties->getEnginePower()
                  * m_kart_properties->getGearPowerIncrease()[i]
                  + add_force;
         }
     }
-    assert(!isnan(m_kart_properties->getEnginePower()));
+    assert(!std::isnan(m_kart_properties->getEnginePower()));
     return m_kart_properties->getEnginePower() + add_force * 2;
 
 }   // getActualWheelForce
@@ -2255,7 +2249,7 @@ void Kart::updateEngineSFX()
         if (f>1.0f) f=1.0f;
 
         float gears = 3.0f * fmod(f, 0.333334f);
-        assert(!isnan(f));
+        assert(!std::isnan(f));
         m_engine_sound->setSpeedPosition(0.6f + (f + gears) * 0.35f, getXYZ());
     }
     else
@@ -2350,8 +2344,8 @@ void Kart::updateEnginePowerAndBrakes(float dt)
         {
             m_brake_time = 0;
             // lift the foot from throttle, brakes with 10% engine_power
-            assert(!isnan(m_controls.m_accel));
-            assert(!isnan(engine_power));
+            assert(!std::isnan(m_controls.m_accel));
+            assert(!std::isnan(engine_power));
             applyEngineForce(-m_controls.m_accel*engine_power*0.1f);
 
             // If not giving power (forward or reverse gear), and speed is low
@@ -2526,7 +2520,7 @@ void Kart::loadData(RaceManager::KartType type, bool is_animated_model)
  */
 void Kart::applyEngineForce(float force)
 {
-    assert(!isnan(force));
+    assert(!std::isnan(force));
     // Split power to simulate a 4WD 40-60, other values possible
     // FWD or RWD is a matter of putting a 0 and 1 in the right place
     float frontForce = force*0.4f;

--- a/src/physics/kart_motion_state.hpp
+++ b/src/physics/kart_motion_state.hpp
@@ -19,7 +19,7 @@
 #ifndef HEADER_KART_MOTION_STATE_HPP
 #define HEADER_KART_MOTION_STATE_HPP
 
-#include <math.h>
+#include <cmath>
 #include "utils/vs.hpp"
 
 #include "LinearMath/btMotionState.h"
@@ -63,13 +63,13 @@ public:
      */
     virtual void setWorldTransform(const btTransform &new_trans)
     {
-        assert(!isnan(new_trans.getOrigin().getX()));
-        assert(!isnan(new_trans.getOrigin().getY()));
-        assert(!isnan(new_trans.getOrigin().getZ()));
-        assert(!isnan(new_trans.getRotation().getX()));
-        assert(!isnan(new_trans.getRotation().getY()));
-        assert(!isnan(new_trans.getRotation().getZ()));
-        assert(!isnan(new_trans.getRotation().getW()));
+        assert(!std::isnan(new_trans.getOrigin().getX()));
+        assert(!std::isnan(new_trans.getOrigin().getY()));
+        assert(!std::isnan(new_trans.getOrigin().getZ()));
+        assert(!std::isnan(new_trans.getRotation().getX()));
+        assert(!std::isnan(new_trans.getRotation().getY()));
+        assert(!std::isnan(new_trans.getRotation().getZ()));
+        assert(!std::isnan(new_trans.getRotation().getW()));
         m_center_of_mass = new_trans;
     }   // setWorldTransform
 


### PR DESCRIPTION
Replaced instances of \<math.h\> with \<cmath\>, and replaced all instances of isnan() with std::isnan(). This fixes the debug build on GCC 5.3.0. 
Requires testing on Windows and Mac.