### PR TITLE
New GP point system

### DIFF
--- a/data/stk_config.xml
+++ b/data/stk_config.xml
@@ -28,7 +28,7 @@
 
        In the above example, the last kart will have 0 point, the one before
        before 1 (0+1) ; the one before 2 (0+1+1), the one before 4 (0+1+1+2),
-       etc. until the 1st which have 0 (0+1+1+2+2+3)
+       etc. until the 1st which have 9 (0+1+1+2+2+3)
 
        There shall be at least as much points nodes as max-numbers kart -->
     <points points="0" /> <!-- added with 1 kart, score for the last kart -->

--- a/data/stk_config.xml
+++ b/data/stk_config.xml
@@ -16,12 +16,51 @@
 
   <!-- Scores are the number of points given when the race ends. -->
   <grand-prix>
-    <!-- Karts on position 1 and 2 will have 3 more points than the next kart;
-         a kart on position 3 and 4 will have two more points than the next;
-         and all remaining karts will have one more point than the next. -->
-    <points from="1" to="2" points="3"/>
-    <points from="3" to="4" points="2"/>
-    <points from="5"        points="1"/>
+  <!-- Establish the distribution of points in GP.
+
+       For a race of N karts ; the N-first point values are taken.
+       Then, they are sorted. E.g. ; 0 1 2 1 3 2 becomes 0 1 1 2 2 3.
+       Then these numbers are used to establish the DIFFERENCE of points
+       between consecutive karts.
+
+       The smaller of the numbers is used to establish the score for the
+       last kart and not the difference between 2 karts.
+
+       In the above example, the last kart will have 0 point, the one before
+       before 1 (0+1) ; the one before 2 (0+1+1), the one before 4 (0+1+1+2),
+       etc. until the 1st which have 0 (0+1+1+2+2+3)
+
+       There shall be at least as much points nodes as max-numbers kart -->
+    <points points="0" /> <!-- added with 1 kart, score for the last kart -->
+    <points points="1" /> <!-- added with 2 karts -->
+    <points points="1" /> <!-- added with 3 karts -->
+    <points points="2" /> <!-- added with 4 karts -->
+    <points points="2" /> <!-- added with 5 karts -->
+    <points points="1" /> <!-- added with 6 karts -->
+    <points points="3" /> <!-- added with 7 karts -->
+    <points points="2" /> <!-- added with 8 karts -->
+    <points points="3" /> <!-- added with 9 karts -->
+    <points points="1" /> <!-- added with 10 karts -->
+    <points points="4" /> <!-- added with 11 karts -->
+    <points points="2" /> <!-- added with 12 karts -->
+    <points points="1" /> <!-- added with 13 karts -->
+    <points points="3" /> <!-- added with 14 karts -->
+    <points points="2" /> <!-- added with 15 karts -->
+    <points points="1" /> <!-- added with 16 karts -->
+    <points points="4" /> <!-- added with 17 karts -->
+    <points points="2" /> <!-- added with 18 karts -->
+    <points points="3" /> <!-- added with 19 karts -->
+    <points points="1" /> <!-- added with 20 karts -->
+    <points points="5" /> <!-- added with 21 karts -->
+    <points points="2" /> <!-- added with 22 karts -->
+    <points points="1" /> <!-- added with 23 karts -->
+    <points points="3" /> <!-- added with 24 karts -->
+    <points points="4" /> <!-- added with 25 karts -->
+    <points points="1" /> <!-- added with 26 karts -->
+    <points points="2" /> <!-- added with 27 karts -->
+    <points points="1" /> <!-- added with 28 karts -->
+    <points points="3" /> <!-- added with 29 karts -->
+    <points points="5" /> <!-- added with 30 karts -->
   </grand-prix>
 
   <!-- Time in follow-the-leader after which karts are removed.

--- a/src/config/stk_config.cpp
+++ b/src/config/stk_config.cpp
@@ -103,7 +103,7 @@ void STKConfig::load(const std::string &filename)
                    strA,filename.c_str());              \
     }
 
-    if(m_score_increase.size()==0 || (int)m_score_increase.size()!=m_max_karts)
+    if(m_score_increase.size()==0)
     {
         Log::fatal("StkConfig", "Not or not enough scores defined in stk_config");
     }
@@ -214,22 +214,25 @@ void STKConfig::getAllData(const XMLNode * root)
         for(unsigned int i=0; i<gp_node->getNumNodes(); i++)
         {
             const XMLNode *pn=gp_node->getNode(i);
-            int from=-1;
-            pn->get("from", &from);
-            int to=-1;
-            pn->get("to", &to);
-            if(to<0) to=m_max_karts;
             int points=-1;
             pn->get("points", &points);
-            if(points<0 || from<0 || from>to||
-               (int)m_score_increase.size()!=from-1)
+            if(points<0)
             {
                 Log::error("StkConfig", "Incorrect GP point specification:");
-                Log::fatal("StkConfig", "from: %d  to: %d  points: %d",
-                        from, to, points);
+                Log::fatal("StkConfig", "points: %d",
+                        points);
             }
-            for(int j=from; j<=to; j++)
+            m_score_increase.push_back(points);
+        }
+        if(m_max_karts>(gp_node->getNumNodes()))
+        {
+            Log::error("StkConfig", "Not enough grand-prix ranking nodes:");
+
+            for(unsigned int i=0; i<(m_max_karts-(gp_node->getNumNodes())); i++)
+            {
+                int points=0;
                 m_score_increase.push_back(points);
+            }
         }
     }
 
@@ -391,15 +394,27 @@ void STKConfig::getAllData(const XMLNode * root)
  */
 void  STKConfig::getAllScores(std::vector<int> *all_scores, int num_karts)
 {
+    std::vector<int> sorted_score_increase;
+
     if (num_karts == 0) return;
 
     assert(num_karts <= m_max_karts);
     all_scores->resize(num_karts);
-    (*all_scores)[num_karts-1] = 1;  // last position gets one point
+    sorted_score_increase.resize(num_karts+1); //sorting function is [begin, end[
+
+    //get increase data into sorted_score_increase
+    for(int i=0; i<num_karts; i++)
+    {
+        sorted_score_increase[i] = m_score_increase[i];
+    }
+
+    std::sort (sorted_score_increase.begin(), sorted_score_increase.end());
+
+    (*all_scores)[num_karts-1] = sorted_score_increase[0];  // last position score
 
     // Must be signed, in case that num_karts==1
     for(int i=num_karts-2; i>=0; i--)
     {
-        (*all_scores)[i] = (*all_scores)[i+1] + m_score_increase[i];
+        (*all_scores)[i] = (*all_scores)[i+1] + sorted_score_increase[num_karts-i];
     }
 }   // getAllScores


### PR DESCRIPTION
New GP point system as discussed on the IRC with @auriamg & @Arthur-D.

Compiled & tested.

It adds a compilation warning about a comparison between an unsigned int and a signed int. It shouldn't have any consequence, and I'm not sure how to solve the warning. For info, it's on the line 227 of the .cpp.

Tested, and everything works. The point are attributed correctly according to what is in the config, it also tolerates the case where there is more karts than points nodes (it defaults to a zero difference for the supernumerary karts, but the config supports up to 30 before defaulting to it).

I used my own formula for the scoring, but the new system is more powerful - even if one would prefer to tweak the specifics differently, he would have more options.

Commit fixing #1699