### PR TITLE
Android: Run at a reduced resolution

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -8,7 +8,7 @@
     <application android:label="@string/app_name"
                  android:icon="@drawable/icon"
                  android:hasCode="false"
-                 android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
+                 android:theme="@style/AppTheme.NoActionBar"
                  android:hardwareAccelerated="true">
 
         <activity android:name="android.app.NativeActivity"

--- a/android/res/values/style.xml
+++ b/android/res/values/style.xml
@@ -1,0 +1,9 @@
+<resources>
+
+    <!-- Credit: https://stackoverflow.com/a/37324030 -->
+    <style name="AppTheme.NoActionBar">
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+    </style>
+
+</resources>

--- a/lib/irrlicht/source/Irrlicht/CIrrDeviceAndroid.cpp
+++ b/lib/irrlicht/source/Irrlicht/CIrrDeviceAndroid.cpp
@@ -122,11 +122,34 @@ void CIrrDeviceAndroid::createVideoModeList()
 		
 	int width = ANativeWindow_getWidth(Android->window);
 	int height = ANativeWindow_getHeight(Android->window);
-	
+	int widthReduced = width;
+	int heightReduced = height;
+
+	if (width == 1440 && height == 2560)
+	{
+		widthReduced = 1080;
+		heightReduced = 1920;
+	}
+	else if (width == 1200 && height == 1920)
+	{
+		widthReduced = 900;
+		heightReduced = 1440;
+	}
+	else if (width == 1080 && height == 1920)
+	{
+		widthReduced = 720;
+		heightReduced = 1280;
+	}
+	else if (width == 768 && height == 1280)
+	{
+		widthReduced = 576;
+		heightReduced = 960;
+	}
+
 	if (width > 0 && height > 0)
 	{
-		CreationParams.WindowSize.Width = width;
-		CreationParams.WindowSize.Height = height;
+		CreationParams.WindowSize.Width = widthReduced;
+		CreationParams.WindowSize.Height = heightReduced;
 	}
 
 	core::dimension2d<u32> size = core::dimension2d<u32>(


### PR DESCRIPTION
Running at a reduced resolution dramatically increases performance while also reducing battery drain.

Based off of https://github.com/supertuxkart/stk-code/pull/2863#issuecomment-309864131

This also enables immersive/expanded mode which hides the title bar and navigation bar, which is necessary to get access to the screen's entire real estate.

Edit: This doesn't do anything, height and width is probably mixed