### PR TITLE
Provide nightly builds from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,4 +62,4 @@ notifications:
       - "Build: %{build_url}"
 
 deploy:
-	skip_cleanup: true
+  skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,3 +60,6 @@ notifications:
       - "[%{repository}#%{branch} @%{commit}] %{author}): %{message}"
       - "Diff: %{compare_url}"
       - "Build: %{build_url}"
+
+deploy:
+	skip_cleanup: true


### PR DESCRIPTION
This is a PR and an issue in one.  The issue part: It would be nice to provide builds from Travis, so that it is easier for people to test the current git version.  The PR part: From https://docs.travis-ci.com/user/deployment/, don't delete the built files.