### PR TITLE
Update appdata to very latest standards

### DIFF
--- a/data/supertuxkart.appdata.xml
+++ b/data/supertuxkart.appdata.xml
@@ -46,4 +46,5 @@
   <url type="donation">https://supertuxkart.net/Donate</url>
   <url type="help">https://supertuxkart.net/Community</url>
   <url type="translate">https://supertuxkart.net/Translating_STK</url>
+  <developer_name>SuperTuxKart Team</developer_name>
 </component>


### PR DESCRIPTION
I run Ubuntu Yakkety, so `appstream-util upgrade` added one more thing, probably because of a newer package version in Yakkety.

There is still an issue that needs to be fixed:
```
qwerty@qwerty-Inspiron-3520:~$ appstream-util validate-relax /home/qwerty/Downloads/supertuxkart.appdata.xml 
/home/qwerty/Downloads/supertuxkart.appdata.xml: FAILED:
• tag-invalid           : <url> type invalid [unknown]
Validation of files failed
```