### PR TITLE
Fix warning for cards without "Radeon" in string

### DIFF
--- a/data/graphical_restrictions.xml
+++ b/data/graphical_restrictions.xml
@@ -26,5 +26,6 @@
        1.32.20 -->
   <card contains="Radeon"         os="linux"    version="<14.300"  disable="DriverRecentEnough"/>
   <card contains="Radeon"         os="windows"  version="<14.300"  disable="DriverRecentEnough"/>
+  <card contains="ATI"            os="windows"  version="<14.300"  disable="DriverRecentEnough"/>
 </graphical-restrictions>
 


### PR DESCRIPTION
See https://github.com/supertuxkart/stk-code/issues/2521.