### PR TITLE
Fix clang compilation

### DIFF
--- a/src/utils/time.hpp
+++ b/src/utils/time.hpp
@@ -26,13 +26,13 @@
 #ifdef WIN32
 #  define WIN32_LEAN_AND_MEAN
 #  include <windows.h>
-#  include <time.h>
 #else
 #  include <stdint.h>
 #  include <sys/time.h>
 #  include <unistd.h>
 #endif
 
+#include <time.h>
 #include <string>
 #include <stdio.h>
 


### PR DESCRIPTION
Hi, this is some very minor change but it fixes a compilation bug when using this configuration :
```
CC=clang CXX=clang++ \
CFLAGS="${CFLAGS} -flto=thin" \
CXXFLAGS="${CXXFLAGS} -flto=thin"\
LDFLAGS="${LDFLAGS} -flto=thin" \
cmake -D_CMAKE_TOOLCHAIN_PREFIX=llvm- \
-DUSE_FRIBIDI=0 -DUSE_WIIUSE=0 -DCMAKE_BUILD_TYPE=Debug ..
```

The linker used was ld.gold and I had to increase my tmpfs used by clang from ~750MB to ~1GB for all the objects to be stored during link time.