### PR TITLE
Add option to unlock everything with a command line flag

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -558,6 +558,8 @@ void cmdLineHelp()
                               "laps.\n"
     "       --profile-time=n   Enable automatic driven profile mode for n "
                               "seconds.\n"
+    "       --unlock-all       Permanently unlock all karts and tracks for testing.\n"
+    "       --no-unlock-all    Disable unlock-all (i.e. base unlocking on player achievement).\n"
     "       --no-graphics      Do not display the actual race.\n"
     "       --demo-mode=t      Enables demo mode after t seconds of idle time in "
                                "main menu.\n"
@@ -1234,7 +1236,17 @@ int handleCmdLine()
             race_manager->setNumLaps(n);
         }
     }   // --profile-laps
-
+    
+    if(CommandLine::has("--unlock-all"))
+    {
+        UserConfigParams::m_everything_unlocked = true;
+    } // --unlock-all
+    
+    if(CommandLine::has("--no-unlock-all"))
+    {
+        UserConfigParams::m_everything_unlocked = false;
+    } // --no-unlock-all
+    
     if(CommandLine::has("--profile-time",  &n))
     {
         Log::verbose("main", "Profiling: %d seconds.", n);


### PR DESCRIPTION
This was a complaint of Michael Larabel from Phoronix and is why he doesn't use STK in benchmarks; because the new tracks are mostly locked from the start and unavailable even with the --track flag. I'm looking into updating the test profile on OpenBenchmarking.org and hopefully this will lead to some new visibility if Michael benchmarks STK.