### PR TITLE
Fix the --cutscene=<cutscene> commandline flag

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1160,6 +1160,7 @@ int handleCmdLine()
     // used only for debugging/testing
     if (CommandLine::has("--cutscene", &s))
     {
+        UserConfigParams::m_no_start_screen = true; // Purple menu background otherwise
         race_manager->setTrack(s);
         StateManager::get()->enterGameState();
         race_manager->setMinorMode(RaceManager::MINOR_MODE_CUTSCENE);


### PR DESCRIPTION
If the menu is shown, there's this ugly purple background (the OpenGL default, I think) and the cutscene won't play. It doesn't make sense to show the menu anyway if the user wants to immediately play a cutscene.