### PR TITLE
Use track version 7 for walldriving tracks

### DIFF
--- a/data/stk_config.xml
+++ b/data/stk_config.xml
@@ -7,7 +7,7 @@
 
   <!-- Minimum and maxium track versions that be be read by this binary.
        Older versions will be ignored. -->
-  <track-version min="6" max="6"/>
+  <track-version min="6" max="7"/>
 
   <!-- Maximum number of karts to be used at the same time. This limit
        can easily be increased, but some tracks might not have valid start


### PR DESCRIPTION
Any track/arena that depends on walldriving (e.g. icecave) should use version 7.