### PR TITLE
Small tweaks in graphics options

### DIFF
--- a/data/gui/custom_video_settings.stkgui
+++ b/data/gui/custom_video_settings.stkgui
@@ -5,16 +5,6 @@
 
         <spacer height="20" width="10" />
 
-        <!--
-        <div layout="horizontal-row" width="100%" height="fit">
-            <checkbox id="pixelshaders"/>
-            <spacer width="10" height="10"/>
-            <label text="Pixel Shaders" I18N="Video settings"/>
-        </div>
-
-        <spacer height="4" width="10" />
-        -->
-
         <div layout="horizontal-row" width="100%" proportion="1">
             <checkbox id="dynamiclight"/>
             <spacer width="10" height="10"/>
@@ -160,7 +150,7 @@
         <spacer height="4" width="10" />
 
         <div layout="horizontal-row" width="100%" proportion="1">
-            <label text="Texture quality" I18N="Video settings" width="45%"/>
+            <label text="Texture quality*" I18N="Video settings" width="45%"/>
             <spacer width="10" height="10"/>
             <gauge id="image_quality" min_value="0" max_value="3" width="45%" />
         </div>
@@ -175,7 +165,7 @@
 
         <spacer height="10" width="10" />
 
-        <label text="* Restart STK to apply new settings" width="100%" text_align="center" I18N="Video settings"/>
+        <label text="* Restart STK to apply changes" width="100%" text_align="center" I18N="Video settings"/>
 
         <spacer proportion="1"/>
 

--- a/data/gui/custom_video_settings.stkgui
+++ b/data/gui/custom_video_settings.stkgui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <stkgui>
     <div x="2%" y="1%" width="96%" height="98%" layout="vertical-row" >
-        <header id="title" width="100%" height="fit" text_align="center" word_wrap="true" text="Graphics Settings" />
+        <header id="title" width="100%" height="fit" text_align="center" word_wrap="true" text="Advanced Graphics Settings" />
 
         <spacer height="20" width="10" />
 
@@ -145,32 +145,32 @@
             <div layout="horizontal-row" proportion="1" height="fit">
                 <checkbox id="texture_compression"/>
                 <spacer width="10" height="10"/>
-                <label text="Texture compression" I18N="Video settings"/>
+                <label text="Texture compression*" I18N="Video settings"/>
             </div>
         </div>
 
         <spacer height="20" width="10" />
 
         <div layout="horizontal-row" width="100%" proportion="1">
-            <label text="Animated Characters" I18N="Video settings" width="40%"/>
+            <label text="Animated Characters" I18N="Video settings" width="45%"/>
             <spacer width="10" height="10"/>
-            <gauge id="steering_animations" min_value="0" max_value="2" width="50%" />
+            <gauge id="steering_animations" min_value="0" max_value="2" width="45%" />
         </div>
 
         <spacer height="4" width="10" />
 
         <div layout="horizontal-row" width="100%" proportion="1">
-            <label text="Rendered image quality" I18N="Video settings" width="40%"/>
+            <label text="Texture quality" I18N="Video settings" width="45%"/>
             <spacer width="10" height="10"/>
-            <gauge id="image_quality" min_value="0" max_value="3" width="50%" />
+            <gauge id="image_quality" min_value="0" max_value="3" width="45%" />
         </div>
 
         <spacer height="4" width="10" />
 
         <div layout="horizontal-row" width="100%" proportion="1">
-            <label text="Geometry detail" I18N="Video settings" width="40%"/>
+            <label text="Amount of scenery (Geometry detail)" I18N="Video settings" width="45%"/>
             <spacer width="10" height="10"/>
-            <gauge id="geometry_detail" min_value="0" max_value="2" width="50%" />
+            <gauge id="geometry_detail" min_value="0" max_value="2" width="45%" />
         </div>
 
         <spacer height="10" width="10" />

--- a/data/gui/options_video.stkgui
+++ b/data/gui/options_video.stkgui
@@ -19,20 +19,20 @@
             <spacer height="15" width="10"/>
 
             <!-- ************ GRAPHICAL EFFECTS SETTINGS ************ -->
-            <div width="75%" height="fit" layout="horizontal-row" id="outer_box" >
-                <label I18N="In the video settings" text="Graphical Effects Level" align="center"/>
-                <spacer width="20" height="20"/>
+            <div width="100%" height="fit" layout="horizontal-row" id="outer_box" >
+                <label width="25%" I18N="In the video settings" text="Graphical Effects Level" />
 
-                <div layout="vertical-row" proportion="1" height="fit" id="inner_box">
+                <div layout="vertical-row" proportion="1" height="fit" width="50%" id="inner_box" >
                     <gauge id="gfx_level" min_value="1" max_value="8" width="300" align="center" />
                     <spacer height="5" width="10"/>
-                    <button id="custom" text="Custom settings..." I18N="In the video settings" align="center"/>
+                    <button id="custom" text="Advanced settings..." I18N="In the video settings" align="center"/>
                 </div>
+                <spacer height="10" width="25%"/>
             </div>
 
             <spacer height="10" width="10"/>
 
-            <!-- ************ VSYNC ************ -->
+            <<!-- ****************** VSYNC ****************** -->
             <div width="75%" height="fit" layout="horizontal-row" >
                 <spacer width="40" height="2" />
                 <checkbox id="vsync"/>
@@ -42,7 +42,7 @@
 
             <spacer height="10" width="10"/>
 
-            <!-- ************ RESOLUTION CHOICE ************ -->
+            <!-- ************ RESOLUTION CHOICE ************* -->
             <spacer height="10" width="10"/>
             <label width="100%" I18N="In the video settings" text="Resolution"/>
 

--- a/data/gui/options_video.stkgui
+++ b/data/gui/options_video.stkgui
@@ -32,7 +32,7 @@
 
             <spacer height="10" width="10"/>
 
-            <<!-- ****************** VSYNC ****************** -->
+            <!-- ******************* VSYNC ****************** -->
             <div width="75%" height="fit" layout="horizontal-row" >
                 <spacer width="40" height="2" />
                 <checkbox id="vsync"/>

--- a/src/states_screens/dialogs/custom_video_settings.cpp
+++ b/src/states_screens/dialogs/custom_video_settings.cpp
@@ -74,11 +74,11 @@ void CustomVideoSettingsDialog::beforeAddingWidgets()
         1 : UserConfigParams::m_show_steering_animations);
 
     SpinnerWidget* geometry_level = getWidget<SpinnerWidget>("geometry_detail");
-    //I18N: Geometry level disabled : lowest level, no details
-    geometry_level->addLabel(_("Disabled"));
-    //I18N: Geometry level low : few details are displayed
+    //I18N: Geometry level low: lowest level, very few details are displayed
     geometry_level->addLabel(_("Low"));
-    //I18N: Geometry level high : everything is displayed
+    //I18N: Geometry level medium: some more details are displayed
+    geometry_level->addLabel(_("Medium"));
+    //I18N: Geometry level high: everything is displayed
     geometry_level->addLabel(_("High"));
     geometry_level->setValue(
         UserConfigParams::m_geometry_level == 2 ? 0 :

--- a/src/states_screens/options_screen_video.cpp
+++ b/src/states_screens/options_screen_video.cpp
@@ -1,5 +1,5 @@
 //  SuperTuxKart - a fun racing game with go-kart
-//  Copyright (C) 2009-2015 Marianne Gagnon
+//  Copyright (C) 2009-2017 Marianne Gagnon
 //
 //  This program is free software; you can redistribute it and/or
 //  modify it under the terms of the GNU General Public License
@@ -143,26 +143,22 @@ struct Resolution
 // ----------------------------------------------------------------------------
 int OptionsScreenVideo::getImageQuality()
 {
-    if (UserConfigParams::m_scale_rtts_factor == 0.8f &&
-        UserConfigParams::m_trilinear == false &&
+    if (UserConfigParams::m_trilinear == false &&
         UserConfigParams::m_anisotropic == 0 &&
         (UserConfigParams::m_high_definition_textures & 0x01) == 0x00 &&
         UserConfigParams::m_hq_mipmap == false)
         return 0;
-    if (UserConfigParams::m_scale_rtts_factor == 1.0f &&
-        UserConfigParams::m_trilinear == true &&
+    if (UserConfigParams::m_trilinear == true &&
         UserConfigParams::m_anisotropic == 2 &&
         (UserConfigParams::m_high_definition_textures & 0x01) == 0x00 &&
         UserConfigParams::m_hq_mipmap == false)
         return 1;
-    if (UserConfigParams::m_scale_rtts_factor == 1.0f &&
-        UserConfigParams::m_trilinear == true &&
+    if (UserConfigParams::m_trilinear == true &&
         UserConfigParams::m_anisotropic == 4 &&
         (UserConfigParams::m_high_definition_textures & 0x01) == 0x01 &&
         UserConfigParams::m_hq_mipmap == false)
         return 2;
-    if (UserConfigParams::m_scale_rtts_factor == 1.0f &&
-        UserConfigParams::m_trilinear == true &&
+    if (UserConfigParams::m_trilinear == true &&
         UserConfigParams::m_anisotropic == 16 &&
         (UserConfigParams::m_high_definition_textures & 0x01) == 0x01 &&
         UserConfigParams::m_hq_mipmap == true)
@@ -176,28 +172,24 @@ void OptionsScreenVideo::setImageQuality(int quality)
     switch (quality)
     {
         case 0:
-            UserConfigParams::m_scale_rtts_factor = 0.8f;
             UserConfigParams::m_trilinear = false;
             UserConfigParams::m_anisotropic = 0;
             UserConfigParams::m_high_definition_textures = 0x02;
             UserConfigParams::m_hq_mipmap = false;
             break;
         case 1:
-            UserConfigParams::m_scale_rtts_factor = 1.0f;
             UserConfigParams::m_trilinear = true;
             UserConfigParams::m_anisotropic = 2;
             UserConfigParams::m_high_definition_textures = 0x02;
             UserConfigParams::m_hq_mipmap = false;
             break;
         case 2:
-            UserConfigParams::m_scale_rtts_factor = 1.0f;
             UserConfigParams::m_trilinear = true;
             UserConfigParams::m_anisotropic = 4;
             UserConfigParams::m_high_definition_textures = 0x03;
             UserConfigParams::m_hq_mipmap = false;
             break;
         case 3:
-            UserConfigParams::m_scale_rtts_factor = 1.0f;
             UserConfigParams::m_trilinear = true;
             UserConfigParams::m_anisotropic = 16;
             UserConfigParams::m_high_definition_textures = 0x03;


### PR DESCRIPTION
Changes based on feedback on https://github.com/supertuxkart/stk-code/pull/2863.

Scale_rtts was removed from Image Quality because:

1. All the other options in this slider affect textures, so scale_rtts does not really fit here
2. It causes inconsistent/confusing behavior, as it only makes a difference when advanced lighting is enabled, so it will never be used in the presets anyways (1 uses "Very Low" but uses non-advanced lighting, 2-6 don't use "Very Low").