### PR TITLE
Don't show/play skidding effects when kart is in the air

### DIFF
--- a/src/karts/kart.cpp
+++ b/src/karts/kart.cpp
@@ -2306,7 +2306,7 @@ void Kart::updatePhysics(float dt)
     m_vehicle->setVisualRotation(m_skidding->getVisualSkidRotation());
     if(( m_skidding->getSkidState() == Skidding::SKID_ACCUMULATE_LEFT ||
          m_skidding->getSkidState() == Skidding::SKID_ACCUMULATE_RIGHT  ) &&
-        m_skidding->getGraphicalJumpOffset()==0)
+        m_skidding->getGraphicalJumpOffset()==0 && isOnGround())
     {
         if(m_skid_sound->getStatus()!=SFXBase::SFX_PLAYING && !isWheeless())
             m_skid_sound->play(getXYZ());

--- a/src/karts/kart_gfx.cpp
+++ b/src/karts/kart_gfx.cpp
@@ -506,7 +506,7 @@ void KartGFX::setGFXFromReplay(int nitro, bool zipper,
     if (zipper)
         setCreationRateAbsolute(KartGFX::KGFX_ZIPPER, 800.0f);
 
-    if (skidding > 0)
+    if (skidding > 0 && m_kart->isOnGround())
     {
         const ParticleKind* skid_kind = red_skidding ? m_skid_kind2 
                                                      : m_skid_kind1;

--- a/src/karts/skidding.cpp
+++ b/src/karts/skidding.cpp
@@ -349,6 +349,9 @@ void Skidding::update(float dt, bool is_on_ground,
                          * 0.5f * kp->getSkidGraphicalJumpTime();
             m_remaining_jump_time = kp->getSkidGraphicalJumpTime();
 
+            // Don't "play-sound-than-pause-sound-when-jumping-then-play-sound-when-jump-done"
+            m_gfx_jump_offset = 0.001f;
+
 #ifdef SKID_DEBUG
 #define SPEED 20.0f
             m_real_steering = updateSteering(steering, dt);
@@ -389,6 +392,14 @@ void Skidding::update(float dt, bool is_on_ground,
     case SKID_ACCUMULATE_LEFT:
     case SKID_ACCUMULATE_RIGHT:
         {
+            if (!is_on_ground) {
+                m_kart->getKartGFX()
+                      ->setCreationRateAbsolute(KartGFX::KGFX_SKIDL, 0);
+                m_kart->getKartGFX()
+                      ->setCreationRateAbsolute(KartGFX::KGFX_SKIDR, 0);
+                m_kart->getKartGFX()->updateSkidLight(0);
+                break;
+            }
 #ifdef SKID_DEBUG
             Vec3 v=m_kart->getVelocity();
             if(v.length()>5)


### PR DESCRIPTION
This is the visual/auditory only version of https://github.com/supertuxkart/stk-code/pull/2925 and does not change the physics behavior, it just disables sound/visual effects when the kart is in the air.