### PR TITLE
Add missing space in string for wiimote manager

### DIFF
--- a/src/input/wiimote_manager.cpp
+++ b/src/input/wiimote_manager.cpp
@@ -386,11 +386,11 @@ int WiimoteManager::askUserToConnectWiimotes()
 {
     new MessageDialog(
 #ifdef WIN32
-        _("Connect your wiimote to the Bluetooth manager, then click on Ok."
+        _("Connect your wiimote to the Bluetooth manager, then click on Ok. "
                   "Detailed instructions at supertuxkart.net/Wiimote"),
 #else
         _("Press the buttons 1+2 simultaneously on your wiimote to put "
-          "it in discovery mode, then click on Ok."
+          "it in discovery mode, then click on Ok. "
                   "Detailed instructions at supertuxkart.net/Wiimote"),
 #endif
         MessageDialog::MESSAGE_DIALOG_OK_CANCEL,


### PR DESCRIPTION
There was a missing space in a string for the wiimote manager.