### PR TITLE
Disable Compute Shader for ATI / Radeon GPUs on Linux

### DIFF
--- a/data/graphical_restrictions.xml
+++ b/data/graphical_restrictions.xml
@@ -29,4 +29,6 @@
   <card contains="Radeon"         os="windows"  version="<14.300"  disable="DriverRecentEnough"/>
   <card contains="ATI"            os="windows"  version="<14.300"  disable="DriverRecentEnough"/>
   <card contains="ATI"            os="windows"  version="<=3.1.8787" disable="ForceLegacyDevice"/>
+  <card contains="Radeon" os="linux" disable="ComputeShader"/>
+  <card contains="ATI" os="linux" disable="ComputeShader"/>
 </graphical-restrictions>


### PR DESCRIPTION
Compute shaders cause a segmentation fault on Linux with AMD / ATI cards with fglrx.I do not have this problem if I run STK from Windows 10 so this issue only applies the Linux :smiley:.

I don't have a Mac (with AMD graphics) to test for the segmentation fault on OS X.

Feel free to revert the PR when the compute shader crash with fglrx is fixed.This won't close #2595 since the issue is still there and compute shaders improve performance