### PR TITLE
Changed "macOS X" to "macOS"

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ msbuild.exe SuperTuxKart.sln
 ``` 
 SuperTuxKart can now be run as `bin\Debug\supertuxkart.exe` or `bin\Release\supertuxkart.exe` 
 
-## Building SuperTuxKart on macOS X
+## Building SuperTuxKart on macOS
 
 ### Getting Started
 


### PR DESCRIPTION
No such system stylized as "macOS X."

Left "OS X Install" because I don't think Apple uses install DVD's anymore since renaming as macOS?