### PR TITLE
README: Correct building cmake command sentence

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Run the following commands to compile SuperTuxKart:
 ```bash
 mkdir cmake_build
 cd cmake_build
-cmake ..
+cmake ../stk-code
 make -j4
 ```
 STK can then be run from the build directory with `bin/supertuxkart`


### PR DESCRIPTION
cmake doesn't find CMakeLists.txt according to the README. Needs to specify stk-code folder