### PR TITLE
Fix typo in main_loop.cpp

### DIFF
--- a/src/main_loop.cpp
+++ b/src/main_loop.cpp
@@ -178,7 +178,7 @@ void MainLoop::run()
 
             // Update sfx and music after graphics, so that graphics code
             // can use as many threads as possible without interfering
-            // with audia
+            // with audio
             PROFILER_PUSH_CPU_MARKER("Music/input/GUI", 0x7F, 0x00, 0x00);
             SFXManager::get()->update();
             PROFILER_POP_CPU_MARKER();


### PR DESCRIPTION
This patch changes audia to audio in the source code of src/main_loop.cpp.