### PR TITLE
Remove #ifdef Explicit_Attrib_Location_Usable in vertex shaders

### DIFF
--- a/data/shaders/billboard.vert
+++ b/data/shaders/billboard.vert
@@ -2,13 +2,8 @@ uniform mat4 ModelViewMatrix;
 uniform vec3 Position;
 uniform vec2 Size;
 
-#ifdef Explicit_Attrib_Location_Usable
 layout(location = 0) in vec2 Corner;
 layout(location = 3) in vec2 Texcoord;
-#else
-in vec2 Corner;
-in vec2 Texcoord;
-#endif
 
 out vec2 uv;
 

--- a/data/shaders/coloredquad.vert
+++ b/data/shaders/coloredquad.vert
@@ -1,12 +1,7 @@
 uniform vec2 center;
 uniform vec2 size;
 
-#ifdef Explicit_Attrib_Location_Usable
 layout(location = 0) in vec2 Position;
-#else
-in vec2 Position;
-#endif
-
 
 void main()
 {

--- a/data/shaders/colortexturedquad.vert
+++ b/data/shaders/colortexturedquad.vert
@@ -3,15 +3,9 @@ uniform vec2 size;
 uniform vec2 texcenter;
 uniform vec2 texsize;
 
-#ifdef Explicit_Attrib_Location_Usable
 layout(location=0) in vec2 Position;
 layout(location=3) in vec2 Texcoord;
 layout(location=2) in uvec4 Color;
-#else
-in vec2 Position;
-in vec2 Texcoord;
-in uvec4 Color;
-#endif
 
 out vec2 uv;
 out vec4 col;

--- a/data/shaders/displace.vert
+++ b/data/shaders/displace.vert
@@ -1,14 +1,8 @@
 uniform mat4 ModelMatrix;
 
-#ifdef Explicit_Attrib_Location_Usable
 layout(location = 0) in vec3 Position;
 layout(location = 3) in vec2 Texcoord;
 layout(location = 4) in vec2 SecondTexcoord;
-#else
-in vec3 Position;
-in vec2 Texcoord;
-in vec2 SecondTexcoord;
-#endif
 
 out vec2 uv;
 out vec2 uv_bis;

--- a/data/shaders/flipparticle.vert
+++ b/data/shaders/flipparticle.vert
@@ -1,4 +1,3 @@
-#ifdef Explicit_Attrib_Location_Usable
 layout(location=0) in vec3 Position;
 layout(location = 1) in float lifetime;
 layout(location = 2) in float size;
@@ -8,17 +7,6 @@ layout(location = 4) in vec2 quadcorner;
 
 layout(location = 5) in vec3 rotationvec;
 layout(location = 6) in float anglespeed;
-#else
-in vec3 Position;
-in float lifetime;
-in float size;
-
-in vec2 Texcoord;
-in vec2 quadcorner;
-
-in vec3 rotationvec;
-float anglespeed;
-#endif
 
 out float lf;
 out vec2 tc;

--- a/data/shaders/glow_object.vert
+++ b/data/shaders/glow_object.vert
@@ -1,16 +1,9 @@
-#ifdef Explicit_Attrib_Location_Usable
 layout(location = 0) in vec3 Position;
 layout(location = 7) in vec3 Origin;
 layout(location = 8) in vec3 Orientation;
 layout(location = 9) in vec3 Scale;
 layout(location = 10) in vec4 misc_data;
-#else
-in vec3 Position;
-in vec3 Origin;
-in vec3 Orientation;
-in vec3 Scale;
-in vec4 misc_data;
-#endif
+
 flat out vec4 glowColor;
 
 #stk_include "utils/getworldmatrix.vert"

--- a/data/shaders/grass_pass.vert
+++ b/data/shaders/grass_pass.vert
@@ -2,17 +2,10 @@ uniform vec3 windDir;
 uniform mat4 ModelMatrix;
 uniform mat4 InverseModelMatrix;
 
-#ifdef Explicit_Attrib_Location_Usable
 layout(location = 0) in vec3 Position;
 layout(location = 1) in vec3 Normal;
 layout(location = 2) in vec4 Color;
 layout(location = 3) in vec2 Texcoord;
-#else
-in vec3 Position;
-in vec3 Normal;
-in vec4 Color;
-in vec2 Texcoord;
-#endif
 
 out vec3 nor;
 out vec2 uv;

--- a/data/shaders/instanced_grass.vert
+++ b/data/shaders/instanced_grass.vert
@@ -1,6 +1,5 @@
 uniform vec3 windDir;
 
-#ifdef Explicit_Attrib_Location_Usable
 layout(location = 0) in vec3 Position;
 layout(location = 1) in vec3 Normal;
 layout(location = 2) in vec4 Color;
@@ -14,18 +13,6 @@ layout(location = 10) in vec4 misc_data;
 layout(location = 11) in sampler2D Handle;
 layout(location = 12) in sampler2D SecondHandle;
 layout(location = 13) in sampler2D ThirdHandle;
-#endif
-
-#else
-in vec3 Position;
-in vec3 Normal;
-in vec4 Color;
-in vec2 Texcoord;
-
-in vec3 Origin;
-in vec3 Orientation;
-in vec3 Scale;
-in vec4 misc_data;
 #endif
 
 out vec3 nor;

--- a/data/shaders/instanced_grassshadow.vert
+++ b/data/shaders/instanced_grassshadow.vert
@@ -1,7 +1,7 @@
 uniform int layer;
 
 uniform vec3 windDir;
-#ifdef Explicit_Attrib_Location_Usable
+
 layout(location = 0) in vec3 Position;
 layout(location = 2) in vec4 Color;
 layout(location = 3) in vec2 Texcoord;
@@ -11,16 +11,6 @@ layout(location = 8) in vec3 Orientation;
 layout(location = 9) in vec3 Scale;
 #ifdef Use_Bindless_Texture
 layout(location = 11) in uvec2 Handle;
-#endif
-
-#else
-in vec3 Position;
-in vec4 Color;
-in vec2 Texcoord;
-
-in vec3 Origin;
-in vec3 Orientation;
-in vec3 Scale;
 #endif
 
 #ifdef VSLayer

--- a/data/shaders/instanced_object_pass.vert
+++ b/data/shaders/instanced_object_pass.vert
@@ -1,4 +1,3 @@
-#ifdef Explicit_Attrib_Location_Usable
 layout(location = 0) in vec3 Position;
 layout(location = 1) in vec3 Normal;
 layout(location = 2) in vec4 Color;
@@ -16,21 +15,6 @@ layout(location = 11) in sampler2D Handle;
 layout(location = 12) in sampler2D SecondHandle;
 layout(location = 13) in sampler2D ThirdHandle;
 layout(location = 14) in sampler2D FourthHandle;
-#endif
-
-#else
-in vec3 Position;
-in vec3 Normal;
-in vec4 Color;
-in vec2 Texcoord;
-in vec2 SecondTexcoord;
-in vec3 Tangent;
-in vec3 Bitangent;
-
-in vec3 Origin;
-in vec3 Orientation;
-in vec3 Scale;
-in vec4 misc_data;
 #endif
 
 out vec3 nor;

--- a/data/shaders/instanced_shadow.vert
+++ b/data/shaders/instanced_shadow.vert
@@ -1,6 +1,5 @@
 uniform int layer;
 
-#ifdef Explicit_Attrib_Location_Usable
 layout(location = 0) in vec3 Position;
 layout(location = 3) in vec2 Texcoord;
 
@@ -9,15 +8,6 @@ layout(location = 8) in vec3 Orientation;
 layout(location = 9) in vec3 Scale;
 #ifdef Use_Bindless_Texture
 layout(location = 11) in uvec2 Handle;
-#endif
-
-#else
-in vec3 Position;
-in vec2 Texcoord;
-
-in vec3 Origin;
-in vec3 Orientation;
-in vec3 Scale;
 #endif
 
 #ifdef VSLayer

--- a/data/shaders/instanced_skinning.vert
+++ b/data/shaders/instanced_skinning.vert
@@ -1,4 +1,3 @@
-#ifdef Explicit_Attrib_Location_Usable
 layout(location = 0) in vec3 Position;
 layout(location = 1) in vec3 Normal;
 layout(location = 2) in vec4 Color;
@@ -18,21 +17,6 @@ layout(location = 13) in sampler2D ThirdHandle;
 layout(location = 14) in sampler2D FourthHandle;
 #endif
 layout(location = 15) in int skinning_offset;
-#else
-in vec3 Position;
-in vec3 Normal;
-in vec4 Color;
-in vec4 Data1;
-in vec4 Data2;
-in ivec4 Joint;
-in vec4 Weight;
-
-in vec3 Origin;
-in vec3 Orientation;
-in vec3 Scale;
-in vec4 misc_data;
-in int skinning_offset;
-#endif
 
 out vec3 nor;
 out vec3 tangent;

--- a/data/shaders/instanced_skinning_shadow.vert
+++ b/data/shaders/instanced_skinning_shadow.vert
@@ -1,6 +1,5 @@
 uniform int layer;
 
-#ifdef Explicit_Attrib_Location_Usable
 layout(location = 0) in vec3 Position;
 layout(location = 3) in vec4 Data1;
 layout(location = 5) in ivec4 Joint;
@@ -12,16 +11,6 @@ layout(location = 9) in vec3 Scale;
 layout(location = 11) in uvec2 Handle;
 #endif
 layout(location = 15) in int skinning_offset;
-#else
-in vec3 Position;
-in vec4 Data1;
-in ivec4 Joint;
-in vec4 Weight;
-in vec3 Origin;
-in vec3 Orientation;
-in vec3 Scale;
-in int skinning_offset;
-#endif
 
 #ifdef VSLayer
 out vec2 uv;

--- a/data/shaders/object_pass.vert
+++ b/data/shaders/object_pass.vert
@@ -17,7 +17,6 @@ uniform mat4 InverseModelMatrix =
 uniform vec2 texture_trans = vec2(0., 0.);
 #endif
 
-#ifdef Explicit_Attrib_Location_Usable
 layout(location = 0) in vec3 Position;
 layout(location = 1) in vec3 Normal;
 layout(location = 2) in vec4 Color;
@@ -25,15 +24,6 @@ layout(location = 3) in vec2 Texcoord;
 layout(location = 4) in vec2 SecondTexcoord;
 layout(location = 5) in vec3 Tangent;
 layout(location = 6) in vec3 Bitangent;
-#else
-in vec3 Position;
-in vec3 Normal;
-in vec4 Color;
-in vec2 Texcoord;
-in vec2 SecondTexcoord;
-in vec3 Tangent;
-in vec3 Bitangent;
-#endif
 
 out vec3 nor;
 out vec3 tangent;

--- a/data/shaders/particle.vert
+++ b/data/shaders/particle.vert
@@ -1,21 +1,12 @@
 uniform vec3 color_from;
 uniform vec3 color_to;
 
-#ifdef Explicit_Attrib_Location_Usable
 layout(location=0) in vec3 Position;
 layout(location = 1) in float lifetime;
 layout(location = 2) in float size;
 
 layout(location=3) in vec2 Texcoord;
 layout(location = 4) in vec2 quadcorner;
-#else
-in vec3 Position;
-in float lifetime;
-in float size;
-
-in vec2 Texcoord;
-in vec2 quadcorner;
-#endif
 
 out float lf;
 out vec2 tc;

--- a/data/shaders/particlesimheightmap.vert
+++ b/data/shaders/particlesimheightmap.vert
@@ -9,7 +9,6 @@ uniform float track_x_len;
 uniform float track_z_len;
 uniform samplerBuffer heightmap;
 
-#ifdef Explicit_Attrib_Location_Usable
 layout (location = 4) in vec3 particle_position_initial;
 layout (location = 5) in float lifetime_initial;
 layout (location = 6) in vec3 particle_velocity_initial;
@@ -19,17 +18,6 @@ layout (location = 0) in vec3 particle_position;
 layout (location = 1) in float lifetime;
 layout (location = 2) in vec3 particle_velocity;
 layout (location = 3) in float size;
-#else
-in vec3 particle_position_initial;
-in float lifetime_initial;
-in vec3 particle_velocity_initial;
-in float size_initial;
-
-in vec3 particle_position;
-in float lifetime;
-in vec3 particle_velocity;
-in float size;
-#endif
 
 out vec3 new_particle_position;
 out float new_lifetime;

--- a/data/shaders/pointemitter.vert
+++ b/data/shaders/pointemitter.vert
@@ -4,7 +4,6 @@ uniform mat4 sourcematrix;
 uniform int level;
 uniform float size_increase_factor;
 
-#ifdef Explicit_Attrib_Location_Usable
 layout (location = 4) in vec3 particle_position_initial;
 layout (location = 5) in float lifetime_initial;
 layout (location = 6) in vec3 particle_velocity_initial;
@@ -14,17 +13,6 @@ layout (location = 0) in vec3 particle_position;
 layout (location = 1) in float lifetime;
 layout (location = 2) in vec3 particle_velocity;
 layout (location = 3) in float size;
-#else
-in vec3 particle_position_initial;
-in float lifetime_initial;
-in vec3 particle_velocity_initial;
-in float size_initial;
-
-in vec3 particle_position;
-in float lifetime;
-in vec3 particle_velocity;
-in float size;
-#endif
 
 out vec3 new_particle_position;
 out float new_lifetime;

--- a/data/shaders/primitive2dlist.vert
+++ b/data/shaders/primitive2dlist.vert
@@ -1,4 +1,3 @@
-#ifdef Explicit_Attrib_Location_Usable
 layout(location = 0) in vec3 Position;
 layout(location = 1) in vec3 Normal;
 layout(location = 2) in vec4 Color;
@@ -6,15 +5,6 @@ layout(location = 3) in vec2 Texcoord;
 layout(location = 4) in vec2 SecondTexcoord;
 layout(location = 5) in vec3 Tangent;
 layout(location = 6) in vec3 Bitangent;
-#else
-in vec3 Position;
-in vec3 Normal;
-in vec4 Color;
-in vec2 Texcoord;
-in vec2 SecondTexcoord;
-in vec3 Tangent;
-in vec3 Bitangent;
-#endif
 
 out vec2 uv;
 out vec4 color;

--- a/data/shaders/rsm.vert
+++ b/data/shaders/rsm.vert
@@ -2,19 +2,11 @@ uniform mat4 ModelMatrix;
 uniform mat4 RSMMatrix;
 uniform vec2 texture_trans = vec2(0., 0.);
 
-#ifdef Explicit_Attrib_Location_Usable
 layout(location = 0) in vec3 Position;
 layout(location = 1) in vec3 Normal;
 layout(location = 2) in vec4 Color;
 layout(location = 3) in vec2 Texcoord;
 layout(location = 4) in vec2 SecondTexcoord;
-#else
-in vec3 Position;
-in vec3 Normal;
-in vec4 Color;
-in vec2 Texcoord;
-in vec2 SecondTexcoord;
-#endif
 
 out vec3 nor;
 out vec2 uv;

--- a/data/shaders/screenquad.vert
+++ b/data/shaders/screenquad.vert
@@ -1,10 +1,5 @@
-#ifdef Explicit_Attrib_Location_Usable
 layout(location = 0) in vec2 Position;
 layout(location = 3) in vec2 Texcoord;
-#else
-in vec2 Position;
-in vec2 Texcoord;
-#endif
 
 out vec2 uv;
 

--- a/data/shaders/shadow.vert
+++ b/data/shaders/shadow.vert
@@ -1,13 +1,8 @@
 uniform int layer;
 uniform mat4 ModelMatrix;
 
-#ifdef Explicit_Attrib_Location_Usable
 layout(location = 0) in vec3 Position;
 layout(location = 3) in vec2 Texcoord;
-#else
-in vec3 Position;
-in vec2 Texcoord;
-#endif
 
 #ifdef VSLayer
 out vec2 uv;

--- a/data/shaders/shadow_grass.vert
+++ b/data/shaders/shadow_grass.vert
@@ -2,15 +2,9 @@ uniform int layer;
 uniform mat4 ModelMatrix;
 uniform vec3 windDir;
 
-#ifdef Explicit_Attrib_Location_Usable
 layout(location = 0) in vec3 Position;
 layout(location = 2) in vec4 Color;
 layout(location = 3) in vec2 Texcoord;
-#else
-in vec3 Position;
-in vec4 Color;
-in vec2 Texcoord;
-#endif
 
 #ifdef VSLayer
 out vec2 uv;

--- a/data/shaders/skinning.vert
+++ b/data/shaders/skinning.vert
@@ -18,7 +18,6 @@ uniform vec2 texture_trans = vec2(0., 0.);
 #endif
 uniform int skinning_offset;
 
-#ifdef Explicit_Attrib_Location_Usable
 layout(location = 0) in vec3 Position;
 layout(location = 1) in vec3 Normal;
 layout(location = 2) in vec4 Color;
@@ -26,15 +25,6 @@ layout(location = 3) in vec4 Data1;
 layout(location = 4) in vec4 Data2;
 layout(location = 5) in ivec4 Joint;
 layout(location = 6) in vec4 Weight;
-#else
-in vec3 Position;
-in vec3 Normal;
-in vec4 Color;
-in vec4 Data1;
-in vec4 Data2;
-in ivec4 Joint;
-in vec4 Weight;
-#endif
 
 out vec3 nor;
 out vec3 tangent;

--- a/data/shaders/skinning_shadow.vert
+++ b/data/shaders/skinning_shadow.vert
@@ -2,17 +2,10 @@ uniform mat4 ModelMatrix;
 uniform int skinning_offset;
 uniform int layer;
 
-#ifdef Explicit_Attrib_Location_Usable
 layout(location = 0) in vec3 Position;
 layout(location = 3) in vec4 Data1;
 layout(location = 5) in ivec4 Joint;
 layout(location = 6) in vec4 Weight;
-#else
-in vec3 Position;
-in vec4 Data1;
-in ivec4 Joint;
-in vec4 Weight;
-#endif
 
 #ifdef VSLayer
 out vec2 uv;

--- a/data/shaders/sky.vert
+++ b/data/shaders/sky.vert
@@ -1,8 +1,4 @@
-#ifdef Explicit_Attrib_Location_Usable
 layout(location = 0) in vec3 Position;
-#else
-in vec3 Position;
-#endif
 
 void main()
 {

--- a/data/shaders/texturedquad.vert
+++ b/data/shaders/texturedquad.vert
@@ -3,13 +3,8 @@ uniform vec2 size;
 uniform vec2 texcenter;
 uniform vec2 texsize;
 
-#ifdef Explicit_Attrib_Location_Usable
 layout(location=0) in vec2 Position;
 layout(location=3) in vec2 Texcoord;
-#else
-in vec2 Position;
-in vec2 Texcoord;
-#endif
 
 out vec2 uv;
 

--- a/src/graphics/shader_files_manager.cpp
+++ b/src/graphics/shader_files_manager.cpp
@@ -24,6 +24,7 @@
 #include "utils/log.hpp"
 
 #include <fstream>
+#include <regex>
 #include <sstream>
 
 // ----------------------------------------------------------------------------
@@ -130,6 +131,8 @@ GLuint ShaderFilesManager::loadShader(const std::string &file, unsigned type)
     if (stream.is_open())
     {
         const std::string stk_include = "#stk_include";
+        std::regex explicit_attrib_regex("layout\\s*\\(\\s*location\\s*=\\s*\\d*\\s*\\)\\s*in");
+
         std::string line;
 
         while (std::getline(stream, line))
@@ -179,7 +182,16 @@ GLuint ShaderFilesManager::loadShader(const std::string &file, unsigned type)
             }
             else
             {
-                code << "\n" << line;
+                if(CVS->isARBExplicitAttribLocationUsable())
+                {
+                    code << "\n" << line;
+                }
+                else
+                {
+                    //replace for example "layout(location = 0) in vec3 Position;"
+                    //with "in vec3 Position;"
+                    code << "\n" << std::regex_replace (line, explicit_attrib_regex, "in");
+                }
             }
         }
 


### PR DESCRIPTION
I have simplified vertex shaders. Instead of for example:
```
#ifdef Explicit_Attrib_Location_Usable
layout(location = 0) in vec3 Position;
#else
in vec3 Position;
#endif
```

We can just write
`layout(location = 0) in vec3 Position;`

And when GL_ARB_explicit_attrib_location extension is not supported, the line is modified (remove "layout(location = 0)") when the shader file is loaded (in ShaderFilesManager class).