### PR TITLE
[WIP] Add Android compiling support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ bld*/
 build*/
 cmake_build/
 cmake_build*/
+android_build/
+android_build*/
 dependencies/
 CMakeFiles/
 stk-editor/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,8 @@ if(APPLE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -arch x86_64 -F/Library/Frameworks")
 elseif(MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")   # Enable multi-processor compilation (faster)
+elseif(ANDROID)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -frtti")
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,11 @@ if (UNIX AND NOT APPLE)
     option(USE_GLES2 "Use OpenGL ES2 renderer" OFF)
 endif()
 
+if (ANDROID)
+    message(STATUS "Building Android APK and library")
+    set(USE_GLES2 ON)
+endif()
+
 if(MSVC AND (MSVC_VERSION LESS 1900))
     # Normally hide the option to build wiiuse on VS, since it depends
     # on the installation of the Windows DDK (Driver Developer Kit),

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,8 +87,8 @@ if(NOT USE_GLES2)
     include_directories("${PROJECT_SOURCE_DIR}/lib/glew/include")
 endif()
 
-if((WIN32 AND NOT MINGW) OR APPLE)
-    if (NOT APPLE)
+if((WIN32 AND NOT MINGW) OR APPLE OR ANDROID)
+    if (NOT APPLE OR ANDROID)
     # Build zlib library
     add_subdirectory("${PROJECT_SOURCE_DIR}/lib/zlib")
     include_directories("${PROJECT_SOURCE_DIR}/lib/zlib")

--- a/lib/irrlicht/CMakeLists.txt
+++ b/lib/irrlicht/CMakeLists.txt
@@ -13,7 +13,7 @@ if(NOT USE_GLES2)
     include_directories(${OPENGL_INCLUDE_DIR})
 endif()
 
-if (UNIX AND NOT APPLE)
+if (UNIX AND NOT (APPLE OR ANDROID))
     find_package(X11 REQUIRED)
     include_directories(${X11_INCLUDE_DIR})
 endif()
@@ -47,7 +47,7 @@ if(USE_GLES2)
 endif()
 
 # Xrandr
-if(UNIX AND NOT APPLE)
+if(UNIX AND NOT (APPLE OR ANDROID))
     add_definitions(-DNO_IRR_LINUX_X11_VIDMODE_)
     add_definitions(-D_IRR_LINUX_X11_RANDR_)
 endif()


### PR DESCRIPTION
Working on getting STK to run on Android without dirty hacks (like other ports disabling audio). STK should still compile for other platforms

To compile for Android download CMake and NDK bundle using SDK manager and run something like the following command : `cmake -DCMAKE_TOOLCHAIN_FILE=[SDKPATH]/ndk-bundle/build/cmake/android.toolchain.cmake -DANDROID_ABI=armeabi ..`

Currently work in progress.

Should work if you add all the dependencies to SYSROOT of the toolchain and add a native activity (i will add later). I was unable to find an Android port of libvorbisfile so I cannot test it (probably the reason other ports used dirty hacks).
