### PR TITLE
Fix #1929

### DIFF
--- a/tools/windows_installer/supertuxkart.nsi
+++ b/tools/windows_installer/supertuxkart.nsi
@@ -197,6 +197,7 @@ Section "Main Section" SecMain
     CreateDirectory "$SMPROGRAMS\$STARTMENU_FOLDER"
     CreateShortCut "$SMPROGRAMS\$STARTMENU_FOLDER\Uninstall.lnk" "$INSTDIR\Uninstall.exe" "" "$INSTDIR\uninstall.ico"
     CreateShortCut "$SMPROGRAMS\$STARTMENU_FOLDER\SuperTuxKart.lnk" "$INSTDIR\supertuxkart.exe" "" "$INSTDIR\icon.ico"
+    CreateShortCut "$DESKTOP\SuperTuxKart.lnk" "$INSTDIR\supertuxkart.exe" "" "$INSTDIR\icon.ico"
     CreateShortCut "$SMPROGRAMS\$STARTMENU_FOLDER\supertuxkart-editor (beta).lnk" "$INSTDIR\supertuxkart-editor.exe" "" "$INSTDIR\supertuxkart-editor.ico"
     ShellLink::SetShortCutShowMode $SMPROGRAMS\$STARTMENU_FOLDER\SuperTuxKart.lnk 0
 


### PR DESCRIPTION
Create link on desktop.  Although there is no option to choose whether or not to put the icon there, it probably doesn't matter that much, as it is really easy to delete an icon from the desktop.

According to [this](http://nsis.sourceforge.net/Simple_tutorials), the $DESKTOP variable is automatically defined by NSIS.