### PR TITLE
Reset FeatureAvailable array to a sane default

### DIFF
--- a/lib/irrlicht/source/Irrlicht/COpenGLExtensionHandler.cpp
+++ b/lib/irrlicht/source/Irrlicht/COpenGLExtensionHandler.cpp
@@ -329,6 +329,8 @@ void COpenGLExtensionHandler::dumpFramebufferFormats() const
 
 void COpenGLExtensionHandler::initExtensions(bool stencilBuffer, bool useCoreContext)
 {
+	memset(FeatureAvailable, 0, sizeof(FeatureAvailable));
+
 	const f32 ogl_ver = core::fast_atof(reinterpret_cast<const c8*>(glGetString(GL_VERSION)));
 	Version = static_cast<u16>(core::floor32(ogl_ver)*100+core::round32(core::fract(ogl_ver)*10.0f));
 	if ( Version >= 102)


### PR DESCRIPTION
The FeatureAvailable array elements never get reseted to false. This
causes random problems when using the fixed pipeline rendering path.
This problem was found during testing of the etnaviv gallium driver
found in recent versions of mesa.

Signed-off-by: Christian Gmeiner <christian.gmeiner@gmail.com>