### PR TITLE
Fix compilation on macOS 10.12

### DIFF
--- a/lib/irrlicht/source/Irrlicht/MacOSX/CIrrDeviceMacOSX.mm
+++ b/lib/irrlicht/source/Irrlicht/MacOSX/CIrrDeviceMacOSX.mm
@@ -719,7 +719,7 @@ bool CIrrDeviceMacOSX::createWindow()
 					if (!CreationParams.WindowId)
 					{
 						[Window center];
-						[(NSFileManager *)Window setDelegate:[NSApp delegate]];
+						[(NSFileManager *)Window setDelegate:[(NSFileManager *)NSApp delegate]];
 
 						if(CreationParams.DriverType == video::EDT_OPENGL)
 							[OGLContext setView:[Window contentView]];


### PR DESCRIPTION
The compiler error I got was:
`
lib/irrlicht/source/Irrlicht/MacOSX/CIrrDeviceMacOSX.mm:722:44: error: cannot initialize a parameter of type 'id<NSFileManagerDelegate> _Nullable' with an rvalue of type
      'id<NSApplicationDelegate> _Nullable'
`