### PR TITLE
Adding appveyor config file

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,57 @@
+environment:
+    DEPS_DIR: c:\\projects\dependencies
+    ASSETS_DIR: c:\\projects\stk-assets
+    APPVEYOR_CACHE_ENTRY_ZIP_ARGS: -t7z -m0=lzma2 -mx=9
+
+os: Visual Studio 2015
+clone_depth: 1
+shallow_clone: true
+
+platform:
+    - x86
+      #- x64
+      
+configuration:
+    - Debug
+    - Release
+
+matrix:
+    fast_finish: true
+
+cache:
+    - '%DEPS_DIR%'
+    #- '%ASSETS_DIR%'
+
+install:
+    - ps: >-
+        If(!(Test-Path "$env:DEPS_DIR")) {
+            Write-Host "Downloading dependencies";
+            Start-Process -FilePath "git" -ArgumentList "clone --branch master --single-branch --depth 1 https://github.com/supertuxkart/dependencies.git $env:DEPS_DIR" -Wait;
+        }
+        Else {
+            Write-Host "Updating dependencies";
+            Start-Process -FilePath "git" -ArgumentList "fetch --depth 1" -WorkingDirectory "$env:DEPS_DIR" -Wait;
+        }
+        Get-ChildItem $env:DEPS_DIR | Measure-Object -property length -sum
+        #- ps: >-
+        #If(!(Test-Path "$env:ASSETS_DIR")) {
+        #    Write-Host "Downloading assets";
+        #    Start-Process -FilePath "svn" -ArgumentList "checkout https://svn.code.sf.net/p/supertuxkart/code/stk-assets $env:ASSETS_DIR" -Wait;
+        #}
+        #Else {
+        #    Write-Host "Updating assets";
+        #    Start-Process -FilePath "svn" -ArgumentList "update" -WorkingDirectory "$env:ASSETS_DIR" -Wait;
+        #}
+        #Get-ChildItem $env:ASSETS_DIR | Measure-Object -property length -sum
+
+before_build:
+    - ps: Copy-Item "${env:DEPS_DIR}\windows\dependencies" c:\projects\stk-code\dependencies –Recurse
+    - cmd: |
+        md build
+        cd build
+        if "%platform%"=="x86" set CMAKE_GENERATOR_NAME="Visual Studio 14 2015"
+        cmake -G %CMAKE_GENERATOR_NAME% -DCMAKE_BUILD_TYPE="%configuration%" .. -DCHECK_ASSETS=OFF
+
+build:
+    parallel: true
+    project: build\ALL_BUILD.vcxproj


### PR DESCRIPTION
Only x86 VS 2015
No notification, probably best for the first uses.

All you need to do to start using the appveyor CI is to create an account and link the GH repo to it, and select branches or PR to be built.

See #2649 for the rest of the discussion
