### PR TITLE
Support disabling race intro sound

### DIFF
--- a/src/modes/cutscene_world.cpp
+++ b/src/modes/cutscene_world.cpp
@@ -58,7 +58,8 @@ CutsceneWorld::CutsceneWorld() : World()
     m_aborted = false;
     WorldStatus::setClockMode(CLOCK_NONE);
     m_use_highscores = false;
-    m_play_racestart_sounds = false;
+    m_play_track_intro_sound = false;
+    m_play_ready_set_go_sounds = false;
     m_fade_duration = 1.0f;
 }   // CutsceneWorld
 

--- a/src/modes/world_status.cpp
+++ b/src/modes/world_status.cpp
@@ -39,7 +39,8 @@ WorldStatus::WorldStatus()
     m_start_sound       = SFXManager::get()->createSoundSource("start_race");
     m_track_intro_sound = SFXManager::get()->createSoundSource("track_intro");
 
-    m_play_racestart_sounds = true;
+    m_play_track_intro_sound = UserConfigParams::m_music;
+    m_play_ready_set_go_sounds = true;
 
     IrrlichtDevice *device = irr_driver->getDevice();
 
@@ -149,7 +150,7 @@ void WorldStatus::update(const float dt)
             m_auxiliary_timer = 0.0f;
             m_phase = TRACK_INTRO_PHASE;
             
-            if (m_play_racestart_sounds)
+            if (m_play_track_intro_sound)
             {
                 m_track_intro_sound->play();
             }
@@ -186,7 +187,7 @@ void WorldStatus::update(const float dt)
 
             m_auxiliary_timer = 0.0f;
 
-            if (m_play_racestart_sounds)
+            if (m_play_ready_set_go_sounds)
                 m_prestart_sound->play();
 
             m_phase = READY_PHASE;
@@ -200,7 +201,7 @@ void WorldStatus::update(const float dt)
         case READY_PHASE:
             if (m_auxiliary_timer > 1.0)
             {
-                if (m_play_racestart_sounds)
+                if (m_play_ready_set_go_sounds)
                 {
                     m_prestart_sound->play();
                 }
@@ -224,7 +225,7 @@ void WorldStatus::update(const float dt)
             {
                 // set phase is over, go to the next one
                 m_phase = GO_PHASE;
-                if (m_play_racestart_sounds)
+                if (m_play_ready_set_go_sounds)
                 {
                     m_start_sound->play();
                 }

--- a/src/modes/world_status.cpp
+++ b/src/modes/world_status.cpp
@@ -31,6 +31,21 @@
 #include <irrlicht.h>
 
 //-----------------------------------------------------------------------------
+/** Starts the kart engines.
+ */
+void WorldStatus::startEngines()
+{
+    if (m_engines_started)
+        return;
+
+    m_engines_started = true;
+    for (unsigned int i = 0; i < World::getWorld()->getNumKarts(); i++)
+    {
+        World::getWorld()->getKart(i)->startEngineSFX();
+    }
+}
+
+//-----------------------------------------------------------------------------
 WorldStatus::WorldStatus()
 {
     m_clock_mode        = CLOCK_CHRONO;
@@ -55,6 +70,9 @@ void WorldStatus::reset()
 {
     m_time            = 0.0f;
     m_auxiliary_timer = 0.0f;
+    
+    m_engines_started = false;
+    
     // Using SETUP_PHASE will play the track into sfx first, and has no
     // other side effects.
     m_phase           = UserConfigParams::m_race_now ? MUSIC_PHASE : SETUP_PHASE;
@@ -184,6 +202,13 @@ void WorldStatus::update(const float dt)
             // Wait before ready phase if sounds are disabled
             if (!UserConfigParams::m_sfx && m_auxiliary_timer < 3.0f)
                 return;
+            
+            if (!m_play_track_intro_sound)
+            {
+                startEngines();
+                if (m_auxiliary_timer < 3.0f)
+                    return;
+            }
 
             m_auxiliary_timer = 0.0f;
 
@@ -192,10 +217,7 @@ void WorldStatus::update(const float dt)
 
             m_phase = READY_PHASE;
             
-            for (unsigned int i = 0; i < World::getWorld()->getNumKarts(); i++)
-            {
-                World::getWorld()->getKart(i)->startEngineSFX();
-            }
+            startEngines();
 
             break;
         case READY_PHASE:

--- a/src/modes/world_status.hpp
+++ b/src/modes/world_status.hpp
@@ -114,6 +114,8 @@ private:
      */
     float           m_auxiliary_timer;
 
+    bool            m_engines_started;
+    void            startEngines();
 public:
              WorldStatus();
     virtual ~WorldStatus();

--- a/src/modes/world_status.hpp
+++ b/src/modes/world_status.hpp
@@ -97,7 +97,8 @@ protected:
     double          m_time;
     ClockType       m_clock_mode;
 
-    bool            m_play_racestart_sounds;
+    bool            m_play_track_intro_sound;
+    bool            m_play_ready_set_go_sounds;
 
 private:
     Phase           m_phase;


### PR DESCRIPTION
I've added a user config entry for disabling the sound at race start. This is useful when you're listening to some music on your PC and don't want it to clash acoustically with the race start sounds.