### PR TITLE
Remove duplicate include statements from kart.cpp

### DIFF
--- a/src/karts/kart.cpp
+++ b/src/karts/kart.cpp
@@ -90,13 +90,6 @@
 #include <iostream>
 #include <cmath>
 
-#include <math.h>
-#include <iostream>
-#include <algorithm> // for min and max
-
-#include <ICameraSceneNode.h>
-#include <ISceneManager.h>
-
 
 #if defined(WIN32) && !defined(__CYGWIN__)  && !defined(__MINGW32__)
    // Disable warning for using 'this' in base member initializer list


### PR DESCRIPTION
A few of the include statements in `kart.cpp` were written twice. It looks like `kart.cpp` is the only file with obvious redundant include statements like this.