### PR TITLE
Improve SSAO performance by using swizzle mask

### DIFF
--- a/data/shaders/ssao.frag
+++ b/data/shaders/ssao.frag
@@ -44,10 +44,8 @@ void main(void)
     vec2 offset = vec2(cos(invSamples), sin(invSamples));
 
     for(int i = 0; i < SAMPLES; ++i) {
-        float alpha = (float(i) + .5) * invSamples;
-        rotations = vec2(rotations.x * offset.x - rotations.y * offset.y, rotations.x * offset.y + rotations.y * offset.x);
-        float h = r * alpha;
-        vec2 localoffset = h * rotations;
+        rotations.xy = rotations.xy * offset.xy - rotations.yx * offset.yx;
+        vec2 localoffset = (r * ((float(i) + .5) * invSamples)) * rotations;
 
         m = m + .5;
         ivec2 ioccluder_uv = ivec2(x, y) + ivec2(localoffset);


### PR DESCRIPTION
Just using swizzle mask instead of creating a new **vec3** in the `ssao.frag` shader.  Swizzle masks make code faster according to https://www.opengl.org/wiki/GLSL_Optimizations.

Improves FPS (with SSAO and high shadows) by +3 FPS on HP Pavilion g7  2269wm with A8-4500M and 7640G. 

Tested on Nessie's Pond track at 1600x900 (FPS is 15 - 22)

![scotland-2016 10 18_12 34 29](https://cloud.githubusercontent.com/assets/13938848/19467589/9411dea6-952f-11e6-8a9d-97d9135ed20b.png)
### SSAO shader time (Cocoa Temple)
- With swizzle mask : 0.375ms
- Old : 0.487ms
