### PR TITLE
Prevent upgrades to 0.9.3 causing all particles to be disabled

### DIFF
--- a/src/config/user_config.hpp
+++ b/src/config/user_config.hpp
@@ -728,7 +728,7 @@ namespace UserConfigParams
 #endif
 
     PARAM_PREFIX IntUserConfigParam        m_graphical_effects
-            PARAM_DEFAULT(  IntUserConfigParam(2, "anim_gfx",
+            PARAM_DEFAULT(  IntUserConfigParam(2, "animate_graphics",
                             &m_graphics_quality, "Scenery animations: 0 disabled, 1 only important, 2 enabled") );
 
     // This saves the actual user preference.


### PR DESCRIPTION
Older version's "false" in the config file translates to "0", which disables all particles in 0.9.3.  Mitigate this by renaming the config name.

See https://forum.freegamedev.net/viewtopic.php?f=17&t=7662&sid=71b18d47f0b9d436d4bd17c2da8cbb86#p74823 for an example of this causing confusion.