### PR TITLE
Place buttons in confirm dialog horizontally

### DIFF
--- a/data/gui/confirm_dialog.stkgui
+++ b/data/gui/confirm_dialog.stkgui
@@ -5,7 +5,7 @@
 
         <spacer height="25" width="10" />
 
-        <ribbon id="buttons" height="30%" width="30%" align="center">
+        <buttonbar id="buttons" height="30%" width="30%" align="center">
 
             <icon-button id="confirm" icon="gui/green_check.png" I18N="In a 'are you sure?' dialog"
                 text="Yes" align="center"/>
@@ -13,7 +13,7 @@
             <icon-button id="cancel" icon="gui/remove.png" I18N="In a 'are you sure?' dialog"
                 text="Cancel" align="center"/>
 
-        </ribbon>
+        </buttonbar>
 
         <spacer height="10" width="10" />
     </div>

--- a/data/gui/confirm_dialog.stkgui
+++ b/data/gui/confirm_dialog.stkgui
@@ -5,15 +5,15 @@
 
         <spacer height="25" width="10" />
 
-        <div layout="horizontal-row" width="fit" height="fit" align="center">
+        <ribbon id="buttons" height="30%" width="30%" align="center">
 
-            <button id="confirm" I18N="In a 'are you sure?' dialog" text="Yes" align="center"/>
+            <icon-button id="confirm" icon="gui/green_check.png" I18N="In a 'are you sure?' dialog"
+                text="Yes" align="center"/>
 
-            <spacer height="15" width="10" />
+            <icon-button id="cancel" icon="gui/remove.png" I18N="In a 'are you sure?' dialog"
+                text="Cancel" align="center"/>
 
-            <button id="cancel" I18N="In a 'are you sure?' dialog" text="Cancel" align="center"/>
-
-	</div>
+        </ribbon>
 
         <spacer height="10" width="10" />
     </div>

--- a/data/gui/confirm_dialog.stkgui
+++ b/data/gui/confirm_dialog.stkgui
@@ -1,15 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <stkgui>
     <div x="2%" y="10%" width="96%" height="80%" layout="vertical-row" >
-        <label id="title" width="100%" text_align="center" word_wrap="true" proportion="1" />
+        <label id="title" width="100%" text_align="top" word_wrap="true" proportion="1" />
 
         <spacer height="25" width="10" />
 
-        <button id="confirm" I18N="In a 'are you sure?' dialog" text="Yes" align="center"/>
+        <div layout="horizontal-row" width="fit" height="fit" align="center">
 
-        <spacer height="15" width="10" />
+            <button id="confirm" I18N="In a 'are you sure?' dialog" text="Yes" align="center"/>
 
-        <button id="cancel" I18N="In a 'are you sure?' dialog" text="Cancel" align="center"/>
+            <spacer height="15" width="10" />
+
+            <button id="cancel" I18N="In a 'are you sure?' dialog" text="Cancel" align="center"/>
+
+	</div>
 
         <spacer height="10" width="10" />
     </div>

--- a/src/states_screens/dialogs/message_dialog.cpp
+++ b/src/states_screens/dialogs/message_dialog.cpp
@@ -21,6 +21,7 @@
 #include "guiengine/screen.hpp"
 #include "guiengine/widgets/button_widget.hpp"
 #include "guiengine/widgets/label_widget.hpp"
+#include "guiengine/widgets/ribbon_widget.hpp"
 #include "modes/world.hpp"
 #include "states_screens/state_manager.hpp"
 #include "utils/translation.hpp"
@@ -97,7 +98,7 @@ void MessageDialog::doInit(bool from_queue)
 
 MessageDialog::~MessageDialog()
 {
-    if (m_own_listener) delete m_listener; 
+    if (m_own_listener) delete m_listener;
     m_listener = NULL;
 
     if (StateManager::get()->getGameState() == GUIEngine::GAME)
@@ -111,30 +112,33 @@ void MessageDialog::loadedFromFile()
 {
     LabelWidget* message = getWidget<LabelWidget>("title");
     message->setText( m_msg, false );
+    RibbonWidget* ribbon = getWidget<RibbonWidget>("buttons");
+    ribbon->setFocusForPlayer(PLAYER_ID_GAME_MASTER);
 
     // If the dialog is a simple 'OK' dialog, then hide the "Yes" button and
     // change "Cancel" to "OK"
     if (m_type == MessageDialog::MESSAGE_DIALOG_OK)
     {
-        ButtonWidget* yesbtn = getWidget<ButtonWidget>("confirm");
+        IconButtonWidget* yesbtn = getWidget<IconButtonWidget>("cancel");
         yesbtn->setVisible(false);
 
-        ButtonWidget* cancelbtn = getWidget<ButtonWidget>("cancel");
+        IconButtonWidget* cancelbtn = getWidget<IconButtonWidget>("confirm");
         cancelbtn->setText(_("OK"));
         cancelbtn->setFocusForPlayer(PLAYER_ID_GAME_MASTER);
     }
     else if (m_type == MessageDialog::MESSAGE_DIALOG_YESNO)
     {
-        ButtonWidget* cancelbtn = getWidget<ButtonWidget>("cancel");
+        IconButtonWidget* cancelbtn = getWidget<IconButtonWidget>("cancel");
         cancelbtn->setText(_("No"));
-
     }
     else if (m_type == MessageDialog::MESSAGE_DIALOG_OK_CANCEL)
     {
         // In case of a OK_CANCEL dialog, change the text from 'Yes' to 'Ok'
-        ButtonWidget* yesbtn = getWidget<ButtonWidget>("confirm");
+        IconButtonWidget* yesbtn = getWidget<IconButtonWidget>("confirm");
         yesbtn->setText(_("OK"));
+        yesbtn->setFocusForPlayer(PLAYER_ID_GAME_MASTER);
     }
+    ribbon->setSelection(0, PLAYER_ID_GAME_MASTER);
 }
 
 // ----------------------------------------------------------------------------
@@ -147,8 +151,11 @@ void MessageDialog::onEnterPressedInternal()
 
 GUIEngine::EventPropagation MessageDialog::processEvent(const std::string& eventSource)
 {
+    RibbonWidget* ribbon = getWidget<RibbonWidget>(eventSource.c_str());
 
-    if (eventSource == "cancel")
+    // m_cancel_selected makes it so that the the dialog closes when the user presses
+    // enter and not just when the user navigates to a button with the arrow keys
+    if (ribbon->getSelectionIDString(PLAYER_ID_GAME_MASTER) == "cancel" && m_cancel_selected)
     {
         if (m_listener == NULL)
         {
@@ -161,7 +168,7 @@ GUIEngine::EventPropagation MessageDialog::processEvent(const std::string& event
 
         return GUIEngine::EVENT_BLOCK;
     }
-    else if (eventSource == "confirm")
+    else if (ribbon->getSelectionIDString(PLAYER_ID_GAME_MASTER) == "confirm" && !m_cancel_selected)
     {
         if (m_listener == NULL)
         {
@@ -174,6 +181,8 @@ GUIEngine::EventPropagation MessageDialog::processEvent(const std::string& event
 
         return GUIEngine::EVENT_BLOCK;
     }
+
+    m_cancel_selected = ribbon->getSelectionIDString(PLAYER_ID_GAME_MASTER) == "cancel";
 
     return GUIEngine::EVENT_LET;
 }

--- a/src/states_screens/dialogs/message_dialog.cpp
+++ b/src/states_screens/dialogs/message_dialog.cpp
@@ -17,9 +17,6 @@
 
 #include "states_screens/dialogs/message_dialog.hpp"
 
-#include "guiengine/engine.hpp"
-#include "guiengine/screen.hpp"
-#include "guiengine/widgets/button_widget.hpp"
 #include "guiengine/widgets/label_widget.hpp"
 #include "guiengine/widgets/ribbon_widget.hpp"
 #include "modes/world.hpp"
@@ -136,9 +133,7 @@ void MessageDialog::loadedFromFile()
         // In case of a OK_CANCEL dialog, change the text from 'Yes' to 'Ok'
         IconButtonWidget* yesbtn = getWidget<IconButtonWidget>("confirm");
         yesbtn->setText(_("OK"));
-        yesbtn->setFocusForPlayer(PLAYER_ID_GAME_MASTER);
     }
-    ribbon->setSelection(0, PLAYER_ID_GAME_MASTER);
 }
 
 // ----------------------------------------------------------------------------
@@ -152,10 +147,8 @@ void MessageDialog::onEnterPressedInternal()
 GUIEngine::EventPropagation MessageDialog::processEvent(const std::string& eventSource)
 {
     RibbonWidget* ribbon = getWidget<RibbonWidget>(eventSource.c_str());
-
-    // m_cancel_selected makes it so that the the dialog closes when the user presses
-    // enter and not just when the user navigates to a button with the arrow keys
-    if (ribbon->getSelectionIDString(PLAYER_ID_GAME_MASTER) == "cancel" && m_cancel_selected)
+    
+    if (ribbon->getSelectionIDString(PLAYER_ID_GAME_MASTER) == "cancel")
     {
         if (m_listener == NULL)
         {
@@ -168,7 +161,7 @@ GUIEngine::EventPropagation MessageDialog::processEvent(const std::string& event
 
         return GUIEngine::EVENT_BLOCK;
     }
-    else if (ribbon->getSelectionIDString(PLAYER_ID_GAME_MASTER) == "confirm" && !m_cancel_selected)
+    else if (ribbon->getSelectionIDString(PLAYER_ID_GAME_MASTER) == "confirm")
     {
         if (m_listener == NULL)
         {
@@ -181,8 +174,6 @@ GUIEngine::EventPropagation MessageDialog::processEvent(const std::string& event
 
         return GUIEngine::EVENT_BLOCK;
     }
-
-    m_cancel_selected = ribbon->getSelectionIDString(PLAYER_ID_GAME_MASTER) == "cancel";
 
     return GUIEngine::EVENT_LET;
 }

--- a/src/states_screens/dialogs/message_dialog.hpp
+++ b/src/states_screens/dialogs/message_dialog.hpp
@@ -30,7 +30,7 @@
 class MessageDialog : public GUIEngine::ModalDialog
 {
 public:
-    
+
     /**
      * \brief Listener interface to get notified of whether the user chose to confirm or cancel
      * \ingroup states_screens
@@ -38,24 +38,24 @@ public:
     class IConfirmDialogListener
     {
     public:
-        
+
         LEAK_CHECK()
-        
+
         IConfirmDialogListener() {}
         virtual ~IConfirmDialogListener() {}
-        
+
         /** \brief Implement to be notified of dialog confirmed.
           * \note  The dialog is not closed automatically, close it in the callback if this
           *        behavior is desired.
           */
         virtual void onConfirm() { ModalDialog::dismiss(); };
-        
+
         /** \brief Implement to be notified of dialog cancelled.
           * \note  The default implementation is to close the modal dialog, but you may override
           *        this method to change the behavior.
           */
         virtual void onCancel() { ModalDialog::dismiss(); };
-        
+
         /**
           * \brief Optional callback
           */
@@ -64,13 +64,14 @@ public:
 
     enum MessageDialogType { MESSAGE_DIALOG_OK, MESSAGE_DIALOG_CONFIRM,
                              MESSAGE_DIALOG_OK_CANCEL, MESSAGE_DIALOG_YESNO };
-    
+
     MessageDialogType m_type;
 
 private:
-    
+
     IConfirmDialogListener* m_listener;
     bool m_own_listener;
+    bool m_cancel_selected;// should be assigned every time onUpdate is called
     irr::core::stringw m_msg;
     void doInit(bool from_queue);
 
@@ -85,15 +86,15 @@ public:
     MessageDialog(const irr::core::stringw &msg, MessageDialogType type,
                   IConfirmDialogListener* listener, bool delete_listener,
                   bool from_queue = false, float width = 0.6f, float height = 0.6f);
-    
+
     /**
       * Variant of MessageDialog where cancelling is not possible (i.e. just shows a message box with OK)
       * \param msg Message to display in the dialog
       */
     MessageDialog(const irr::core::stringw &msg, bool from_queue = false);
-    
+
     ~MessageDialog();
-    
+
     virtual void onEnterPressedInternal() OVERRIDE;
     virtual void onUpdate(float dt) OVERRIDE;
     virtual void load() OVERRIDE;

--- a/src/states_screens/dialogs/message_dialog.hpp
+++ b/src/states_screens/dialogs/message_dialog.hpp
@@ -30,7 +30,7 @@
 class MessageDialog : public GUIEngine::ModalDialog
 {
 public:
-
+    
     /**
      * \brief Listener interface to get notified of whether the user chose to confirm or cancel
      * \ingroup states_screens
@@ -38,24 +38,24 @@ public:
     class IConfirmDialogListener
     {
     public:
-
+        
         LEAK_CHECK()
-
+        
         IConfirmDialogListener() {}
         virtual ~IConfirmDialogListener() {}
-
+        
         /** \brief Implement to be notified of dialog confirmed.
           * \note  The dialog is not closed automatically, close it in the callback if this
           *        behavior is desired.
           */
         virtual void onConfirm() { ModalDialog::dismiss(); };
-
+        
         /** \brief Implement to be notified of dialog cancelled.
           * \note  The default implementation is to close the modal dialog, but you may override
           *        this method to change the behavior.
           */
         virtual void onCancel() { ModalDialog::dismiss(); };
-
+        
         /**
           * \brief Optional callback
           */
@@ -64,14 +64,13 @@ public:
 
     enum MessageDialogType { MESSAGE_DIALOG_OK, MESSAGE_DIALOG_CONFIRM,
                              MESSAGE_DIALOG_OK_CANCEL, MESSAGE_DIALOG_YESNO };
-
+    
     MessageDialogType m_type;
 
 private:
-
+    
     IConfirmDialogListener* m_listener;
     bool m_own_listener;
-    bool m_cancel_selected;// should be assigned every time onUpdate is called
     irr::core::stringw m_msg;
     void doInit(bool from_queue);
 
@@ -86,15 +85,15 @@ public:
     MessageDialog(const irr::core::stringw &msg, MessageDialogType type,
                   IConfirmDialogListener* listener, bool delete_listener,
                   bool from_queue = false, float width = 0.6f, float height = 0.6f);
-
+    
     /**
       * Variant of MessageDialog where cancelling is not possible (i.e. just shows a message box with OK)
       * \param msg Message to display in the dialog
       */
     MessageDialog(const irr::core::stringw &msg, bool from_queue = false);
-
+    
     ~MessageDialog();
-
+    
     virtual void onEnterPressedInternal() OVERRIDE;
     virtual void onUpdate(float dt) OVERRIDE;
     virtual void load() OVERRIDE;


### PR DESCRIPTION
When you start SuperTuxKart for the first time the buttons will now be next to each other horizontally.