### PR TITLE
Tweak graphics options

### DIFF
--- a/data/gui/custom_video_settings.stkgui
+++ b/data/gui/custom_video_settings.stkgui
@@ -152,25 +152,25 @@
         <spacer height="20" width="10" />
 
         <div layout="horizontal-row" width="100%" proportion="1">
-            <label text="Animated Characters" I18N="Video settings" width="40%"/>
+            <label text="Animated Characters" I18N="Video settings" width="50%"/>
             <spacer width="10" height="10"/>
-            <gauge id="steering_animations" min_value="0" max_value="2" width="50%" />
+            <gauge id="steering_animations" min_value="0" max_value="2" width="45%" />
         </div>
 
         <spacer height="4" width="10" />
 
         <div layout="horizontal-row" width="100%" proportion="1">
-            <label text="Rendered image quality" I18N="Video settings" width="40%"/>
+            <label text="Rendered image quality" I18N="Video settings" width="50%"/>
             <spacer width="10" height="10"/>
-            <gauge id="image_quality" min_value="0" max_value="3" width="50%" />
+            <gauge id="image_quality" min_value="0" max_value="3" width="45%" />
         </div>
 
         <spacer height="4" width="10" />
 
         <div layout="horizontal-row" width="100%" proportion="1">
-            <label text="Amount of scenery (Geometry detail)" I18N="Video settings" width="40%"/>
+            <label text="Amount of scenery (Geometry detail)" I18N="Video settings" width="50%"/>
             <spacer width="10" height="10"/>
-            <gauge id="geometry_detail" min_value="0" max_value="2" width="50%" />
+            <gauge id="geometry_detail" min_value="0" max_value="2" width="45%" />
         </div>
 
         <spacer height="10" width="10" />

--- a/data/gui/custom_video_settings.stkgui
+++ b/data/gui/custom_video_settings.stkgui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <stkgui>
     <div x="2%" y="1%" width="96%" height="98%" layout="vertical-row" >
-        <header id="title" width="100%" height="fit" text_align="center" word_wrap="true" text="Graphics Settings" />
+        <header id="title" width="100%" height="fit" text_align="center" word_wrap="true" text="Advanced Graphics Settings" />
 
         <spacer height="20" width="10" />
 
@@ -145,7 +145,7 @@
             <div layout="horizontal-row" proportion="1" height="fit">
                 <checkbox id="texture_compression"/>
                 <spacer width="10" height="10"/>
-                <label text="Texture compression" I18N="Video settings"/>
+                <label text="Texture compression*" I18N="Video settings"/>
             </div>
         </div>
 
@@ -168,7 +168,7 @@
         <spacer height="4" width="10" />
 
         <div layout="horizontal-row" width="100%" proportion="1">
-            <label text="Geometry detail" I18N="Video settings" width="40%"/>
+            <label text="Amount of scenery (Geometry detail)" I18N="Video settings" width="40%"/>
             <spacer width="10" height="10"/>
             <gauge id="geometry_detail" min_value="0" max_value="2" width="50%" />
         </div>
@@ -177,7 +177,7 @@
 
         <label text="* Restart STK to apply new settings" width="100%" text_align="center" I18N="Video settings"/>
 
-        <spacer proportion="1"/>
+        <spacer height="10" width="10" />
 
         <button id="close" text="Apply" align="center"/>
     </div>

--- a/data/gui/options_video.stkgui
+++ b/data/gui/options_video.stkgui
@@ -19,15 +19,15 @@
             <spacer height="15" width="10"/>
 
             <!-- ************ GRAPHICAL EFFECTS SETTINGS ************ -->
-            <div width="75%" height="fit" layout="horizontal-row" id="outer_box" >
-                <label I18N="In the video settings" text="Graphical Effects Level" align="center"/>
-                <spacer width="20" height="20"/>
+            <div width="100%" height="fit" layout="horizontal-row" id="outer_box" >
+                <label width="25%" I18N="In the video settings" text="Graphical Effects Level" />
 
-                <div layout="vertical-row" proportion="1" height="fit" id="inner_box">
+                <div layout="vertical-row" proportion="1" height="fit" width="50%" id="inner_box" >
                     <gauge id="gfx_level" min_value="1" max_value="8" width="300" align="center" />
                     <spacer height="5" width="10"/>
-                    <button id="custom" text="Custom settings..." I18N="In the video settings" align="center"/>
+                    <button id="custom" text="Advanced settings..." I18N="In the video settings" align="center"/>
                 </div>
+                <spacer height="10" width="25%"/>
             </div>
 
             <spacer height="10" width="10"/>
@@ -41,6 +41,15 @@
             </div>
 
             <spacer height="10" width="10"/>
+
+            <div width="100%" height="fit" layout="horizontal-row" >
+                <label width="25%" I18N="In the video settings" text="Rendered image scale" />
+
+                <div layout="vertical-row" proportion="1" height="fit" width="50%" >
+                    <gauge id="scale_rtts_factor" min_value="0" max_value="2" width="300" align="center" />
+                </div>
+                <spacer height="10" width="25%"/>
+            </div>
 
             <!-- ************ RESOLUTION CHOICE ************ -->
             <spacer height="10" width="10"/>

--- a/data/gui/options_video.stkgui
+++ b/data/gui/options_video.stkgui
@@ -32,7 +32,7 @@
 
             <spacer height="10" width="10"/>
 
-            <!-- ************ VSYNC ************ -->
+            <!-- ****************** VSYNC ****************** -->
             <div width="75%" height="fit" layout="horizontal-row" >
                 <spacer width="40" height="2" />
                 <checkbox id="vsync"/>
@@ -42,11 +42,12 @@
 
             <spacer height="10" width="10"/>
 
+            <!-- ************* SCALING CHOICE ************** -->
             <div width="100%" height="fit" layout="horizontal-row" >
                 <label width="25%" I18N="In the video settings" text="Rendered image scale" />
 
                 <div layout="vertical-row" proportion="1" height="fit" width="50%" >
-                    <gauge id="scale_rtts_factor" min_value="0" max_value="2" width="300" align="center" />
+                    <gauge id="scale_rtts_factor" min_value="0" max_value="5" width="300" align="center" />
                 </div>
                 <spacer height="10" width="25%"/>
             </div>

--- a/src/states_screens/dialogs/custom_video_settings.cpp
+++ b/src/states_screens/dialogs/custom_video_settings.cpp
@@ -74,11 +74,11 @@ void CustomVideoSettingsDialog::beforeAddingWidgets()
         1 : UserConfigParams::m_show_steering_animations);
 
     SpinnerWidget* geometry_level = getWidget<SpinnerWidget>("geometry_detail");
-    //I18N: Geometry level disabled : lowest level, no details
-    geometry_level->addLabel(_("Disabled"));
-    //I18N: Geometry level low : few details are displayed
-    geometry_level->addLabel(_("Low"));
-    //I18N: Geometry level high : everything is displayed
+    //I18N: Geometry level low: lowest level, just basic details
+     geometry_level->addLabel(_("Low"));
+    //I18N: Geometry level medium: some more details are displayed
+    geometry_level->addLabel(_("Medium"));
+    //I18N: Geometry level high: everything is displayed
     geometry_level->addLabel(_("High"));
     geometry_level->setValue(
         UserConfigParams::m_geometry_level == 2 ? 0 :

--- a/src/states_screens/options_screen_video.cpp
+++ b/src/states_screens/options_screen_video.cpp
@@ -1,5 +1,5 @@
 //  SuperTuxKart - a fun racing game with go-kart
-//  Copyright (C) 2009-2015 Marianne Gagnon
+//  Copyright (C) 2009-2017 Marianne Gagnon, STK Team and contributors
 //
 //  This program is free software; you can redistribute it and/or
 //  modify it under the terms of the GNU General Public License
@@ -143,26 +143,22 @@ struct Resolution
 // ----------------------------------------------------------------------------
 int OptionsScreenVideo::getImageQuality()
 {
-    if (UserConfigParams::m_scale_rtts_factor == 0.8f &&
-        UserConfigParams::m_trilinear == false &&
+    if (UserConfigParams::m_trilinear == false &&
         UserConfigParams::m_anisotropic == 0 &&
         (UserConfigParams::m_high_definition_textures & 0x01) == 0x00 &&
         UserConfigParams::m_hq_mipmap == false)
         return 0;
-    if (UserConfigParams::m_scale_rtts_factor == 1.0f &&
-        UserConfigParams::m_trilinear == true &&
+    if (UserConfigParams::m_trilinear == true &&
         UserConfigParams::m_anisotropic == 2 &&
         (UserConfigParams::m_high_definition_textures & 0x01) == 0x00 &&
         UserConfigParams::m_hq_mipmap == false)
         return 1;
-    if (UserConfigParams::m_scale_rtts_factor == 1.0f &&
-        UserConfigParams::m_trilinear == true &&
+    if (UserConfigParams::m_trilinear == true &&
         UserConfigParams::m_anisotropic == 4 &&
         (UserConfigParams::m_high_definition_textures & 0x01) == 0x01 &&
         UserConfigParams::m_hq_mipmap == false)
         return 2;
-    if (UserConfigParams::m_scale_rtts_factor == 1.0f &&
-        UserConfigParams::m_trilinear == true &&
+    if (UserConfigParams::m_trilinear == true &&
         UserConfigParams::m_anisotropic == 16 &&
         (UserConfigParams::m_high_definition_textures & 0x01) == 0x01 &&
         UserConfigParams::m_hq_mipmap == true)
@@ -176,28 +172,24 @@ void OptionsScreenVideo::setImageQuality(int quality)
     switch (quality)
     {
         case 0:
-            UserConfigParams::m_scale_rtts_factor = 0.8f;
             UserConfigParams::m_trilinear = false;
             UserConfigParams::m_anisotropic = 0;
             UserConfigParams::m_high_definition_textures = 0x02;
             UserConfigParams::m_hq_mipmap = false;
             break;
         case 1:
-            UserConfigParams::m_scale_rtts_factor = 1.0f;
             UserConfigParams::m_trilinear = true;
             UserConfigParams::m_anisotropic = 2;
             UserConfigParams::m_high_definition_textures = 0x02;
             UserConfigParams::m_hq_mipmap = false;
             break;
         case 2:
-            UserConfigParams::m_scale_rtts_factor = 1.0f;
             UserConfigParams::m_trilinear = true;
             UserConfigParams::m_anisotropic = 4;
             UserConfigParams::m_high_definition_textures = 0x03;
             UserConfigParams::m_hq_mipmap = false;
             break;
         case 3:
-            UserConfigParams::m_scale_rtts_factor = 1.0f;
             UserConfigParams::m_trilinear = true;
             UserConfigParams::m_anisotropic = 16;
             UserConfigParams::m_high_definition_textures = 0x03;
@@ -260,6 +252,17 @@ void OptionsScreenVideo::init()
         getWidget<GUIEngine::CheckBoxWidget>("vsync");
     assert( vsync != NULL );
     vsync->setState( UserConfigParams::m_vsync );
+
+    GUIEngine::SpinnerWidget* scale_rtts_factor =
+        getWidget<GUIEngine::SpinnerWidget>("scale_rtts_factor");
+    assert( scale_rtts_factor != NULL );
+    int scale_rtts_factor_value = 2;
+    if (UserConfigParams::m_scale_rtts_factor == 0.5f)  scale_rtts_factor_value = 0;
+    else if (UserConfigParams::m_scale_rtts_factor == 0.75f)  scale_rtts_factor_value = 1;
+    scale_rtts_factor->addLabel(_("0.5x"));
+    scale_rtts_factor->addLabel(_("0.75x"));
+    scale_rtts_factor->addLabel(_("1x"));
+    scale_rtts_factor->setValue(scale_rtts_factor_value);
 
 
     // ---- video modes
@@ -461,7 +464,7 @@ void OptionsScreenVideo::updateTooltip()
     //I18N: if all kart animations are enabled
     const core::stringw all = _LTR("All");
     //I18N: if some kart animations are enabled
-    const core::stringw me = _LTR("Me Only");
+    const core::stringw me = _LTR("Human players only");
     //I18N: if no kart animations are enabled
     const core::stringw none = _LTR("None");
 
@@ -638,6 +641,21 @@ void OptionsScreenVideo::eventCallback(Widget* widget, const std::string& name,
         CheckBoxWidget* rememberWinpos = getWidget<CheckBoxWidget>("rememberWinpos");
 
         rememberWinpos->setActive(!fullscreen->getState());
+    }
+    else if (name == "scale_rtts_factor")
+    {
+        switch (getWidget<SpinnerWidget>("scale_rtts_factor")->getValue())
+        {
+            case 0:
+                UserConfigParams::m_scale_rtts_factor = 0.5f;
+                break;
+            case 1:
+                UserConfigParams::m_scale_rtts_factor = 0.75f;
+                break;
+            case 2:
+                UserConfigParams::m_scale_rtts_factor = 1.0f;
+                break;
+        }
     }
 }   // eventCallback
 

--- a/src/states_screens/options_screen_video.cpp
+++ b/src/states_screens/options_screen_video.cpp
@@ -256,11 +256,18 @@ void OptionsScreenVideo::init()
     GUIEngine::SpinnerWidget* scale_rtts_factor =
         getWidget<GUIEngine::SpinnerWidget>("scale_rtts_factor");
     assert( scale_rtts_factor != NULL );
-    int scale_rtts_factor_value = 2;
+    int scale_rtts_factor_value = 5;
     if (UserConfigParams::m_scale_rtts_factor == 0.5f)  scale_rtts_factor_value = 0;
-    else if (UserConfigParams::m_scale_rtts_factor == 0.75f)  scale_rtts_factor_value = 1;
+    else if (UserConfigParams::m_scale_rtts_factor == 0.6f)  scale_rtts_factor_value = 1;
+    else if (UserConfigParams::m_scale_rtts_factor == 0.7f)  scale_rtts_factor_value = 2;
+    else if (UserConfigParams::m_scale_rtts_factor == 0.8f)  scale_rtts_factor_value = 3;
+    else if (UserConfigParams::m_scale_rtts_factor == 0.9f)  scale_rtts_factor_value = 4;
+    scale_rtts_factor->clearLabels();
     scale_rtts_factor->addLabel(_("0.5x"));
-    scale_rtts_factor->addLabel(_("0.75x"));
+    scale_rtts_factor->addLabel(_("0.6x"));
+    scale_rtts_factor->addLabel(_("0.7x"));
+    scale_rtts_factor->addLabel(_("0.8x"));
+    scale_rtts_factor->addLabel(_("0.9x"));
     scale_rtts_factor->addLabel(_("1x"));
     scale_rtts_factor->setValue(scale_rtts_factor_value);
 
@@ -650,9 +657,18 @@ void OptionsScreenVideo::eventCallback(Widget* widget, const std::string& name,
                 UserConfigParams::m_scale_rtts_factor = 0.5f;
                 break;
             case 1:
-                UserConfigParams::m_scale_rtts_factor = 0.75f;
+                UserConfigParams::m_scale_rtts_factor = 0.6f;
                 break;
             case 2:
+                UserConfigParams::m_scale_rtts_factor = 0.7f;
+                break;
+            case 3:
+                UserConfigParams::m_scale_rtts_factor = 0.8f;
+                break;
+            case 4:
+                UserConfigParams::m_scale_rtts_factor = 0.9f;
+                break;
+            case 5:
                 UserConfigParams::m_scale_rtts_factor = 1.0f;
                 break;
         }


### PR DESCRIPTION
Changes based on feedback on https://github.com/supertuxkart/stk-code/pull/2858.

 - Put option for scale_rtts above resolution switcher, as it is a "replacement" for changing the resolution, especially on Android
 - Clarification of "Geometry detail"
 - Change header of advanced graphics settings dialog from "Graphics Settings" to "Advanced Graphics Settings"
 - Add * to Texture Compression checkbox to indicate changes to it will not take effect until restarting STK (Took me a long time to figure this out myself)

![](http://i.imgur.com/hDvBZiV.png)

![](http://i.imgur.com/RxqXdlH.png)