### PR TITLE
Fix double slash in include

### DIFF
--- a/src/network/protocols/server_lobby_room_protocol.cpp
+++ b/src/network/protocols/server_lobby_room_protocol.cpp
@@ -33,7 +33,7 @@
 #include "network/stk_peer.hpp"
 #include "online/online_profile.hpp"
 #include "online/request_manager.hpp"
-#include "states_screens//networking_lobby.hpp"
+#include "states_screens/networking_lobby.hpp"
 #include "states_screens/race_result_gui.hpp"
 #include "states_screens/waiting_for_others.hpp"
 #include "utils/log.hpp"


### PR DESCRIPTION
Triggers a weird 9 year old RPM bug when extracting debugging information for the compiled binary:
https://bugzilla.redhat.com/show_bug.cgi?id=304121