### PR TITLE
Add a little more BSD support

### DIFF
--- a/lib/irrlicht/source/Irrlicht/os.cpp
+++ b/lib/irrlicht/source/Irrlicht/os.cpp
@@ -22,7 +22,7 @@
 	#include <libkern/OSByteOrder.h>
 	#define bswap_16(X) OSReadSwapInt16(&X,0)
 	#define bswap_32(X) OSReadSwapInt32(&X,0)
-#elif defined(__FreeBSD__)
+#elif defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
 	#include <sys/endian.h>
 	#define bswap_16(X) bswap16(X)
 	#define bswap_32(X) bswap32(X)


### PR DESCRIPTION
Tested for NetBSD, the same signature has DragonFly(http://fxr.watson.org/fxr/source/sys/endian.h?v=DFBSD#L42)