### PR TITLE
GLEW: Update to pristine upstream 2.1.0

### DIFF
--- a/lib/glew/CMakeLists.txt
+++ b/lib/glew/CMakeLists.txt
@@ -14,8 +14,8 @@ include_directories(${OPENGL_INCLUDE_DIR})
 add_definitions(-DGLEW_STATIC)
 
 add_library(glew STATIC
-    include/GL/glew.h  include/GL/glxew.h  include/GL/wglew.h
-    src/glew.c         src/glewinfo.c
+    src/glew.c
+    src/glewinfo.c
 )
 
 target_link_libraries(glew ${OPENGL_gl_LIBRARY})

--- a/lib/glew/include/GL/eglew.h
+++ b/lib/glew/include/GL/eglew.h
@@ -1,0 +1,2618 @@
+/*
+** The OpenGL Extension Wrangler Library
+** Copyright (C) 2008-2017, Nigel Stewart <nigels[]users sourceforge net>
+** Copyright (C) 2002-2008, Milan Ikits <milan ikits[]ieee org>
+** Copyright (C) 2002-2008, Marcelo E. Magallon <mmagallo[]debian org>
+** Copyright (C) 2002, Lev Povalahev
+** All rights reserved.
+** 
+** Redistribution and use in source and binary forms, with or without 
+** modification, are permitted provided that the following conditions are met:
+** 
+** * Redistributions of source code must retain the above copyright notice, 
+**   this list of conditions and the following disclaimer.
+** * Redistributions in binary form must reproduce the above copyright notice, 
+**   this list of conditions and the following disclaimer in the documentation 
+**   and/or other materials provided with the distribution.
+** * The name of the author may be used to endorse or promote products 
+**   derived from this software without specific prior written permission.
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+** AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+** IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+** ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+** LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+** CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+** SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+** INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+** CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+** ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+** THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/*
+ * Mesa 3-D graphics library
+ * Version:  7.0
+ *
+ * Copyright (C) 1999-2007  Brian Paul   All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * BRIAN PAUL BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*
+** Copyright (c) 2007 The Khronos Group Inc.
+** 
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+** 
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+** 
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+#ifndef __eglew_h__
+#define __eglew_h__
+#define __EGLEW_H__
+
+#ifdef __eglext_h_
+#error eglext.h included before eglew.h
+#endif
+
+#if defined(__egl_h_)
+#error egl.h included before eglew.h
+#endif
+
+#define __eglext_h_
+
+#define __egl_h_
+
+#ifndef EGLAPIENTRY
+#define EGLAPIENTRY
+#endif
+#ifndef EGLAPI
+#define EGLAPI extern
+#endif
+
+/* EGL Types */
+#include <sys/types.h>
+
+#include <KHR/khrplatform.h>
+#include <EGL/eglplatform.h>
+
+#include <GL/glew.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef int32_t EGLint;
+
+typedef unsigned int EGLBoolean;
+typedef void *EGLDisplay;
+typedef void *EGLConfig;
+typedef void *EGLSurface;
+typedef void *EGLContext;
+typedef void (*__eglMustCastToProperFunctionPointerType)(void);
+
+typedef unsigned int EGLenum;
+typedef void *EGLClientBuffer;
+
+typedef void *EGLSync;
+typedef intptr_t EGLAttrib;
+typedef khronos_utime_nanoseconds_t EGLTime;
+typedef void *EGLImage;
+
+typedef void *EGLSyncKHR;
+typedef intptr_t EGLAttribKHR;
+typedef void *EGLLabelKHR;
+typedef void *EGLObjectKHR;
+typedef void (EGLAPIENTRY  *EGLDEBUGPROCKHR)(EGLenum error,const char *command,EGLint messageType,EGLLabelKHR threadLabel,EGLLabelKHR objectLabel,const char* message);
+typedef khronos_utime_nanoseconds_t EGLTimeKHR;
+typedef void *EGLImageKHR;
+typedef void *EGLStreamKHR;
+typedef khronos_uint64_t EGLuint64KHR;
+typedef int EGLNativeFileDescriptorKHR;
+typedef khronos_ssize_t EGLsizeiANDROID;
+typedef void (*EGLSetBlobFuncANDROID) (const void *key, EGLsizeiANDROID keySize, const void *value, EGLsizeiANDROID valueSize);
+typedef EGLsizeiANDROID (*EGLGetBlobFuncANDROID) (const void *key, EGLsizeiANDROID keySize, void *value, EGLsizeiANDROID valueSize);
+typedef void *EGLDeviceEXT;
+typedef void *EGLOutputLayerEXT;
+typedef void *EGLOutputPortEXT;
+typedef void *EGLSyncNV;
+typedef khronos_utime_nanoseconds_t EGLTimeNV;
+typedef khronos_utime_nanoseconds_t EGLuint64NV;
+typedef khronos_stime_nanoseconds_t EGLnsecsANDROID;
+
+struct EGLClientPixmapHI;
+
+#define EGL_DONT_CARE                     ((EGLint)-1)
+
+#define EGL_NO_CONTEXT                    ((EGLContext)0)
+#define EGL_NO_DISPLAY                    ((EGLDisplay)0)
+#define EGL_NO_IMAGE                      ((EGLImage)0)
+#define EGL_NO_SURFACE                    ((EGLSurface)0)
+#define EGL_NO_SYNC                       ((EGLSync)0)
+
+#define EGL_UNKNOWN                       ((EGLint)-1)
+
+#define EGL_DEFAULT_DISPLAY               ((EGLNativeDisplayType)0)
+
+EGLAPI __eglMustCastToProperFunctionPointerType EGLAPIENTRY eglGetProcAddress (const char *procname);
+/* ---------------------------- EGL_VERSION_1_0 ---------------------------- */
+
+#ifndef EGL_VERSION_1_0
+#define EGL_VERSION_1_0 1
+
+#define EGL_FALSE 0
+#define EGL_PBUFFER_BIT 0x0001
+#define EGL_TRUE 1
+#define EGL_PIXMAP_BIT 0x0002
+#define EGL_WINDOW_BIT 0x0004
+#define EGL_SUCCESS 0x3000
+#define EGL_NOT_INITIALIZED 0x3001
+#define EGL_BAD_ACCESS 0x3002
+#define EGL_BAD_ALLOC 0x3003
+#define EGL_BAD_ATTRIBUTE 0x3004
+#define EGL_BAD_CONFIG 0x3005
+#define EGL_BAD_CONTEXT 0x3006
+#define EGL_BAD_CURRENT_SURFACE 0x3007
+#define EGL_BAD_DISPLAY 0x3008
+#define EGL_BAD_MATCH 0x3009
+#define EGL_BAD_NATIVE_PIXMAP 0x300A
+#define EGL_BAD_NATIVE_WINDOW 0x300B
+#define EGL_BAD_PARAMETER 0x300C
+#define EGL_BAD_SURFACE 0x300D
+#define EGL_BUFFER_SIZE 0x3020
+#define EGL_ALPHA_SIZE 0x3021
+#define EGL_BLUE_SIZE 0x3022
+#define EGL_GREEN_SIZE 0x3023
+#define EGL_RED_SIZE 0x3024
+#define EGL_DEPTH_SIZE 0x3025
+#define EGL_STENCIL_SIZE 0x3026
+#define EGL_CONFIG_CAVEAT 0x3027
+#define EGL_CONFIG_ID 0x3028
+#define EGL_LEVEL 0x3029
+#define EGL_MAX_PBUFFER_HEIGHT 0x302A
+#define EGL_MAX_PBUFFER_PIXELS 0x302B
+#define EGL_MAX_PBUFFER_WIDTH 0x302C
+#define EGL_NATIVE_RENDERABLE 0x302D
+#define EGL_NATIVE_VISUAL_ID 0x302E
+#define EGL_NATIVE_VISUAL_TYPE 0x302F
+#define EGL_SAMPLES 0x3031
+#define EGL_SAMPLE_BUFFERS 0x3032
+#define EGL_SURFACE_TYPE 0x3033
+#define EGL_TRANSPARENT_TYPE 0x3034
+#define EGL_TRANSPARENT_BLUE_VALUE 0x3035
+#define EGL_TRANSPARENT_GREEN_VALUE 0x3036
+#define EGL_TRANSPARENT_RED_VALUE 0x3037
+#define EGL_NONE 0x3038
+#define EGL_SLOW_CONFIG 0x3050
+#define EGL_NON_CONFORMANT_CONFIG 0x3051
+#define EGL_TRANSPARENT_RGB 0x3052
+#define EGL_VENDOR 0x3053
+#define EGL_VERSION 0x3054
+#define EGL_EXTENSIONS 0x3055
+#define EGL_HEIGHT 0x3056
+#define EGL_WIDTH 0x3057
+#define EGL_LARGEST_PBUFFER 0x3058
+#define EGL_DRAW 0x3059
+#define EGL_READ 0x305A
+#define EGL_CORE_NATIVE_ENGINE 0x305B
+
+typedef EGLBoolean  ( * PFNEGLCHOOSECONFIGPROC) (EGLDisplay  dpy, const EGLint * attrib_list, EGLConfig * configs, EGLint  config_size, EGLint * num_config);
+typedef EGLBoolean  ( * PFNEGLCOPYBUFFERSPROC) (EGLDisplay  dpy, EGLSurface  surface, EGLNativePixmapType  target);
+typedef EGLContext  ( * PFNEGLCREATECONTEXTPROC) (EGLDisplay  dpy, EGLConfig  config, EGLContext  share_context, const EGLint * attrib_list);
+typedef EGLSurface  ( * PFNEGLCREATEPBUFFERSURFACEPROC) (EGLDisplay  dpy, EGLConfig  config, const EGLint * attrib_list);
+typedef EGLSurface  ( * PFNEGLCREATEPIXMAPSURFACEPROC) (EGLDisplay  dpy, EGLConfig  config, EGLNativePixmapType  pixmap, const EGLint * attrib_list);
+typedef EGLSurface  ( * PFNEGLCREATEWINDOWSURFACEPROC) (EGLDisplay  dpy, EGLConfig  config, EGLNativeWindowType  win, const EGLint * attrib_list);
+typedef EGLBoolean  ( * PFNEGLDESTROYCONTEXTPROC) (EGLDisplay  dpy, EGLContext  ctx);
+typedef EGLBoolean  ( * PFNEGLDESTROYSURFACEPROC) (EGLDisplay  dpy, EGLSurface  surface);
+typedef EGLBoolean  ( * PFNEGLGETCONFIGATTRIBPROC) (EGLDisplay  dpy, EGLConfig  config, EGLint  attribute, EGLint * value);
+typedef EGLBoolean  ( * PFNEGLGETCONFIGSPROC) (EGLDisplay  dpy, EGLConfig * configs, EGLint  config_size, EGLint * num_config);
+typedef EGLDisplay  ( * PFNEGLGETCURRENTDISPLAYPROC) ( void );
+typedef EGLSurface  ( * PFNEGLGETCURRENTSURFACEPROC) (EGLint  readdraw);
+typedef EGLDisplay  ( * PFNEGLGETDISPLAYPROC) (EGLNativeDisplayType  display_id);
+typedef EGLint  ( * PFNEGLGETERRORPROC) ( void );
+typedef EGLBoolean  ( * PFNEGLINITIALIZEPROC) (EGLDisplay  dpy, EGLint * major, EGLint * minor);
+typedef EGLBoolean  ( * PFNEGLMAKECURRENTPROC) (EGLDisplay  dpy, EGLSurface  draw, EGLSurface  read, EGLContext  ctx);
+typedef EGLBoolean  ( * PFNEGLQUERYCONTEXTPROC) (EGLDisplay  dpy, EGLContext  ctx, EGLint  attribute, EGLint * value);
+typedef const char * ( * PFNEGLQUERYSTRINGPROC) (EGLDisplay  dpy, EGLint  name);
+typedef EGLBoolean  ( * PFNEGLQUERYSURFACEPROC) (EGLDisplay  dpy, EGLSurface  surface, EGLint  attribute, EGLint * value);
+typedef EGLBoolean  ( * PFNEGLSWAPBUFFERSPROC) (EGLDisplay  dpy, EGLSurface  surface);
+typedef EGLBoolean  ( * PFNEGLTERMINATEPROC) (EGLDisplay  dpy);
+typedef EGLBoolean  ( * PFNEGLWAITGLPROC) ( void );
+typedef EGLBoolean  ( * PFNEGLWAITNATIVEPROC) (EGLint  engine);
+
+#define eglChooseConfig EGLEW_GET_FUN(__eglewChooseConfig)
+#define eglCopyBuffers EGLEW_GET_FUN(__eglewCopyBuffers)
+#define eglCreateContext EGLEW_GET_FUN(__eglewCreateContext)
+#define eglCreatePbufferSurface EGLEW_GET_FUN(__eglewCreatePbufferSurface)
+#define eglCreatePixmapSurface EGLEW_GET_FUN(__eglewCreatePixmapSurface)
+#define eglCreateWindowSurface EGLEW_GET_FUN(__eglewCreateWindowSurface)
+#define eglDestroyContext EGLEW_GET_FUN(__eglewDestroyContext)
+#define eglDestroySurface EGLEW_GET_FUN(__eglewDestroySurface)
+#define eglGetConfigAttrib EGLEW_GET_FUN(__eglewGetConfigAttrib)
+#define eglGetConfigs EGLEW_GET_FUN(__eglewGetConfigs)
+#define eglGetCurrentDisplay EGLEW_GET_FUN(__eglewGetCurrentDisplay)
+#define eglGetCurrentSurface EGLEW_GET_FUN(__eglewGetCurrentSurface)
+#define eglGetDisplay EGLEW_GET_FUN(__eglewGetDisplay)
+#define eglGetError EGLEW_GET_FUN(__eglewGetError)
+#define eglInitialize EGLEW_GET_FUN(__eglewInitialize)
+#define eglMakeCurrent EGLEW_GET_FUN(__eglewMakeCurrent)
+#define eglQueryContext EGLEW_GET_FUN(__eglewQueryContext)
+#define eglQueryString EGLEW_GET_FUN(__eglewQueryString)
+#define eglQuerySurface EGLEW_GET_FUN(__eglewQuerySurface)
+#define eglSwapBuffers EGLEW_GET_FUN(__eglewSwapBuffers)
+#define eglTerminate EGLEW_GET_FUN(__eglewTerminate)
+#define eglWaitGL EGLEW_GET_FUN(__eglewWaitGL)
+#define eglWaitNative EGLEW_GET_FUN(__eglewWaitNative)
+
+#define EGLEW_VERSION_1_0 EGLEW_GET_VAR(__EGLEW_VERSION_1_0)
+
+#endif /* EGL_VERSION_1_0 */
+
+/* ---------------------------- EGL_VERSION_1_1 ---------------------------- */
+
+#ifndef EGL_VERSION_1_1
+#define EGL_VERSION_1_1 1
+
+#define EGL_CONTEXT_LOST 0x300E
+#define EGL_BIND_TO_TEXTURE_RGB 0x3039
+#define EGL_BIND_TO_TEXTURE_RGBA 0x303A
+#define EGL_MIN_SWAP_INTERVAL 0x303B
+#define EGL_MAX_SWAP_INTERVAL 0x303C
+#define EGL_NO_TEXTURE 0x305C
+#define EGL_TEXTURE_RGB 0x305D
+#define EGL_TEXTURE_RGBA 0x305E
+#define EGL_TEXTURE_2D 0x305F
+#define EGL_TEXTURE_FORMAT 0x3080
+#define EGL_TEXTURE_TARGET 0x3081
+#define EGL_MIPMAP_TEXTURE 0x3082
+#define EGL_MIPMAP_LEVEL 0x3083
+#define EGL_BACK_BUFFER 0x3084
+
+typedef EGLBoolean  ( * PFNEGLBINDTEXIMAGEPROC) (EGLDisplay  dpy, EGLSurface  surface, EGLint  buffer);
+typedef EGLBoolean  ( * PFNEGLRELEASETEXIMAGEPROC) (EGLDisplay  dpy, EGLSurface  surface, EGLint  buffer);
+typedef EGLBoolean  ( * PFNEGLSURFACEATTRIBPROC) (EGLDisplay  dpy, EGLSurface  surface, EGLint  attribute, EGLint  value);
+typedef EGLBoolean  ( * PFNEGLSWAPINTERVALPROC) (EGLDisplay  dpy, EGLint  interval);
+
+#define eglBindTexImage EGLEW_GET_FUN(__eglewBindTexImage)
+#define eglReleaseTexImage EGLEW_GET_FUN(__eglewReleaseTexImage)
+#define eglSurfaceAttrib EGLEW_GET_FUN(__eglewSurfaceAttrib)
+#define eglSwapInterval EGLEW_GET_FUN(__eglewSwapInterval)
+
+#define EGLEW_VERSION_1_1 EGLEW_GET_VAR(__EGLEW_VERSION_1_1)
+
+#endif /* EGL_VERSION_1_1 */
+
+/* ---------------------------- EGL_VERSION_1_2 ---------------------------- */
+
+#ifndef EGL_VERSION_1_2
+#define EGL_VERSION_1_2 1
+
+#define EGL_OPENGL_ES_BIT 0x0001
+#define EGL_OPENVG_BIT 0x0002
+#define EGL_LUMINANCE_SIZE 0x303D
+#define EGL_ALPHA_MASK_SIZE 0x303E
+#define EGL_COLOR_BUFFER_TYPE 0x303F
+#define EGL_RENDERABLE_TYPE 0x3040
+#define EGL_SINGLE_BUFFER 0x3085
+#define EGL_RENDER_BUFFER 0x3086
+#define EGL_COLORSPACE 0x3087
+#define EGL_ALPHA_FORMAT 0x3088
+#define EGL_COLORSPACE_LINEAR 0x308A
+#define EGL_ALPHA_FORMAT_NONPRE 0x308B
+#define EGL_ALPHA_FORMAT_PRE 0x308C
+#define EGL_CLIENT_APIS 0x308D
+#define EGL_RGB_BUFFER 0x308E
+#define EGL_LUMINANCE_BUFFER 0x308F
+#define EGL_HORIZONTAL_RESOLUTION 0x3090
+#define EGL_VERTICAL_RESOLUTION 0x3091
+#define EGL_PIXEL_ASPECT_RATIO 0x3092
+#define EGL_SWAP_BEHAVIOR 0x3093
+#define EGL_BUFFER_PRESERVED 0x3094
+#define EGL_BUFFER_DESTROYED 0x3095
+#define EGL_OPENVG_IMAGE 0x3096
+#define EGL_CONTEXT_CLIENT_TYPE 0x3097
+#define EGL_OPENGL_ES_API 0x30A0
+#define EGL_OPENVG_API 0x30A1
+#define EGL_DISPLAY_SCALING 10000
+
+typedef EGLBoolean  ( * PFNEGLBINDAPIPROC) (EGLenum  api);
+typedef EGLSurface  ( * PFNEGLCREATEPBUFFERFROMCLIENTBUFFERPROC) (EGLDisplay  dpy, EGLenum  buftype, EGLClientBuffer  buffer, EGLConfig  config, const EGLint * attrib_list);
+typedef EGLenum  ( * PFNEGLQUERYAPIPROC) ( void );
+typedef EGLBoolean  ( * PFNEGLRELEASETHREADPROC) ( void );
+typedef EGLBoolean  ( * PFNEGLWAITCLIENTPROC) ( void );
+
+#define eglBindAPI EGLEW_GET_FUN(__eglewBindAPI)
+#define eglCreatePbufferFromClientBuffer EGLEW_GET_FUN(__eglewCreatePbufferFromClientBuffer)
+#define eglQueryAPI EGLEW_GET_FUN(__eglewQueryAPI)
+#define eglReleaseThread EGLEW_GET_FUN(__eglewReleaseThread)
+#define eglWaitClient EGLEW_GET_FUN(__eglewWaitClient)
+
+#define EGLEW_VERSION_1_2 EGLEW_GET_VAR(__EGLEW_VERSION_1_2)
+
+#endif /* EGL_VERSION_1_2 */
+
+/* ---------------------------- EGL_VERSION_1_3 ---------------------------- */
+
+#ifndef EGL_VERSION_1_3
+#define EGL_VERSION_1_3 1
+
+#define EGL_OPENGL_ES2_BIT 0x0004
+#define EGL_VG_COLORSPACE_LINEAR_BIT 0x0020
+#define EGL_VG_ALPHA_FORMAT_PRE_BIT 0x0040
+#define EGL_MATCH_NATIVE_PIXMAP 0x3041
+#define EGL_CONFORMANT 0x3042
+#define EGL_VG_COLORSPACE 0x3087
+#define EGL_VG_ALPHA_FORMAT 0x3088
+#define EGL_VG_COLORSPACE_LINEAR 0x308A
+#define EGL_VG_ALPHA_FORMAT_NONPRE 0x308B
+#define EGL_VG_ALPHA_FORMAT_PRE 0x308C
+#define EGL_CONTEXT_CLIENT_VERSION 0x3098
+
+#define EGLEW_VERSION_1_3 EGLEW_GET_VAR(__EGLEW_VERSION_1_3)
+
+#endif /* EGL_VERSION_1_3 */
+
+/* ---------------------------- EGL_VERSION_1_4 ---------------------------- */
+
+#ifndef EGL_VERSION_1_4
+#define EGL_VERSION_1_4 1
+
+#define EGL_OPENGL_BIT 0x0008
+#define EGL_MULTISAMPLE_RESOLVE_BOX_BIT 0x0200
+#define EGL_SWAP_BEHAVIOR_PRESERVED_BIT 0x0400
+#define EGL_MULTISAMPLE_RESOLVE 0x3099
+#define EGL_MULTISAMPLE_RESOLVE_DEFAULT 0x309A
+#define EGL_MULTISAMPLE_RESOLVE_BOX 0x309B
+#define EGL_OPENGL_API 0x30A2
+
+typedef EGLContext  ( * PFNEGLGETCURRENTCONTEXTPROC) ( void );
+
+#define eglGetCurrentContext EGLEW_GET_FUN(__eglewGetCurrentContext)
+
+#define EGLEW_VERSION_1_4 EGLEW_GET_VAR(__EGLEW_VERSION_1_4)
+
+#endif /* EGL_VERSION_1_4 */
+
+/* ---------------------------- EGL_VERSION_1_5 ---------------------------- */
+
+#ifndef EGL_VERSION_1_5
+#define EGL_VERSION_1_5 1
+
+#define EGL_CONTEXT_OPENGL_CORE_PROFILE_BIT 0x00000001
+#define EGL_SYNC_FLUSH_COMMANDS_BIT 0x0001
+#define EGL_CONTEXT_OPENGL_COMPATIBILITY_PROFILE_BIT 0x00000002
+#define EGL_OPENGL_ES3_BIT 0x00000040
+#define EGL_GL_COLORSPACE_SRGB 0x3089
+#define EGL_GL_COLORSPACE_LINEAR 0x308A
+#define EGL_CONTEXT_MAJOR_VERSION 0x3098
+#define EGL_CL_EVENT_HANDLE 0x309C
+#define EGL_GL_COLORSPACE 0x309D
+#define EGL_GL_TEXTURE_2D 0x30B1
+#define EGL_GL_TEXTURE_3D 0x30B2
+#define EGL_GL_TEXTURE_CUBE_MAP_POSITIVE_X 0x30B3
+#define EGL_GL_TEXTURE_CUBE_MAP_NEGATIVE_X 0x30B4
+#define EGL_GL_TEXTURE_CUBE_MAP_POSITIVE_Y 0x30B5
+#define EGL_GL_TEXTURE_CUBE_MAP_NEGATIVE_Y 0x30B6
+#define EGL_GL_TEXTURE_CUBE_MAP_POSITIVE_Z 0x30B7
+#define EGL_GL_TEXTURE_CUBE_MAP_NEGATIVE_Z 0x30B8
+#define EGL_GL_RENDERBUFFER 0x30B9
+#define EGL_GL_TEXTURE_LEVEL 0x30BC
+#define EGL_GL_TEXTURE_ZOFFSET 0x30BD
+#define EGL_IMAGE_PRESERVED 0x30D2
+#define EGL_SYNC_PRIOR_COMMANDS_COMPLETE 0x30F0
+#define EGL_SYNC_STATUS 0x30F1
+#define EGL_SIGNALED 0x30F2
+#define EGL_UNSIGNALED 0x30F3
+#define EGL_TIMEOUT_EXPIRED 0x30F5
+#define EGL_CONDITION_SATISFIED 0x30F6
+#define EGL_SYNC_TYPE 0x30F7
+#define EGL_SYNC_CONDITION 0x30F8
+#define EGL_SYNC_FENCE 0x30F9
+#define EGL_CONTEXT_MINOR_VERSION 0x30FB
+#define EGL_CONTEXT_OPENGL_PROFILE_MASK 0x30FD
+#define EGL_SYNC_CL_EVENT 0x30FE
+#define EGL_SYNC_CL_EVENT_COMPLETE 0x30FF
+#define EGL_CONTEXT_OPENGL_DEBUG 0x31B0
+#define EGL_CONTEXT_OPENGL_FORWARD_COMPATIBLE 0x31B1
+#define EGL_CONTEXT_OPENGL_ROBUST_ACCESS 0x31B2
+#define EGL_CONTEXT_OPENGL_RESET_NOTIFICATION_STRATEGY 0x31BD
+#define EGL_NO_RESET_NOTIFICATION 0x31BE
+#define EGL_LOSE_CONTEXT_ON_RESET 0x31BF
+#define EGL_FOREVER 0xFFFFFFFFFFFFFFFF
+
+typedef EGLint  ( * PFNEGLCLIENTWAITSYNCPROC) (EGLDisplay  dpy, EGLSync  sync, EGLint  flags, EGLTime  timeout);
+typedef EGLImage  ( * PFNEGLCREATEIMAGEPROC) (EGLDisplay  dpy, EGLContext  ctx, EGLenum  target, EGLClientBuffer  buffer, const EGLAttrib * attrib_list);
+typedef EGLSurface  ( * PFNEGLCREATEPLATFORMPIXMAPSURFACEPROC) (EGLDisplay  dpy, EGLConfig  config, void * native_pixmap, const EGLAttrib * attrib_list);
+typedef EGLSurface  ( * PFNEGLCREATEPLATFORMWINDOWSURFACEPROC) (EGLDisplay  dpy, EGLConfig  config, void * native_window, const EGLAttrib * attrib_list);
+typedef EGLSync  ( * PFNEGLCREATESYNCPROC) (EGLDisplay  dpy, EGLenum  type, const EGLAttrib * attrib_list);
+typedef EGLBoolean  ( * PFNEGLDESTROYIMAGEPROC) (EGLDisplay  dpy, EGLImage  image);
+typedef EGLBoolean  ( * PFNEGLDESTROYSYNCPROC) (EGLDisplay  dpy, EGLSync  sync);
+typedef EGLDisplay  ( * PFNEGLGETPLATFORMDISPLAYPROC) (EGLenum  platform, void * native_display, const EGLAttrib * attrib_list);
+typedef EGLBoolean  ( * PFNEGLGETSYNCATTRIBPROC) (EGLDisplay  dpy, EGLSync  sync, EGLint  attribute, EGLAttrib * value);
+typedef EGLBoolean  ( * PFNEGLWAITSYNCPROC) (EGLDisplay  dpy, EGLSync  sync, EGLint  flags);
+
+#define eglClientWaitSync EGLEW_GET_FUN(__eglewClientWaitSync)
+#define eglCreateImage EGLEW_GET_FUN(__eglewCreateImage)
+#define eglCreatePlatformPixmapSurface EGLEW_GET_FUN(__eglewCreatePlatformPixmapSurface)
+#define eglCreatePlatformWindowSurface EGLEW_GET_FUN(__eglewCreatePlatformWindowSurface)
+#define eglCreateSync EGLEW_GET_FUN(__eglewCreateSync)
+#define eglDestroyImage EGLEW_GET_FUN(__eglewDestroyImage)
+#define eglDestroySync EGLEW_GET_FUN(__eglewDestroySync)
+#define eglGetPlatformDisplay EGLEW_GET_FUN(__eglewGetPlatformDisplay)
+#define eglGetSyncAttrib EGLEW_GET_FUN(__eglewGetSyncAttrib)
+#define eglWaitSync EGLEW_GET_FUN(__eglewWaitSync)
+
+#define EGLEW_VERSION_1_5 EGLEW_GET_VAR(__EGLEW_VERSION_1_5)
+
+#endif /* EGL_VERSION_1_5 */
+
+/* ------------------------- EGL_ANDROID_blob_cache ------------------------ */
+
+#ifndef EGL_ANDROID_blob_cache
+#define EGL_ANDROID_blob_cache 1
+
+typedef void  ( * PFNEGLSETBLOBCACHEFUNCSANDROIDPROC) (EGLDisplay  dpy, EGLSetBlobFuncANDROID  set, EGLGetBlobFuncANDROID  get);
+
+#define eglSetBlobCacheFuncsANDROID EGLEW_GET_FUN(__eglewSetBlobCacheFuncsANDROID)
+
+#define EGLEW_ANDROID_blob_cache EGLEW_GET_VAR(__EGLEW_ANDROID_blob_cache)
+
+#endif /* EGL_ANDROID_blob_cache */
+
+/* ---------------- EGL_ANDROID_create_native_client_buffer ---------------- */
+
+#ifndef EGL_ANDROID_create_native_client_buffer
+#define EGL_ANDROID_create_native_client_buffer 1
+
+#define EGL_NATIVE_BUFFER_USAGE_PROTECTED_BIT_ANDROID 0x00000001
+#define EGL_NATIVE_BUFFER_USAGE_RENDERBUFFER_BIT_ANDROID 0x00000002
+#define EGL_NATIVE_BUFFER_USAGE_TEXTURE_BIT_ANDROID 0x00000004
+#define EGL_NATIVE_BUFFER_USAGE_ANDROID 0x3143
+
+typedef EGLClientBuffer  ( * PFNEGLCREATENATIVECLIENTBUFFERANDROIDPROC) (const EGLint * attrib_list);
+
+#define eglCreateNativeClientBufferANDROID EGLEW_GET_FUN(__eglewCreateNativeClientBufferANDROID)
+
+#define EGLEW_ANDROID_create_native_client_buffer EGLEW_GET_VAR(__EGLEW_ANDROID_create_native_client_buffer)
+
+#endif /* EGL_ANDROID_create_native_client_buffer */
+
+/* --------------------- EGL_ANDROID_framebuffer_target -------------------- */
+
+#ifndef EGL_ANDROID_framebuffer_target
+#define EGL_ANDROID_framebuffer_target 1
+
+#define EGL_FRAMEBUFFER_TARGET_ANDROID 0x3147
+
+#define EGLEW_ANDROID_framebuffer_target EGLEW_GET_VAR(__EGLEW_ANDROID_framebuffer_target)
+
+#endif /* EGL_ANDROID_framebuffer_target */
+
+/* ----------------- EGL_ANDROID_front_buffer_auto_refresh ----------------- */
+
+#ifndef EGL_ANDROID_front_buffer_auto_refresh
+#define EGL_ANDROID_front_buffer_auto_refresh 1
+
+#define EGL_FRONT_BUFFER_AUTO_REFRESH_ANDROID 0x314C
+
+#define EGLEW_ANDROID_front_buffer_auto_refresh EGLEW_GET_VAR(__EGLEW_ANDROID_front_buffer_auto_refresh)
+
+#endif /* EGL_ANDROID_front_buffer_auto_refresh */
+
+/* -------------------- EGL_ANDROID_image_native_buffer -------------------- */
+
+#ifndef EGL_ANDROID_image_native_buffer
+#define EGL_ANDROID_image_native_buffer 1
+
+#define EGL_NATIVE_BUFFER_ANDROID 0x3140
+
+#define EGLEW_ANDROID_image_native_buffer EGLEW_GET_VAR(__EGLEW_ANDROID_image_native_buffer)
+
+#endif /* EGL_ANDROID_image_native_buffer */
+
+/* --------------------- EGL_ANDROID_native_fence_sync --------------------- */
+
+#ifndef EGL_ANDROID_native_fence_sync
+#define EGL_ANDROID_native_fence_sync 1
+
+#define EGL_SYNC_NATIVE_FENCE_ANDROID 0x3144
+#define EGL_SYNC_NATIVE_FENCE_FD_ANDROID 0x3145
+#define EGL_SYNC_NATIVE_FENCE_SIGNALED_ANDROID 0x3146
+
+typedef EGLint  ( * PFNEGLDUPNATIVEFENCEFDANDROIDPROC) (EGLDisplay  dpy, EGLSyncKHR  sync);
+
+#define eglDupNativeFenceFDANDROID EGLEW_GET_FUN(__eglewDupNativeFenceFDANDROID)
+
+#define EGLEW_ANDROID_native_fence_sync EGLEW_GET_VAR(__EGLEW_ANDROID_native_fence_sync)
+
+#endif /* EGL_ANDROID_native_fence_sync */
+
+/* --------------------- EGL_ANDROID_presentation_time --------------------- */
+
+#ifndef EGL_ANDROID_presentation_time
+#define EGL_ANDROID_presentation_time 1
+
+typedef EGLBoolean  ( * PFNEGLPRESENTATIONTIMEANDROIDPROC) (EGLDisplay  dpy, EGLSurface  surface, EGLnsecsANDROID  time);
+
+#define eglPresentationTimeANDROID EGLEW_GET_FUN(__eglewPresentationTimeANDROID)
+
+#define EGLEW_ANDROID_presentation_time EGLEW_GET_VAR(__EGLEW_ANDROID_presentation_time)
+
+#endif /* EGL_ANDROID_presentation_time */
+
+/* ------------------------- EGL_ANDROID_recordable ------------------------ */
+
+#ifndef EGL_ANDROID_recordable
+#define EGL_ANDROID_recordable 1
+
+#define EGL_RECORDABLE_ANDROID 0x3142
+
+#define EGLEW_ANDROID_recordable EGLEW_GET_VAR(__EGLEW_ANDROID_recordable)
+
+#endif /* EGL_ANDROID_recordable */
+
+/* ---------------- EGL_ANGLE_d3d_share_handle_client_buffer --------------- */
+
+#ifndef EGL_ANGLE_d3d_share_handle_client_buffer
+#define EGL_ANGLE_d3d_share_handle_client_buffer 1
+
+#define EGL_D3D_TEXTURE_2D_SHARE_HANDLE_ANGLE 0x3200
+
+#define EGLEW_ANGLE_d3d_share_handle_client_buffer EGLEW_GET_VAR(__EGLEW_ANGLE_d3d_share_handle_client_buffer)
+
+#endif /* EGL_ANGLE_d3d_share_handle_client_buffer */
+
+/* -------------------------- EGL_ANGLE_device_d3d ------------------------- */
+
+#ifndef EGL_ANGLE_device_d3d
+#define EGL_ANGLE_device_d3d 1
+
+#define EGL_D3D9_DEVICE_ANGLE 0x33A0
+#define EGL_D3D11_DEVICE_ANGLE 0x33A1
+
+#define EGLEW_ANGLE_device_d3d EGLEW_GET_VAR(__EGLEW_ANGLE_device_d3d)
+
+#endif /* EGL_ANGLE_device_d3d */
+
+/* -------------------- EGL_ANGLE_query_surface_pointer -------------------- */
+
+#ifndef EGL_ANGLE_query_surface_pointer
+#define EGL_ANGLE_query_surface_pointer 1
+
+typedef EGLBoolean  ( * PFNEGLQUERYSURFACEPOINTERANGLEPROC) (EGLDisplay  dpy, EGLSurface  surface, EGLint  attribute, void ** value);
+
+#define eglQuerySurfacePointerANGLE EGLEW_GET_FUN(__eglewQuerySurfacePointerANGLE)
+
+#define EGLEW_ANGLE_query_surface_pointer EGLEW_GET_VAR(__EGLEW_ANGLE_query_surface_pointer)
+
+#endif /* EGL_ANGLE_query_surface_pointer */
+
+/* ------------- EGL_ANGLE_surface_d3d_texture_2d_share_handle ------------- */
+
+#ifndef EGL_ANGLE_surface_d3d_texture_2d_share_handle
+#define EGL_ANGLE_surface_d3d_texture_2d_share_handle 1
+
+#define EGL_D3D_TEXTURE_2D_SHARE_HANDLE_ANGLE 0x3200
+
+#define EGLEW_ANGLE_surface_d3d_texture_2d_share_handle EGLEW_GET_VAR(__EGLEW_ANGLE_surface_d3d_texture_2d_share_handle)
+
+#endif /* EGL_ANGLE_surface_d3d_texture_2d_share_handle */
+
+/* ---------------------- EGL_ANGLE_window_fixed_size ---------------------- */
+
+#ifndef EGL_ANGLE_window_fixed_size
+#define EGL_ANGLE_window_fixed_size 1
+
+#define EGL_FIXED_SIZE_ANGLE 0x3201
+
+#define EGLEW_ANGLE_window_fixed_size EGLEW_GET_VAR(__EGLEW_ANGLE_window_fixed_size)
+
+#endif /* EGL_ANGLE_window_fixed_size */
+
+/* --------------------- EGL_ARM_implicit_external_sync -------------------- */
+
+#ifndef EGL_ARM_implicit_external_sync
+#define EGL_ARM_implicit_external_sync 1
+
+#define EGL_SYNC_PRIOR_COMMANDS_IMPLICIT_EXTERNAL_ARM 0x328A
+
+#define EGLEW_ARM_implicit_external_sync EGLEW_GET_VAR(__EGLEW_ARM_implicit_external_sync)
+
+#endif /* EGL_ARM_implicit_external_sync */
+
+/* ------------------- EGL_ARM_pixmap_multisample_discard ------------------ */
+
+#ifndef EGL_ARM_pixmap_multisample_discard
+#define EGL_ARM_pixmap_multisample_discard 1
+
+#define EGL_DISCARD_SAMPLES_ARM 0x3286
+
+#define EGLEW_ARM_pixmap_multisample_discard EGLEW_GET_VAR(__EGLEW_ARM_pixmap_multisample_discard)
+
+#endif /* EGL_ARM_pixmap_multisample_discard */
+
+/* --------------------------- EGL_EXT_buffer_age -------------------------- */
+
+#ifndef EGL_EXT_buffer_age
+#define EGL_EXT_buffer_age 1
+
+#define EGL_BUFFER_AGE_EXT 0x313D
+
+#define EGLEW_EXT_buffer_age EGLEW_GET_VAR(__EGLEW_EXT_buffer_age)
+
+#endif /* EGL_EXT_buffer_age */
+
+/* ----------------------- EGL_EXT_client_extensions ----------------------- */
+
+#ifndef EGL_EXT_client_extensions
+#define EGL_EXT_client_extensions 1
+
+#define EGLEW_EXT_client_extensions EGLEW_GET_VAR(__EGLEW_EXT_client_extensions)
+
+#endif /* EGL_EXT_client_extensions */
+
+/* ------------------- EGL_EXT_create_context_robustness ------------------- */
+
+#ifndef EGL_EXT_create_context_robustness
+#define EGL_EXT_create_context_robustness 1
+
+#define EGL_CONTEXT_OPENGL_ROBUST_ACCESS_EXT 0x30BF
+#define EGL_CONTEXT_OPENGL_RESET_NOTIFICATION_STRATEGY_EXT 0x3138
+#define EGL_NO_RESET_NOTIFICATION_EXT 0x31BE
+#define EGL_LOSE_CONTEXT_ON_RESET_EXT 0x31BF
+
+#define EGLEW_EXT_create_context_robustness EGLEW_GET_VAR(__EGLEW_EXT_create_context_robustness)
+
+#endif /* EGL_EXT_create_context_robustness */
+
+/* -------------------------- EGL_EXT_device_base -------------------------- */
+
+#ifndef EGL_EXT_device_base
+#define EGL_EXT_device_base 1
+
+#define EGL_BAD_DEVICE_EXT 0x322B
+#define EGL_DEVICE_EXT 0x322C
+
+#define EGLEW_EXT_device_base EGLEW_GET_VAR(__EGLEW_EXT_device_base)
+
+#endif /* EGL_EXT_device_base */
+
+/* --------------------------- EGL_EXT_device_drm -------------------------- */
+
+#ifndef EGL_EXT_device_drm
+#define EGL_EXT_device_drm 1
+
+#define EGL_DRM_DEVICE_FILE_EXT 0x3233
+
+#define EGLEW_EXT_device_drm EGLEW_GET_VAR(__EGLEW_EXT_device_drm)
+
+#endif /* EGL_EXT_device_drm */
+
+/* ----------------------- EGL_EXT_device_enumeration ---------------------- */
+
+#ifndef EGL_EXT_device_enumeration
+#define EGL_EXT_device_enumeration 1
+
+typedef EGLBoolean  ( * PFNEGLQUERYDEVICESEXTPROC) (EGLint  max_devices, EGLDeviceEXT * devices, EGLint * num_devices);
+
+#define eglQueryDevicesEXT EGLEW_GET_FUN(__eglewQueryDevicesEXT)
+
+#define EGLEW_EXT_device_enumeration EGLEW_GET_VAR(__EGLEW_EXT_device_enumeration)
+
+#endif /* EGL_EXT_device_enumeration */
+
+/* ------------------------- EGL_EXT_device_openwf ------------------------- */
+
+#ifndef EGL_EXT_device_openwf
+#define EGL_EXT_device_openwf 1
+
+#define EGL_OPENWF_DEVICE_ID_EXT 0x3237
+
+#define EGLEW_EXT_device_openwf EGLEW_GET_VAR(__EGLEW_EXT_device_openwf)
+
+#endif /* EGL_EXT_device_openwf */
+
+/* -------------------------- EGL_EXT_device_query ------------------------- */
+
+#ifndef EGL_EXT_device_query
+#define EGL_EXT_device_query 1
+
+#define EGL_BAD_DEVICE_EXT 0x322B
+#define EGL_DEVICE_EXT 0x322C
+
+typedef EGLBoolean  ( * PFNEGLQUERYDEVICEATTRIBEXTPROC) (EGLDeviceEXT  device, EGLint  attribute, EGLAttrib * value);
+typedef const char * ( * PFNEGLQUERYDEVICESTRINGEXTPROC) (EGLDeviceEXT  device, EGLint  name);
+typedef EGLBoolean  ( * PFNEGLQUERYDISPLAYATTRIBEXTPROC) (EGLDisplay  dpy, EGLint  attribute, EGLAttrib * value);
+
+#define eglQueryDeviceAttribEXT EGLEW_GET_FUN(__eglewQueryDeviceAttribEXT)
+#define eglQueryDeviceStringEXT EGLEW_GET_FUN(__eglewQueryDeviceStringEXT)
+#define eglQueryDisplayAttribEXT EGLEW_GET_FUN(__eglewQueryDisplayAttribEXT)
+
+#define EGLEW_EXT_device_query EGLEW_GET_VAR(__EGLEW_EXT_device_query)
+
+#endif /* EGL_EXT_device_query */
+
+/* ------------------ EGL_EXT_gl_colorspace_bt2020_linear ------------------ */
+
+#ifndef EGL_EXT_gl_colorspace_bt2020_linear
+#define EGL_EXT_gl_colorspace_bt2020_linear 1
+
+#define EGL_GL_COLORSPACE_BT2020_LINEAR_EXT 0x333F
+
+#define EGLEW_EXT_gl_colorspace_bt2020_linear EGLEW_GET_VAR(__EGLEW_EXT_gl_colorspace_bt2020_linear)
+
+#endif /* EGL_EXT_gl_colorspace_bt2020_linear */
+
+/* -------------------- EGL_EXT_gl_colorspace_bt2020_pq -------------------- */
+
+#ifndef EGL_EXT_gl_colorspace_bt2020_pq
+#define EGL_EXT_gl_colorspace_bt2020_pq 1
+
+#define EGL_GL_COLORSPACE_BT2020_PQ_EXT 0x3340
+
+#define EGLEW_EXT_gl_colorspace_bt2020_pq EGLEW_GET_VAR(__EGLEW_EXT_gl_colorspace_bt2020_pq)
+
+#endif /* EGL_EXT_gl_colorspace_bt2020_pq */
+
+/* ------------------- EGL_EXT_gl_colorspace_scrgb_linear ------------------ */
+
+#ifndef EGL_EXT_gl_colorspace_scrgb_linear
+#define EGL_EXT_gl_colorspace_scrgb_linear 1
+
+#define EGL_GL_COLORSPACE_SCRGB_LINEAR_EXT 0x3350
+
+#define EGLEW_EXT_gl_colorspace_scrgb_linear EGLEW_GET_VAR(__EGLEW_EXT_gl_colorspace_scrgb_linear)
+
+#endif /* EGL_EXT_gl_colorspace_scrgb_linear */
+
+/* ---------------------- EGL_EXT_image_dma_buf_import --------------------- */
+
+#ifndef EGL_EXT_image_dma_buf_import
+#define EGL_EXT_image_dma_buf_import 1
+
+#define EGL_LINUX_DMA_BUF_EXT 0x3270
+#define EGL_LINUX_DRM_FOURCC_EXT 0x3271
+#define EGL_DMA_BUF_PLANE0_FD_EXT 0x3272
+#define EGL_DMA_BUF_PLANE0_OFFSET_EXT 0x3273
+#define EGL_DMA_BUF_PLANE0_PITCH_EXT 0x3274
+#define EGL_DMA_BUF_PLANE1_FD_EXT 0x3275
+#define EGL_DMA_BUF_PLANE1_OFFSET_EXT 0x3276
+#define EGL_DMA_BUF_PLANE1_PITCH_EXT 0x3277
+#define EGL_DMA_BUF_PLANE2_FD_EXT 0x3278
+#define EGL_DMA_BUF_PLANE2_OFFSET_EXT 0x3279
+#define EGL_DMA_BUF_PLANE2_PITCH_EXT 0x327A
+#define EGL_YUV_COLOR_SPACE_HINT_EXT 0x327B
+#define EGL_SAMPLE_RANGE_HINT_EXT 0x327C
+#define EGL_YUV_CHROMA_HORIZONTAL_SITING_HINT_EXT 0x327D
+#define EGL_YUV_CHROMA_VERTICAL_SITING_HINT_EXT 0x327E
+#define EGL_ITU_REC601_EXT 0x327F
+#define EGL_ITU_REC709_EXT 0x3280
+#define EGL_ITU_REC2020_EXT 0x3281
+#define EGL_YUV_FULL_RANGE_EXT 0x3282
+#define EGL_YUV_NARROW_RANGE_EXT 0x3283
+#define EGL_YUV_CHROMA_SITING_0_EXT 0x3284
+#define EGL_YUV_CHROMA_SITING_0_5_EXT 0x3285
+
+#define EGLEW_EXT_image_dma_buf_import EGLEW_GET_VAR(__EGLEW_EXT_image_dma_buf_import)
+
+#endif /* EGL_EXT_image_dma_buf_import */
+
+/* ----------------- EGL_EXT_image_dma_buf_import_modifiers ---------------- */
+
+#ifndef EGL_EXT_image_dma_buf_import_modifiers
+#define EGL_EXT_image_dma_buf_import_modifiers 1
+
+#define EGL_DMA_BUF_PLANE3_FD_EXT 0x3440
+#define EGL_DMA_BUF_PLANE3_OFFSET_EXT 0x3441
+#define EGL_DMA_BUF_PLANE3_PITCH_EXT 0x3442
+#define EGL_DMA_BUF_PLANE0_MODIFIER_LO_EXT 0x3443
+#define EGL_DMA_BUF_PLANE0_MODIFIER_HI_EXT 0x3444
+#define EGL_DMA_BUF_PLANE1_MODIFIER_LO_EXT 0x3445
+#define EGL_DMA_BUF_PLANE1_MODIFIER_HI_EXT 0x3446
+#define EGL_DMA_BUF_PLANE2_MODIFIER_LO_EXT 0x3447
+#define EGL_DMA_BUF_PLANE2_MODIFIER_HI_EXT 0x3448
+#define EGL_DMA_BUF_PLANE3_MODIFIER_LO_EXT 0x3449
+#define EGL_DMA_BUF_PLANE3_MODIFIER_HI_EXT 0x344A
+
+typedef EGLBoolean  ( * PFNEGLQUERYDMABUFFORMATSEXTPROC) (EGLDisplay  dpy, EGLint  max_formats, EGLint  *formats, EGLint  *num_formats);
+typedef EGLBoolean  ( * PFNEGLQUERYDMABUFMODIFIERSEXTPROC) (EGLDisplay  dpy, EGLint  format, EGLint  max_modifiers, EGLuint64KHR  *modifiers, EGLBoolean  *external_only, EGLint  *num_modifiers);
+
+#define eglQueryDmaBufFormatsEXT EGLEW_GET_FUN(__eglewQueryDmaBufFormatsEXT)
+#define eglQueryDmaBufModifiersEXT EGLEW_GET_FUN(__eglewQueryDmaBufModifiersEXT)
+
+#define EGLEW_EXT_image_dma_buf_import_modifiers EGLEW_GET_VAR(__EGLEW_EXT_image_dma_buf_import_modifiers)
+
+#endif /* EGL_EXT_image_dma_buf_import_modifiers */
+
+/* ------------------------ EGL_EXT_multiview_window ----------------------- */
+
+#ifndef EGL_EXT_multiview_window
+#define EGL_EXT_multiview_window 1
+
+#define EGL_MULTIVIEW_VIEW_COUNT_EXT 0x3134
+
+#define EGLEW_EXT_multiview_window EGLEW_GET_VAR(__EGLEW_EXT_multiview_window)
+
+#endif /* EGL_EXT_multiview_window */
+
+/* -------------------------- EGL_EXT_output_base -------------------------- */
+
+#ifndef EGL_EXT_output_base
+#define EGL_EXT_output_base 1
+
+#define EGL_BAD_OUTPUT_LAYER_EXT 0x322D
+#define EGL_BAD_OUTPUT_PORT_EXT 0x322E
+#define EGL_SWAP_INTERVAL_EXT 0x322F
+
+typedef EGLBoolean  ( * PFNEGLGETOUTPUTLAYERSEXTPROC) (EGLDisplay  dpy, const EGLAttrib * attrib_list, EGLOutputLayerEXT * layers, EGLint  max_layers, EGLint * num_layers);
+typedef EGLBoolean  ( * PFNEGLGETOUTPUTPORTSEXTPROC) (EGLDisplay  dpy, const EGLAttrib * attrib_list, EGLOutputPortEXT * ports, EGLint  max_ports, EGLint * num_ports);
+typedef EGLBoolean  ( * PFNEGLOUTPUTLAYERATTRIBEXTPROC) (EGLDisplay  dpy, EGLOutputLayerEXT  layer, EGLint  attribute, EGLAttrib  value);
+typedef EGLBoolean  ( * PFNEGLOUTPUTPORTATTRIBEXTPROC) (EGLDisplay  dpy, EGLOutputPortEXT  port, EGLint  attribute, EGLAttrib  value);
+typedef EGLBoolean  ( * PFNEGLQUERYOUTPUTLAYERATTRIBEXTPROC) (EGLDisplay  dpy, EGLOutputLayerEXT  layer, EGLint  attribute, EGLAttrib * value);
+typedef const char * ( * PFNEGLQUERYOUTPUTLAYERSTRINGEXTPROC) (EGLDisplay  dpy, EGLOutputLayerEXT  layer, EGLint  name);
+typedef EGLBoolean  ( * PFNEGLQUERYOUTPUTPORTATTRIBEXTPROC) (EGLDisplay  dpy, EGLOutputPortEXT  port, EGLint  attribute, EGLAttrib * value);
+typedef const char * ( * PFNEGLQUERYOUTPUTPORTSTRINGEXTPROC) (EGLDisplay  dpy, EGLOutputPortEXT  port, EGLint  name);
+
+#define eglGetOutputLayersEXT EGLEW_GET_FUN(__eglewGetOutputLayersEXT)
+#define eglGetOutputPortsEXT EGLEW_GET_FUN(__eglewGetOutputPortsEXT)
+#define eglOutputLayerAttribEXT EGLEW_GET_FUN(__eglewOutputLayerAttribEXT)
+#define eglOutputPortAttribEXT EGLEW_GET_FUN(__eglewOutputPortAttribEXT)
+#define eglQueryOutputLayerAttribEXT EGLEW_GET_FUN(__eglewQueryOutputLayerAttribEXT)
+#define eglQueryOutputLayerStringEXT EGLEW_GET_FUN(__eglewQueryOutputLayerStringEXT)
+#define eglQueryOutputPortAttribEXT EGLEW_GET_FUN(__eglewQueryOutputPortAttribEXT)
+#define eglQueryOutputPortStringEXT EGLEW_GET_FUN(__eglewQueryOutputPortStringEXT)
+
+#define EGLEW_EXT_output_base EGLEW_GET_VAR(__EGLEW_EXT_output_base)
+
+#endif /* EGL_EXT_output_base */
+
+/* --------------------------- EGL_EXT_output_drm -------------------------- */
+
+#ifndef EGL_EXT_output_drm
+#define EGL_EXT_output_drm 1
+
+#define EGL_DRM_CRTC_EXT 0x3234
+#define EGL_DRM_PLANE_EXT 0x3235
+#define EGL_DRM_CONNECTOR_EXT 0x3236
+
+#define EGLEW_EXT_output_drm EGLEW_GET_VAR(__EGLEW_EXT_output_drm)
+
+#endif /* EGL_EXT_output_drm */
+
+/* ------------------------- EGL_EXT_output_openwf ------------------------- */
+
+#ifndef EGL_EXT_output_openwf
+#define EGL_EXT_output_openwf 1
+
+#define EGL_OPENWF_PIPELINE_ID_EXT 0x3238
+#define EGL_OPENWF_PORT_ID_EXT 0x3239
+
+#define EGLEW_EXT_output_openwf EGLEW_GET_VAR(__EGLEW_EXT_output_openwf)
+
+#endif /* EGL_EXT_output_openwf */
+
+/* ----------------------- EGL_EXT_pixel_format_float ---------------------- */
+
+#ifndef EGL_EXT_pixel_format_float
+#define EGL_EXT_pixel_format_float 1
+
+#define EGL_COLOR_COMPONENT_TYPE_EXT 0x3339
+#define EGL_COLOR_COMPONENT_TYPE_FIXED_EXT 0x333A
+#define EGL_COLOR_COMPONENT_TYPE_FLOAT_EXT 0x333B
+
+#define EGLEW_EXT_pixel_format_float EGLEW_GET_VAR(__EGLEW_EXT_pixel_format_float)
+
+#endif /* EGL_EXT_pixel_format_float */
+
+/* ------------------------- EGL_EXT_platform_base ------------------------- */
+
+#ifndef EGL_EXT_platform_base
+#define EGL_EXT_platform_base 1
+
+typedef EGLSurface  ( * PFNEGLCREATEPLATFORMPIXMAPSURFACEEXTPROC) (EGLDisplay  dpy, EGLConfig  config, void * native_pixmap, const EGLint * attrib_list);
+typedef EGLSurface  ( * PFNEGLCREATEPLATFORMWINDOWSURFACEEXTPROC) (EGLDisplay  dpy, EGLConfig  config, void * native_window, const EGLint * attrib_list);
+typedef EGLDisplay  ( * PFNEGLGETPLATFORMDISPLAYEXTPROC) (EGLenum  platform, void * native_display, const EGLint * attrib_list);
+
+#define eglCreatePlatformPixmapSurfaceEXT EGLEW_GET_FUN(__eglewCreatePlatformPixmapSurfaceEXT)
+#define eglCreatePlatformWindowSurfaceEXT EGLEW_GET_FUN(__eglewCreatePlatformWindowSurfaceEXT)
+#define eglGetPlatformDisplayEXT EGLEW_GET_FUN(__eglewGetPlatformDisplayEXT)
+
+#define EGLEW_EXT_platform_base EGLEW_GET_VAR(__EGLEW_EXT_platform_base)
+
+#endif /* EGL_EXT_platform_base */
+
+/* ------------------------ EGL_EXT_platform_device ------------------------ */
+
+#ifndef EGL_EXT_platform_device
+#define EGL_EXT_platform_device 1
+
+#define EGL_PLATFORM_DEVICE_EXT 0x313F
+
+#define EGLEW_EXT_platform_device EGLEW_GET_VAR(__EGLEW_EXT_platform_device)
+
+#endif /* EGL_EXT_platform_device */
+
+/* ------------------------ EGL_EXT_platform_wayland ----------------------- */
+
+#ifndef EGL_EXT_platform_wayland
+#define EGL_EXT_platform_wayland 1
+
+#define EGL_PLATFORM_WAYLAND_EXT 0x31D8
+
+#define EGLEW_EXT_platform_wayland EGLEW_GET_VAR(__EGLEW_EXT_platform_wayland)
+
+#endif /* EGL_EXT_platform_wayland */
+
+/* -------------------------- EGL_EXT_platform_x11 ------------------------- */
+
+#ifndef EGL_EXT_platform_x11
+#define EGL_EXT_platform_x11 1
+
+#define EGL_PLATFORM_X11_EXT 0x31D5
+#define EGL_PLATFORM_X11_SCREEN_EXT 0x31D6
+
+#define EGLEW_EXT_platform_x11 EGLEW_GET_VAR(__EGLEW_EXT_platform_x11)
+
+#endif /* EGL_EXT_platform_x11 */
+
+/* ----------------------- EGL_EXT_protected_content ----------------------- */
+
+#ifndef EGL_EXT_protected_content
+#define EGL_EXT_protected_content 1
+
+#define EGL_PROTECTED_CONTENT_EXT 0x32C0
+
+#define EGLEW_EXT_protected_content EGLEW_GET_VAR(__EGLEW_EXT_protected_content)
+
+#endif /* EGL_EXT_protected_content */
+
+/* ----------------------- EGL_EXT_protected_surface ----------------------- */
+
+#ifndef EGL_EXT_protected_surface
+#define EGL_EXT_protected_surface 1
+
+#define EGL_PROTECTED_CONTENT_EXT 0x32C0
+
+#define EGLEW_EXT_protected_surface EGLEW_GET_VAR(__EGLEW_EXT_protected_surface)
+
+#endif /* EGL_EXT_protected_surface */
+
+/* ------------------- EGL_EXT_stream_consumer_egloutput ------------------- */
+
+#ifndef EGL_EXT_stream_consumer_egloutput
+#define EGL_EXT_stream_consumer_egloutput 1
+
+typedef EGLBoolean  ( * PFNEGLSTREAMCONSUMEROUTPUTEXTPROC) (EGLDisplay  dpy, EGLStreamKHR  stream, EGLOutputLayerEXT  layer);
+
+#define eglStreamConsumerOutputEXT EGLEW_GET_FUN(__eglewStreamConsumerOutputEXT)
+
+#define EGLEW_EXT_stream_consumer_egloutput EGLEW_GET_VAR(__EGLEW_EXT_stream_consumer_egloutput)
+
+#endif /* EGL_EXT_stream_consumer_egloutput */
+
+/* ------------------- EGL_EXT_surface_SMPTE2086_metadata ------------------ */
+
+#ifndef EGL_EXT_surface_SMPTE2086_metadata
+#define EGL_EXT_surface_SMPTE2086_metadata 1
+
+#define EGL_SMPTE2086_DISPLAY_PRIMARY_RX_EXT 0x3341
+#define EGL_SMPTE2086_DISPLAY_PRIMARY_RY_EXT 0x3342
+#define EGL_SMPTE2086_DISPLAY_PRIMARY_GX_EXT 0x3343
+#define EGL_SMPTE2086_DISPLAY_PRIMARY_GY_EXT 0x3344
+#define EGL_SMPTE2086_DISPLAY_PRIMARY_BX_EXT 0x3345
+#define EGL_SMPTE2086_DISPLAY_PRIMARY_BY_EXT 0x3346
+#define EGL_SMPTE2086_WHITE_POINT_X_EXT 0x3347
+#define EGL_SMPTE2086_WHITE_POINT_Y_EXT 0x3348
+#define EGL_SMPTE2086_MAX_LUMINANCE_EXT 0x3349
+#define EGL_SMPTE2086_MIN_LUMINANCE_EXT 0x334A
+
+#define EGLEW_EXT_surface_SMPTE2086_metadata EGLEW_GET_VAR(__EGLEW_EXT_surface_SMPTE2086_metadata)
+
+#endif /* EGL_EXT_surface_SMPTE2086_metadata */
+
+/* -------------------- EGL_EXT_swap_buffers_with_damage ------------------- */
+
+#ifndef EGL_EXT_swap_buffers_with_damage
+#define EGL_EXT_swap_buffers_with_damage 1
+
+typedef EGLBoolean  ( * PFNEGLSWAPBUFFERSWITHDAMAGEEXTPROC) (EGLDisplay  dpy, EGLSurface  surface, EGLint * rects, EGLint  n_rects);
+
+#define eglSwapBuffersWithDamageEXT EGLEW_GET_FUN(__eglewSwapBuffersWithDamageEXT)
+
+#define EGLEW_EXT_swap_buffers_with_damage EGLEW_GET_VAR(__EGLEW_EXT_swap_buffers_with_damage)
+
+#endif /* EGL_EXT_swap_buffers_with_damage */
+
+/* -------------------------- EGL_EXT_yuv_surface -------------------------- */
+
+#ifndef EGL_EXT_yuv_surface
+#define EGL_EXT_yuv_surface 1
+
+#define EGL_YUV_BUFFER_EXT 0x3300
+#define EGL_YUV_ORDER_EXT 0x3301
+#define EGL_YUV_ORDER_YUV_EXT 0x3302
+#define EGL_YUV_ORDER_YVU_EXT 0x3303
+#define EGL_YUV_ORDER_YUYV_EXT 0x3304
+#define EGL_YUV_ORDER_UYVY_EXT 0x3305
+#define EGL_YUV_ORDER_YVYU_EXT 0x3306
+#define EGL_YUV_ORDER_VYUY_EXT 0x3307
+#define EGL_YUV_ORDER_AYUV_EXT 0x3308
+#define EGL_YUV_CSC_STANDARD_EXT 0x330A
+#define EGL_YUV_CSC_STANDARD_601_EXT 0x330B
+#define EGL_YUV_CSC_STANDARD_709_EXT 0x330C
+#define EGL_YUV_CSC_STANDARD_2020_EXT 0x330D
+#define EGL_YUV_NUMBER_OF_PLANES_EXT 0x3311
+#define EGL_YUV_SUBSAMPLE_EXT 0x3312
+#define EGL_YUV_SUBSAMPLE_4_2_0_EXT 0x3313
+#define EGL_YUV_SUBSAMPLE_4_2_2_EXT 0x3314
+#define EGL_YUV_SUBSAMPLE_4_4_4_EXT 0x3315
+#define EGL_YUV_DEPTH_RANGE_EXT 0x3317
+#define EGL_YUV_DEPTH_RANGE_LIMITED_EXT 0x3318
+#define EGL_YUV_DEPTH_RANGE_FULL_EXT 0x3319
+#define EGL_YUV_PLANE_BPP_EXT 0x331A
+#define EGL_YUV_PLANE_BPP_0_EXT 0x331B
+#define EGL_YUV_PLANE_BPP_8_EXT 0x331C
+#define EGL_YUV_PLANE_BPP_10_EXT 0x331D
+
+#define EGLEW_EXT_yuv_surface EGLEW_GET_VAR(__EGLEW_EXT_yuv_surface)
+
+#endif /* EGL_EXT_yuv_surface */
+
+/* -------------------------- EGL_HI_clientpixmap -------------------------- */
+
+#ifndef EGL_HI_clientpixmap
+#define EGL_HI_clientpixmap 1
+
+#define EGL_CLIENT_PIXMAP_POINTER_HI 0x8F74
+
+typedef EGLSurface  ( * PFNEGLCREATEPIXMAPSURFACEHIPROC) (EGLDisplay  dpy, EGLConfig  config, struct EGLClientPixmapHI * pixmap);
+
+#define eglCreatePixmapSurfaceHI EGLEW_GET_FUN(__eglewCreatePixmapSurfaceHI)
+
+#define EGLEW_HI_clientpixmap EGLEW_GET_VAR(__EGLEW_HI_clientpixmap)
+
+#endif /* EGL_HI_clientpixmap */
+
+/* -------------------------- EGL_HI_colorformats -------------------------- */
+
+#ifndef EGL_HI_colorformats
+#define EGL_HI_colorformats 1
+
+#define EGL_COLOR_FORMAT_HI 0x8F70
+#define EGL_COLOR_RGB_HI 0x8F71
+#define EGL_COLOR_RGBA_HI 0x8F72
+#define EGL_COLOR_ARGB_HI 0x8F73
+
+#define EGLEW_HI_colorformats EGLEW_GET_VAR(__EGLEW_HI_colorformats)
+
+#endif /* EGL_HI_colorformats */
+
+/* ------------------------ EGL_IMG_context_priority ----------------------- */
+
+#ifndef EGL_IMG_context_priority
+#define EGL_IMG_context_priority 1
+
+#define EGL_CONTEXT_PRIORITY_LEVEL_IMG 0x3100
+#define EGL_CONTEXT_PRIORITY_HIGH_IMG 0x3101
+#define EGL_CONTEXT_PRIORITY_MEDIUM_IMG 0x3102
+#define EGL_CONTEXT_PRIORITY_LOW_IMG 0x3103
+
+#define EGLEW_IMG_context_priority EGLEW_GET_VAR(__EGLEW_IMG_context_priority)
+
+#endif /* EGL_IMG_context_priority */
+
+/* ---------------------- EGL_IMG_image_plane_attribs ---------------------- */
+
+#ifndef EGL_IMG_image_plane_attribs
+#define EGL_IMG_image_plane_attribs 1
+
+#define EGL_NATIVE_BUFFER_MULTIPLANE_SEPARATE_IMG 0x3105
+#define EGL_NATIVE_BUFFER_PLANE_OFFSET_IMG 0x3106
+
+#define EGLEW_IMG_image_plane_attribs EGLEW_GET_VAR(__EGLEW_IMG_image_plane_attribs)
+
+#endif /* EGL_IMG_image_plane_attribs */
+
+/* ---------------------------- EGL_KHR_cl_event --------------------------- */
+
+#ifndef EGL_KHR_cl_event
+#define EGL_KHR_cl_event 1
+
+#define EGL_CL_EVENT_HANDLE_KHR 0x309C
+#define EGL_SYNC_CL_EVENT_KHR 0x30FE
+#define EGL_SYNC_CL_EVENT_COMPLETE_KHR 0x30FF
+
+#define EGLEW_KHR_cl_event EGLEW_GET_VAR(__EGLEW_KHR_cl_event)
+
+#endif /* EGL_KHR_cl_event */
+
+/* --------------------------- EGL_KHR_cl_event2 --------------------------- */
+
+#ifndef EGL_KHR_cl_event2
+#define EGL_KHR_cl_event2 1
+
+#define EGL_CL_EVENT_HANDLE_KHR 0x309C
+#define EGL_SYNC_CL_EVENT_KHR 0x30FE
+#define EGL_SYNC_CL_EVENT_COMPLETE_KHR 0x30FF
+
+typedef EGLSyncKHR  ( * PFNEGLCREATESYNC64KHRPROC) (EGLDisplay  dpy, EGLenum  type, const EGLAttribKHR * attrib_list);
+
+#define eglCreateSync64KHR EGLEW_GET_FUN(__eglewCreateSync64KHR)
+
+#define EGLEW_KHR_cl_event2 EGLEW_GET_VAR(__EGLEW_KHR_cl_event2)
+
+#endif /* EGL_KHR_cl_event2 */
+
+/* ----------------- EGL_KHR_client_get_all_proc_addresses ----------------- */
+
+#ifndef EGL_KHR_client_get_all_proc_addresses
+#define EGL_KHR_client_get_all_proc_addresses 1
+
+#define EGLEW_KHR_client_get_all_proc_addresses EGLEW_GET_VAR(__EGLEW_KHR_client_get_all_proc_addresses)
+
+#endif /* EGL_KHR_client_get_all_proc_addresses */
+
+/* ------------------------- EGL_KHR_config_attribs ------------------------ */
+
+#ifndef EGL_KHR_config_attribs
+#define EGL_KHR_config_attribs 1
+
+#define EGL_VG_COLORSPACE_LINEAR_BIT_KHR 0x0020
+#define EGL_VG_ALPHA_FORMAT_PRE_BIT_KHR 0x0040
+#define EGL_CONFORMANT_KHR 0x3042
+
+#define EGLEW_KHR_config_attribs EGLEW_GET_VAR(__EGLEW_KHR_config_attribs)
+
+#endif /* EGL_KHR_config_attribs */
+
+/* --------------------- EGL_KHR_context_flush_control --------------------- */
+
+#ifndef EGL_KHR_context_flush_control
+#define EGL_KHR_context_flush_control 1
+
+#define EGL_CONTEXT_RELEASE_BEHAVIOR_NONE_KHR 0
+#define EGL_CONTEXT_RELEASE_BEHAVIOR_KHR 0x2097
+#define EGL_CONTEXT_RELEASE_BEHAVIOR_FLUSH_KHR 0x2098
+
+#define EGLEW_KHR_context_flush_control EGLEW_GET_VAR(__EGLEW_KHR_context_flush_control)
+
+#endif /* EGL_KHR_context_flush_control */
+
+/* ------------------------- EGL_KHR_create_context ------------------------ */
+
+#ifndef EGL_KHR_create_context
+#define EGL_KHR_create_context 1
+
+#define EGL_CONTEXT_OPENGL_CORE_PROFILE_BIT_KHR 0x00000001
+#define EGL_CONTEXT_OPENGL_DEBUG_BIT_KHR 0x00000001
+#define EGL_CONTEXT_OPENGL_COMPATIBILITY_PROFILE_BIT_KHR 0x00000002
+#define EGL_CONTEXT_OPENGL_FORWARD_COMPATIBLE_BIT_KHR 0x00000002
+#define EGL_CONTEXT_OPENGL_ROBUST_ACCESS_BIT_KHR 0x00000004
+#define EGL_OPENGL_ES3_BIT 0x00000040
+#define EGL_OPENGL_ES3_BIT_KHR 0x00000040
+#define EGL_CONTEXT_MAJOR_VERSION_KHR 0x3098
+#define EGL_CONTEXT_MINOR_VERSION_KHR 0x30FB
+#define EGL_CONTEXT_FLAGS_KHR 0x30FC
+#define EGL_CONTEXT_OPENGL_PROFILE_MASK_KHR 0x30FD
+#define EGL_CONTEXT_OPENGL_RESET_NOTIFICATION_STRATEGY_KHR 0x31BD
+#define EGL_NO_RESET_NOTIFICATION_KHR 0x31BE
+#define EGL_LOSE_CONTEXT_ON_RESET_KHR 0x31BF
+
+#define EGLEW_KHR_create_context EGLEW_GET_VAR(__EGLEW_KHR_create_context)
+
+#endif /* EGL_KHR_create_context */
+
+/* -------------------- EGL_KHR_create_context_no_error -------------------- */
+
+#ifndef EGL_KHR_create_context_no_error
+#define EGL_KHR_create_context_no_error 1
+
+#define EGL_CONTEXT_OPENGL_NO_ERROR_KHR 0x31B3
+
+#define EGLEW_KHR_create_context_no_error EGLEW_GET_VAR(__EGLEW_KHR_create_context_no_error)
+
+#endif /* EGL_KHR_create_context_no_error */
+
+/* ----------------------------- EGL_KHR_debug ----------------------------- */
+
+#ifndef EGL_KHR_debug
+#define EGL_KHR_debug 1
+
+#define EGL_OBJECT_THREAD_KHR 0x33B0
+#define EGL_OBJECT_DISPLAY_KHR 0x33B1
+#define EGL_OBJECT_CONTEXT_KHR 0x33B2
+#define EGL_OBJECT_SURFACE_KHR 0x33B3
+#define EGL_OBJECT_IMAGE_KHR 0x33B4
+#define EGL_OBJECT_SYNC_KHR 0x33B5
+#define EGL_OBJECT_STREAM_KHR 0x33B6
+#define EGL_DEBUG_CALLBACK_KHR 0x33B8
+#define EGL_DEBUG_MSG_CRITICAL_KHR 0x33B9
+#define EGL_DEBUG_MSG_ERROR_KHR 0x33BA
+#define EGL_DEBUG_MSG_WARN_KHR 0x33BB
+#define EGL_DEBUG_MSG_INFO_KHR 0x33BC
+
+typedef EGLint  ( * PFNEGLDEBUGMESSAGECONTROLKHRPROC) (EGLDEBUGPROCKHR  callback, const EGLAttrib * attrib_list);
+typedef EGLint  ( * PFNEGLLABELOBJECTKHRPROC) (EGLDisplay  display, EGLenum  objectType, EGLObjectKHR  object, EGLLabelKHR  label);
+typedef EGLBoolean  ( * PFNEGLQUERYDEBUGKHRPROC) (EGLint  attribute, EGLAttrib * value);
+
+#define eglDebugMessageControlKHR EGLEW_GET_FUN(__eglewDebugMessageControlKHR)
+#define eglLabelObjectKHR EGLEW_GET_FUN(__eglewLabelObjectKHR)
+#define eglQueryDebugKHR EGLEW_GET_FUN(__eglewQueryDebugKHR)
+
+#define EGLEW_KHR_debug EGLEW_GET_VAR(__EGLEW_KHR_debug)
+
+#endif /* EGL_KHR_debug */
+
+/* --------------------------- EGL_KHR_fence_sync -------------------------- */
+
+#ifndef EGL_KHR_fence_sync
+#define EGL_KHR_fence_sync 1
+
+#define EGL_SYNC_PRIOR_COMMANDS_COMPLETE_KHR 0x30F0
+#define EGL_SYNC_CONDITION_KHR 0x30F8
+#define EGL_SYNC_FENCE_KHR 0x30F9
+
+#define EGLEW_KHR_fence_sync EGLEW_GET_VAR(__EGLEW_KHR_fence_sync)
+
+#endif /* EGL_KHR_fence_sync */
+
+/* --------------------- EGL_KHR_get_all_proc_addresses -------------------- */
+
+#ifndef EGL_KHR_get_all_proc_addresses
+#define EGL_KHR_get_all_proc_addresses 1
+
+#define EGLEW_KHR_get_all_proc_addresses EGLEW_GET_VAR(__EGLEW_KHR_get_all_proc_addresses)
+
+#endif /* EGL_KHR_get_all_proc_addresses */
+
+/* ------------------------- EGL_KHR_gl_colorspace ------------------------- */
+
+#ifndef EGL_KHR_gl_colorspace
+#define EGL_KHR_gl_colorspace 1
+
+#define EGL_GL_COLORSPACE_SRGB_KHR 0x3089
+#define EGL_GL_COLORSPACE_LINEAR_KHR 0x308A
+#define EGL_GL_COLORSPACE_KHR 0x309D
+
+#define EGLEW_KHR_gl_colorspace EGLEW_GET_VAR(__EGLEW_KHR_gl_colorspace)
+
+#endif /* EGL_KHR_gl_colorspace */
+
+/* --------------------- EGL_KHR_gl_renderbuffer_image --------------------- */
+
+#ifndef EGL_KHR_gl_renderbuffer_image
+#define EGL_KHR_gl_renderbuffer_image 1
+
+#define EGL_GL_RENDERBUFFER_KHR 0x30B9
+
+#define EGLEW_KHR_gl_renderbuffer_image EGLEW_GET_VAR(__EGLEW_KHR_gl_renderbuffer_image)
+
+#endif /* EGL_KHR_gl_renderbuffer_image */
+
+/* ---------------------- EGL_KHR_gl_texture_2D_image ---------------------- */
+
+#ifndef EGL_KHR_gl_texture_2D_image
+#define EGL_KHR_gl_texture_2D_image 1
+
+#define EGL_GL_TEXTURE_2D_KHR 0x30B1
+#define EGL_GL_TEXTURE_LEVEL_KHR 0x30BC
+
+#define EGLEW_KHR_gl_texture_2D_image EGLEW_GET_VAR(__EGLEW_KHR_gl_texture_2D_image)
+
+#endif /* EGL_KHR_gl_texture_2D_image */
+
+/* ---------------------- EGL_KHR_gl_texture_3D_image ---------------------- */
+
+#ifndef EGL_KHR_gl_texture_3D_image
+#define EGL_KHR_gl_texture_3D_image 1
+
+#define EGL_GL_TEXTURE_3D_KHR 0x30B2
+#define EGL_GL_TEXTURE_ZOFFSET_KHR 0x30BD
+
+#define EGLEW_KHR_gl_texture_3D_image EGLEW_GET_VAR(__EGLEW_KHR_gl_texture_3D_image)
+
+#endif /* EGL_KHR_gl_texture_3D_image */
+
+/* -------------------- EGL_KHR_gl_texture_cubemap_image ------------------- */
+
+#ifndef EGL_KHR_gl_texture_cubemap_image
+#define EGL_KHR_gl_texture_cubemap_image 1
+
+#define EGL_GL_TEXTURE_CUBE_MAP_POSITIVE_X_KHR 0x30B3
+#define EGL_GL_TEXTURE_CUBE_MAP_NEGATIVE_X_KHR 0x30B4
+#define EGL_GL_TEXTURE_CUBE_MAP_POSITIVE_Y_KHR 0x30B5
+#define EGL_GL_TEXTURE_CUBE_MAP_NEGATIVE_Y_KHR 0x30B6
+#define EGL_GL_TEXTURE_CUBE_MAP_POSITIVE_Z_KHR 0x30B7
+#define EGL_GL_TEXTURE_CUBE_MAP_NEGATIVE_Z_KHR 0x30B8
+
+#define EGLEW_KHR_gl_texture_cubemap_image EGLEW_GET_VAR(__EGLEW_KHR_gl_texture_cubemap_image)
+
+#endif /* EGL_KHR_gl_texture_cubemap_image */
+
+/* ----------------------------- EGL_KHR_image ----------------------------- */
+
+#ifndef EGL_KHR_image
+#define EGL_KHR_image 1
+
+#define EGL_NATIVE_PIXMAP_KHR 0x30B0
+
+typedef EGLImageKHR  ( * PFNEGLCREATEIMAGEKHRPROC) (EGLDisplay  dpy, EGLContext  ctx, EGLenum  target, EGLClientBuffer  buffer, const EGLint * attrib_list);
+typedef EGLBoolean  ( * PFNEGLDESTROYIMAGEKHRPROC) (EGLDisplay  dpy, EGLImageKHR  image);
+
+#define eglCreateImageKHR EGLEW_GET_FUN(__eglewCreateImageKHR)
+#define eglDestroyImageKHR EGLEW_GET_FUN(__eglewDestroyImageKHR)
+
+#define EGLEW_KHR_image EGLEW_GET_VAR(__EGLEW_KHR_image)
+
+#endif /* EGL_KHR_image */
+
+/* --------------------------- EGL_KHR_image_base -------------------------- */
+
+#ifndef EGL_KHR_image_base
+#define EGL_KHR_image_base 1
+
+#define EGL_IMAGE_PRESERVED_KHR 0x30D2
+
+#define EGLEW_KHR_image_base EGLEW_GET_VAR(__EGLEW_KHR_image_base)
+
+#endif /* EGL_KHR_image_base */
+
+/* -------------------------- EGL_KHR_image_pixmap ------------------------- */
+
+#ifndef EGL_KHR_image_pixmap
+#define EGL_KHR_image_pixmap 1
+
+#define EGL_NATIVE_PIXMAP_KHR 0x30B0
+
+#define EGLEW_KHR_image_pixmap EGLEW_GET_VAR(__EGLEW_KHR_image_pixmap)
+
+#endif /* EGL_KHR_image_pixmap */
+
+/* -------------------------- EGL_KHR_lock_surface ------------------------- */
+
+#ifndef EGL_KHR_lock_surface
+#define EGL_KHR_lock_surface 1
+
+#define EGL_READ_SURFACE_BIT_KHR 0x0001
+#define EGL_WRITE_SURFACE_BIT_KHR 0x0002
+#define EGL_LOCK_SURFACE_BIT_KHR 0x0080
+#define EGL_OPTIMAL_FORMAT_BIT_KHR 0x0100
+#define EGL_MATCH_FORMAT_KHR 0x3043
+#define EGL_FORMAT_RGB_565_EXACT_KHR 0x30C0
+#define EGL_FORMAT_RGB_565_KHR 0x30C1
+#define EGL_FORMAT_RGBA_8888_EXACT_KHR 0x30C2
+#define EGL_FORMAT_RGBA_8888_KHR 0x30C3
+#define EGL_MAP_PRESERVE_PIXELS_KHR 0x30C4
+#define EGL_LOCK_USAGE_HINT_KHR 0x30C5
+#define EGL_BITMAP_POINTER_KHR 0x30C6
+#define EGL_BITMAP_PITCH_KHR 0x30C7
+#define EGL_BITMAP_ORIGIN_KHR 0x30C8
+#define EGL_BITMAP_PIXEL_RED_OFFSET_KHR 0x30C9
+#define EGL_BITMAP_PIXEL_GREEN_OFFSET_KHR 0x30CA
+#define EGL_BITMAP_PIXEL_BLUE_OFFSET_KHR 0x30CB
+#define EGL_BITMAP_PIXEL_ALPHA_OFFSET_KHR 0x30CC
+#define EGL_BITMAP_PIXEL_LUMINANCE_OFFSET_KHR 0x30CD
+#define EGL_LOWER_LEFT_KHR 0x30CE
+#define EGL_UPPER_LEFT_KHR 0x30CF
+
+typedef EGLBoolean  ( * PFNEGLLOCKSURFACEKHRPROC) (EGLDisplay  dpy, EGLSurface  surface, const EGLint * attrib_list);
+typedef EGLBoolean  ( * PFNEGLUNLOCKSURFACEKHRPROC) (EGLDisplay  dpy, EGLSurface  surface);
+
+#define eglLockSurfaceKHR EGLEW_GET_FUN(__eglewLockSurfaceKHR)
+#define eglUnlockSurfaceKHR EGLEW_GET_FUN(__eglewUnlockSurfaceKHR)
+
+#define EGLEW_KHR_lock_surface EGLEW_GET_VAR(__EGLEW_KHR_lock_surface)
+
+#endif /* EGL_KHR_lock_surface */
+
+/* ------------------------- EGL_KHR_lock_surface2 ------------------------- */
+
+#ifndef EGL_KHR_lock_surface2
+#define EGL_KHR_lock_surface2 1
+
+#define EGL_BITMAP_PIXEL_SIZE_KHR 0x3110
+
+#define EGLEW_KHR_lock_surface2 EGLEW_GET_VAR(__EGLEW_KHR_lock_surface2)
+
+#endif /* EGL_KHR_lock_surface2 */
+
+/* ------------------------- EGL_KHR_lock_surface3 ------------------------- */
+
+#ifndef EGL_KHR_lock_surface3
+#define EGL_KHR_lock_surface3 1
+
+#define EGL_READ_SURFACE_BIT_KHR 0x0001
+#define EGL_WRITE_SURFACE_BIT_KHR 0x0002
+#define EGL_LOCK_SURFACE_BIT_KHR 0x0080
+#define EGL_OPTIMAL_FORMAT_BIT_KHR 0x0100
+#define EGL_MATCH_FORMAT_KHR 0x3043
+#define EGL_FORMAT_RGB_565_EXACT_KHR 0x30C0
+#define EGL_FORMAT_RGB_565_KHR 0x30C1
+#define EGL_FORMAT_RGBA_8888_EXACT_KHR 0x30C2
+#define EGL_FORMAT_RGBA_8888_KHR 0x30C3
+#define EGL_MAP_PRESERVE_PIXELS_KHR 0x30C4
+#define EGL_LOCK_USAGE_HINT_KHR 0x30C5
+#define EGL_BITMAP_POINTER_KHR 0x30C6
+#define EGL_BITMAP_PITCH_KHR 0x30C7
+#define EGL_BITMAP_ORIGIN_KHR 0x30C8
+#define EGL_BITMAP_PIXEL_RED_OFFSET_KHR 0x30C9
+#define EGL_BITMAP_PIXEL_GREEN_OFFSET_KHR 0x30CA
+#define EGL_BITMAP_PIXEL_BLUE_OFFSET_KHR 0x30CB
+#define EGL_BITMAP_PIXEL_ALPHA_OFFSET_KHR 0x30CC
+#define EGL_BITMAP_PIXEL_LUMINANCE_OFFSET_KHR 0x30CD
+#define EGL_LOWER_LEFT_KHR 0x30CE
+#define EGL_UPPER_LEFT_KHR 0x30CF
+#define EGL_BITMAP_PIXEL_SIZE_KHR 0x3110
+
+typedef EGLBoolean  ( * PFNEGLQUERYSURFACE64KHRPROC) (EGLDisplay  dpy, EGLSurface  surface, EGLint  attribute, EGLAttribKHR * value);
+
+#define eglQuerySurface64KHR EGLEW_GET_FUN(__eglewQuerySurface64KHR)
+
+#define EGLEW_KHR_lock_surface3 EGLEW_GET_VAR(__EGLEW_KHR_lock_surface3)
+
+#endif /* EGL_KHR_lock_surface3 */
+
+/* --------------------- EGL_KHR_mutable_render_buffer --------------------- */
+
+#ifndef EGL_KHR_mutable_render_buffer
+#define EGL_KHR_mutable_render_buffer 1
+
+#define EGL_MUTABLE_RENDER_BUFFER_BIT_KHR 0x1000
+
+#define EGLEW_KHR_mutable_render_buffer EGLEW_GET_VAR(__EGLEW_KHR_mutable_render_buffer)
+
+#endif /* EGL_KHR_mutable_render_buffer */
+
+/* ----------------------- EGL_KHR_no_config_context ----------------------- */
+
+#ifndef EGL_KHR_no_config_context
+#define EGL_KHR_no_config_context 1
+
+#define EGLEW_KHR_no_config_context EGLEW_GET_VAR(__EGLEW_KHR_no_config_context)
+
+#endif /* EGL_KHR_no_config_context */
+
+/* ------------------------- EGL_KHR_partial_update ------------------------ */
+
+#ifndef EGL_KHR_partial_update
+#define EGL_KHR_partial_update 1
+
+#define EGL_BUFFER_AGE_KHR 0x313D
+
+typedef EGLBoolean  ( * PFNEGLSETDAMAGEREGIONKHRPROC) (EGLDisplay  dpy, EGLSurface  surface, EGLint * rects, EGLint  n_rects);
+
+#define eglSetDamageRegionKHR EGLEW_GET_FUN(__eglewSetDamageRegionKHR)
+
+#define EGLEW_KHR_partial_update EGLEW_GET_VAR(__EGLEW_KHR_partial_update)
+
+#endif /* EGL_KHR_partial_update */
+
+/* ------------------------ EGL_KHR_platform_android ----------------------- */
+
+#ifndef EGL_KHR_platform_android
+#define EGL_KHR_platform_android 1
+
+#define EGL_PLATFORM_ANDROID_KHR 0x3141
+
+#define EGLEW_KHR_platform_android EGLEW_GET_VAR(__EGLEW_KHR_platform_android)
+
+#endif /* EGL_KHR_platform_android */
+
+/* -------------------------- EGL_KHR_platform_gbm ------------------------- */
+
+#ifndef EGL_KHR_platform_gbm
+#define EGL_KHR_platform_gbm 1
+
+#define EGL_PLATFORM_GBM_KHR 0x31D7
+
+#define EGLEW_KHR_platform_gbm EGLEW_GET_VAR(__EGLEW_KHR_platform_gbm)
+
+#endif /* EGL_KHR_platform_gbm */
+
+/* ------------------------ EGL_KHR_platform_wayland ----------------------- */
+
+#ifndef EGL_KHR_platform_wayland
+#define EGL_KHR_platform_wayland 1
+
+#define EGL_PLATFORM_WAYLAND_KHR 0x31D8
+
+#define EGLEW_KHR_platform_wayland EGLEW_GET_VAR(__EGLEW_KHR_platform_wayland)
+
+#endif /* EGL_KHR_platform_wayland */
+
+/* -------------------------- EGL_KHR_platform_x11 ------------------------- */
+
+#ifndef EGL_KHR_platform_x11
+#define EGL_KHR_platform_x11 1
+
+#define EGL_PLATFORM_X11_KHR 0x31D5
+#define EGL_PLATFORM_X11_SCREEN_KHR 0x31D6
+
+#define EGLEW_KHR_platform_x11 EGLEW_GET_VAR(__EGLEW_KHR_platform_x11)
+
+#endif /* EGL_KHR_platform_x11 */
+
+/* ------------------------- EGL_KHR_reusable_sync ------------------------- */
+
+#ifndef EGL_KHR_reusable_sync
+#define EGL_KHR_reusable_sync 1
+
+#define EGL_SYNC_FLUSH_COMMANDS_BIT_KHR 0x0001
+#define EGL_SYNC_STATUS_KHR 0x30F1
+#define EGL_SIGNALED_KHR 0x30F2
+#define EGL_UNSIGNALED_KHR 0x30F3
+#define EGL_TIMEOUT_EXPIRED_KHR 0x30F5
+#define EGL_CONDITION_SATISFIED_KHR 0x30F6
+#define EGL_SYNC_TYPE_KHR 0x30F7
+#define EGL_SYNC_REUSABLE_KHR 0x30FA
+#define EGL_FOREVER_KHR 0xFFFFFFFFFFFFFFFF
+
+typedef EGLint  ( * PFNEGLCLIENTWAITSYNCKHRPROC) (EGLDisplay  dpy, EGLSyncKHR  sync, EGLint  flags, EGLTimeKHR  timeout);
+typedef EGLSyncKHR  ( * PFNEGLCREATESYNCKHRPROC) (EGLDisplay  dpy, EGLenum  type, const EGLint * attrib_list);
+typedef EGLBoolean  ( * PFNEGLDESTROYSYNCKHRPROC) (EGLDisplay  dpy, EGLSyncKHR  sync);
+typedef EGLBoolean  ( * PFNEGLGETSYNCATTRIBKHRPROC) (EGLDisplay  dpy, EGLSyncKHR  sync, EGLint  attribute, EGLint * value);
+typedef EGLBoolean  ( * PFNEGLSIGNALSYNCKHRPROC) (EGLDisplay  dpy, EGLSyncKHR  sync, EGLenum  mode);
+
+#define eglClientWaitSyncKHR EGLEW_GET_FUN(__eglewClientWaitSyncKHR)
+#define eglCreateSyncKHR EGLEW_GET_FUN(__eglewCreateSyncKHR)
+#define eglDestroySyncKHR EGLEW_GET_FUN(__eglewDestroySyncKHR)
+#define eglGetSyncAttribKHR EGLEW_GET_FUN(__eglewGetSyncAttribKHR)
+#define eglSignalSyncKHR EGLEW_GET_FUN(__eglewSignalSyncKHR)
+
+#define EGLEW_KHR_reusable_sync EGLEW_GET_VAR(__EGLEW_KHR_reusable_sync)
+
+#endif /* EGL_KHR_reusable_sync */
+
+/* ----------------------------- EGL_KHR_stream ---------------------------- */
+
+#ifndef EGL_KHR_stream
+#define EGL_KHR_stream 1
+
+#define EGL_CONSUMER_LATENCY_USEC_KHR 0x3210
+#define EGL_PRODUCER_FRAME_KHR 0x3212
+#define EGL_CONSUMER_FRAME_KHR 0x3213
+#define EGL_STREAM_STATE_KHR 0x3214
+#define EGL_STREAM_STATE_CREATED_KHR 0x3215
+#define EGL_STREAM_STATE_CONNECTING_KHR 0x3216
+#define EGL_STREAM_STATE_EMPTY_KHR 0x3217
+#define EGL_STREAM_STATE_NEW_FRAME_AVAILABLE_KHR 0x3218
+#define EGL_STREAM_STATE_OLD_FRAME_AVAILABLE_KHR 0x3219
+#define EGL_STREAM_STATE_DISCONNECTED_KHR 0x321A
+#define EGL_BAD_STREAM_KHR 0x321B
+#define EGL_BAD_STATE_KHR 0x321C
+
+typedef EGLStreamKHR  ( * PFNEGLCREATESTREAMKHRPROC) (EGLDisplay  dpy, const EGLint * attrib_list);
+typedef EGLBoolean  ( * PFNEGLDESTROYSTREAMKHRPROC) (EGLDisplay  dpy, EGLStreamKHR  stream);
+typedef EGLBoolean  ( * PFNEGLQUERYSTREAMKHRPROC) (EGLDisplay  dpy, EGLStreamKHR  stream, EGLenum  attribute, EGLint * value);
+typedef EGLBoolean  ( * PFNEGLQUERYSTREAMU64KHRPROC) (EGLDisplay  dpy, EGLStreamKHR  stream, EGLenum  attribute, EGLuint64KHR * value);
+typedef EGLBoolean  ( * PFNEGLSTREAMATTRIBKHRPROC) (EGLDisplay  dpy, EGLStreamKHR  stream, EGLenum  attribute, EGLint  value);
+
+#define eglCreateStreamKHR EGLEW_GET_FUN(__eglewCreateStreamKHR)
+#define eglDestroyStreamKHR EGLEW_GET_FUN(__eglewDestroyStreamKHR)
+#define eglQueryStreamKHR EGLEW_GET_FUN(__eglewQueryStreamKHR)
+#define eglQueryStreamu64KHR EGLEW_GET_FUN(__eglewQueryStreamu64KHR)
+#define eglStreamAttribKHR EGLEW_GET_FUN(__eglewStreamAttribKHR)
+
+#define EGLEW_KHR_stream EGLEW_GET_VAR(__EGLEW_KHR_stream)
+
+#endif /* EGL_KHR_stream */
+
+/* ------------------------- EGL_KHR_stream_attrib ------------------------- */
+
+#ifndef EGL_KHR_stream_attrib
+#define EGL_KHR_stream_attrib 1
+
+#define EGL_CONSUMER_LATENCY_USEC_KHR 0x3210
+#define EGL_STREAM_STATE_KHR 0x3214
+#define EGL_STREAM_STATE_CREATED_KHR 0x3215
+#define EGL_STREAM_STATE_CONNECTING_KHR 0x3216
+
+typedef EGLStreamKHR  ( * PFNEGLCREATESTREAMATTRIBKHRPROC) (EGLDisplay  dpy, const EGLAttrib * attrib_list);
+typedef EGLBoolean  ( * PFNEGLQUERYSTREAMATTRIBKHRPROC) (EGLDisplay  dpy, EGLStreamKHR  stream, EGLenum  attribute, EGLAttrib * value);
+typedef EGLBoolean  ( * PFNEGLSETSTREAMATTRIBKHRPROC) (EGLDisplay  dpy, EGLStreamKHR  stream, EGLenum  attribute, EGLAttrib  value);
+typedef EGLBoolean  ( * PFNEGLSTREAMCONSUMERACQUIREATTRIBKHRPROC) (EGLDisplay  dpy, EGLStreamKHR  stream, const EGLAttrib * attrib_list);
+typedef EGLBoolean  ( * PFNEGLSTREAMCONSUMERRELEASEATTRIBKHRPROC) (EGLDisplay  dpy, EGLStreamKHR  stream, const EGLAttrib * attrib_list);
+
+#define eglCreateStreamAttribKHR EGLEW_GET_FUN(__eglewCreateStreamAttribKHR)
+#define eglQueryStreamAttribKHR EGLEW_GET_FUN(__eglewQueryStreamAttribKHR)
+#define eglSetStreamAttribKHR EGLEW_GET_FUN(__eglewSetStreamAttribKHR)
+#define eglStreamConsumerAcquireAttribKHR EGLEW_GET_FUN(__eglewStreamConsumerAcquireAttribKHR)
+#define eglStreamConsumerReleaseAttribKHR EGLEW_GET_FUN(__eglewStreamConsumerReleaseAttribKHR)
+
+#define EGLEW_KHR_stream_attrib EGLEW_GET_VAR(__EGLEW_KHR_stream_attrib)
+
+#endif /* EGL_KHR_stream_attrib */
+
+/* ------------------- EGL_KHR_stream_consumer_gltexture ------------------- */
+
+#ifndef EGL_KHR_stream_consumer_gltexture
+#define EGL_KHR_stream_consumer_gltexture 1
+
+#define EGL_CONSUMER_ACQUIRE_TIMEOUT_USEC_KHR 0x321E
+
+typedef EGLBoolean  ( * PFNEGLSTREAMCONSUMERACQUIREKHRPROC) (EGLDisplay  dpy, EGLStreamKHR  stream);
+typedef EGLBoolean  ( * PFNEGLSTREAMCONSUMERGLTEXTUREEXTERNALKHRPROC) (EGLDisplay  dpy, EGLStreamKHR  stream);
+typedef EGLBoolean  ( * PFNEGLSTREAMCONSUMERRELEASEKHRPROC) (EGLDisplay  dpy, EGLStreamKHR  stream);
+
+#define eglStreamConsumerAcquireKHR EGLEW_GET_FUN(__eglewStreamConsumerAcquireKHR)
+#define eglStreamConsumerGLTextureExternalKHR EGLEW_GET_FUN(__eglewStreamConsumerGLTextureExternalKHR)
+#define eglStreamConsumerReleaseKHR EGLEW_GET_FUN(__eglewStreamConsumerReleaseKHR)
+
+#define EGLEW_KHR_stream_consumer_gltexture EGLEW_GET_VAR(__EGLEW_KHR_stream_consumer_gltexture)
+
+#endif /* EGL_KHR_stream_consumer_gltexture */
+
+/* -------------------- EGL_KHR_stream_cross_process_fd -------------------- */
+
+#ifndef EGL_KHR_stream_cross_process_fd
+#define EGL_KHR_stream_cross_process_fd 1
+
+typedef EGLStreamKHR  ( * PFNEGLCREATESTREAMFROMFILEDESCRIPTORKHRPROC) (EGLDisplay  dpy, EGLNativeFileDescriptorKHR  file_descriptor);
+typedef EGLNativeFileDescriptorKHR  ( * PFNEGLGETSTREAMFILEDESCRIPTORKHRPROC) (EGLDisplay  dpy, EGLStreamKHR  stream);
+
+#define eglCreateStreamFromFileDescriptorKHR EGLEW_GET_FUN(__eglewCreateStreamFromFileDescriptorKHR)
+#define eglGetStreamFileDescriptorKHR EGLEW_GET_FUN(__eglewGetStreamFileDescriptorKHR)
+
+#define EGLEW_KHR_stream_cross_process_fd EGLEW_GET_VAR(__EGLEW_KHR_stream_cross_process_fd)
+
+#endif /* EGL_KHR_stream_cross_process_fd */
+
+/* -------------------------- EGL_KHR_stream_fifo -------------------------- */
+
+#ifndef EGL_KHR_stream_fifo
+#define EGL_KHR_stream_fifo 1
+
+#define EGL_STREAM_FIFO_LENGTH_KHR 0x31FC
+#define EGL_STREAM_TIME_NOW_KHR 0x31FD
+#define EGL_STREAM_TIME_CONSUMER_KHR 0x31FE
+#define EGL_STREAM_TIME_PRODUCER_KHR 0x31FF
+
+typedef EGLBoolean  ( * PFNEGLQUERYSTREAMTIMEKHRPROC) (EGLDisplay  dpy, EGLStreamKHR  stream, EGLenum  attribute, EGLTimeKHR * value);
+
+#define eglQueryStreamTimeKHR EGLEW_GET_FUN(__eglewQueryStreamTimeKHR)
+
+#define EGLEW_KHR_stream_fifo EGLEW_GET_VAR(__EGLEW_KHR_stream_fifo)
+
+#endif /* EGL_KHR_stream_fifo */
+
+/* ----------------- EGL_KHR_stream_producer_aldatalocator ----------------- */
+
+#ifndef EGL_KHR_stream_producer_aldatalocator
+#define EGL_KHR_stream_producer_aldatalocator 1
+
+#define EGLEW_KHR_stream_producer_aldatalocator EGLEW_GET_VAR(__EGLEW_KHR_stream_producer_aldatalocator)
+
+#endif /* EGL_KHR_stream_producer_aldatalocator */
+
+/* ------------------- EGL_KHR_stream_producer_eglsurface ------------------ */
+
+#ifndef EGL_KHR_stream_producer_eglsurface
+#define EGL_KHR_stream_producer_eglsurface 1
+
+#define EGL_STREAM_BIT_KHR 0x0800
+
+typedef EGLSurface  ( * PFNEGLCREATESTREAMPRODUCERSURFACEKHRPROC) (EGLDisplay  dpy, EGLConfig  config, EGLStreamKHR  stream, const EGLint * attrib_list);
+
+#define eglCreateStreamProducerSurfaceKHR EGLEW_GET_FUN(__eglewCreateStreamProducerSurfaceKHR)
+
+#define EGLEW_KHR_stream_producer_eglsurface EGLEW_GET_VAR(__EGLEW_KHR_stream_producer_eglsurface)
+
+#endif /* EGL_KHR_stream_producer_eglsurface */
+
+/* ---------------------- EGL_KHR_surfaceless_context ---------------------- */
+
+#ifndef EGL_KHR_surfaceless_context
+#define EGL_KHR_surfaceless_context 1
+
+#define EGLEW_KHR_surfaceless_context EGLEW_GET_VAR(__EGLEW_KHR_surfaceless_context)
+
+#endif /* EGL_KHR_surfaceless_context */
+
+/* -------------------- EGL_KHR_swap_buffers_with_damage ------------------- */
+
+#ifndef EGL_KHR_swap_buffers_with_damage
+#define EGL_KHR_swap_buffers_with_damage 1
+
+typedef EGLBoolean  ( * PFNEGLSWAPBUFFERSWITHDAMAGEKHRPROC) (EGLDisplay  dpy, EGLSurface  surface, EGLint * rects, EGLint  n_rects);
+
+#define eglSwapBuffersWithDamageKHR EGLEW_GET_FUN(__eglewSwapBuffersWithDamageKHR)
+
+#define EGLEW_KHR_swap_buffers_with_damage EGLEW_GET_VAR(__EGLEW_KHR_swap_buffers_with_damage)
+
+#endif /* EGL_KHR_swap_buffers_with_damage */
+
+/* ------------------------ EGL_KHR_vg_parent_image ------------------------ */
+
+#ifndef EGL_KHR_vg_parent_image
+#define EGL_KHR_vg_parent_image 1
+
+#define EGL_VG_PARENT_IMAGE_KHR 0x30BA
+
+#define EGLEW_KHR_vg_parent_image EGLEW_GET_VAR(__EGLEW_KHR_vg_parent_image)
+
+#endif /* EGL_KHR_vg_parent_image */
+
+/* --------------------------- EGL_KHR_wait_sync --------------------------- */
+
+#ifndef EGL_KHR_wait_sync
+#define EGL_KHR_wait_sync 1
+
+typedef EGLint  ( * PFNEGLWAITSYNCKHRPROC) (EGLDisplay  dpy, EGLSyncKHR  sync, EGLint  flags);
+
+#define eglWaitSyncKHR EGLEW_GET_FUN(__eglewWaitSyncKHR)
+
+#define EGLEW_KHR_wait_sync EGLEW_GET_VAR(__EGLEW_KHR_wait_sync)
+
+#endif /* EGL_KHR_wait_sync */
+
+/* --------------------------- EGL_MESA_drm_image -------------------------- */
+
+#ifndef EGL_MESA_drm_image
+#define EGL_MESA_drm_image 1
+
+#define EGL_DRM_BUFFER_USE_SCANOUT_MESA 0x00000001
+#define EGL_DRM_BUFFER_USE_SHARE_MESA 0x00000002
+#define EGL_DRM_BUFFER_FORMAT_MESA 0x31D0
+#define EGL_DRM_BUFFER_USE_MESA 0x31D1
+#define EGL_DRM_BUFFER_FORMAT_ARGB32_MESA 0x31D2
+#define EGL_DRM_BUFFER_MESA 0x31D3
+#define EGL_DRM_BUFFER_STRIDE_MESA 0x31D4
+
+typedef EGLImageKHR  ( * PFNEGLCREATEDRMIMAGEMESAPROC) (EGLDisplay  dpy, const EGLint * attrib_list);
+typedef EGLBoolean  ( * PFNEGLEXPORTDRMIMAGEMESAPROC) (EGLDisplay  dpy, EGLImageKHR  image, EGLint * name, EGLint * handle, EGLint * stride);
+
+#define eglCreateDRMImageMESA EGLEW_GET_FUN(__eglewCreateDRMImageMESA)
+#define eglExportDRMImageMESA EGLEW_GET_FUN(__eglewExportDRMImageMESA)
+
+#define EGLEW_MESA_drm_image EGLEW_GET_VAR(__EGLEW_MESA_drm_image)
+
+#endif /* EGL_MESA_drm_image */
+
+/* --------------------- EGL_MESA_image_dma_buf_export --------------------- */
+
+#ifndef EGL_MESA_image_dma_buf_export
+#define EGL_MESA_image_dma_buf_export 1
+
+typedef EGLBoolean  ( * PFNEGLEXPORTDMABUFIMAGEMESAPROC) (EGLDisplay  dpy, EGLImageKHR  image, int * fds, EGLint * strides, EGLint * offsets);
+typedef EGLBoolean  ( * PFNEGLEXPORTDMABUFIMAGEQUERYMESAPROC) (EGLDisplay  dpy, EGLImageKHR  image, int * fourcc, int * num_planes, EGLuint64KHR * modifiers);
+
+#define eglExportDMABUFImageMESA EGLEW_GET_FUN(__eglewExportDMABUFImageMESA)
+#define eglExportDMABUFImageQueryMESA EGLEW_GET_FUN(__eglewExportDMABUFImageQueryMESA)
+
+#define EGLEW_MESA_image_dma_buf_export EGLEW_GET_VAR(__EGLEW_MESA_image_dma_buf_export)
+
+#endif /* EGL_MESA_image_dma_buf_export */
+
+/* ------------------------- EGL_MESA_platform_gbm ------------------------- */
+
+#ifndef EGL_MESA_platform_gbm
+#define EGL_MESA_platform_gbm 1
+
+#define EGL_PLATFORM_GBM_MESA 0x31D7
+
+#define EGLEW_MESA_platform_gbm EGLEW_GET_VAR(__EGLEW_MESA_platform_gbm)
+
+#endif /* EGL_MESA_platform_gbm */
+
+/* --------------------- EGL_MESA_platform_surfaceless --------------------- */
+
+#ifndef EGL_MESA_platform_surfaceless
+#define EGL_MESA_platform_surfaceless 1
+
+#define EGL_PLATFORM_SURFACELESS_MESA 0x31DD
+
+#define EGLEW_MESA_platform_surfaceless EGLEW_GET_VAR(__EGLEW_MESA_platform_surfaceless)
+
+#endif /* EGL_MESA_platform_surfaceless */
+
+/* -------------------------- EGL_NOK_swap_region -------------------------- */
+
+#ifndef EGL_NOK_swap_region
+#define EGL_NOK_swap_region 1
+
+typedef EGLBoolean  ( * PFNEGLSWAPBUFFERSREGIONNOKPROC) (EGLDisplay  dpy, EGLSurface  surface, EGLint  numRects, const EGLint * rects);
+
+#define eglSwapBuffersRegionNOK EGLEW_GET_FUN(__eglewSwapBuffersRegionNOK)
+
+#define EGLEW_NOK_swap_region EGLEW_GET_VAR(__EGLEW_NOK_swap_region)
+
+#endif /* EGL_NOK_swap_region */
+
+/* -------------------------- EGL_NOK_swap_region2 ------------------------- */
+
+#ifndef EGL_NOK_swap_region2
+#define EGL_NOK_swap_region2 1
+
+typedef EGLBoolean  ( * PFNEGLSWAPBUFFERSREGION2NOKPROC) (EGLDisplay  dpy, EGLSurface  surface, EGLint  numRects, const EGLint * rects);
+
+#define eglSwapBuffersRegion2NOK EGLEW_GET_FUN(__eglewSwapBuffersRegion2NOK)
+
+#define EGLEW_NOK_swap_region2 EGLEW_GET_VAR(__EGLEW_NOK_swap_region2)
+
+#endif /* EGL_NOK_swap_region2 */
+
+/* ---------------------- EGL_NOK_texture_from_pixmap ---------------------- */
+
+#ifndef EGL_NOK_texture_from_pixmap
+#define EGL_NOK_texture_from_pixmap 1
+
+#define EGL_Y_INVERTED_NOK 0x307F
+
+#define EGLEW_NOK_texture_from_pixmap EGLEW_GET_VAR(__EGLEW_NOK_texture_from_pixmap)
+
+#endif /* EGL_NOK_texture_from_pixmap */
+
+/* ------------------------ EGL_NV_3dvision_surface ------------------------ */
+
+#ifndef EGL_NV_3dvision_surface
+#define EGL_NV_3dvision_surface 1
+
+#define EGL_AUTO_STEREO_NV 0x3136
+
+#define EGLEW_NV_3dvision_surface EGLEW_GET_VAR(__EGLEW_NV_3dvision_surface)
+
+#endif /* EGL_NV_3dvision_surface */
+
+/* ------------------------- EGL_NV_coverage_sample ------------------------ */
+
+#ifndef EGL_NV_coverage_sample
+#define EGL_NV_coverage_sample 1
+
+#define EGL_COVERAGE_BUFFERS_NV 0x30E0
+#define EGL_COVERAGE_SAMPLES_NV 0x30E1
+
+#define EGLEW_NV_coverage_sample EGLEW_GET_VAR(__EGLEW_NV_coverage_sample)
+
+#endif /* EGL_NV_coverage_sample */
+
+/* --------------------- EGL_NV_coverage_sample_resolve -------------------- */
+
+#ifndef EGL_NV_coverage_sample_resolve
+#define EGL_NV_coverage_sample_resolve 1
+
+#define EGL_COVERAGE_SAMPLE_RESOLVE_NV 0x3131
+#define EGL_COVERAGE_SAMPLE_RESOLVE_DEFAULT_NV 0x3132
+#define EGL_COVERAGE_SAMPLE_RESOLVE_NONE_NV 0x3133
+
+#define EGLEW_NV_coverage_sample_resolve EGLEW_GET_VAR(__EGLEW_NV_coverage_sample_resolve)
+
+#endif /* EGL_NV_coverage_sample_resolve */
+
+/* --------------------------- EGL_NV_cuda_event --------------------------- */
+
+#ifndef EGL_NV_cuda_event
+#define EGL_NV_cuda_event 1
+
+#define EGL_CUDA_EVENT_HANDLE_NV 0x323B
+#define EGL_SYNC_CUDA_EVENT_NV 0x323C
+#define EGL_SYNC_CUDA_EVENT_COMPLETE_NV 0x323D
+
+#define EGLEW_NV_cuda_event EGLEW_GET_VAR(__EGLEW_NV_cuda_event)
+
+#endif /* EGL_NV_cuda_event */
+
+/* ------------------------- EGL_NV_depth_nonlinear ------------------------ */
+
+#ifndef EGL_NV_depth_nonlinear
+#define EGL_NV_depth_nonlinear 1
+
+#define EGL_DEPTH_ENCODING_NONE_NV 0
+#define EGL_DEPTH_ENCODING_NV 0x30E2
+#define EGL_DEPTH_ENCODING_NONLINEAR_NV 0x30E3
+
+#define EGLEW_NV_depth_nonlinear EGLEW_GET_VAR(__EGLEW_NV_depth_nonlinear)
+
+#endif /* EGL_NV_depth_nonlinear */
+
+/* --------------------------- EGL_NV_device_cuda -------------------------- */
+
+#ifndef EGL_NV_device_cuda
+#define EGL_NV_device_cuda 1
+
+#define EGL_CUDA_DEVICE_NV 0x323A
+
+#define EGLEW_NV_device_cuda EGLEW_GET_VAR(__EGLEW_NV_device_cuda)
+
+#endif /* EGL_NV_device_cuda */
+
+/* -------------------------- EGL_NV_native_query -------------------------- */
+
+#ifndef EGL_NV_native_query
+#define EGL_NV_native_query 1
+
+typedef EGLBoolean  ( * PFNEGLQUERYNATIVEDISPLAYNVPROC) (EGLDisplay  dpy, EGLNativeDisplayType * display_id);
+typedef EGLBoolean  ( * PFNEGLQUERYNATIVEPIXMAPNVPROC) (EGLDisplay  dpy, EGLSurface  surf, EGLNativePixmapType * pixmap);
+typedef EGLBoolean  ( * PFNEGLQUERYNATIVEWINDOWNVPROC) (EGLDisplay  dpy, EGLSurface  surf, EGLNativeWindowType * window);
+
+#define eglQueryNativeDisplayNV EGLEW_GET_FUN(__eglewQueryNativeDisplayNV)
+#define eglQueryNativePixmapNV EGLEW_GET_FUN(__eglewQueryNativePixmapNV)
+#define eglQueryNativeWindowNV EGLEW_GET_FUN(__eglewQueryNativeWindowNV)
+
+#define EGLEW_NV_native_query EGLEW_GET_VAR(__EGLEW_NV_native_query)
+
+#endif /* EGL_NV_native_query */
+
+/* ---------------------- EGL_NV_post_convert_rounding --------------------- */
+
+#ifndef EGL_NV_post_convert_rounding
+#define EGL_NV_post_convert_rounding 1
+
+#define EGLEW_NV_post_convert_rounding EGLEW_GET_VAR(__EGLEW_NV_post_convert_rounding)
+
+#endif /* EGL_NV_post_convert_rounding */
+
+/* ------------------------- EGL_NV_post_sub_buffer ------------------------ */
+
+#ifndef EGL_NV_post_sub_buffer
+#define EGL_NV_post_sub_buffer 1
+
+#define EGL_POST_SUB_BUFFER_SUPPORTED_NV 0x30BE
+
+typedef EGLBoolean  ( * PFNEGLPOSTSUBBUFFERNVPROC) (EGLDisplay  dpy, EGLSurface  surface, EGLint  x, EGLint  y, EGLint  width, EGLint  height);
+
+#define eglPostSubBufferNV EGLEW_GET_FUN(__eglewPostSubBufferNV)
+
+#define EGLEW_NV_post_sub_buffer EGLEW_GET_VAR(__EGLEW_NV_post_sub_buffer)
+
+#endif /* EGL_NV_post_sub_buffer */
+
+/* ------------------ EGL_NV_robustness_video_memory_purge ----------------- */
+
+#ifndef EGL_NV_robustness_video_memory_purge
+#define EGL_NV_robustness_video_memory_purge 1
+
+#define EGL_GENERATE_RESET_ON_VIDEO_MEMORY_PURGE_NV 0x334C
+
+#define EGLEW_NV_robustness_video_memory_purge EGLEW_GET_VAR(__EGLEW_NV_robustness_video_memory_purge)
+
+#endif /* EGL_NV_robustness_video_memory_purge */
+
+/* ------------------ EGL_NV_stream_consumer_gltexture_yuv ----------------- */
+
+#ifndef EGL_NV_stream_consumer_gltexture_yuv
+#define EGL_NV_stream_consumer_gltexture_yuv 1
+
+#define EGL_YUV_BUFFER_EXT 0x3300
+#define EGL_YUV_NUMBER_OF_PLANES_EXT 0x3311
+#define EGL_YUV_PLANE0_TEXTURE_UNIT_NV 0x332C
+#define EGL_YUV_PLANE1_TEXTURE_UNIT_NV 0x332D
+#define EGL_YUV_PLANE2_TEXTURE_UNIT_NV 0x332E
+
+typedef EGLBoolean  ( * PFNEGLSTREAMCONSUMERGLTEXTUREEXTERNALATTRIBSNVPROC) (EGLDisplay  dpy, EGLStreamKHR  stream, EGLAttrib  *attrib_list);
+
+#define eglStreamConsumerGLTextureExternalAttribsNV EGLEW_GET_FUN(__eglewStreamConsumerGLTextureExternalAttribsNV)
+
+#define EGLEW_NV_stream_consumer_gltexture_yuv EGLEW_GET_VAR(__EGLEW_NV_stream_consumer_gltexture_yuv)
+
+#endif /* EGL_NV_stream_consumer_gltexture_yuv */
+
+/* ---------------------- EGL_NV_stream_cross_display ---------------------- */
+
+#ifndef EGL_NV_stream_cross_display
+#define EGL_NV_stream_cross_display 1
+
+#define EGL_STREAM_CROSS_DISPLAY_NV 0x334E
+
+#define EGLEW_NV_stream_cross_display EGLEW_GET_VAR(__EGLEW_NV_stream_cross_display)
+
+#endif /* EGL_NV_stream_cross_display */
+
+/* ----------------------- EGL_NV_stream_cross_object ---------------------- */
+
+#ifndef EGL_NV_stream_cross_object
+#define EGL_NV_stream_cross_object 1
+
+#define EGL_STREAM_CROSS_OBJECT_NV 0x334D
+
+#define EGLEW_NV_stream_cross_object EGLEW_GET_VAR(__EGLEW_NV_stream_cross_object)
+
+#endif /* EGL_NV_stream_cross_object */
+
+/* --------------------- EGL_NV_stream_cross_partition --------------------- */
+
+#ifndef EGL_NV_stream_cross_partition
+#define EGL_NV_stream_cross_partition 1
+
+#define EGL_STREAM_CROSS_PARTITION_NV 0x323F
+
+#define EGLEW_NV_stream_cross_partition EGLEW_GET_VAR(__EGLEW_NV_stream_cross_partition)
+
+#endif /* EGL_NV_stream_cross_partition */
+
+/* ---------------------- EGL_NV_stream_cross_process ---------------------- */
+
+#ifndef EGL_NV_stream_cross_process
+#define EGL_NV_stream_cross_process 1
+
+#define EGL_STREAM_CROSS_PROCESS_NV 0x3245
+
+#define EGLEW_NV_stream_cross_process EGLEW_GET_VAR(__EGLEW_NV_stream_cross_process)
+
+#endif /* EGL_NV_stream_cross_process */
+
+/* ----------------------- EGL_NV_stream_cross_system ---------------------- */
+
+#ifndef EGL_NV_stream_cross_system
+#define EGL_NV_stream_cross_system 1
+
+#define EGL_STREAM_CROSS_SYSTEM_NV 0x334F
+
+#define EGLEW_NV_stream_cross_system EGLEW_GET_VAR(__EGLEW_NV_stream_cross_system)
+
+#endif /* EGL_NV_stream_cross_system */
+
+/* ------------------------ EGL_NV_stream_fifo_next ------------------------ */
+
+#ifndef EGL_NV_stream_fifo_next
+#define EGL_NV_stream_fifo_next 1
+
+#define EGL_PENDING_FRAME_NV 0x3329
+#define EGL_STREAM_TIME_PENDING_NV 0x332A
+
+#define EGLEW_NV_stream_fifo_next EGLEW_GET_VAR(__EGLEW_NV_stream_fifo_next)
+
+#endif /* EGL_NV_stream_fifo_next */
+
+/* --------------------- EGL_NV_stream_fifo_synchronous -------------------- */
+
+#ifndef EGL_NV_stream_fifo_synchronous
+#define EGL_NV_stream_fifo_synchronous 1
+
+#define EGL_STREAM_FIFO_SYNCHRONOUS_NV 0x3336
+
+#define EGLEW_NV_stream_fifo_synchronous EGLEW_GET_VAR(__EGLEW_NV_stream_fifo_synchronous)
+
+#endif /* EGL_NV_stream_fifo_synchronous */
+
+/* ----------------------- EGL_NV_stream_frame_limits ---------------------- */
+
+#ifndef EGL_NV_stream_frame_limits
+#define EGL_NV_stream_frame_limits 1
+
+#define EGL_PRODUCER_MAX_FRAME_HINT_NV 0x3337
+#define EGL_CONSUMER_MAX_FRAME_HINT_NV 0x3338
+
+#define EGLEW_NV_stream_frame_limits EGLEW_GET_VAR(__EGLEW_NV_stream_frame_limits)
+
+#endif /* EGL_NV_stream_frame_limits */
+
+/* ------------------------- EGL_NV_stream_metadata ------------------------ */
+
+#ifndef EGL_NV_stream_metadata
+#define EGL_NV_stream_metadata 1
+
+#define EGL_MAX_STREAM_METADATA_BLOCKS_NV 0x3250
+#define EGL_MAX_STREAM_METADATA_BLOCK_SIZE_NV 0x3251
+#define EGL_MAX_STREAM_METADATA_TOTAL_SIZE_NV 0x3252
+#define EGL_PRODUCER_METADATA_NV 0x3253
+#define EGL_CONSUMER_METADATA_NV 0x3254
+#define EGL_METADATA0_SIZE_NV 0x3255
+#define EGL_METADATA1_SIZE_NV 0x3256
+#define EGL_METADATA2_SIZE_NV 0x3257
+#define EGL_METADATA3_SIZE_NV 0x3258
+#define EGL_METADATA0_TYPE_NV 0x3259
+#define EGL_METADATA1_TYPE_NV 0x325A
+#define EGL_METADATA2_TYPE_NV 0x325B
+#define EGL_METADATA3_TYPE_NV 0x325C
+#define EGL_PENDING_METADATA_NV 0x3328
+
+typedef EGLBoolean  ( * PFNEGLQUERYDISPLAYATTRIBNVPROC) (EGLDisplay  dpy, EGLint  attribute, EGLAttrib * value);
+typedef EGLBoolean  ( * PFNEGLQUERYSTREAMMETADATANVPROC) (EGLDisplay  dpy, EGLStreamKHR  stream, EGLenum  name, EGLint  n, EGLint  offset, EGLint  size, void * data);
+typedef EGLBoolean  ( * PFNEGLSETSTREAMMETADATANVPROC) (EGLDisplay  dpy, EGLStreamKHR  stream, EGLint  n, EGLint  offset, EGLint  size, const void * data);
+
+#define eglQueryDisplayAttribNV EGLEW_GET_FUN(__eglewQueryDisplayAttribNV)
+#define eglQueryStreamMetadataNV EGLEW_GET_FUN(__eglewQueryStreamMetadataNV)
+#define eglSetStreamMetadataNV EGLEW_GET_FUN(__eglewSetStreamMetadataNV)
+
+#define EGLEW_NV_stream_metadata EGLEW_GET_VAR(__EGLEW_NV_stream_metadata)
+
+#endif /* EGL_NV_stream_metadata */
+
+/* -------------------------- EGL_NV_stream_remote ------------------------- */
+
+#ifndef EGL_NV_stream_remote
+#define EGL_NV_stream_remote 1
+
+#define EGL_STREAM_STATE_INITIALIZING_NV 0x3240
+#define EGL_STREAM_TYPE_NV 0x3241
+#define EGL_STREAM_PROTOCOL_NV 0x3242
+#define EGL_STREAM_ENDPOINT_NV 0x3243
+#define EGL_STREAM_LOCAL_NV 0x3244
+#define EGL_STREAM_PROTOCOL_FD_NV 0x3246
+#define EGL_STREAM_PRODUCER_NV 0x3247
+#define EGL_STREAM_CONSUMER_NV 0x3248
+
+#define EGLEW_NV_stream_remote EGLEW_GET_VAR(__EGLEW_NV_stream_remote)
+
+#endif /* EGL_NV_stream_remote */
+
+/* -------------------------- EGL_NV_stream_reset -------------------------- */
+
+#ifndef EGL_NV_stream_reset
+#define EGL_NV_stream_reset 1
+
+#define EGL_SUPPORT_RESET_NV 0x3334
+#define EGL_SUPPORT_REUSE_NV 0x3335
+
+typedef EGLBoolean  ( * PFNEGLRESETSTREAMNVPROC) (EGLDisplay  dpy, EGLStreamKHR  stream);
+
+#define eglResetStreamNV EGLEW_GET_FUN(__eglewResetStreamNV)
+
+#define EGLEW_NV_stream_reset EGLEW_GET_VAR(__EGLEW_NV_stream_reset)
+
+#endif /* EGL_NV_stream_reset */
+
+/* -------------------------- EGL_NV_stream_socket ------------------------- */
+
+#ifndef EGL_NV_stream_socket
+#define EGL_NV_stream_socket 1
+
+#define EGL_STREAM_PROTOCOL_SOCKET_NV 0x324B
+#define EGL_SOCKET_HANDLE_NV 0x324C
+#define EGL_SOCKET_TYPE_NV 0x324D
+
+#define EGLEW_NV_stream_socket EGLEW_GET_VAR(__EGLEW_NV_stream_socket)
+
+#endif /* EGL_NV_stream_socket */
+
+/* ----------------------- EGL_NV_stream_socket_inet ----------------------- */
+
+#ifndef EGL_NV_stream_socket_inet
+#define EGL_NV_stream_socket_inet 1
+
+#define EGL_SOCKET_TYPE_INET_NV 0x324F
+
+#define EGLEW_NV_stream_socket_inet EGLEW_GET_VAR(__EGLEW_NV_stream_socket_inet)
+
+#endif /* EGL_NV_stream_socket_inet */
+
+/* ----------------------- EGL_NV_stream_socket_unix ----------------------- */
+
+#ifndef EGL_NV_stream_socket_unix
+#define EGL_NV_stream_socket_unix 1
+
+#define EGL_SOCKET_TYPE_UNIX_NV 0x324E
+
+#define EGLEW_NV_stream_socket_unix EGLEW_GET_VAR(__EGLEW_NV_stream_socket_unix)
+
+#endif /* EGL_NV_stream_socket_unix */
+
+/* --------------------------- EGL_NV_stream_sync -------------------------- */
+
+#ifndef EGL_NV_stream_sync
+#define EGL_NV_stream_sync 1
+
+#define EGL_SYNC_TYPE_KHR 0x30F7
+#define EGL_SYNC_NEW_FRAME_NV 0x321F
+
+typedef EGLSyncKHR  ( * PFNEGLCREATESTREAMSYNCNVPROC) (EGLDisplay  dpy, EGLStreamKHR  stream, EGLenum  type, const EGLint * attrib_list);
+
+#define eglCreateStreamSyncNV EGLEW_GET_FUN(__eglewCreateStreamSyncNV)
+
+#define EGLEW_NV_stream_sync EGLEW_GET_VAR(__EGLEW_NV_stream_sync)
+
+#endif /* EGL_NV_stream_sync */
+
+/* ------------------------------ EGL_NV_sync ------------------------------ */
+
+#ifndef EGL_NV_sync
+#define EGL_NV_sync 1
+
+#define EGL_SYNC_FLUSH_COMMANDS_BIT_NV 0x0001
+#define EGL_SYNC_PRIOR_COMMANDS_COMPLETE_NV 0x30E6
+#define EGL_SYNC_STATUS_NV 0x30E7
+#define EGL_SIGNALED_NV 0x30E8
+#define EGL_UNSIGNALED_NV 0x30E9
+#define EGL_ALREADY_SIGNALED_NV 0x30EA
+#define EGL_TIMEOUT_EXPIRED_NV 0x30EB
+#define EGL_CONDITION_SATISFIED_NV 0x30EC
+#define EGL_SYNC_TYPE_NV 0x30ED
+#define EGL_SYNC_CONDITION_NV 0x30EE
+#define EGL_SYNC_FENCE_NV 0x30EF
+#define EGL_FOREVER_NV 0xFFFFFFFFFFFFFFFF
+
+typedef EGLint  ( * PFNEGLCLIENTWAITSYNCNVPROC) (EGLSyncNV  sync, EGLint  flags, EGLTimeNV  timeout);
+typedef EGLSyncNV  ( * PFNEGLCREATEFENCESYNCNVPROC) (EGLDisplay  dpy, EGLenum  condition, const EGLint * attrib_list);
+typedef EGLBoolean  ( * PFNEGLDESTROYSYNCNVPROC) (EGLSyncNV  sync);
+typedef EGLBoolean  ( * PFNEGLFENCENVPROC) (EGLSyncNV  sync);
+typedef EGLBoolean  ( * PFNEGLGETSYNCATTRIBNVPROC) (EGLSyncNV  sync, EGLint  attribute, EGLint * value);
+typedef EGLBoolean  ( * PFNEGLSIGNALSYNCNVPROC) (EGLSyncNV  sync, EGLenum  mode);
+
+#define eglClientWaitSyncNV EGLEW_GET_FUN(__eglewClientWaitSyncNV)
+#define eglCreateFenceSyncNV EGLEW_GET_FUN(__eglewCreateFenceSyncNV)
+#define eglDestroySyncNV EGLEW_GET_FUN(__eglewDestroySyncNV)
+#define eglFenceNV EGLEW_GET_FUN(__eglewFenceNV)
+#define eglGetSyncAttribNV EGLEW_GET_FUN(__eglewGetSyncAttribNV)
+#define eglSignalSyncNV EGLEW_GET_FUN(__eglewSignalSyncNV)
+
+#define EGLEW_NV_sync EGLEW_GET_VAR(__EGLEW_NV_sync)
+
+#endif /* EGL_NV_sync */
+
+/* --------------------------- EGL_NV_system_time -------------------------- */
+
+#ifndef EGL_NV_system_time
+#define EGL_NV_system_time 1
+
+typedef EGLuint64NV  ( * PFNEGLGETSYSTEMTIMEFREQUENCYNVPROC) ( void );
+typedef EGLuint64NV  ( * PFNEGLGETSYSTEMTIMENVPROC) ( void );
+
+#define eglGetSystemTimeFrequencyNV EGLEW_GET_FUN(__eglewGetSystemTimeFrequencyNV)
+#define eglGetSystemTimeNV EGLEW_GET_FUN(__eglewGetSystemTimeNV)
+
+#define EGLEW_NV_system_time EGLEW_GET_VAR(__EGLEW_NV_system_time)
+
+#endif /* EGL_NV_system_time */
+
+/* --------------------- EGL_TIZEN_image_native_buffer --------------------- */
+
+#ifndef EGL_TIZEN_image_native_buffer
+#define EGL_TIZEN_image_native_buffer 1
+
+#define EGL_NATIVE_BUFFER_TIZEN 0x32A0
+
+#define EGLEW_TIZEN_image_native_buffer EGLEW_GET_VAR(__EGLEW_TIZEN_image_native_buffer)
+
+#endif /* EGL_TIZEN_image_native_buffer */
+
+/* --------------------- EGL_TIZEN_image_native_surface -------------------- */
+
+#ifndef EGL_TIZEN_image_native_surface
+#define EGL_TIZEN_image_native_surface 1
+
+#define EGL_NATIVE_SURFACE_TIZEN 0x32A1
+
+#define EGLEW_TIZEN_image_native_surface EGLEW_GET_VAR(__EGLEW_TIZEN_image_native_surface)
+
+#endif /* EGL_TIZEN_image_native_surface */
+
+/* ------------------------------------------------------------------------- */
+
+#define EGLEW_FUN_EXPORT GLEW_FUN_EXPORT
+#define EGLEW_VAR_EXPORT GLEW_VAR_EXPORT
+
+EGLEW_FUN_EXPORT PFNEGLCHOOSECONFIGPROC __eglewChooseConfig;
+EGLEW_FUN_EXPORT PFNEGLCOPYBUFFERSPROC __eglewCopyBuffers;
+EGLEW_FUN_EXPORT PFNEGLCREATECONTEXTPROC __eglewCreateContext;
+EGLEW_FUN_EXPORT PFNEGLCREATEPBUFFERSURFACEPROC __eglewCreatePbufferSurface;
+EGLEW_FUN_EXPORT PFNEGLCREATEPIXMAPSURFACEPROC __eglewCreatePixmapSurface;
+EGLEW_FUN_EXPORT PFNEGLCREATEWINDOWSURFACEPROC __eglewCreateWindowSurface;
+EGLEW_FUN_EXPORT PFNEGLDESTROYCONTEXTPROC __eglewDestroyContext;
+EGLEW_FUN_EXPORT PFNEGLDESTROYSURFACEPROC __eglewDestroySurface;
+EGLEW_FUN_EXPORT PFNEGLGETCONFIGATTRIBPROC __eglewGetConfigAttrib;
+EGLEW_FUN_EXPORT PFNEGLGETCONFIGSPROC __eglewGetConfigs;
+EGLEW_FUN_EXPORT PFNEGLGETCURRENTDISPLAYPROC __eglewGetCurrentDisplay;
+EGLEW_FUN_EXPORT PFNEGLGETCURRENTSURFACEPROC __eglewGetCurrentSurface;
+EGLEW_FUN_EXPORT PFNEGLGETDISPLAYPROC __eglewGetDisplay;
+EGLEW_FUN_EXPORT PFNEGLGETERRORPROC __eglewGetError;
+EGLEW_FUN_EXPORT PFNEGLINITIALIZEPROC __eglewInitialize;
+EGLEW_FUN_EXPORT PFNEGLMAKECURRENTPROC __eglewMakeCurrent;
+EGLEW_FUN_EXPORT PFNEGLQUERYCONTEXTPROC __eglewQueryContext;
+EGLEW_FUN_EXPORT PFNEGLQUERYSTRINGPROC __eglewQueryString;
+EGLEW_FUN_EXPORT PFNEGLQUERYSURFACEPROC __eglewQuerySurface;
+EGLEW_FUN_EXPORT PFNEGLSWAPBUFFERSPROC __eglewSwapBuffers;
+EGLEW_FUN_EXPORT PFNEGLTERMINATEPROC __eglewTerminate;
+EGLEW_FUN_EXPORT PFNEGLWAITGLPROC __eglewWaitGL;
+EGLEW_FUN_EXPORT PFNEGLWAITNATIVEPROC __eglewWaitNative;
+
+EGLEW_FUN_EXPORT PFNEGLBINDTEXIMAGEPROC __eglewBindTexImage;
+EGLEW_FUN_EXPORT PFNEGLRELEASETEXIMAGEPROC __eglewReleaseTexImage;
+EGLEW_FUN_EXPORT PFNEGLSURFACEATTRIBPROC __eglewSurfaceAttrib;
+EGLEW_FUN_EXPORT PFNEGLSWAPINTERVALPROC __eglewSwapInterval;
+
+EGLEW_FUN_EXPORT PFNEGLBINDAPIPROC __eglewBindAPI;
+EGLEW_FUN_EXPORT PFNEGLCREATEPBUFFERFROMCLIENTBUFFERPROC __eglewCreatePbufferFromClientBuffer;
+EGLEW_FUN_EXPORT PFNEGLQUERYAPIPROC __eglewQueryAPI;
+EGLEW_FUN_EXPORT PFNEGLRELEASETHREADPROC __eglewReleaseThread;
+EGLEW_FUN_EXPORT PFNEGLWAITCLIENTPROC __eglewWaitClient;
+
+EGLEW_FUN_EXPORT PFNEGLGETCURRENTCONTEXTPROC __eglewGetCurrentContext;
+
+EGLEW_FUN_EXPORT PFNEGLCLIENTWAITSYNCPROC __eglewClientWaitSync;
+EGLEW_FUN_EXPORT PFNEGLCREATEIMAGEPROC __eglewCreateImage;
+EGLEW_FUN_EXPORT PFNEGLCREATEPLATFORMPIXMAPSURFACEPROC __eglewCreatePlatformPixmapSurface;
+EGLEW_FUN_EXPORT PFNEGLCREATEPLATFORMWINDOWSURFACEPROC __eglewCreatePlatformWindowSurface;
+EGLEW_FUN_EXPORT PFNEGLCREATESYNCPROC __eglewCreateSync;
+EGLEW_FUN_EXPORT PFNEGLDESTROYIMAGEPROC __eglewDestroyImage;
+EGLEW_FUN_EXPORT PFNEGLDESTROYSYNCPROC __eglewDestroySync;
+EGLEW_FUN_EXPORT PFNEGLGETPLATFORMDISPLAYPROC __eglewGetPlatformDisplay;
+EGLEW_FUN_EXPORT PFNEGLGETSYNCATTRIBPROC __eglewGetSyncAttrib;
+EGLEW_FUN_EXPORT PFNEGLWAITSYNCPROC __eglewWaitSync;
+
+EGLEW_FUN_EXPORT PFNEGLSETBLOBCACHEFUNCSANDROIDPROC __eglewSetBlobCacheFuncsANDROID;
+
+EGLEW_FUN_EXPORT PFNEGLCREATENATIVECLIENTBUFFERANDROIDPROC __eglewCreateNativeClientBufferANDROID;
+
+EGLEW_FUN_EXPORT PFNEGLDUPNATIVEFENCEFDANDROIDPROC __eglewDupNativeFenceFDANDROID;
+
+EGLEW_FUN_EXPORT PFNEGLPRESENTATIONTIMEANDROIDPROC __eglewPresentationTimeANDROID;
+
+EGLEW_FUN_EXPORT PFNEGLQUERYSURFACEPOINTERANGLEPROC __eglewQuerySurfacePointerANGLE;
+
+EGLEW_FUN_EXPORT PFNEGLQUERYDEVICESEXTPROC __eglewQueryDevicesEXT;
+
+EGLEW_FUN_EXPORT PFNEGLQUERYDEVICEATTRIBEXTPROC __eglewQueryDeviceAttribEXT;
+EGLEW_FUN_EXPORT PFNEGLQUERYDEVICESTRINGEXTPROC __eglewQueryDeviceStringEXT;
+EGLEW_FUN_EXPORT PFNEGLQUERYDISPLAYATTRIBEXTPROC __eglewQueryDisplayAttribEXT;
+
+EGLEW_FUN_EXPORT PFNEGLQUERYDMABUFFORMATSEXTPROC __eglewQueryDmaBufFormatsEXT;
+EGLEW_FUN_EXPORT PFNEGLQUERYDMABUFMODIFIERSEXTPROC __eglewQueryDmaBufModifiersEXT;
+
+EGLEW_FUN_EXPORT PFNEGLGETOUTPUTLAYERSEXTPROC __eglewGetOutputLayersEXT;
+EGLEW_FUN_EXPORT PFNEGLGETOUTPUTPORTSEXTPROC __eglewGetOutputPortsEXT;
+EGLEW_FUN_EXPORT PFNEGLOUTPUTLAYERATTRIBEXTPROC __eglewOutputLayerAttribEXT;
+EGLEW_FUN_EXPORT PFNEGLOUTPUTPORTATTRIBEXTPROC __eglewOutputPortAttribEXT;
+EGLEW_FUN_EXPORT PFNEGLQUERYOUTPUTLAYERATTRIBEXTPROC __eglewQueryOutputLayerAttribEXT;
+EGLEW_FUN_EXPORT PFNEGLQUERYOUTPUTLAYERSTRINGEXTPROC __eglewQueryOutputLayerStringEXT;
+EGLEW_FUN_EXPORT PFNEGLQUERYOUTPUTPORTATTRIBEXTPROC __eglewQueryOutputPortAttribEXT;
+EGLEW_FUN_EXPORT PFNEGLQUERYOUTPUTPORTSTRINGEXTPROC __eglewQueryOutputPortStringEXT;
+
+EGLEW_FUN_EXPORT PFNEGLCREATEPLATFORMPIXMAPSURFACEEXTPROC __eglewCreatePlatformPixmapSurfaceEXT;
+EGLEW_FUN_EXPORT PFNEGLCREATEPLATFORMWINDOWSURFACEEXTPROC __eglewCreatePlatformWindowSurfaceEXT;
+EGLEW_FUN_EXPORT PFNEGLGETPLATFORMDISPLAYEXTPROC __eglewGetPlatformDisplayEXT;
+
+EGLEW_FUN_EXPORT PFNEGLSTREAMCONSUMEROUTPUTEXTPROC __eglewStreamConsumerOutputEXT;
+
+EGLEW_FUN_EXPORT PFNEGLSWAPBUFFERSWITHDAMAGEEXTPROC __eglewSwapBuffersWithDamageEXT;
+
+EGLEW_FUN_EXPORT PFNEGLCREATEPIXMAPSURFACEHIPROC __eglewCreatePixmapSurfaceHI;
+
+EGLEW_FUN_EXPORT PFNEGLCREATESYNC64KHRPROC __eglewCreateSync64KHR;
+
+EGLEW_FUN_EXPORT PFNEGLDEBUGMESSAGECONTROLKHRPROC __eglewDebugMessageControlKHR;
+EGLEW_FUN_EXPORT PFNEGLLABELOBJECTKHRPROC __eglewLabelObjectKHR;
+EGLEW_FUN_EXPORT PFNEGLQUERYDEBUGKHRPROC __eglewQueryDebugKHR;
+
+EGLEW_FUN_EXPORT PFNEGLCREATEIMAGEKHRPROC __eglewCreateImageKHR;
+EGLEW_FUN_EXPORT PFNEGLDESTROYIMAGEKHRPROC __eglewDestroyImageKHR;
+
+EGLEW_FUN_EXPORT PFNEGLLOCKSURFACEKHRPROC __eglewLockSurfaceKHR;
+EGLEW_FUN_EXPORT PFNEGLUNLOCKSURFACEKHRPROC __eglewUnlockSurfaceKHR;
+
+EGLEW_FUN_EXPORT PFNEGLQUERYSURFACE64KHRPROC __eglewQuerySurface64KHR;
+
+EGLEW_FUN_EXPORT PFNEGLSETDAMAGEREGIONKHRPROC __eglewSetDamageRegionKHR;
+
+EGLEW_FUN_EXPORT PFNEGLCLIENTWAITSYNCKHRPROC __eglewClientWaitSyncKHR;
+EGLEW_FUN_EXPORT PFNEGLCREATESYNCKHRPROC __eglewCreateSyncKHR;
+EGLEW_FUN_EXPORT PFNEGLDESTROYSYNCKHRPROC __eglewDestroySyncKHR;
+EGLEW_FUN_EXPORT PFNEGLGETSYNCATTRIBKHRPROC __eglewGetSyncAttribKHR;
+EGLEW_FUN_EXPORT PFNEGLSIGNALSYNCKHRPROC __eglewSignalSyncKHR;
+
+EGLEW_FUN_EXPORT PFNEGLCREATESTREAMKHRPROC __eglewCreateStreamKHR;
+EGLEW_FUN_EXPORT PFNEGLDESTROYSTREAMKHRPROC __eglewDestroyStreamKHR;
+EGLEW_FUN_EXPORT PFNEGLQUERYSTREAMKHRPROC __eglewQueryStreamKHR;
+EGLEW_FUN_EXPORT PFNEGLQUERYSTREAMU64KHRPROC __eglewQueryStreamu64KHR;
+EGLEW_FUN_EXPORT PFNEGLSTREAMATTRIBKHRPROC __eglewStreamAttribKHR;
+
+EGLEW_FUN_EXPORT PFNEGLCREATESTREAMATTRIBKHRPROC __eglewCreateStreamAttribKHR;
+EGLEW_FUN_EXPORT PFNEGLQUERYSTREAMATTRIBKHRPROC __eglewQueryStreamAttribKHR;
+EGLEW_FUN_EXPORT PFNEGLSETSTREAMATTRIBKHRPROC __eglewSetStreamAttribKHR;
+EGLEW_FUN_EXPORT PFNEGLSTREAMCONSUMERACQUIREATTRIBKHRPROC __eglewStreamConsumerAcquireAttribKHR;
+EGLEW_FUN_EXPORT PFNEGLSTREAMCONSUMERRELEASEATTRIBKHRPROC __eglewStreamConsumerReleaseAttribKHR;
+
+EGLEW_FUN_EXPORT PFNEGLSTREAMCONSUMERACQUIREKHRPROC __eglewStreamConsumerAcquireKHR;
+EGLEW_FUN_EXPORT PFNEGLSTREAMCONSUMERGLTEXTUREEXTERNALKHRPROC __eglewStreamConsumerGLTextureExternalKHR;
+EGLEW_FUN_EXPORT PFNEGLSTREAMCONSUMERRELEASEKHRPROC __eglewStreamConsumerReleaseKHR;
+
+EGLEW_FUN_EXPORT PFNEGLCREATESTREAMFROMFILEDESCRIPTORKHRPROC __eglewCreateStreamFromFileDescriptorKHR;
+EGLEW_FUN_EXPORT PFNEGLGETSTREAMFILEDESCRIPTORKHRPROC __eglewGetStreamFileDescriptorKHR;
+
+EGLEW_FUN_EXPORT PFNEGLQUERYSTREAMTIMEKHRPROC __eglewQueryStreamTimeKHR;
+
+EGLEW_FUN_EXPORT PFNEGLCREATESTREAMPRODUCERSURFACEKHRPROC __eglewCreateStreamProducerSurfaceKHR;
+
+EGLEW_FUN_EXPORT PFNEGLSWAPBUFFERSWITHDAMAGEKHRPROC __eglewSwapBuffersWithDamageKHR;
+
+EGLEW_FUN_EXPORT PFNEGLWAITSYNCKHRPROC __eglewWaitSyncKHR;
+
+EGLEW_FUN_EXPORT PFNEGLCREATEDRMIMAGEMESAPROC __eglewCreateDRMImageMESA;
+EGLEW_FUN_EXPORT PFNEGLEXPORTDRMIMAGEMESAPROC __eglewExportDRMImageMESA;
+
+EGLEW_FUN_EXPORT PFNEGLEXPORTDMABUFIMAGEMESAPROC __eglewExportDMABUFImageMESA;
+EGLEW_FUN_EXPORT PFNEGLEXPORTDMABUFIMAGEQUERYMESAPROC __eglewExportDMABUFImageQueryMESA;
+
+EGLEW_FUN_EXPORT PFNEGLSWAPBUFFERSREGIONNOKPROC __eglewSwapBuffersRegionNOK;
+
+EGLEW_FUN_EXPORT PFNEGLSWAPBUFFERSREGION2NOKPROC __eglewSwapBuffersRegion2NOK;
+
+EGLEW_FUN_EXPORT PFNEGLQUERYNATIVEDISPLAYNVPROC __eglewQueryNativeDisplayNV;
+EGLEW_FUN_EXPORT PFNEGLQUERYNATIVEPIXMAPNVPROC __eglewQueryNativePixmapNV;
+EGLEW_FUN_EXPORT PFNEGLQUERYNATIVEWINDOWNVPROC __eglewQueryNativeWindowNV;
+
+EGLEW_FUN_EXPORT PFNEGLPOSTSUBBUFFERNVPROC __eglewPostSubBufferNV;
+
+EGLEW_FUN_EXPORT PFNEGLSTREAMCONSUMERGLTEXTUREEXTERNALATTRIBSNVPROC __eglewStreamConsumerGLTextureExternalAttribsNV;
+
+EGLEW_FUN_EXPORT PFNEGLQUERYDISPLAYATTRIBNVPROC __eglewQueryDisplayAttribNV;
+EGLEW_FUN_EXPORT PFNEGLQUERYSTREAMMETADATANVPROC __eglewQueryStreamMetadataNV;
+EGLEW_FUN_EXPORT PFNEGLSETSTREAMMETADATANVPROC __eglewSetStreamMetadataNV;
+
+EGLEW_FUN_EXPORT PFNEGLRESETSTREAMNVPROC __eglewResetStreamNV;
+
+EGLEW_FUN_EXPORT PFNEGLCREATESTREAMSYNCNVPROC __eglewCreateStreamSyncNV;
+
+EGLEW_FUN_EXPORT PFNEGLCLIENTWAITSYNCNVPROC __eglewClientWaitSyncNV;
+EGLEW_FUN_EXPORT PFNEGLCREATEFENCESYNCNVPROC __eglewCreateFenceSyncNV;
+EGLEW_FUN_EXPORT PFNEGLDESTROYSYNCNVPROC __eglewDestroySyncNV;
+EGLEW_FUN_EXPORT PFNEGLFENCENVPROC __eglewFenceNV;
+EGLEW_FUN_EXPORT PFNEGLGETSYNCATTRIBNVPROC __eglewGetSyncAttribNV;
+EGLEW_FUN_EXPORT PFNEGLSIGNALSYNCNVPROC __eglewSignalSyncNV;
+
+EGLEW_FUN_EXPORT PFNEGLGETSYSTEMTIMEFREQUENCYNVPROC __eglewGetSystemTimeFrequencyNV;
+EGLEW_FUN_EXPORT PFNEGLGETSYSTEMTIMENVPROC __eglewGetSystemTimeNV;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_VERSION_1_0;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_VERSION_1_1;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_VERSION_1_2;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_VERSION_1_3;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_VERSION_1_4;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_VERSION_1_5;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_ANDROID_blob_cache;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_ANDROID_create_native_client_buffer;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_ANDROID_framebuffer_target;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_ANDROID_front_buffer_auto_refresh;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_ANDROID_image_native_buffer;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_ANDROID_native_fence_sync;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_ANDROID_presentation_time;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_ANDROID_recordable;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_ANGLE_d3d_share_handle_client_buffer;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_ANGLE_device_d3d;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_ANGLE_query_surface_pointer;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_ANGLE_surface_d3d_texture_2d_share_handle;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_ANGLE_window_fixed_size;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_ARM_implicit_external_sync;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_ARM_pixmap_multisample_discard;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_EXT_buffer_age;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_EXT_client_extensions;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_EXT_create_context_robustness;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_EXT_device_base;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_EXT_device_drm;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_EXT_device_enumeration;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_EXT_device_openwf;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_EXT_device_query;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_EXT_gl_colorspace_bt2020_linear;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_EXT_gl_colorspace_bt2020_pq;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_EXT_gl_colorspace_scrgb_linear;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_EXT_image_dma_buf_import;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_EXT_image_dma_buf_import_modifiers;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_EXT_multiview_window;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_EXT_output_base;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_EXT_output_drm;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_EXT_output_openwf;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_EXT_pixel_format_float;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_EXT_platform_base;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_EXT_platform_device;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_EXT_platform_wayland;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_EXT_platform_x11;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_EXT_protected_content;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_EXT_protected_surface;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_EXT_stream_consumer_egloutput;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_EXT_surface_SMPTE2086_metadata;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_EXT_swap_buffers_with_damage;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_EXT_yuv_surface;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_HI_clientpixmap;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_HI_colorformats;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_IMG_context_priority;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_IMG_image_plane_attribs;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_KHR_cl_event;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_KHR_cl_event2;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_KHR_client_get_all_proc_addresses;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_KHR_config_attribs;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_KHR_context_flush_control;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_KHR_create_context;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_KHR_create_context_no_error;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_KHR_debug;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_KHR_fence_sync;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_KHR_get_all_proc_addresses;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_KHR_gl_colorspace;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_KHR_gl_renderbuffer_image;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_KHR_gl_texture_2D_image;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_KHR_gl_texture_3D_image;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_KHR_gl_texture_cubemap_image;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_KHR_image;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_KHR_image_base;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_KHR_image_pixmap;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_KHR_lock_surface;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_KHR_lock_surface2;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_KHR_lock_surface3;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_KHR_mutable_render_buffer;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_KHR_no_config_context;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_KHR_partial_update;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_KHR_platform_android;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_KHR_platform_gbm;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_KHR_platform_wayland;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_KHR_platform_x11;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_KHR_reusable_sync;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_KHR_stream;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_KHR_stream_attrib;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_KHR_stream_consumer_gltexture;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_KHR_stream_cross_process_fd;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_KHR_stream_fifo;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_KHR_stream_producer_aldatalocator;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_KHR_stream_producer_eglsurface;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_KHR_surfaceless_context;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_KHR_swap_buffers_with_damage;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_KHR_vg_parent_image;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_KHR_wait_sync;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_MESA_drm_image;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_MESA_image_dma_buf_export;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_MESA_platform_gbm;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_MESA_platform_surfaceless;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_NOK_swap_region;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_NOK_swap_region2;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_NOK_texture_from_pixmap;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_NV_3dvision_surface;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_NV_coverage_sample;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_NV_coverage_sample_resolve;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_NV_cuda_event;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_NV_depth_nonlinear;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_NV_device_cuda;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_NV_native_query;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_NV_post_convert_rounding;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_NV_post_sub_buffer;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_NV_robustness_video_memory_purge;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_NV_stream_consumer_gltexture_yuv;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_NV_stream_cross_display;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_NV_stream_cross_object;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_NV_stream_cross_partition;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_NV_stream_cross_process;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_NV_stream_cross_system;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_NV_stream_fifo_next;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_NV_stream_fifo_synchronous;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_NV_stream_frame_limits;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_NV_stream_metadata;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_NV_stream_remote;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_NV_stream_reset;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_NV_stream_socket;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_NV_stream_socket_inet;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_NV_stream_socket_unix;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_NV_stream_sync;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_NV_sync;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_NV_system_time;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_TIZEN_image_native_buffer;
+EGLEW_VAR_EXPORT GLboolean __EGLEW_TIZEN_image_native_surface;
+/* ------------------------------------------------------------------------ */
+
+GLEWAPI GLenum GLEWAPIENTRY eglewInit (EGLDisplay display);
+GLEWAPI GLboolean GLEWAPIENTRY eglewIsSupported (const char *name);
+
+#define EGLEW_GET_VAR(x) (*(const GLboolean*)&x)
+#define EGLEW_GET_FUN(x) x
+
+GLEWAPI GLboolean GLEWAPIENTRY eglewGetExtension (const char *name);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __eglew_h__ */

--- a/lib/glew/include/GL/glew.h
+++ b/lib/glew/include/GL/glew.h
@@ -1,6 +1,6 @@
 /*
 ** The OpenGL Extension Wrangler Library
-** Copyright (C) 2008-2014, Nigel Stewart <nigels[]users sourceforge net>
+** Copyright (C) 2008-2017, Nigel Stewart <nigels[]users sourceforge net>
 ** Copyright (C) 2002-2008, Milan Ikits <milan ikits[]ieee org>
 ** Copyright (C) 2002-2008, Marcelo E. Magallon <mmagallo[]debian org>
 ** Copyright (C) 2002, Lev Povalahev
@@ -81,7 +81,7 @@
 #define __glew_h__
 #define __GLEW_H__
 
-#if defined(__gl_h_) || defined(__GL_H__) || defined(__X_GL_H)
+#if defined(__gl_h_) || defined(__GL_H__) || defined(_GL_H) || defined(__X_GL_H)
 #error gl.h included before glew.h
 #endif
 #if defined(__gl2_h_)
@@ -103,6 +103,7 @@
 #define __gl_h_
 #define __gl2_h_
 #define __GL_H__
+#define _GL_H
 #define __gltypes_h_
 #define __REGAL_H__
 #define __X_GL_H
@@ -261,6 +262,9 @@ typedef _W64 int ptrdiff_t;
 #ifndef GLEWAPIENTRY
 #define GLEWAPIENTRY
 #endif
+
+#define GLEW_VAR_EXPORT GLEWAPI
+#define GLEW_FUN_EXPORT GLEWAPI
 
 #ifdef __cplusplus
 extern "C" {
@@ -2433,10 +2437,14 @@ typedef void (GLAPIENTRY * PFNGLMINSAMPLESHADINGPROC) (GLclampf value);
 #ifndef GL_VERSION_4_2
 #define GL_VERSION_4_2 1
 
+#define GL_TRANSFORM_FEEDBACK_PAUSED 0x8E23
+#define GL_TRANSFORM_FEEDBACK_ACTIVE 0x8E24
 #define GL_COMPRESSED_RGBA_BPTC_UNORM 0x8E8C
 #define GL_COMPRESSED_SRGB_ALPHA_BPTC_UNORM 0x8E8D
 #define GL_COMPRESSED_RGB_BPTC_SIGNED_FLOAT 0x8E8E
 #define GL_COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT 0x8E8F
+#define GL_COPY_READ_BUFFER_BINDING 0x8F36
+#define GL_COPY_WRITE_BUFFER_BINDING 0x8F37
 
 #define GLEW_VERSION_4_2 GLEW_GET_VAR(__GLEW_VERSION_4_2)
 
@@ -2472,9 +2480,61 @@ typedef void (GLAPIENTRY * PFNGLMINSAMPLESHADINGPROC) (GLclampf value);
 #ifndef GL_VERSION_4_5
 #define GL_VERSION_4_5 1
 
+#define GL_CONTEXT_FLAG_ROBUST_ACCESS_BIT 0x00000004
+
+typedef GLenum (GLAPIENTRY * PFNGLGETGRAPHICSRESETSTATUSPROC) (void);
+typedef void (GLAPIENTRY * PFNGLGETNCOMPRESSEDTEXIMAGEPROC) (GLenum target, GLint lod, GLsizei bufSize, GLvoid *pixels);
+typedef void (GLAPIENTRY * PFNGLGETNTEXIMAGEPROC) (GLenum tex, GLint level, GLenum format, GLenum type, GLsizei bufSize, GLvoid *pixels);
+typedef void (GLAPIENTRY * PFNGLGETNUNIFORMDVPROC) (GLuint program, GLint location, GLsizei bufSize, GLdouble *params);
+
+#define glGetGraphicsResetStatus GLEW_GET_FUN(__glewGetGraphicsResetStatus)
+#define glGetnCompressedTexImage GLEW_GET_FUN(__glewGetnCompressedTexImage)
+#define glGetnTexImage GLEW_GET_FUN(__glewGetnTexImage)
+#define glGetnUniformdv GLEW_GET_FUN(__glewGetnUniformdv)
+
 #define GLEW_VERSION_4_5 GLEW_GET_VAR(__GLEW_VERSION_4_5)
 
 #endif /* GL_VERSION_4_5 */
+
+/* ----------------------------- GL_VERSION_4_6 ---------------------------- */
+
+#ifndef GL_VERSION_4_6
+#define GL_VERSION_4_6 1
+
+#define GL_CONTEXT_FLAG_NO_ERROR_BIT 0x00000008
+#define GL_PARAMETER_BUFFER 0x80EE
+#define GL_PARAMETER_BUFFER_BINDING 0x80EF
+#define GL_TRANSFORM_FEEDBACK_OVERFLOW 0x82EC
+#define GL_TRANSFORM_FEEDBACK_STREAM_OVERFLOW 0x82ED
+#define GL_VERTICES_SUBMITTED 0x82EE
+#define GL_PRIMITIVES_SUBMITTED 0x82EF
+#define GL_VERTEX_SHADER_INVOCATIONS 0x82F0
+#define GL_TESS_CONTROL_SHADER_PATCHES 0x82F1
+#define GL_TESS_EVALUATION_SHADER_INVOCATIONS 0x82F2
+#define GL_GEOMETRY_SHADER_PRIMITIVES_EMITTED 0x82F3
+#define GL_FRAGMENT_SHADER_INVOCATIONS 0x82F4
+#define GL_COMPUTE_SHADER_INVOCATIONS 0x82F5
+#define GL_CLIPPING_INPUT_PRIMITIVES 0x82F6
+#define GL_CLIPPING_OUTPUT_PRIMITIVES 0x82F7
+#define GL_TEXTURE_MAX_ANISOTROPY 0x84FE
+#define GL_MAX_TEXTURE_MAX_ANISOTROPY 0x84FF
+#define GL_POLYGON_OFFSET_CLAMP 0x8E1B
+#define GL_SHADER_BINARY_FORMAT_SPIR_V 0x9551
+#define GL_SPIR_V_BINARY 0x9552
+#define GL_SPIR_V_EXTENSIONS 0x9553
+#define GL_NUM_SPIR_V_EXTENSIONS 0x9554
+
+typedef void (GLAPIENTRY * PFNGLMULTIDRAWARRAYSINDIRECTCOUNTPROC) (GLenum mode, const GLvoid *indirect, GLintptr drawcount, GLsizei maxdrawcount, GLsizei stride);
+typedef void (GLAPIENTRY * PFNGLMULTIDRAWELEMENTSINDIRECTCOUNTPROC) (GLenum mode, GLenum type, const GLvoid *indirect, GLintptr drawcount, GLsizei maxdrawcount, GLsizei stride);
+typedef void (GLAPIENTRY * PFNGLSPECIALIZESHADERPROC) (GLuint shader, const GLchar *pEntryPoint, GLuint numSpecializationConstants, const GLuint *pConstantIndex, const GLuint *pConstantValue);
+
+#define glMultiDrawArraysIndirectCount GLEW_GET_FUN(__glewMultiDrawArraysIndirectCount)
+#define glMultiDrawElementsIndirectCount GLEW_GET_FUN(__glewMultiDrawElementsIndirectCount)
+#define glSpecializeShader GLEW_GET_FUN(__glewSpecializeShader)
+
+#define GLEW_VERSION_4_6 GLEW_GET_VAR(__GLEW_VERSION_4_6)
+
+#endif /* GL_VERSION_4_6 */
 
 /* -------------------------- GL_3DFX_multisample -------------------------- */
 
@@ -2526,6 +2586,31 @@ typedef void (GLAPIENTRY * PFNGLTBUFFERMASK3DFXPROC) (GLuint mask);
 #define GLEW_AMD_blend_minmax_factor GLEW_GET_VAR(__GLEW_AMD_blend_minmax_factor)
 
 #endif /* GL_AMD_blend_minmax_factor */
+
+/* --------------------- GL_AMD_compressed_3DC_texture --------------------- */
+
+#ifndef GL_AMD_compressed_3DC_texture
+#define GL_AMD_compressed_3DC_texture 1
+
+#define GL_3DC_X_AMD 0x87F9
+#define GL_3DC_XY_AMD 0x87FA
+
+#define GLEW_AMD_compressed_3DC_texture GLEW_GET_VAR(__GLEW_AMD_compressed_3DC_texture)
+
+#endif /* GL_AMD_compressed_3DC_texture */
+
+/* --------------------- GL_AMD_compressed_ATC_texture --------------------- */
+
+#ifndef GL_AMD_compressed_ATC_texture
+#define GL_AMD_compressed_ATC_texture 1
+
+#define GL_ATC_RGBA_INTERPOLATED_ALPHA_AMD 0x87EE
+#define GL_ATC_RGB_AMD 0x8C92
+#define GL_ATC_RGBA_EXPLICIT_ALPHA_AMD 0x8C93
+
+#define GLEW_AMD_compressed_ATC_texture GLEW_GET_VAR(__GLEW_AMD_compressed_ATC_texture)
+
+#endif /* GL_AMD_compressed_ATC_texture */
 
 /* ----------------------- GL_AMD_conservative_depth ----------------------- */
 
@@ -2603,6 +2688,30 @@ typedef void (GLAPIENTRY * PFNGLBLENDFUNCSEPARATEINDEXEDAMDPROC) (GLuint buf, GL
 
 #endif /* GL_AMD_draw_buffers_blend */
 
+/* ------------------ GL_AMD_framebuffer_sample_positions ------------------ */
+
+#ifndef GL_AMD_framebuffer_sample_positions
+#define GL_AMD_framebuffer_sample_positions 1
+
+#define GL_SUBSAMPLE_DISTANCE_AMD 0x883F
+#define GL_PIXELS_PER_SAMPLE_PATTERN_X_AMD 0x91AE
+#define GL_PIXELS_PER_SAMPLE_PATTERN_Y_AMD 0x91AF
+#define GL_ALL_PIXELS_AMD 0xFFFFFFFF
+
+typedef void (GLAPIENTRY * PFNGLFRAMEBUFFERSAMPLEPOSITIONSFVAMDPROC) (GLenum target, GLuint numsamples, GLuint pixelindex, const GLfloat* values);
+typedef void (GLAPIENTRY * PFNGLGETFRAMEBUFFERPARAMETERFVAMDPROC) (GLenum target, GLenum pname, GLuint numsamples, GLuint pixelindex, GLsizei size, GLfloat* values);
+typedef void (GLAPIENTRY * PFNGLGETNAMEDFRAMEBUFFERPARAMETERFVAMDPROC) (GLuint framebuffer, GLenum pname, GLuint numsamples, GLuint pixelindex, GLsizei size, GLfloat* values);
+typedef void (GLAPIENTRY * PFNGLNAMEDFRAMEBUFFERSAMPLEPOSITIONSFVAMDPROC) (GLuint framebuffer, GLuint numsamples, GLuint pixelindex, const GLfloat* values);
+
+#define glFramebufferSamplePositionsfvAMD GLEW_GET_FUN(__glewFramebufferSamplePositionsfvAMD)
+#define glGetFramebufferParameterfvAMD GLEW_GET_FUN(__glewGetFramebufferParameterfvAMD)
+#define glGetNamedFramebufferParameterfvAMD GLEW_GET_FUN(__glewGetNamedFramebufferParameterfvAMD)
+#define glNamedFramebufferSamplePositionsfvAMD GLEW_GET_FUN(__glewNamedFramebufferSamplePositionsfvAMD)
+
+#define GLEW_AMD_framebuffer_sample_positions GLEW_GET_VAR(__GLEW_AMD_framebuffer_sample_positions)
+
+#endif /* GL_AMD_framebuffer_sample_positions */
+
 /* --------------------------- GL_AMD_gcn_shader --------------------------- */
 
 #ifndef GL_AMD_gcn_shader
@@ -2611,6 +2720,38 @@ typedef void (GLAPIENTRY * PFNGLBLENDFUNCSEPARATEINDEXEDAMDPROC) (GLuint buf, GL
 #define GLEW_AMD_gcn_shader GLEW_GET_VAR(__GLEW_AMD_gcn_shader)
 
 #endif /* GL_AMD_gcn_shader */
+
+/* ---------------------- GL_AMD_gpu_shader_half_float --------------------- */
+
+#ifndef GL_AMD_gpu_shader_half_float
+#define GL_AMD_gpu_shader_half_float 1
+
+#define GL_FLOAT16_NV 0x8FF8
+#define GL_FLOAT16_VEC2_NV 0x8FF9
+#define GL_FLOAT16_VEC3_NV 0x8FFA
+#define GL_FLOAT16_VEC4_NV 0x8FFB
+#define GL_FLOAT16_MAT2_AMD 0x91C5
+#define GL_FLOAT16_MAT3_AMD 0x91C6
+#define GL_FLOAT16_MAT4_AMD 0x91C7
+#define GL_FLOAT16_MAT2x3_AMD 0x91C8
+#define GL_FLOAT16_MAT2x4_AMD 0x91C9
+#define GL_FLOAT16_MAT3x2_AMD 0x91CA
+#define GL_FLOAT16_MAT3x4_AMD 0x91CB
+#define GL_FLOAT16_MAT4x2_AMD 0x91CC
+#define GL_FLOAT16_MAT4x3_AMD 0x91CD
+
+#define GLEW_AMD_gpu_shader_half_float GLEW_GET_VAR(__GLEW_AMD_gpu_shader_half_float)
+
+#endif /* GL_AMD_gpu_shader_half_float */
+
+/* ------------------------ GL_AMD_gpu_shader_int16 ------------------------ */
+
+#ifndef GL_AMD_gpu_shader_int16
+#define GL_AMD_gpu_shader_int16 1
+
+#define GLEW_AMD_gpu_shader_int16 GLEW_GET_VAR(__GLEW_AMD_gpu_shader_int16)
+
+#endif /* GL_AMD_gpu_shader_int16 */
 
 /* ------------------------ GL_AMD_gpu_shader_int64 ------------------------ */
 
@@ -2754,6 +2895,17 @@ typedef void (GLAPIENTRY * PFNGLSELECTPERFMONITORCOUNTERSAMDPROC) (GLuint monito
 
 #endif /* GL_AMD_pinned_memory */
 
+/* ----------------------- GL_AMD_program_binary_Z400 ---------------------- */
+
+#ifndef GL_AMD_program_binary_Z400
+#define GL_AMD_program_binary_Z400 1
+
+#define GL_Z400_BINARY_AMD 0x8740
+
+#define GLEW_AMD_program_binary_Z400 GLEW_GET_VAR(__GLEW_AMD_program_binary_Z400)
+
+#endif /* GL_AMD_program_binary_Z400 */
+
 /* ----------------------- GL_AMD_query_buffer_object ---------------------- */
 
 #ifndef GL_AMD_query_buffer_object
@@ -2787,7 +2939,7 @@ typedef void (GLAPIENTRY * PFNGLSETMULTISAMPLEFVAMDPROC) (GLenum pname, GLuint i
 #ifndef GL_AMD_seamless_cubemap_per_texture
 #define GL_AMD_seamless_cubemap_per_texture 1
 
-#define GL_TEXTURE_CUBE_MAP_SEAMLESS_ARB 0x884F
+#define GL_TEXTURE_CUBE_MAP_SEAMLESS 0x884F
 
 #define GLEW_AMD_seamless_cubemap_per_texture GLEW_GET_VAR(__GLEW_AMD_seamless_cubemap_per_texture)
 
@@ -2801,6 +2953,24 @@ typedef void (GLAPIENTRY * PFNGLSETMULTISAMPLEFVAMDPROC) (GLenum pname, GLuint i
 #define GLEW_AMD_shader_atomic_counter_ops GLEW_GET_VAR(__GLEW_AMD_shader_atomic_counter_ops)
 
 #endif /* GL_AMD_shader_atomic_counter_ops */
+
+/* -------------------------- GL_AMD_shader_ballot ------------------------- */
+
+#ifndef GL_AMD_shader_ballot
+#define GL_AMD_shader_ballot 1
+
+#define GLEW_AMD_shader_ballot GLEW_GET_VAR(__GLEW_AMD_shader_ballot)
+
+#endif /* GL_AMD_shader_ballot */
+
+/* ---------------- GL_AMD_shader_explicit_vertex_parameter ---------------- */
+
+#ifndef GL_AMD_shader_explicit_vertex_parameter
+#define GL_AMD_shader_explicit_vertex_parameter 1
+
+#define GLEW_AMD_shader_explicit_vertex_parameter GLEW_GET_VAR(__GLEW_AMD_shader_explicit_vertex_parameter)
+
+#endif /* GL_AMD_shader_explicit_vertex_parameter */
 
 /* ---------------------- GL_AMD_shader_stencil_export --------------------- */
 
@@ -2872,6 +3042,15 @@ typedef void (GLAPIENTRY * PFNGLSTENCILOPVALUEAMDPROC) (GLenum face, GLuint valu
 
 #endif /* GL_AMD_stencil_operation_extended */
 
+/* --------------------- GL_AMD_texture_gather_bias_lod -------------------- */
+
+#ifndef GL_AMD_texture_gather_bias_lod
+#define GL_AMD_texture_gather_bias_lod 1
+
+#define GLEW_AMD_texture_gather_bias_lod GLEW_GET_VAR(__GLEW_AMD_texture_gather_bias_lod)
+
+#endif /* GL_AMD_texture_gather_bias_lod */
+
 /* ------------------------ GL_AMD_texture_texture4 ------------------------ */
 
 #ifndef GL_AMD_texture_texture4
@@ -2941,6 +3120,15 @@ typedef void (GLAPIENTRY * PFNGLTESSELLATIONMODEAMDPROC) (GLenum mode);
 #define GLEW_AMD_vertex_shader_viewport_index GLEW_GET_VAR(__GLEW_AMD_vertex_shader_viewport_index)
 
 #endif /* GL_AMD_vertex_shader_viewport_index */
+
+/* -------------------- GL_ANDROID_extension_pack_es31a -------------------- */
+
+#ifndef GL_ANDROID_extension_pack_es31a
+#define GL_ANDROID_extension_pack_es31a 1
+
+#define GLEW_ANDROID_extension_pack_es31a GLEW_GET_VAR(__GLEW_ANDROID_extension_pack_es31a)
+
+#endif /* GL_ANDROID_extension_pack_es31a */
 
 /* ------------------------- GL_ANGLE_depth_texture ------------------------ */
 
@@ -3158,6 +3346,47 @@ typedef void (GLAPIENTRY * PFNGLGETTRANSLATEDSHADERSOURCEANGLEPROC) (GLuint shad
 
 #endif /* GL_APPLE_client_storage */
 
+/* ------------------------- GL_APPLE_clip_distance ------------------------ */
+
+#ifndef GL_APPLE_clip_distance
+#define GL_APPLE_clip_distance 1
+
+#define GL_MAX_CLIP_DISTANCES_APPLE 0x0D32
+#define GL_CLIP_DISTANCE0_APPLE 0x3000
+#define GL_CLIP_DISTANCE1_APPLE 0x3001
+#define GL_CLIP_DISTANCE2_APPLE 0x3002
+#define GL_CLIP_DISTANCE3_APPLE 0x3003
+#define GL_CLIP_DISTANCE4_APPLE 0x3004
+#define GL_CLIP_DISTANCE5_APPLE 0x3005
+#define GL_CLIP_DISTANCE6_APPLE 0x3006
+#define GL_CLIP_DISTANCE7_APPLE 0x3007
+
+#define GLEW_APPLE_clip_distance GLEW_GET_VAR(__GLEW_APPLE_clip_distance)
+
+#endif /* GL_APPLE_clip_distance */
+
+/* ------------------- GL_APPLE_color_buffer_packed_float ------------------ */
+
+#ifndef GL_APPLE_color_buffer_packed_float
+#define GL_APPLE_color_buffer_packed_float 1
+
+#define GLEW_APPLE_color_buffer_packed_float GLEW_GET_VAR(__GLEW_APPLE_color_buffer_packed_float)
+
+#endif /* GL_APPLE_color_buffer_packed_float */
+
+/* ---------------------- GL_APPLE_copy_texture_levels --------------------- */
+
+#ifndef GL_APPLE_copy_texture_levels
+#define GL_APPLE_copy_texture_levels 1
+
+typedef void (GLAPIENTRY * PFNGLCOPYTEXTURELEVELSAPPLEPROC) (GLuint destinationTexture, GLuint sourceTexture, GLint sourceBaseLevel, GLsizei sourceLevelCount);
+
+#define glCopyTextureLevelsAPPLE GLEW_GET_FUN(__glewCopyTextureLevelsAPPLE)
+
+#define GLEW_APPLE_copy_texture_levels GLEW_GET_VAR(__GLEW_APPLE_copy_texture_levels)
+
+#endif /* GL_APPLE_copy_texture_levels */
+
 /* ------------------------- GL_APPLE_element_array ------------------------ */
 
 #ifndef GL_APPLE_element_array
@@ -3255,6 +3484,29 @@ typedef void (GLAPIENTRY * PFNGLFLUSHMAPPEDBUFFERRANGEAPPLEPROC) (GLenum target,
 
 #endif /* GL_APPLE_flush_buffer_range */
 
+/* -------------------- GL_APPLE_framebuffer_multisample ------------------- */
+
+#ifndef GL_APPLE_framebuffer_multisample
+#define GL_APPLE_framebuffer_multisample 1
+
+#define GL_DRAW_FRAMEBUFFER_BINDING_APPLE 0x8CA6
+#define GL_READ_FRAMEBUFFER_APPLE 0x8CA8
+#define GL_DRAW_FRAMEBUFFER_APPLE 0x8CA9
+#define GL_READ_FRAMEBUFFER_BINDING_APPLE 0x8CAA
+#define GL_RENDERBUFFER_SAMPLES_APPLE 0x8CAB
+#define GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE_APPLE 0x8D56
+#define GL_MAX_SAMPLES_APPLE 0x8D57
+
+typedef void (GLAPIENTRY * PFNGLRENDERBUFFERSTORAGEMULTISAMPLEAPPLEPROC) (GLenum target, GLsizei samples, GLenum internalformat, GLsizei width, GLsizei height);
+typedef void (GLAPIENTRY * PFNGLRESOLVEMULTISAMPLEFRAMEBUFFERAPPLEPROC) (void);
+
+#define glRenderbufferStorageMultisampleAPPLE GLEW_GET_FUN(__glewRenderbufferStorageMultisampleAPPLE)
+#define glResolveMultisampleFramebufferAPPLE GLEW_GET_FUN(__glewResolveMultisampleFramebufferAPPLE)
+
+#define GLEW_APPLE_framebuffer_multisample GLEW_GET_VAR(__GLEW_APPLE_framebuffer_multisample)
+
+#endif /* GL_APPLE_framebuffer_multisample */
+
 /* ----------------------- GL_APPLE_object_purgeable ----------------------- */
 
 #ifndef GL_APPLE_object_purgeable
@@ -3326,6 +3578,94 @@ typedef GLenum (GLAPIENTRY * PFNGLOBJECTUNPURGEABLEAPPLEPROC) (GLenum objectType
 #define GLEW_APPLE_specular_vector GLEW_GET_VAR(__GLEW_APPLE_specular_vector)
 
 #endif /* GL_APPLE_specular_vector */
+
+/* ----------------------------- GL_APPLE_sync ----------------------------- */
+
+#ifndef GL_APPLE_sync
+#define GL_APPLE_sync 1
+
+#define GL_SYNC_FLUSH_COMMANDS_BIT_APPLE 0x00000001
+#define GL_SYNC_OBJECT_APPLE 0x8A53
+#define GL_MAX_SERVER_WAIT_TIMEOUT_APPLE 0x9111
+#define GL_OBJECT_TYPE_APPLE 0x9112
+#define GL_SYNC_CONDITION_APPLE 0x9113
+#define GL_SYNC_STATUS_APPLE 0x9114
+#define GL_SYNC_FLAGS_APPLE 0x9115
+#define GL_SYNC_FENCE_APPLE 0x9116
+#define GL_SYNC_GPU_COMMANDS_COMPLETE_APPLE 0x9117
+#define GL_UNSIGNALED_APPLE 0x9118
+#define GL_SIGNALED_APPLE 0x9119
+#define GL_ALREADY_SIGNALED_APPLE 0x911A
+#define GL_TIMEOUT_EXPIRED_APPLE 0x911B
+#define GL_CONDITION_SATISFIED_APPLE 0x911C
+#define GL_WAIT_FAILED_APPLE 0x911D
+#define GL_TIMEOUT_IGNORED_APPLE 0xFFFFFFFFFFFFFFFFull
+
+typedef GLenum (GLAPIENTRY * PFNGLCLIENTWAITSYNCAPPLEPROC) (GLsync GLsync, GLbitfield flags, GLuint64 timeout);
+typedef void (GLAPIENTRY * PFNGLDELETESYNCAPPLEPROC) (GLsync GLsync);
+typedef GLsync (GLAPIENTRY * PFNGLFENCESYNCAPPLEPROC) (GLenum condition, GLbitfield flags);
+typedef void (GLAPIENTRY * PFNGLGETINTEGER64VAPPLEPROC) (GLenum pname, GLint64* params);
+typedef void (GLAPIENTRY * PFNGLGETSYNCIVAPPLEPROC) (GLsync GLsync, GLenum pname, GLsizei bufSize, GLsizei* length, GLint *values);
+typedef GLboolean (GLAPIENTRY * PFNGLISSYNCAPPLEPROC) (GLsync GLsync);
+typedef void (GLAPIENTRY * PFNGLWAITSYNCAPPLEPROC) (GLsync GLsync, GLbitfield flags, GLuint64 timeout);
+
+#define glClientWaitSyncAPPLE GLEW_GET_FUN(__glewClientWaitSyncAPPLE)
+#define glDeleteSyncAPPLE GLEW_GET_FUN(__glewDeleteSyncAPPLE)
+#define glFenceSyncAPPLE GLEW_GET_FUN(__glewFenceSyncAPPLE)
+#define glGetInteger64vAPPLE GLEW_GET_FUN(__glewGetInteger64vAPPLE)
+#define glGetSyncivAPPLE GLEW_GET_FUN(__glewGetSyncivAPPLE)
+#define glIsSyncAPPLE GLEW_GET_FUN(__glewIsSyncAPPLE)
+#define glWaitSyncAPPLE GLEW_GET_FUN(__glewWaitSyncAPPLE)
+
+#define GLEW_APPLE_sync GLEW_GET_VAR(__GLEW_APPLE_sync)
+
+#endif /* GL_APPLE_sync */
+
+/* -------------------- GL_APPLE_texture_2D_limited_npot ------------------- */
+
+#ifndef GL_APPLE_texture_2D_limited_npot
+#define GL_APPLE_texture_2D_limited_npot 1
+
+#define GLEW_APPLE_texture_2D_limited_npot GLEW_GET_VAR(__GLEW_APPLE_texture_2D_limited_npot)
+
+#endif /* GL_APPLE_texture_2D_limited_npot */
+
+/* -------------------- GL_APPLE_texture_format_BGRA8888 ------------------- */
+
+#ifndef GL_APPLE_texture_format_BGRA8888
+#define GL_APPLE_texture_format_BGRA8888 1
+
+#define GL_BGRA_EXT 0x80E1
+#define GL_BGRA8_EXT 0x93A1
+
+#define GLEW_APPLE_texture_format_BGRA8888 GLEW_GET_VAR(__GLEW_APPLE_texture_format_BGRA8888)
+
+#endif /* GL_APPLE_texture_format_BGRA8888 */
+
+/* ----------------------- GL_APPLE_texture_max_level ---------------------- */
+
+#ifndef GL_APPLE_texture_max_level
+#define GL_APPLE_texture_max_level 1
+
+#define GL_TEXTURE_MAX_LEVEL_APPLE 0x813D
+
+#define GLEW_APPLE_texture_max_level GLEW_GET_VAR(__GLEW_APPLE_texture_max_level)
+
+#endif /* GL_APPLE_texture_max_level */
+
+/* --------------------- GL_APPLE_texture_packed_float --------------------- */
+
+#ifndef GL_APPLE_texture_packed_float
+#define GL_APPLE_texture_packed_float 1
+
+#define GL_R11F_G11F_B10F_APPLE 0x8C3A
+#define GL_UNSIGNED_INT_10F_11F_11F_REV_APPLE 0x8C3B
+#define GL_RGB9_E5_APPLE 0x8C3D
+#define GL_UNSIGNED_INT_5_9_9_9_REV_APPLE 0x8C3E
+
+#define GLEW_APPLE_texture_packed_float GLEW_GET_VAR(__GLEW_APPLE_texture_packed_float)
+
+#endif /* GL_APPLE_texture_packed_float */
 
 /* ------------------------- GL_APPLE_texture_range ------------------------ */
 
@@ -3507,6 +3847,23 @@ typedef void (GLAPIENTRY * PFNGLMEMORYBARRIERBYREGIONPROC) (GLbitfield barriers)
 
 #endif /* GL_ARB_ES3_1_compatibility */
 
+/* ----------------------- GL_ARB_ES3_2_compatibility ---------------------- */
+
+#ifndef GL_ARB_ES3_2_compatibility
+#define GL_ARB_ES3_2_compatibility 1
+
+#define GL_PRIMITIVE_BOUNDING_BOX_ARB 0x92BE
+#define GL_MULTISAMPLE_LINE_WIDTH_RANGE_ARB 0x9381
+#define GL_MULTISAMPLE_LINE_WIDTH_GRANULARITY_ARB 0x9382
+
+typedef void (GLAPIENTRY * PFNGLPRIMITIVEBOUNDINGBOXARBPROC) (GLfloat minX, GLfloat minY, GLfloat minZ, GLfloat minW, GLfloat maxX, GLfloat maxY, GLfloat maxZ, GLfloat maxW);
+
+#define glPrimitiveBoundingBoxARB GLEW_GET_FUN(__glewPrimitiveBoundingBoxARB)
+
+#define GLEW_ARB_ES3_2_compatibility GLEW_GET_VAR(__GLEW_ARB_ES3_2_compatibility)
+
+#endif /* GL_ARB_ES3_2_compatibility */
+
 /* ------------------------ GL_ARB_ES3_compatibility ----------------------- */
 
 #ifndef GL_ARB_ES3_compatibility
@@ -3638,10 +3995,8 @@ typedef GLint (GLAPIENTRY * PFNGLGETFRAGDATAINDEXPROC) (GLuint program, const GL
 #define GL_BUFFER_STORAGE_FLAGS 0x8220
 
 typedef void (GLAPIENTRY * PFNGLBUFFERSTORAGEPROC) (GLenum target, GLsizeiptr size, const void *data, GLbitfield flags);
-typedef void (GLAPIENTRY * PFNGLNAMEDBUFFERSTORAGEEXTPROC) (GLuint buffer, GLsizeiptr size, const void *data, GLbitfield flags);
 
 #define glBufferStorage GLEW_GET_FUN(__glewBufferStorage)
-#define glNamedBufferStorageEXT GLEW_GET_FUN(__glewNamedBufferStorageEXT)
 
 #define GLEW_ARB_buffer_storage GLEW_GET_VAR(__GLEW_ARB_buffer_storage)
 
@@ -3983,15 +4338,14 @@ typedef GLuint (GLAPIENTRY * PFNGLGETDEBUGMESSAGELOGARBPROC) (GLuint count, GLsi
 
 #define GL_TEXTURE_TARGET 0x1006
 #define GL_QUERY_TARGET 0x82EA
-#define GL_TEXTURE_BINDING 0x82EB
 
 typedef void (GLAPIENTRY * PFNGLBINDTEXTUREUNITPROC) (GLuint unit, GLuint texture);
 typedef void (GLAPIENTRY * PFNGLBLITNAMEDFRAMEBUFFERPROC) (GLuint readFramebuffer, GLuint drawFramebuffer, GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0, GLint dstX1, GLint dstY1, GLbitfield mask, GLenum filter);
 typedef GLenum (GLAPIENTRY * PFNGLCHECKNAMEDFRAMEBUFFERSTATUSPROC) (GLuint framebuffer, GLenum target);
 typedef void (GLAPIENTRY * PFNGLCLEARNAMEDBUFFERDATAPROC) (GLuint buffer, GLenum internalformat, GLenum format, GLenum type, const void *data);
 typedef void (GLAPIENTRY * PFNGLCLEARNAMEDBUFFERSUBDATAPROC) (GLuint buffer, GLenum internalformat, GLintptr offset, GLsizeiptr size, GLenum format, GLenum type, const void *data);
-typedef void (GLAPIENTRY * PFNGLCLEARNAMEDFRAMEBUFFERFIPROC) (GLuint framebuffer, GLenum buffer, GLfloat depth, GLint stencil);
-typedef void (GLAPIENTRY * PFNGLCLEARNAMEDFRAMEBUFFERFVPROC) (GLuint framebuffer, GLenum buffer, GLint drawbuffer, const GLfloat* value);
+typedef void (GLAPIENTRY * PFNGLCLEARNAMEDFRAMEBUFFERFIPROC) (GLuint framebuffer, GLenum buffer, GLint drawbuffer, GLfloat depth, GLint stencil);
+typedef void (GLAPIENTRY * PFNGLCLEARNAMEDFRAMEBUFFERFVPROC) (GLuint framebuffer, GLenum buffer, GLint drawbuffer, GLfloat* value);
 typedef void (GLAPIENTRY * PFNGLCLEARNAMEDFRAMEBUFFERIVPROC) (GLuint framebuffer, GLenum buffer, GLint drawbuffer, const GLint* value);
 typedef void (GLAPIENTRY * PFNGLCLEARNAMEDFRAMEBUFFERUIVPROC) (GLuint framebuffer, GLenum buffer, GLint drawbuffer, const GLuint* value);
 typedef void (GLAPIENTRY * PFNGLCOMPRESSEDTEXTURESUBIMAGE1DPROC) (GLuint texture, GLint level, GLint xoffset, GLsizei width, GLenum format, GLsizei imageSize, const void *data);
@@ -4022,6 +4376,10 @@ typedef void (GLAPIENTRY * PFNGLGETNAMEDBUFFERSUBDATAPROC) (GLuint buffer, GLint
 typedef void (GLAPIENTRY * PFNGLGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVPROC) (GLuint framebuffer, GLenum attachment, GLenum pname, GLint* params);
 typedef void (GLAPIENTRY * PFNGLGETNAMEDFRAMEBUFFERPARAMETERIVPROC) (GLuint framebuffer, GLenum pname, GLint* param);
 typedef void (GLAPIENTRY * PFNGLGETNAMEDRENDERBUFFERPARAMETERIVPROC) (GLuint renderbuffer, GLenum pname, GLint* params);
+typedef void (GLAPIENTRY * PFNGLGETQUERYBUFFEROBJECTI64VPROC) (GLuint id, GLuint buffer, GLenum pname, GLintptr offset);
+typedef void (GLAPIENTRY * PFNGLGETQUERYBUFFEROBJECTIVPROC) (GLuint id, GLuint buffer, GLenum pname, GLintptr offset);
+typedef void (GLAPIENTRY * PFNGLGETQUERYBUFFEROBJECTUI64VPROC) (GLuint id, GLuint buffer, GLenum pname, GLintptr offset);
+typedef void (GLAPIENTRY * PFNGLGETQUERYBUFFEROBJECTUIVPROC) (GLuint id, GLuint buffer, GLenum pname, GLintptr offset);
 typedef void (GLAPIENTRY * PFNGLGETTEXTUREIMAGEPROC) (GLuint texture, GLint level, GLenum format, GLenum type, GLsizei bufSize, void *pixels);
 typedef void (GLAPIENTRY * PFNGLGETTEXTURELEVELPARAMETERFVPROC) (GLuint texture, GLint level, GLenum pname, GLfloat* params);
 typedef void (GLAPIENTRY * PFNGLGETTEXTURELEVELPARAMETERIVPROC) (GLuint texture, GLint level, GLenum pname, GLint* params);
@@ -4116,6 +4474,10 @@ typedef void (GLAPIENTRY * PFNGLVERTEXARRAYVERTEXBUFFERSPROC) (GLuint vaobj, GLu
 #define glGetNamedFramebufferAttachmentParameteriv GLEW_GET_FUN(__glewGetNamedFramebufferAttachmentParameteriv)
 #define glGetNamedFramebufferParameteriv GLEW_GET_FUN(__glewGetNamedFramebufferParameteriv)
 #define glGetNamedRenderbufferParameteriv GLEW_GET_FUN(__glewGetNamedRenderbufferParameteriv)
+#define glGetQueryBufferObjecti64v GLEW_GET_FUN(__glewGetQueryBufferObjecti64v)
+#define glGetQueryBufferObjectiv GLEW_GET_FUN(__glewGetQueryBufferObjectiv)
+#define glGetQueryBufferObjectui64v GLEW_GET_FUN(__glewGetQueryBufferObjectui64v)
+#define glGetQueryBufferObjectuiv GLEW_GET_FUN(__glewGetQueryBufferObjectuiv)
 #define glGetTextureImage GLEW_GET_FUN(__glewGetTextureImage)
 #define glGetTextureLevelParameterfv GLEW_GET_FUN(__glewGetTextureLevelParameterfv)
 #define glGetTextureLevelParameteriv GLEW_GET_FUN(__glewGetTextureLevelParameteriv)
@@ -4232,10 +4594,10 @@ typedef void (GLAPIENTRY * PFNGLBLENDFUNCIARBPROC) (GLuint buf, GLenum src, GLen
 #ifndef GL_ARB_draw_elements_base_vertex
 #define GL_ARB_draw_elements_base_vertex 1
 
-typedef void (GLAPIENTRY * PFNGLDRAWELEMENTSBASEVERTEXPROC) (GLenum mode, GLsizei count, GLenum type, const void *indices, GLint basevertex);
+typedef void (GLAPIENTRY * PFNGLDRAWELEMENTSBASEVERTEXPROC) (GLenum mode, GLsizei count, GLenum type, void *indices, GLint basevertex);
 typedef void (GLAPIENTRY * PFNGLDRAWELEMENTSINSTANCEDBASEVERTEXPROC) (GLenum mode, GLsizei count, GLenum type, const void *indices, GLsizei primcount, GLint basevertex);
-typedef void (GLAPIENTRY * PFNGLDRAWRANGEELEMENTSBASEVERTEXPROC) (GLenum mode, GLuint start, GLuint end, GLsizei count, GLenum type, const void *indices, GLint basevertex);
-typedef void (GLAPIENTRY * PFNGLMULTIDRAWELEMENTSBASEVERTEXPROC) (GLenum mode, const GLsizei* count, GLenum type, const void *const *indices, GLsizei primcount, const GLint *basevertex);
+typedef void (GLAPIENTRY * PFNGLDRAWRANGEELEMENTSBASEVERTEXPROC) (GLenum mode, GLuint start, GLuint end, GLsizei count, GLenum type, void *indices, GLint basevertex);
+typedef void (GLAPIENTRY * PFNGLMULTIDRAWELEMENTSBASEVERTEXPROC) (GLenum mode, GLsizei* count, GLenum type, void**indices, GLsizei primcount, GLint *basevertex);
 
 #define glDrawElementsBaseVertex GLEW_GET_FUN(__glewDrawElementsBaseVertex)
 #define glDrawElementsInstancedBaseVertex GLEW_GET_FUN(__glewDrawElementsInstancedBaseVertex)
@@ -4370,6 +4732,15 @@ typedef void (GLAPIENTRY * PFNGLDRAWELEMENTSINDIRECTPROC) (GLenum mode, GLenum t
 #define GLEW_ARB_fragment_shader GLEW_GET_VAR(__GLEW_ARB_fragment_shader)
 
 #endif /* GL_ARB_fragment_shader */
+
+/* -------------------- GL_ARB_fragment_shader_interlock ------------------- */
+
+#ifndef GL_ARB_fragment_shader_interlock
+#define GL_ARB_fragment_shader_interlock 1
+
+#define GLEW_ARB_fragment_shader_interlock GLEW_GET_VAR(__GLEW_ARB_fragment_shader_interlock)
+
+#endif /* GL_ARB_fragment_shader_interlock */
 
 /* ------------------- GL_ARB_framebuffer_no_attachments ------------------- */
 
@@ -4613,6 +4984,22 @@ typedef void (GLAPIENTRY * PFNGLGETTEXTURESUBIMAGEPROC) (GLuint texture, GLint l
 
 #endif /* GL_ARB_get_texture_sub_image */
 
+/* ---------------------------- GL_ARB_gl_spirv ---------------------------- */
+
+#ifndef GL_ARB_gl_spirv
+#define GL_ARB_gl_spirv 1
+
+#define GL_SHADER_BINARY_FORMAT_SPIR_V_ARB 0x9551
+#define GL_SPIR_V_BINARY_ARB 0x9552
+
+typedef void (GLAPIENTRY * PFNGLSPECIALIZESHADERARBPROC) (GLuint shader, const GLchar* pEntryPoint, GLuint numSpecializationConstants, const GLuint* pConstantIndex, const GLuint* pConstantValue);
+
+#define glSpecializeShaderARB GLEW_GET_FUN(__glewSpecializeShaderARB)
+
+#define GLEW_ARB_gl_spirv GLEW_GET_VAR(__GLEW_ARB_gl_spirv)
+
+#endif /* GL_ARB_gl_spirv */
+
 /* --------------------------- GL_ARB_gpu_shader5 -------------------------- */
 
 #ifndef GL_ARB_gpu_shader5
@@ -4688,6 +5075,98 @@ typedef void (GLAPIENTRY * PFNGLUNIFORMMATRIX4X3DVPROC) (GLint location, GLsizei
 #define GLEW_ARB_gpu_shader_fp64 GLEW_GET_VAR(__GLEW_ARB_gpu_shader_fp64)
 
 #endif /* GL_ARB_gpu_shader_fp64 */
+
+/* ------------------------ GL_ARB_gpu_shader_int64 ------------------------ */
+
+#ifndef GL_ARB_gpu_shader_int64
+#define GL_ARB_gpu_shader_int64 1
+
+#define GL_INT64_ARB 0x140E
+#define GL_UNSIGNED_INT64_ARB 0x140F
+#define GL_INT64_VEC2_ARB 0x8FE9
+#define GL_INT64_VEC3_ARB 0x8FEA
+#define GL_INT64_VEC4_ARB 0x8FEB
+#define GL_UNSIGNED_INT64_VEC2_ARB 0x8FF5
+#define GL_UNSIGNED_INT64_VEC3_ARB 0x8FF6
+#define GL_UNSIGNED_INT64_VEC4_ARB 0x8FF7
+
+typedef void (GLAPIENTRY * PFNGLGETUNIFORMI64VARBPROC) (GLuint program, GLint location, GLint64* params);
+typedef void (GLAPIENTRY * PFNGLGETUNIFORMUI64VARBPROC) (GLuint program, GLint location, GLuint64* params);
+typedef void (GLAPIENTRY * PFNGLGETNUNIFORMI64VARBPROC) (GLuint program, GLint location, GLsizei bufSize, GLint64* params);
+typedef void (GLAPIENTRY * PFNGLGETNUNIFORMUI64VARBPROC) (GLuint program, GLint location, GLsizei bufSize, GLuint64* params);
+typedef void (GLAPIENTRY * PFNGLPROGRAMUNIFORM1I64ARBPROC) (GLuint program, GLint location, GLint64 x);
+typedef void (GLAPIENTRY * PFNGLPROGRAMUNIFORM1I64VARBPROC) (GLuint program, GLint location, GLsizei count, const GLint64* value);
+typedef void (GLAPIENTRY * PFNGLPROGRAMUNIFORM1UI64ARBPROC) (GLuint program, GLint location, GLuint64 x);
+typedef void (GLAPIENTRY * PFNGLPROGRAMUNIFORM1UI64VARBPROC) (GLuint program, GLint location, GLsizei count, const GLuint64* value);
+typedef void (GLAPIENTRY * PFNGLPROGRAMUNIFORM2I64ARBPROC) (GLuint program, GLint location, GLint64 x, GLint64 y);
+typedef void (GLAPIENTRY * PFNGLPROGRAMUNIFORM2I64VARBPROC) (GLuint program, GLint location, GLsizei count, const GLint64* value);
+typedef void (GLAPIENTRY * PFNGLPROGRAMUNIFORM2UI64ARBPROC) (GLuint program, GLint location, GLuint64 x, GLuint64 y);
+typedef void (GLAPIENTRY * PFNGLPROGRAMUNIFORM2UI64VARBPROC) (GLuint program, GLint location, GLsizei count, const GLuint64* value);
+typedef void (GLAPIENTRY * PFNGLPROGRAMUNIFORM3I64ARBPROC) (GLuint program, GLint location, GLint64 x, GLint64 y, GLint64 z);
+typedef void (GLAPIENTRY * PFNGLPROGRAMUNIFORM3I64VARBPROC) (GLuint program, GLint location, GLsizei count, const GLint64* value);
+typedef void (GLAPIENTRY * PFNGLPROGRAMUNIFORM3UI64ARBPROC) (GLuint program, GLint location, GLuint64 x, GLuint64 y, GLuint64 z);
+typedef void (GLAPIENTRY * PFNGLPROGRAMUNIFORM3UI64VARBPROC) (GLuint program, GLint location, GLsizei count, const GLuint64* value);
+typedef void (GLAPIENTRY * PFNGLPROGRAMUNIFORM4I64ARBPROC) (GLuint program, GLint location, GLint64 x, GLint64 y, GLint64 z, GLint64 w);
+typedef void (GLAPIENTRY * PFNGLPROGRAMUNIFORM4I64VARBPROC) (GLuint program, GLint location, GLsizei count, const GLint64* value);
+typedef void (GLAPIENTRY * PFNGLPROGRAMUNIFORM4UI64ARBPROC) (GLuint program, GLint location, GLuint64 x, GLuint64 y, GLuint64 z, GLuint64 w);
+typedef void (GLAPIENTRY * PFNGLPROGRAMUNIFORM4UI64VARBPROC) (GLuint program, GLint location, GLsizei count, const GLuint64* value);
+typedef void (GLAPIENTRY * PFNGLUNIFORM1I64ARBPROC) (GLint location, GLint64 x);
+typedef void (GLAPIENTRY * PFNGLUNIFORM1I64VARBPROC) (GLint location, GLsizei count, const GLint64* value);
+typedef void (GLAPIENTRY * PFNGLUNIFORM1UI64ARBPROC) (GLint location, GLuint64 x);
+typedef void (GLAPIENTRY * PFNGLUNIFORM1UI64VARBPROC) (GLint location, GLsizei count, const GLuint64* value);
+typedef void (GLAPIENTRY * PFNGLUNIFORM2I64ARBPROC) (GLint location, GLint64 x, GLint64 y);
+typedef void (GLAPIENTRY * PFNGLUNIFORM2I64VARBPROC) (GLint location, GLsizei count, const GLint64* value);
+typedef void (GLAPIENTRY * PFNGLUNIFORM2UI64ARBPROC) (GLint location, GLuint64 x, GLuint64 y);
+typedef void (GLAPIENTRY * PFNGLUNIFORM2UI64VARBPROC) (GLint location, GLsizei count, const GLuint64* value);
+typedef void (GLAPIENTRY * PFNGLUNIFORM3I64ARBPROC) (GLint location, GLint64 x, GLint64 y, GLint64 z);
+typedef void (GLAPIENTRY * PFNGLUNIFORM3I64VARBPROC) (GLint location, GLsizei count, const GLint64* value);
+typedef void (GLAPIENTRY * PFNGLUNIFORM3UI64ARBPROC) (GLint location, GLuint64 x, GLuint64 y, GLuint64 z);
+typedef void (GLAPIENTRY * PFNGLUNIFORM3UI64VARBPROC) (GLint location, GLsizei count, const GLuint64* value);
+typedef void (GLAPIENTRY * PFNGLUNIFORM4I64ARBPROC) (GLint location, GLint64 x, GLint64 y, GLint64 z, GLint64 w);
+typedef void (GLAPIENTRY * PFNGLUNIFORM4I64VARBPROC) (GLint location, GLsizei count, const GLint64* value);
+typedef void (GLAPIENTRY * PFNGLUNIFORM4UI64ARBPROC) (GLint location, GLuint64 x, GLuint64 y, GLuint64 z, GLuint64 w);
+typedef void (GLAPIENTRY * PFNGLUNIFORM4UI64VARBPROC) (GLint location, GLsizei count, const GLuint64* value);
+
+#define glGetUniformi64vARB GLEW_GET_FUN(__glewGetUniformi64vARB)
+#define glGetUniformui64vARB GLEW_GET_FUN(__glewGetUniformui64vARB)
+#define glGetnUniformi64vARB GLEW_GET_FUN(__glewGetnUniformi64vARB)
+#define glGetnUniformui64vARB GLEW_GET_FUN(__glewGetnUniformui64vARB)
+#define glProgramUniform1i64ARB GLEW_GET_FUN(__glewProgramUniform1i64ARB)
+#define glProgramUniform1i64vARB GLEW_GET_FUN(__glewProgramUniform1i64vARB)
+#define glProgramUniform1ui64ARB GLEW_GET_FUN(__glewProgramUniform1ui64ARB)
+#define glProgramUniform1ui64vARB GLEW_GET_FUN(__glewProgramUniform1ui64vARB)
+#define glProgramUniform2i64ARB GLEW_GET_FUN(__glewProgramUniform2i64ARB)
+#define glProgramUniform2i64vARB GLEW_GET_FUN(__glewProgramUniform2i64vARB)
+#define glProgramUniform2ui64ARB GLEW_GET_FUN(__glewProgramUniform2ui64ARB)
+#define glProgramUniform2ui64vARB GLEW_GET_FUN(__glewProgramUniform2ui64vARB)
+#define glProgramUniform3i64ARB GLEW_GET_FUN(__glewProgramUniform3i64ARB)
+#define glProgramUniform3i64vARB GLEW_GET_FUN(__glewProgramUniform3i64vARB)
+#define glProgramUniform3ui64ARB GLEW_GET_FUN(__glewProgramUniform3ui64ARB)
+#define glProgramUniform3ui64vARB GLEW_GET_FUN(__glewProgramUniform3ui64vARB)
+#define glProgramUniform4i64ARB GLEW_GET_FUN(__glewProgramUniform4i64ARB)
+#define glProgramUniform4i64vARB GLEW_GET_FUN(__glewProgramUniform4i64vARB)
+#define glProgramUniform4ui64ARB GLEW_GET_FUN(__glewProgramUniform4ui64ARB)
+#define glProgramUniform4ui64vARB GLEW_GET_FUN(__glewProgramUniform4ui64vARB)
+#define glUniform1i64ARB GLEW_GET_FUN(__glewUniform1i64ARB)
+#define glUniform1i64vARB GLEW_GET_FUN(__glewUniform1i64vARB)
+#define glUniform1ui64ARB GLEW_GET_FUN(__glewUniform1ui64ARB)
+#define glUniform1ui64vARB GLEW_GET_FUN(__glewUniform1ui64vARB)
+#define glUniform2i64ARB GLEW_GET_FUN(__glewUniform2i64ARB)
+#define glUniform2i64vARB GLEW_GET_FUN(__glewUniform2i64vARB)
+#define glUniform2ui64ARB GLEW_GET_FUN(__glewUniform2ui64ARB)
+#define glUniform2ui64vARB GLEW_GET_FUN(__glewUniform2ui64vARB)
+#define glUniform3i64ARB GLEW_GET_FUN(__glewUniform3i64ARB)
+#define glUniform3i64vARB GLEW_GET_FUN(__glewUniform3i64vARB)
+#define glUniform3ui64ARB GLEW_GET_FUN(__glewUniform3ui64ARB)
+#define glUniform3ui64vARB GLEW_GET_FUN(__glewUniform3ui64vARB)
+#define glUniform4i64ARB GLEW_GET_FUN(__glewUniform4i64ARB)
+#define glUniform4i64vARB GLEW_GET_FUN(__glewUniform4i64vARB)
+#define glUniform4ui64ARB GLEW_GET_FUN(__glewUniform4ui64ARB)
+#define glUniform4ui64vARB GLEW_GET_FUN(__glewUniform4ui64vARB)
+
+#define GLEW_ARB_gpu_shader_int64 GLEW_GET_VAR(__GLEW_ARB_gpu_shader_int64)
+
+#endif /* GL_ARB_gpu_shader_int64 */
 
 /* ------------------------ GL_ARB_half_float_pixel ------------------------ */
 
@@ -5337,6 +5816,22 @@ typedef GLboolean (GLAPIENTRY * PFNGLISQUERYARBPROC) (GLuint id);
 
 #endif /* GL_ARB_occlusion_query2 */
 
+/* --------------------- GL_ARB_parallel_shader_compile -------------------- */
+
+#ifndef GL_ARB_parallel_shader_compile
+#define GL_ARB_parallel_shader_compile 1
+
+#define GL_MAX_SHADER_COMPILER_THREADS_ARB 0x91B0
+#define GL_COMPLETION_STATUS_ARB 0x91B1
+
+typedef void (GLAPIENTRY * PFNGLMAXSHADERCOMPILERTHREADSARBPROC) (GLuint count);
+
+#define glMaxShaderCompilerThreadsARB GLEW_GET_FUN(__glewMaxShaderCompilerThreadsARB)
+
+#define GLEW_ARB_parallel_shader_compile GLEW_GET_VAR(__GLEW_ARB_parallel_shader_compile)
+
+#endif /* GL_ARB_parallel_shader_compile */
+
 /* -------------------- GL_ARB_pipeline_statistics_query ------------------- */
 
 #ifndef GL_ARB_pipeline_statistics_query
@@ -5403,6 +5898,30 @@ typedef void (GLAPIENTRY * PFNGLPOINTPARAMETERFVARBPROC) (GLenum pname, const GL
 #define GLEW_ARB_point_sprite GLEW_GET_VAR(__GLEW_ARB_point_sprite)
 
 #endif /* GL_ARB_point_sprite */
+
+/* ---------------------- GL_ARB_polygon_offset_clamp ---------------------- */
+
+#ifndef GL_ARB_polygon_offset_clamp
+#define GL_ARB_polygon_offset_clamp 1
+
+#define GL_POLYGON_OFFSET_CLAMP 0x8E1B
+
+typedef void (GLAPIENTRY * PFNGLPOLYGONOFFSETCLAMPPROC) (GLfloat factor, GLfloat units, GLfloat clamp);
+
+#define glPolygonOffsetClamp GLEW_GET_FUN(__glewPolygonOffsetClamp)
+
+#define GLEW_ARB_polygon_offset_clamp GLEW_GET_VAR(__GLEW_ARB_polygon_offset_clamp)
+
+#endif /* GL_ARB_polygon_offset_clamp */
+
+/* ----------------------- GL_ARB_post_depth_coverage ---------------------- */
+
+#ifndef GL_ARB_post_depth_coverage
+#define GL_ARB_post_depth_coverage 1
+
+#define GLEW_ARB_post_depth_coverage GLEW_GET_VAR(__GLEW_ARB_post_depth_coverage)
+
+#endif /* GL_ARB_post_depth_coverage */
 
 /* --------------------- GL_ARB_program_interface_query -------------------- */
 
@@ -5592,6 +6111,30 @@ typedef void (GLAPIENTRY * PFNGLREADNPIXELSARBPROC) (GLint x, GLint y, GLsizei w
 #define GLEW_ARB_robustness_share_group_isolation GLEW_GET_VAR(__GLEW_ARB_robustness_share_group_isolation)
 
 #endif /* GL_ARB_robustness_share_group_isolation */
+
+/* ------------------------ GL_ARB_sample_locations ------------------------ */
+
+#ifndef GL_ARB_sample_locations
+#define GL_ARB_sample_locations 1
+
+#define GL_SAMPLE_LOCATION_ARB 0x8E50
+#define GL_SAMPLE_LOCATION_SUBPIXEL_BITS_ARB 0x933D
+#define GL_SAMPLE_LOCATION_PIXEL_GRID_WIDTH_ARB 0x933E
+#define GL_SAMPLE_LOCATION_PIXEL_GRID_HEIGHT_ARB 0x933F
+#define GL_PROGRAMMABLE_SAMPLE_LOCATION_TABLE_SIZE_ARB 0x9340
+#define GL_PROGRAMMABLE_SAMPLE_LOCATION_ARB 0x9341
+#define GL_FRAMEBUFFER_PROGRAMMABLE_SAMPLE_LOCATIONS_ARB 0x9342
+#define GL_FRAMEBUFFER_SAMPLE_LOCATION_PIXEL_GRID_ARB 0x9343
+
+typedef void (GLAPIENTRY * PFNGLFRAMEBUFFERSAMPLELOCATIONSFVARBPROC) (GLenum target, GLuint start, GLsizei count, const GLfloat* v);
+typedef void (GLAPIENTRY * PFNGLNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARBPROC) (GLuint framebuffer, GLuint start, GLsizei count, const GLfloat* v);
+
+#define glFramebufferSampleLocationsfvARB GLEW_GET_FUN(__glewFramebufferSampleLocationsfvARB)
+#define glNamedFramebufferSampleLocationsfvARB GLEW_GET_FUN(__glewNamedFramebufferSampleLocationsfvARB)
+
+#define GLEW_ARB_sample_locations GLEW_GET_VAR(__GLEW_ARB_sample_locations)
+
+#endif /* GL_ARB_sample_locations */
 
 /* ------------------------- GL_ARB_sample_shading ------------------------- */
 
@@ -5813,6 +6356,15 @@ typedef void (GLAPIENTRY * PFNGLVALIDATEPROGRAMPIPELINEPROC) (GLuint pipeline);
 
 #endif /* GL_ARB_separate_shader_objects */
 
+/* -------------------- GL_ARB_shader_atomic_counter_ops ------------------- */
+
+#ifndef GL_ARB_shader_atomic_counter_ops
+#define GL_ARB_shader_atomic_counter_ops 1
+
+#define GLEW_ARB_shader_atomic_counter_ops GLEW_GET_VAR(__GLEW_ARB_shader_atomic_counter_ops)
+
+#endif /* GL_ARB_shader_atomic_counter_ops */
+
 /* --------------------- GL_ARB_shader_atomic_counters --------------------- */
 
 #ifndef GL_ARB_shader_atomic_counters
@@ -5856,6 +6408,15 @@ typedef void (GLAPIENTRY * PFNGLGETACTIVEATOMICCOUNTERBUFFERIVPROC) (GLuint prog
 
 #endif /* GL_ARB_shader_atomic_counters */
 
+/* -------------------------- GL_ARB_shader_ballot ------------------------- */
+
+#ifndef GL_ARB_shader_ballot
+#define GL_ARB_shader_ballot 1
+
+#define GLEW_ARB_shader_ballot GLEW_GET_VAR(__GLEW_ARB_shader_ballot)
+
+#endif /* GL_ARB_shader_ballot */
+
 /* ----------------------- GL_ARB_shader_bit_encoding ---------------------- */
 
 #ifndef GL_ARB_shader_bit_encoding
@@ -5864,6 +6425,15 @@ typedef void (GLAPIENTRY * PFNGLGETACTIVEATOMICCOUNTERBUFFERIVPROC) (GLuint prog
 #define GLEW_ARB_shader_bit_encoding GLEW_GET_VAR(__GLEW_ARB_shader_bit_encoding)
 
 #endif /* GL_ARB_shader_bit_encoding */
+
+/* -------------------------- GL_ARB_shader_clock -------------------------- */
+
+#ifndef GL_ARB_shader_clock
+#define GL_ARB_shader_clock 1
+
+#define GLEW_ARB_shader_clock GLEW_GET_VAR(__GLEW_ARB_shader_clock)
+
+#endif /* GL_ARB_shader_clock */
 
 /* --------------------- GL_ARB_shader_draw_parameters --------------------- */
 
@@ -6202,6 +6772,15 @@ typedef void (GLAPIENTRY * PFNGLUNIFORMSUBROUTINESUIVPROC) (GLenum shadertype, G
 
 #endif /* GL_ARB_shader_texture_lod */
 
+/* ------------------- GL_ARB_shader_viewport_layer_array ------------------ */
+
+#ifndef GL_ARB_shader_viewport_layer_array
+#define GL_ARB_shader_viewport_layer_array 1
+
+#define GLEW_ARB_shader_viewport_layer_array GLEW_GET_VAR(__GLEW_ARB_shader_viewport_layer_array)
+
+#endif /* GL_ARB_shader_viewport_layer_array */
+
 /* ---------------------- GL_ARB_shading_language_100 ---------------------- */
 
 #ifndef GL_ARB_shading_language_100
@@ -6316,14 +6895,42 @@ typedef void (GLAPIENTRY * PFNGLBUFFERPAGECOMMITMENTARBPROC) (GLenum target, GLi
 #define GL_NUM_SPARSE_LEVELS_ARB 0x91AA
 
 typedef void (GLAPIENTRY * PFNGLTEXPAGECOMMITMENTARBPROC) (GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width, GLsizei height, GLsizei depth, GLboolean commit);
-typedef void (GLAPIENTRY * PFNGLTEXTUREPAGECOMMITMENTEXTPROC) (GLuint texture, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width, GLsizei height, GLsizei depth, GLboolean commit);
 
 #define glTexPageCommitmentARB GLEW_GET_FUN(__glewTexPageCommitmentARB)
-#define glTexturePageCommitmentEXT GLEW_GET_FUN(__glewTexturePageCommitmentEXT)
 
 #define GLEW_ARB_sparse_texture GLEW_GET_VAR(__GLEW_ARB_sparse_texture)
 
 #endif /* GL_ARB_sparse_texture */
+
+/* ------------------------- GL_ARB_sparse_texture2 ------------------------ */
+
+#ifndef GL_ARB_sparse_texture2
+#define GL_ARB_sparse_texture2 1
+
+#define GLEW_ARB_sparse_texture2 GLEW_GET_VAR(__GLEW_ARB_sparse_texture2)
+
+#endif /* GL_ARB_sparse_texture2 */
+
+/* ---------------------- GL_ARB_sparse_texture_clamp ---------------------- */
+
+#ifndef GL_ARB_sparse_texture_clamp
+#define GL_ARB_sparse_texture_clamp 1
+
+#define GLEW_ARB_sparse_texture_clamp GLEW_GET_VAR(__GLEW_ARB_sparse_texture_clamp)
+
+#endif /* GL_ARB_sparse_texture_clamp */
+
+/* ------------------------ GL_ARB_spirv_extensions ------------------------ */
+
+#ifndef GL_ARB_spirv_extensions
+#define GL_ARB_spirv_extensions 1
+
+#define GL_SPIR_V_EXTENSIONS 0x9553
+#define GL_NUM_SPIR_V_EXTENSIONS 0x9554
+
+#define GLEW_ARB_spirv_extensions GLEW_GET_VAR(__GLEW_ARB_spirv_extensions)
+
+#endif /* GL_ARB_spirv_extensions */
 
 /* ------------------------ GL_ARB_stencil_texturing ----------------------- */
 
@@ -6355,7 +6962,7 @@ typedef void (GLAPIENTRY * PFNGLTEXTUREPAGECOMMITMENTEXTPROC) (GLuint texture, G
 #define GL_TIMEOUT_EXPIRED 0x911B
 #define GL_CONDITION_SATISFIED 0x911C
 #define GL_WAIT_FAILED 0x911D
-#define GL_TIMEOUT_IGNORED 0xFFFFFFFFFFFFFFFF
+#define GL_TIMEOUT_IGNORED 0xFFFFFFFFFFFFFFFFull
 
 typedef GLenum (GLAPIENTRY * PFNGLCLIENTWAITSYNCPROC) (GLsync GLsync,GLbitfield flags,GLuint64 timeout);
 typedef void (GLAPIENTRY * PFNGLDELETESYNCPROC) (GLsync GLsync);
@@ -6662,6 +7269,30 @@ typedef void (GLAPIENTRY * PFNGLGETCOMPRESSEDTEXIMAGEARBPROC) (GLenum target, GL
 
 #endif /* GL_ARB_texture_env_dot3 */
 
+/* ------------------- GL_ARB_texture_filter_anisotropic ------------------- */
+
+#ifndef GL_ARB_texture_filter_anisotropic
+#define GL_ARB_texture_filter_anisotropic 1
+
+#define GL_TEXTURE_MAX_ANISOTROPY 0x84FE
+#define GL_MAX_TEXTURE_MAX_ANISOTROPY 0x84FF
+
+#define GLEW_ARB_texture_filter_anisotropic GLEW_GET_VAR(__GLEW_ARB_texture_filter_anisotropic)
+
+#endif /* GL_ARB_texture_filter_anisotropic */
+
+/* ---------------------- GL_ARB_texture_filter_minmax --------------------- */
+
+#ifndef GL_ARB_texture_filter_minmax
+#define GL_ARB_texture_filter_minmax 1
+
+#define GL_TEXTURE_REDUCTION_MODE_ARB 0x9366
+#define GL_WEIGHTED_AVERAGE_ARB 0x9367
+
+#define GLEW_ARB_texture_filter_minmax GLEW_GET_VAR(__GLEW_ARB_texture_filter_minmax)
+
+#endif /* GL_ARB_texture_filter_minmax */
+
 /* -------------------------- GL_ARB_texture_float ------------------------- */
 
 #ifndef GL_ARB_texture_float
@@ -6878,16 +7509,10 @@ typedef void (GLAPIENTRY * PFNGLTEXIMAGE3DMULTISAMPLEPROC) (GLenum target, GLsiz
 typedef void (GLAPIENTRY * PFNGLTEXSTORAGE1DPROC) (GLenum target, GLsizei levels, GLenum internalformat, GLsizei width);
 typedef void (GLAPIENTRY * PFNGLTEXSTORAGE2DPROC) (GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height);
 typedef void (GLAPIENTRY * PFNGLTEXSTORAGE3DPROC) (GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth);
-typedef void (GLAPIENTRY * PFNGLTEXTURESTORAGE1DEXTPROC) (GLuint texture, GLenum target, GLsizei levels, GLenum internalformat, GLsizei width);
-typedef void (GLAPIENTRY * PFNGLTEXTURESTORAGE2DEXTPROC) (GLuint texture, GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height);
-typedef void (GLAPIENTRY * PFNGLTEXTURESTORAGE3DEXTPROC) (GLuint texture, GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth);
 
 #define glTexStorage1D GLEW_GET_FUN(__glewTexStorage1D)
 #define glTexStorage2D GLEW_GET_FUN(__glewTexStorage2D)
 #define glTexStorage3D GLEW_GET_FUN(__glewTexStorage3D)
-#define glTextureStorage1DEXT GLEW_GET_FUN(__glewTextureStorage1DEXT)
-#define glTextureStorage2DEXT GLEW_GET_FUN(__glewTextureStorage2DEXT)
-#define glTextureStorage3DEXT GLEW_GET_FUN(__glewTextureStorage3DEXT)
 
 #define GLEW_ARB_texture_storage GLEW_GET_VAR(__GLEW_ARB_texture_storage)
 
@@ -7106,7 +7731,7 @@ typedef void (GLAPIENTRY * PFNGLMULTTRANSPOSEMATRIXFARBPROC) (GLfloat m[16]);
 #define GL_UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER 0x8A44
 #define GL_UNIFORM_BLOCK_REFERENCED_BY_GEOMETRY_SHADER 0x8A45
 #define GL_UNIFORM_BLOCK_REFERENCED_BY_FRAGMENT_SHADER 0x8A46
-#define GL_INVALID_INDEX 0xFFFFFFFF
+#define GL_INVALID_INDEX 0xFFFFFFFFu
 
 typedef void (GLAPIENTRY * PFNGLBINDBUFFERBASEPROC) (GLenum target, GLuint index, GLuint buffer);
 typedef void (GLAPIENTRY * PFNGLBINDBUFFERRANGEPROC) (GLenum target, GLuint index, GLuint buffer, GLintptr offset, GLsizeiptr size);
@@ -7812,6 +8437,60 @@ typedef void (GLAPIENTRY * PFNGLWINDOWPOS3SVARBPROC) (const GLshort* p);
 
 #endif /* GL_ARB_window_pos */
 
+/* ----------------------- GL_ARM_mali_program_binary ---------------------- */
+
+#ifndef GL_ARM_mali_program_binary
+#define GL_ARM_mali_program_binary 1
+
+#define GL_MALI_PROGRAM_BINARY_ARM 0x8F61
+
+#define GLEW_ARM_mali_program_binary GLEW_GET_VAR(__GLEW_ARM_mali_program_binary)
+
+#endif /* GL_ARM_mali_program_binary */
+
+/* ----------------------- GL_ARM_mali_shader_binary ----------------------- */
+
+#ifndef GL_ARM_mali_shader_binary
+#define GL_ARM_mali_shader_binary 1
+
+#define GL_MALI_SHADER_BINARY_ARM 0x8F60
+
+#define GLEW_ARM_mali_shader_binary GLEW_GET_VAR(__GLEW_ARM_mali_shader_binary)
+
+#endif /* GL_ARM_mali_shader_binary */
+
+/* ------------------------------ GL_ARM_rgba8 ----------------------------- */
+
+#ifndef GL_ARM_rgba8
+#define GL_ARM_rgba8 1
+
+#define GL_RGBA8_OES 0x8058
+
+#define GLEW_ARM_rgba8 GLEW_GET_VAR(__GLEW_ARM_rgba8)
+
+#endif /* GL_ARM_rgba8 */
+
+/* -------------------- GL_ARM_shader_framebuffer_fetch -------------------- */
+
+#ifndef GL_ARM_shader_framebuffer_fetch
+#define GL_ARM_shader_framebuffer_fetch 1
+
+#define GL_FETCH_PER_SAMPLE_ARM 0x8F65
+#define GL_FRAGMENT_SHADER_FRAMEBUFFER_FETCH_MRT_ARM 0x8F66
+
+#define GLEW_ARM_shader_framebuffer_fetch GLEW_GET_VAR(__GLEW_ARM_shader_framebuffer_fetch)
+
+#endif /* GL_ARM_shader_framebuffer_fetch */
+
+/* ------------- GL_ARM_shader_framebuffer_fetch_depth_stencil ------------- */
+
+#ifndef GL_ARM_shader_framebuffer_fetch_depth_stencil
+#define GL_ARM_shader_framebuffer_fetch_depth_stencil 1
+
+#define GLEW_ARM_shader_framebuffer_fetch_depth_stencil GLEW_GET_VAR(__GLEW_ARM_shader_framebuffer_fetch_depth_stencil)
+
+#endif /* GL_ARM_shader_framebuffer_fetch_depth_stencil */
+
 /* ------------------------- GL_ATIX_point_sprites ------------------------- */
 
 #ifndef GL_ATIX_point_sprites
@@ -8363,6 +9042,27 @@ typedef void (GLAPIENTRY * PFNGLVERTEXSTREAM4SVATIPROC) (GLenum stream, const GL
 
 #endif /* GL_ATI_vertex_streams */
 
+/* -------------------- GL_EGL_KHR_context_flush_control ------------------- */
+
+#ifndef GL_EGL_KHR_context_flush_control
+#define GL_EGL_KHR_context_flush_control 1
+
+#define GLEW_EGL_KHR_context_flush_control GLEW_GET_VAR(__GLEW_EGL_KHR_context_flush_control)
+
+#endif /* GL_EGL_KHR_context_flush_control */
+
+/* ---------------- GL_EGL_NV_robustness_video_memory_purge ---------------- */
+
+#ifndef GL_EGL_NV_robustness_video_memory_purge
+#define GL_EGL_NV_robustness_video_memory_purge 1
+
+#define GL_EGL_GENERATE_RESET_ON_VIDEO_MEMORY_PURGE_NV 0x334C
+#define GL_PURGED_CONTEXT_RESET_NV 0x92BB
+
+#define GLEW_EGL_NV_robustness_video_memory_purge GLEW_GET_VAR(__GLEW_EGL_NV_robustness_video_memory_purge)
+
+#endif /* GL_EGL_NV_robustness_video_memory_purge */
+
 /* --------------------------- GL_EXT_422_pixels --------------------------- */
 
 #ifndef GL_EXT_422_pixels
@@ -8389,6 +9089,26 @@ typedef void (GLAPIENTRY * PFNGLVERTEXSTREAM4SVATIPROC) (GLenum stream, const GL
 
 #endif /* GL_EXT_Cg_shader */
 
+/* ------------------------- GL_EXT_EGL_image_array ------------------------ */
+
+#ifndef GL_EXT_EGL_image_array
+#define GL_EXT_EGL_image_array 1
+
+#define GLEW_EXT_EGL_image_array GLEW_GET_VAR(__GLEW_EXT_EGL_image_array)
+
+#endif /* GL_EXT_EGL_image_array */
+
+/* --------------------------- GL_EXT_YUV_target --------------------------- */
+
+#ifndef GL_EXT_YUV_target
+#define GL_EXT_YUV_target 1
+
+#define GL_SAMPLER_EXTERNAL_2D_Y2Y_EXT 0x8BE7
+
+#define GLEW_EXT_YUV_target GLEW_GET_VAR(__GLEW_EXT_YUV_target)
+
+#endif /* GL_EXT_YUV_target */
+
 /* ------------------------------ GL_EXT_abgr ------------------------------ */
 
 #ifndef GL_EXT_abgr
@@ -8399,6 +9119,23 @@ typedef void (GLAPIENTRY * PFNGLVERTEXSTREAM4SVATIPROC) (GLenum stream, const GL
 #define GLEW_EXT_abgr GLEW_GET_VAR(__GLEW_EXT_abgr)
 
 #endif /* GL_EXT_abgr */
+
+/* -------------------------- GL_EXT_base_instance ------------------------- */
+
+#ifndef GL_EXT_base_instance
+#define GL_EXT_base_instance 1
+
+typedef void (GLAPIENTRY * PFNGLDRAWARRAYSINSTANCEDBASEINSTANCEEXTPROC) (GLenum mode, GLint first, GLsizei count, GLsizei instancecount, GLuint baseinstance);
+typedef void (GLAPIENTRY * PFNGLDRAWELEMENTSINSTANCEDBASEINSTANCEEXTPROC) (GLenum mode, GLsizei count, GLenum type, const void *indices, GLsizei instancecount, GLuint baseinstance);
+typedef void (GLAPIENTRY * PFNGLDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCEEXTPROC) (GLenum mode, GLsizei count, GLenum type, const void *indices, GLsizei instancecount, GLint basevertex, GLuint baseinstance);
+
+#define glDrawArraysInstancedBaseInstanceEXT GLEW_GET_FUN(__glewDrawArraysInstancedBaseInstanceEXT)
+#define glDrawElementsInstancedBaseInstanceEXT GLEW_GET_FUN(__glewDrawElementsInstancedBaseInstanceEXT)
+#define glDrawElementsInstancedBaseVertexBaseInstanceEXT GLEW_GET_FUN(__glewDrawElementsInstancedBaseVertexBaseInstanceEXT)
+
+#define GLEW_EXT_base_instance GLEW_GET_VAR(__GLEW_EXT_base_instance)
+
+#endif /* GL_EXT_base_instance */
 
 /* ------------------------------ GL_EXT_bgra ------------------------------ */
 
@@ -8471,6 +9208,31 @@ typedef void (GLAPIENTRY * PFNGLBLENDEQUATIONSEPARATEEXTPROC) (GLenum modeRGB, G
 
 #endif /* GL_EXT_blend_equation_separate */
 
+/* ----------------------- GL_EXT_blend_func_extended ---------------------- */
+
+#ifndef GL_EXT_blend_func_extended
+#define GL_EXT_blend_func_extended 1
+
+#define GL_SRC_ALPHA_SATURATE_EXT 0x0308
+#define GL_SRC1_ALPHA_EXT 0x8589
+#define GL_SRC1_COLOR_EXT 0x88F9
+#define GL_ONE_MINUS_SRC1_COLOR_EXT 0x88FA
+#define GL_ONE_MINUS_SRC1_ALPHA_EXT 0x88FB
+#define GL_MAX_DUAL_SOURCE_DRAW_BUFFERS_EXT 0x88FC
+#define GL_LOCATION_INDEX_EXT 0x930F
+
+typedef void (GLAPIENTRY * PFNGLBINDFRAGDATALOCATIONINDEXEDEXTPROC) (GLuint program, GLuint colorNumber, GLuint index, const GLchar * name);
+typedef GLint (GLAPIENTRY * PFNGLGETFRAGDATAINDEXEXTPROC) (GLuint program, const GLchar * name);
+typedef GLint (GLAPIENTRY * PFNGLGETPROGRAMRESOURCELOCATIONINDEXEXTPROC) (GLuint program, GLenum programInterface, const GLchar* name);
+
+#define glBindFragDataLocationIndexedEXT GLEW_GET_FUN(__glewBindFragDataLocationIndexedEXT)
+#define glGetFragDataIndexEXT GLEW_GET_FUN(__glewGetFragDataIndexEXT)
+#define glGetProgramResourceLocationIndexEXT GLEW_GET_FUN(__glewGetProgramResourceLocationIndexEXT)
+
+#define GLEW_EXT_blend_func_extended GLEW_GET_VAR(__GLEW_EXT_blend_func_extended)
+
+#endif /* GL_EXT_blend_func_extended */
+
 /* ----------------------- GL_EXT_blend_func_separate ---------------------- */
 
 #ifndef GL_EXT_blend_func_separate
@@ -8528,6 +9290,67 @@ typedef void (GLAPIENTRY * PFNGLBLENDEQUATIONEXTPROC) (GLenum mode);
 
 #endif /* GL_EXT_blend_subtract */
 
+/* ------------------------- GL_EXT_buffer_storage ------------------------- */
+
+#ifndef GL_EXT_buffer_storage
+#define GL_EXT_buffer_storage 1
+
+#define GL_MAP_READ_BIT 0x0001
+#define GL_MAP_WRITE_BIT 0x0002
+#define GL_MAP_PERSISTENT_BIT_EXT 0x0040
+#define GL_MAP_COHERENT_BIT_EXT 0x0080
+#define GL_DYNAMIC_STORAGE_BIT_EXT 0x0100
+#define GL_CLIENT_STORAGE_BIT_EXT 0x0200
+#define GL_CLIENT_MAPPED_BUFFER_BARRIER_BIT_EXT 0x00004000
+#define GL_BUFFER_IMMUTABLE_STORAGE_EXT 0x821F
+#define GL_BUFFER_STORAGE_FLAGS_EXT 0x8220
+
+typedef void (GLAPIENTRY * PFNGLBUFFERSTORAGEEXTPROC) (GLenum target, GLsizeiptr size, const void *data, GLbitfield flags);
+typedef void (GLAPIENTRY * PFNGLNAMEDBUFFERSTORAGEEXTPROC) (GLuint buffer, GLsizeiptr size, const void *data, GLbitfield flags);
+
+#define glBufferStorageEXT GLEW_GET_FUN(__glewBufferStorageEXT)
+#define glNamedBufferStorageEXT GLEW_GET_FUN(__glewNamedBufferStorageEXT)
+
+#define GLEW_EXT_buffer_storage GLEW_GET_VAR(__GLEW_EXT_buffer_storage)
+
+#endif /* GL_EXT_buffer_storage */
+
+/* -------------------------- GL_EXT_clear_texture ------------------------- */
+
+#ifndef GL_EXT_clear_texture
+#define GL_EXT_clear_texture 1
+
+typedef void (GLAPIENTRY * PFNGLCLEARTEXIMAGEEXTPROC) (GLuint texture, GLint level, GLenum format, GLenum type, const void *data);
+typedef void (GLAPIENTRY * PFNGLCLEARTEXSUBIMAGEEXTPROC) (GLuint texture, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type, const void *data);
+
+#define glClearTexImageEXT GLEW_GET_FUN(__glewClearTexImageEXT)
+#define glClearTexSubImageEXT GLEW_GET_FUN(__glewClearTexSubImageEXT)
+
+#define GLEW_EXT_clear_texture GLEW_GET_VAR(__GLEW_EXT_clear_texture)
+
+#endif /* GL_EXT_clear_texture */
+
+/* ----------------------- GL_EXT_clip_cull_distance ----------------------- */
+
+#ifndef GL_EXT_clip_cull_distance
+#define GL_EXT_clip_cull_distance 1
+
+#define GL_MAX_CLIP_DISTANCES_EXT 0x0D32
+#define GL_CLIP_DISTANCE0_EXT 0x3000
+#define GL_CLIP_DISTANCE1_EXT 0x3001
+#define GL_CLIP_DISTANCE2_EXT 0x3002
+#define GL_CLIP_DISTANCE3_EXT 0x3003
+#define GL_CLIP_DISTANCE4_EXT 0x3004
+#define GL_CLIP_DISTANCE5_EXT 0x3005
+#define GL_CLIP_DISTANCE6_EXT 0x3006
+#define GL_CLIP_DISTANCE7_EXT 0x3007
+#define GL_MAX_CULL_DISTANCES_EXT 0x82F9
+#define GL_MAX_COMBINED_CLIP_AND_CULL_DISTANCES_EXT 0x82FA
+
+#define GLEW_EXT_clip_cull_distance GLEW_GET_VAR(__GLEW_EXT_clip_cull_distance)
+
+#endif /* GL_EXT_clip_cull_distance */
+
 /* ------------------------ GL_EXT_clip_volume_hint ------------------------ */
 
 #ifndef GL_EXT_clip_volume_hint
@@ -8552,6 +9375,31 @@ typedef void (GLAPIENTRY * PFNGLBLENDEQUATIONEXTPROC) (GLenum mode);
 #define GLEW_EXT_cmyka GLEW_GET_VAR(__GLEW_EXT_cmyka)
 
 #endif /* GL_EXT_cmyka */
+
+/* ----------------------- GL_EXT_color_buffer_float ----------------------- */
+
+#ifndef GL_EXT_color_buffer_float
+#define GL_EXT_color_buffer_float 1
+
+#define GLEW_EXT_color_buffer_float GLEW_GET_VAR(__GLEW_EXT_color_buffer_float)
+
+#endif /* GL_EXT_color_buffer_float */
+
+/* --------------------- GL_EXT_color_buffer_half_float -------------------- */
+
+#ifndef GL_EXT_color_buffer_half_float
+#define GL_EXT_color_buffer_half_float 1
+
+#define GL_FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE_EXT 0x8211
+#define GL_R16F_EXT 0x822D
+#define GL_RG16F_EXT 0x822F
+#define GL_RGBA16F_EXT 0x881A
+#define GL_RGB16F_EXT 0x881B
+#define GL_UNSIGNED_NORMALIZED_EXT 0x8C17
+
+#define GLEW_EXT_color_buffer_half_float GLEW_GET_VAR(__GLEW_EXT_color_buffer_half_float)
+
+#endif /* GL_EXT_color_buffer_half_float */
 
 /* ------------------------- GL_EXT_color_subtable ------------------------- */
 
@@ -8585,6 +9433,24 @@ typedef void (GLAPIENTRY * PFNGLUNLOCKARRAYSEXTPROC) (void);
 #define GLEW_EXT_compiled_vertex_array GLEW_GET_VAR(__GLEW_EXT_compiled_vertex_array)
 
 #endif /* GL_EXT_compiled_vertex_array */
+
+/* ---------------- GL_EXT_compressed_ETC1_RGB8_sub_texture ---------------- */
+
+#ifndef GL_EXT_compressed_ETC1_RGB8_sub_texture
+#define GL_EXT_compressed_ETC1_RGB8_sub_texture 1
+
+#define GLEW_EXT_compressed_ETC1_RGB8_sub_texture GLEW_GET_VAR(__GLEW_EXT_compressed_ETC1_RGB8_sub_texture)
+
+#endif /* GL_EXT_compressed_ETC1_RGB8_sub_texture */
+
+/* ----------------------- GL_EXT_conservative_depth ----------------------- */
+
+#ifndef GL_EXT_conservative_depth
+#define GL_EXT_conservative_depth 1
+
+#define GLEW_EXT_conservative_depth GLEW_GET_VAR(__GLEW_EXT_conservative_depth)
+
+#endif /* GL_EXT_conservative_depth */
 
 /* --------------------------- GL_EXT_convolution -------------------------- */
 
@@ -8673,6 +9539,19 @@ typedef void (GLAPIENTRY * PFNGLTANGENTPOINTEREXTPROC) (GLenum type, GLsizei str
 #define GLEW_EXT_coordinate_frame GLEW_GET_VAR(__GLEW_EXT_coordinate_frame)
 
 #endif /* GL_EXT_coordinate_frame */
+
+/* --------------------------- GL_EXT_copy_image --------------------------- */
+
+#ifndef GL_EXT_copy_image
+#define GL_EXT_copy_image 1
+
+typedef void (GLAPIENTRY * PFNGLCOPYIMAGESUBDATAEXTPROC) (GLuint srcName, GLenum srcTarget, GLint srcLevel, GLint srcX, GLint srcY, GLint srcZ, GLuint dstName, GLenum dstTarget, GLint dstLevel, GLint dstX, GLint dstY, GLint dstZ, GLsizei srcWidth, GLsizei srcHeight, GLsizei srcDepth);
+
+#define glCopyImageSubDataEXT GLEW_GET_FUN(__glewCopyImageSubDataEXT)
+
+#define GLEW_EXT_copy_image GLEW_GET_VAR(__GLEW_EXT_copy_image)
+
+#endif /* GL_EXT_copy_image */
 
 /* -------------------------- GL_EXT_copy_texture -------------------------- */
 
@@ -9212,6 +10091,71 @@ typedef void (GLAPIENTRY * PFNGLVERTEXARRAYVERTEXOFFSETEXTPROC) (GLuint vaobj, G
 
 #endif /* GL_EXT_direct_state_access */
 
+/* ----------------------- GL_EXT_discard_framebuffer ---------------------- */
+
+#ifndef GL_EXT_discard_framebuffer
+#define GL_EXT_discard_framebuffer 1
+
+#define GL_COLOR_EXT 0x1800
+#define GL_DEPTH_EXT 0x1801
+#define GL_STENCIL_EXT 0x1802
+
+typedef void (GLAPIENTRY * PFNGLDISCARDFRAMEBUFFEREXTPROC) (GLenum target, GLsizei numAttachments, const GLenum* attachments);
+
+#define glDiscardFramebufferEXT GLEW_GET_FUN(__glewDiscardFramebufferEXT)
+
+#define GLEW_EXT_discard_framebuffer GLEW_GET_VAR(__GLEW_EXT_discard_framebuffer)
+
+#endif /* GL_EXT_discard_framebuffer */
+
+/* -------------------------- GL_EXT_draw_buffers -------------------------- */
+
+#ifndef GL_EXT_draw_buffers
+#define GL_EXT_draw_buffers 1
+
+#define GL_MAX_DRAW_BUFFERS_EXT 0x8824
+#define GL_DRAW_BUFFER0_EXT 0x8825
+#define GL_DRAW_BUFFER1_EXT 0x8826
+#define GL_DRAW_BUFFER2_EXT 0x8827
+#define GL_DRAW_BUFFER3_EXT 0x8828
+#define GL_DRAW_BUFFER4_EXT 0x8829
+#define GL_DRAW_BUFFER5_EXT 0x882A
+#define GL_DRAW_BUFFER6_EXT 0x882B
+#define GL_DRAW_BUFFER7_EXT 0x882C
+#define GL_DRAW_BUFFER8_EXT 0x882D
+#define GL_DRAW_BUFFER9_EXT 0x882E
+#define GL_DRAW_BUFFER10_EXT 0x882F
+#define GL_DRAW_BUFFER11_EXT 0x8830
+#define GL_DRAW_BUFFER12_EXT 0x8831
+#define GL_DRAW_BUFFER13_EXT 0x8832
+#define GL_DRAW_BUFFER14_EXT 0x8833
+#define GL_DRAW_BUFFER15_EXT 0x8834
+#define GL_MAX_COLOR_ATTACHMENTS_EXT 0x8CDF
+#define GL_COLOR_ATTACHMENT0_EXT 0x8CE0
+#define GL_COLOR_ATTACHMENT1_EXT 0x8CE1
+#define GL_COLOR_ATTACHMENT2_EXT 0x8CE2
+#define GL_COLOR_ATTACHMENT3_EXT 0x8CE3
+#define GL_COLOR_ATTACHMENT4_EXT 0x8CE4
+#define GL_COLOR_ATTACHMENT5_EXT 0x8CE5
+#define GL_COLOR_ATTACHMENT6_EXT 0x8CE6
+#define GL_COLOR_ATTACHMENT7_EXT 0x8CE7
+#define GL_COLOR_ATTACHMENT8_EXT 0x8CE8
+#define GL_COLOR_ATTACHMENT9_EXT 0x8CE9
+#define GL_COLOR_ATTACHMENT10_EXT 0x8CEA
+#define GL_COLOR_ATTACHMENT11_EXT 0x8CEB
+#define GL_COLOR_ATTACHMENT12_EXT 0x8CEC
+#define GL_COLOR_ATTACHMENT13_EXT 0x8CED
+#define GL_COLOR_ATTACHMENT14_EXT 0x8CEE
+#define GL_COLOR_ATTACHMENT15_EXT 0x8CEF
+
+typedef void (GLAPIENTRY * PFNGLDRAWBUFFERSEXTPROC) (GLsizei n, const GLenum* bufs);
+
+#define glDrawBuffersEXT GLEW_GET_FUN(__glewDrawBuffersEXT)
+
+#define GLEW_EXT_draw_buffers GLEW_GET_VAR(__GLEW_EXT_draw_buffers)
+
+#endif /* GL_EXT_draw_buffers */
+
 /* -------------------------- GL_EXT_draw_buffers2 ------------------------- */
 
 #ifndef GL_EXT_draw_buffers2
@@ -9234,6 +10178,52 @@ typedef GLboolean (GLAPIENTRY * PFNGLISENABLEDINDEXEDEXTPROC) (GLenum target, GL
 #define GLEW_EXT_draw_buffers2 GLEW_GET_VAR(__GLEW_EXT_draw_buffers2)
 
 #endif /* GL_EXT_draw_buffers2 */
+
+/* ---------------------- GL_EXT_draw_buffers_indexed ---------------------- */
+
+#ifndef GL_EXT_draw_buffers_indexed
+#define GL_EXT_draw_buffers_indexed 1
+
+typedef void (GLAPIENTRY * PFNGLBLENDEQUATIONSEPARATEIEXTPROC) (GLuint buf, GLenum modeRGB, GLenum modeAlpha);
+typedef void (GLAPIENTRY * PFNGLBLENDEQUATIONIEXTPROC) (GLuint buf, GLenum mode);
+typedef void (GLAPIENTRY * PFNGLBLENDFUNCSEPARATEIEXTPROC) (GLuint buf, GLenum srcRGB, GLenum dstRGB, GLenum srcAlpha, GLenum dstAlpha);
+typedef void (GLAPIENTRY * PFNGLBLENDFUNCIEXTPROC) (GLuint buf, GLenum src, GLenum dst);
+typedef void (GLAPIENTRY * PFNGLCOLORMASKIEXTPROC) (GLuint buf, GLboolean r, GLboolean g, GLboolean b, GLboolean a);
+typedef void (GLAPIENTRY * PFNGLDISABLEIEXTPROC) (GLenum target, GLuint index);
+typedef void (GLAPIENTRY * PFNGLENABLEIEXTPROC) (GLenum target, GLuint index);
+typedef GLboolean (GLAPIENTRY * PFNGLISENABLEDIEXTPROC) (GLenum target, GLuint index);
+
+#define glBlendEquationSeparateiEXT GLEW_GET_FUN(__glewBlendEquationSeparateiEXT)
+#define glBlendEquationiEXT GLEW_GET_FUN(__glewBlendEquationiEXT)
+#define glBlendFuncSeparateiEXT GLEW_GET_FUN(__glewBlendFuncSeparateiEXT)
+#define glBlendFunciEXT GLEW_GET_FUN(__glewBlendFunciEXT)
+#define glColorMaskiEXT GLEW_GET_FUN(__glewColorMaskiEXT)
+#define glDisableiEXT GLEW_GET_FUN(__glewDisableiEXT)
+#define glEnableiEXT GLEW_GET_FUN(__glewEnableiEXT)
+#define glIsEnablediEXT GLEW_GET_FUN(__glewIsEnablediEXT)
+
+#define GLEW_EXT_draw_buffers_indexed GLEW_GET_VAR(__GLEW_EXT_draw_buffers_indexed)
+
+#endif /* GL_EXT_draw_buffers_indexed */
+
+/* -------------------- GL_EXT_draw_elements_base_vertex ------------------- */
+
+#ifndef GL_EXT_draw_elements_base_vertex
+#define GL_EXT_draw_elements_base_vertex 1
+
+typedef void (GLAPIENTRY * PFNGLDRAWELEMENTSBASEVERTEXEXTPROC) (GLenum mode, GLsizei count, GLenum type, const void *indices, GLint basevertex);
+typedef void (GLAPIENTRY * PFNGLDRAWELEMENTSINSTANCEDBASEVERTEXEXTPROC) (GLenum mode, GLsizei count, GLenum type, const void *indices, GLsizei instancecount, GLint basevertex);
+typedef void (GLAPIENTRY * PFNGLDRAWRANGEELEMENTSBASEVERTEXEXTPROC) (GLenum mode, GLuint start, GLuint end, GLsizei count, GLenum type, const void *indices, GLint basevertex);
+typedef void (GLAPIENTRY * PFNGLMULTIDRAWELEMENTSBASEVERTEXEXTPROC) (GLenum mode, const GLsizei* count, GLenum type, const void *const *indices, GLsizei primcount, const GLint *basevertex);
+
+#define glDrawElementsBaseVertexEXT GLEW_GET_FUN(__glewDrawElementsBaseVertexEXT)
+#define glDrawElementsInstancedBaseVertexEXT GLEW_GET_FUN(__glewDrawElementsInstancedBaseVertexEXT)
+#define glDrawRangeElementsBaseVertexEXT GLEW_GET_FUN(__glewDrawRangeElementsBaseVertexEXT)
+#define glMultiDrawElementsBaseVertexEXT GLEW_GET_FUN(__glewMultiDrawElementsBaseVertexEXT)
+
+#define GLEW_EXT_draw_elements_base_vertex GLEW_GET_VAR(__GLEW_EXT_draw_elements_base_vertex)
+
+#endif /* GL_EXT_draw_elements_base_vertex */
 
 /* ------------------------- GL_EXT_draw_instanced ------------------------- */
 
@@ -9266,6 +10256,32 @@ typedef void (GLAPIENTRY * PFNGLDRAWRANGEELEMENTSEXTPROC) (GLenum mode, GLuint s
 
 #endif /* GL_EXT_draw_range_elements */
 
+/* ------------------------- GL_EXT_external_buffer ------------------------ */
+
+#ifndef GL_EXT_external_buffer
+#define GL_EXT_external_buffer 1
+
+typedef void* GLeglClientBufferEXT;
+
+typedef void (GLAPIENTRY * PFNGLBUFFERSTORAGEEXTERNALEXTPROC) (GLenum target, GLintptr offset, GLsizeiptr size, GLeglClientBufferEXT clientBuffer, GLbitfield flags);
+typedef void (GLAPIENTRY * PFNGLNAMEDBUFFERSTORAGEEXTERNALEXTPROC) (GLuint buffer, GLintptr offset, GLsizeiptr size, GLeglClientBufferEXT clientBuffer, GLbitfield flags);
+
+#define glBufferStorageExternalEXT GLEW_GET_FUN(__glewBufferStorageExternalEXT)
+#define glNamedBufferStorageExternalEXT GLEW_GET_FUN(__glewNamedBufferStorageExternalEXT)
+
+#define GLEW_EXT_external_buffer GLEW_GET_VAR(__GLEW_EXT_external_buffer)
+
+#endif /* GL_EXT_external_buffer */
+
+/* --------------------------- GL_EXT_float_blend -------------------------- */
+
+#ifndef GL_EXT_float_blend
+#define GL_EXT_float_blend 1
+
+#define GLEW_EXT_float_blend GLEW_GET_VAR(__GLEW_EXT_float_blend)
+
+#endif /* GL_EXT_float_blend */
+
 /* ---------------------------- GL_EXT_fog_coord --------------------------- */
 
 #ifndef GL_EXT_fog_coord
@@ -9295,6 +10311,15 @@ typedef void (GLAPIENTRY * PFNGLFOGCOORDFVEXTPROC) (const GLfloat *coord);
 #define GLEW_EXT_fog_coord GLEW_GET_VAR(__GLEW_EXT_fog_coord)
 
 #endif /* GL_EXT_fog_coord */
+
+/* --------------------------- GL_EXT_frag_depth --------------------------- */
+
+#ifndef GL_EXT_frag_depth
+#define GL_EXT_frag_depth 1
+
+#define GLEW_EXT_frag_depth GLEW_GET_VAR(__GLEW_EXT_frag_depth)
+
+#endif /* GL_EXT_frag_depth */
 
 /* ------------------------ GL_EXT_fragment_lighting ----------------------- */
 
@@ -9514,6 +10539,92 @@ typedef void (GLAPIENTRY * PFNGLRENDERBUFFERSTORAGEEXTPROC) (GLenum target, GLen
 
 #endif /* GL_EXT_framebuffer_sRGB */
 
+/* ----------------------- GL_EXT_geometry_point_size ---------------------- */
+
+#ifndef GL_EXT_geometry_point_size
+#define GL_EXT_geometry_point_size 1
+
+#define GL_GEOMETRY_SHADER_BIT_EXT 0x00000004
+#define GL_LINES_ADJACENCY_EXT 0xA
+#define GL_LINE_STRIP_ADJACENCY_EXT 0xB
+#define GL_TRIANGLES_ADJACENCY_EXT 0xC
+#define GL_TRIANGLE_STRIP_ADJACENCY_EXT 0xD
+#define GL_LAYER_PROVOKING_VERTEX_EXT 0x825E
+#define GL_UNDEFINED_VERTEX_EXT 0x8260
+#define GL_GEOMETRY_SHADER_INVOCATIONS_EXT 0x887F
+#define GL_GEOMETRY_LINKED_VERTICES_OUT_EXT 0x8916
+#define GL_GEOMETRY_LINKED_INPUT_TYPE_EXT 0x8917
+#define GL_GEOMETRY_LINKED_OUTPUT_TYPE_EXT 0x8918
+#define GL_MAX_GEOMETRY_UNIFORM_BLOCKS_EXT 0x8A2C
+#define GL_MAX_COMBINED_GEOMETRY_UNIFORM_COMPONENTS_EXT 0x8A32
+#define GL_MAX_GEOMETRY_TEXTURE_IMAGE_UNITS_EXT 0x8C29
+#define GL_PRIMITIVES_GENERATED_EXT 0x8C87
+#define GL_FRAMEBUFFER_ATTACHMENT_LAYERED_EXT 0x8DA7
+#define GL_FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS_EXT 0x8DA8
+#define GL_GEOMETRY_SHADER_EXT 0x8DD9
+#define GL_MAX_GEOMETRY_UNIFORM_COMPONENTS_EXT 0x8DDF
+#define GL_MAX_GEOMETRY_OUTPUT_VERTICES_EXT 0x8DE0
+#define GL_MAX_GEOMETRY_TOTAL_OUTPUT_COMPONENTS_EXT 0x8DE1
+#define GL_FIRST_VERTEX_CONVENTION_EXT 0x8E4D
+#define GL_LAST_VERTEX_CONVENTION_EXT 0x8E4E
+#define GL_MAX_GEOMETRY_SHADER_INVOCATIONS_EXT 0x8E5A
+#define GL_MAX_GEOMETRY_IMAGE_UNIFORMS_EXT 0x90CD
+#define GL_MAX_GEOMETRY_SHADER_STORAGE_BLOCKS_EXT 0x90D7
+#define GL_MAX_GEOMETRY_INPUT_COMPONENTS_EXT 0x9123
+#define GL_MAX_GEOMETRY_OUTPUT_COMPONENTS_EXT 0x9124
+#define GL_MAX_GEOMETRY_ATOMIC_COUNTER_BUFFERS_EXT 0x92CF
+#define GL_MAX_GEOMETRY_ATOMIC_COUNTERS_EXT 0x92D5
+#define GL_REFERENCED_BY_GEOMETRY_SHADER_EXT 0x9309
+#define GL_FRAMEBUFFER_DEFAULT_LAYERS_EXT 0x9312
+#define GL_MAX_FRAMEBUFFER_LAYERS_EXT 0x9317
+
+#define GLEW_EXT_geometry_point_size GLEW_GET_VAR(__GLEW_EXT_geometry_point_size)
+
+#endif /* GL_EXT_geometry_point_size */
+
+/* ------------------------- GL_EXT_geometry_shader ------------------------ */
+
+#ifndef GL_EXT_geometry_shader
+#define GL_EXT_geometry_shader 1
+
+#define GL_GEOMETRY_SHADER_BIT_EXT 0x00000004
+#define GL_LINES_ADJACENCY_EXT 0xA
+#define GL_LINE_STRIP_ADJACENCY_EXT 0xB
+#define GL_TRIANGLES_ADJACENCY_EXT 0xC
+#define GL_TRIANGLE_STRIP_ADJACENCY_EXT 0xD
+#define GL_LAYER_PROVOKING_VERTEX_EXT 0x825E
+#define GL_UNDEFINED_VERTEX_EXT 0x8260
+#define GL_GEOMETRY_SHADER_INVOCATIONS_EXT 0x887F
+#define GL_GEOMETRY_LINKED_VERTICES_OUT_EXT 0x8916
+#define GL_GEOMETRY_LINKED_INPUT_TYPE_EXT 0x8917
+#define GL_GEOMETRY_LINKED_OUTPUT_TYPE_EXT 0x8918
+#define GL_MAX_GEOMETRY_UNIFORM_BLOCKS_EXT 0x8A2C
+#define GL_MAX_COMBINED_GEOMETRY_UNIFORM_COMPONENTS_EXT 0x8A32
+#define GL_MAX_GEOMETRY_TEXTURE_IMAGE_UNITS_EXT 0x8C29
+#define GL_PRIMITIVES_GENERATED_EXT 0x8C87
+#define GL_FRAMEBUFFER_ATTACHMENT_LAYERED_EXT 0x8DA7
+#define GL_FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS_EXT 0x8DA8
+#define GL_GEOMETRY_SHADER_EXT 0x8DD9
+#define GL_MAX_GEOMETRY_UNIFORM_COMPONENTS_EXT 0x8DDF
+#define GL_MAX_GEOMETRY_OUTPUT_VERTICES_EXT 0x8DE0
+#define GL_MAX_GEOMETRY_TOTAL_OUTPUT_COMPONENTS_EXT 0x8DE1
+#define GL_FIRST_VERTEX_CONVENTION_EXT 0x8E4D
+#define GL_LAST_VERTEX_CONVENTION_EXT 0x8E4E
+#define GL_MAX_GEOMETRY_SHADER_INVOCATIONS_EXT 0x8E5A
+#define GL_MAX_GEOMETRY_IMAGE_UNIFORMS_EXT 0x90CD
+#define GL_MAX_GEOMETRY_SHADER_STORAGE_BLOCKS_EXT 0x90D7
+#define GL_MAX_GEOMETRY_INPUT_COMPONENTS_EXT 0x9123
+#define GL_MAX_GEOMETRY_OUTPUT_COMPONENTS_EXT 0x9124
+#define GL_MAX_GEOMETRY_ATOMIC_COUNTER_BUFFERS_EXT 0x92CF
+#define GL_MAX_GEOMETRY_ATOMIC_COUNTERS_EXT 0x92D5
+#define GL_REFERENCED_BY_GEOMETRY_SHADER_EXT 0x9309
+#define GL_FRAMEBUFFER_DEFAULT_LAYERS_EXT 0x9312
+#define GL_MAX_FRAMEBUFFER_LAYERS_EXT 0x9317
+
+#define GLEW_EXT_geometry_shader GLEW_GET_VAR(__GLEW_EXT_geometry_shader)
+
+#endif /* GL_EXT_geometry_shader */
+
 /* ------------------------ GL_EXT_geometry_shader4 ------------------------ */
 
 #ifndef GL_EXT_geometry_shader4
@@ -9673,6 +10784,15 @@ typedef void (GLAPIENTRY * PFNGLVERTEXATTRIBIPOINTEREXTPROC) (GLuint index, GLin
 
 #endif /* GL_EXT_gpu_shader4 */
 
+/* --------------------------- GL_EXT_gpu_shader5 -------------------------- */
+
+#ifndef GL_EXT_gpu_shader5
+#define GL_EXT_gpu_shader5 1
+
+#define GLEW_EXT_gpu_shader5 GLEW_GET_VAR(__GLEW_EXT_gpu_shader5)
+
+#endif /* GL_EXT_gpu_shader5 */
+
 /* ---------------------------- GL_EXT_histogram --------------------------- */
 
 #ifndef GL_EXT_histogram
@@ -9762,6 +10882,21 @@ typedef void (GLAPIENTRY * PFNGLINDEXMATERIALEXTPROC) (GLenum face, GLenum mode)
 
 #endif /* GL_EXT_index_texture */
 
+/* ------------------------ GL_EXT_instanced_arrays ------------------------ */
+
+#ifndef GL_EXT_instanced_arrays
+#define GL_EXT_instanced_arrays 1
+
+#define GL_VERTEX_ATTRIB_ARRAY_DIVISOR_EXT 0x88FE
+
+typedef void (GLAPIENTRY * PFNGLVERTEXATTRIBDIVISOREXTPROC) (GLuint index, GLuint divisor);
+
+#define glVertexAttribDivisorEXT GLEW_GET_FUN(__glewVertexAttribDivisorEXT)
+
+#define GLEW_EXT_instanced_arrays GLEW_GET_VAR(__GLEW_EXT_instanced_arrays)
+
+#endif /* GL_EXT_instanced_arrays */
+
 /* -------------------------- GL_EXT_light_texture ------------------------- */
 
 #ifndef GL_EXT_light_texture
@@ -9789,6 +10924,138 @@ typedef void (GLAPIENTRY * PFNGLTEXTUREMATERIALEXTPROC) (GLenum face, GLenum mod
 
 #endif /* GL_EXT_light_texture */
 
+/* ------------------------ GL_EXT_map_buffer_range ------------------------ */
+
+#ifndef GL_EXT_map_buffer_range
+#define GL_EXT_map_buffer_range 1
+
+#define GL_MAP_READ_BIT_EXT 0x0001
+#define GL_MAP_WRITE_BIT_EXT 0x0002
+#define GL_MAP_INVALIDATE_RANGE_BIT_EXT 0x0004
+#define GL_MAP_INVALIDATE_BUFFER_BIT_EXT 0x0008
+#define GL_MAP_FLUSH_EXPLICIT_BIT_EXT 0x0010
+#define GL_MAP_UNSYNCHRONIZED_BIT_EXT 0x0020
+
+typedef void (GLAPIENTRY * PFNGLFLUSHMAPPEDBUFFERRANGEEXTPROC) (GLenum target, GLintptr offset, GLsizeiptr length);
+typedef void * (GLAPIENTRY * PFNGLMAPBUFFERRANGEEXTPROC) (GLenum target, GLintptr offset, GLsizeiptr length, GLbitfield access);
+
+#define glFlushMappedBufferRangeEXT GLEW_GET_FUN(__glewFlushMappedBufferRangeEXT)
+#define glMapBufferRangeEXT GLEW_GET_FUN(__glewMapBufferRangeEXT)
+
+#define GLEW_EXT_map_buffer_range GLEW_GET_VAR(__GLEW_EXT_map_buffer_range)
+
+#endif /* GL_EXT_map_buffer_range */
+
+/* -------------------------- GL_EXT_memory_object ------------------------- */
+
+#ifndef GL_EXT_memory_object
+#define GL_EXT_memory_object 1
+
+#define GL_UUID_SIZE_EXT 16
+#define GL_TEXTURE_TILING_EXT 0x9580
+#define GL_DEDICATED_MEMORY_OBJECT_EXT 0x9581
+#define GL_NUM_TILING_TYPES_EXT 0x9582
+#define GL_TILING_TYPES_EXT 0x9583
+#define GL_OPTIMAL_TILING_EXT 0x9584
+#define GL_LINEAR_TILING_EXT 0x9585
+#define GL_LAYOUT_GENERAL_EXT 0x958D
+#define GL_LAYOUT_COLOR_ATTACHMENT_EXT 0x958E
+#define GL_LAYOUT_DEPTH_STENCIL_ATTACHMENT_EXT 0x958F
+#define GL_LAYOUT_DEPTH_STENCIL_READ_ONLY_EXT 0x9590
+#define GL_LAYOUT_SHADER_READ_ONLY_EXT 0x9591
+#define GL_LAYOUT_TRANSFER_SRC_EXT 0x9592
+#define GL_LAYOUT_TRANSFER_DST_EXT 0x9593
+#define GL_NUM_DEVICE_UUIDS_EXT 0x9596
+#define GL_DEVICE_UUID_EXT 0x9597
+#define GL_DRIVER_UUID_EXT 0x9598
+#define GL_PROTECTED_MEMORY_OBJECT_EXT 0x959B
+
+typedef void (GLAPIENTRY * PFNGLBUFFERSTORAGEMEMEXTPROC) (GLenum target, GLsizeiptr size, GLuint memory, GLuint64 offset);
+typedef void (GLAPIENTRY * PFNGLCREATEMEMORYOBJECTSEXTPROC) (GLsizei n, GLuint* memoryObjects);
+typedef void (GLAPIENTRY * PFNGLDELETEMEMORYOBJECTSEXTPROC) (GLsizei n, const GLuint* memoryObjects);
+typedef void (GLAPIENTRY * PFNGLGETMEMORYOBJECTPARAMETERIVEXTPROC) (GLuint memoryObject, GLenum pname, GLint* params);
+typedef void (GLAPIENTRY * PFNGLGETUNSIGNEDBYTEI_VEXTPROC) (GLenum target, GLuint index, GLubyte* data);
+typedef void (GLAPIENTRY * PFNGLGETUNSIGNEDBYTEVEXTPROC) (GLenum pname, GLubyte* data);
+typedef GLboolean (GLAPIENTRY * PFNGLISMEMORYOBJECTEXTPROC) (GLuint memoryObject);
+typedef void (GLAPIENTRY * PFNGLMEMORYOBJECTPARAMETERIVEXTPROC) (GLuint memoryObject, GLenum pname, const GLint* params);
+typedef void (GLAPIENTRY * PFNGLNAMEDBUFFERSTORAGEMEMEXTPROC) (GLuint buffer, GLsizeiptr size, GLuint memory, GLuint64 offset);
+typedef void (GLAPIENTRY * PFNGLTEXSTORAGEMEM1DEXTPROC) (GLenum target, GLsizei levels, GLenum internalFormat, GLsizei width, GLuint memory, GLuint64 offset);
+typedef void (GLAPIENTRY * PFNGLTEXSTORAGEMEM2DEXTPROC) (GLenum target, GLsizei levels, GLenum internalFormat, GLsizei width, GLsizei height, GLuint memory, GLuint64 offset);
+typedef void (GLAPIENTRY * PFNGLTEXSTORAGEMEM2DMULTISAMPLEEXTPROC) (GLenum target, GLsizei samples, GLenum internalFormat, GLsizei width, GLsizei height, GLboolean fixedSampleLocations, GLuint memory, GLuint64 offset);
+typedef void (GLAPIENTRY * PFNGLTEXSTORAGEMEM3DEXTPROC) (GLenum target, GLsizei levels, GLenum internalFormat, GLsizei width, GLsizei height, GLsizei depth, GLuint memory, GLuint64 offset);
+typedef void (GLAPIENTRY * PFNGLTEXSTORAGEMEM3DMULTISAMPLEEXTPROC) (GLenum target, GLsizei samples, GLenum internalFormat, GLsizei width, GLsizei height, GLsizei depth, GLboolean fixedSampleLocations, GLuint memory, GLuint64 offset);
+typedef void (GLAPIENTRY * PFNGLTEXTURESTORAGEMEM1DEXTPROC) (GLuint texture, GLsizei levels, GLenum internalFormat, GLsizei width, GLuint memory, GLuint64 offset);
+typedef void (GLAPIENTRY * PFNGLTEXTURESTORAGEMEM2DEXTPROC) (GLuint texture, GLsizei levels, GLenum internalFormat, GLsizei width, GLsizei height, GLuint memory, GLuint64 offset);
+typedef void (GLAPIENTRY * PFNGLTEXTURESTORAGEMEM2DMULTISAMPLEEXTPROC) (GLuint texture, GLsizei samples, GLenum internalFormat, GLsizei width, GLsizei height, GLboolean fixedSampleLocations, GLuint memory, GLuint64 offset);
+typedef void (GLAPIENTRY * PFNGLTEXTURESTORAGEMEM3DEXTPROC) (GLuint texture, GLsizei levels, GLenum internalFormat, GLsizei width, GLsizei height, GLsizei depth, GLuint memory, GLuint64 offset);
+typedef void (GLAPIENTRY * PFNGLTEXTURESTORAGEMEM3DMULTISAMPLEEXTPROC) (GLuint texture, GLsizei samples, GLenum internalFormat, GLsizei width, GLsizei height, GLsizei depth, GLboolean fixedSampleLocations, GLuint memory, GLuint64 offset);
+
+#define glBufferStorageMemEXT GLEW_GET_FUN(__glewBufferStorageMemEXT)
+#define glCreateMemoryObjectsEXT GLEW_GET_FUN(__glewCreateMemoryObjectsEXT)
+#define glDeleteMemoryObjectsEXT GLEW_GET_FUN(__glewDeleteMemoryObjectsEXT)
+#define glGetMemoryObjectParameterivEXT GLEW_GET_FUN(__glewGetMemoryObjectParameterivEXT)
+#define glGetUnsignedBytei_vEXT GLEW_GET_FUN(__glewGetUnsignedBytei_vEXT)
+#define glGetUnsignedBytevEXT GLEW_GET_FUN(__glewGetUnsignedBytevEXT)
+#define glIsMemoryObjectEXT GLEW_GET_FUN(__glewIsMemoryObjectEXT)
+#define glMemoryObjectParameterivEXT GLEW_GET_FUN(__glewMemoryObjectParameterivEXT)
+#define glNamedBufferStorageMemEXT GLEW_GET_FUN(__glewNamedBufferStorageMemEXT)
+#define glTexStorageMem1DEXT GLEW_GET_FUN(__glewTexStorageMem1DEXT)
+#define glTexStorageMem2DEXT GLEW_GET_FUN(__glewTexStorageMem2DEXT)
+#define glTexStorageMem2DMultisampleEXT GLEW_GET_FUN(__glewTexStorageMem2DMultisampleEXT)
+#define glTexStorageMem3DEXT GLEW_GET_FUN(__glewTexStorageMem3DEXT)
+#define glTexStorageMem3DMultisampleEXT GLEW_GET_FUN(__glewTexStorageMem3DMultisampleEXT)
+#define glTextureStorageMem1DEXT GLEW_GET_FUN(__glewTextureStorageMem1DEXT)
+#define glTextureStorageMem2DEXT GLEW_GET_FUN(__glewTextureStorageMem2DEXT)
+#define glTextureStorageMem2DMultisampleEXT GLEW_GET_FUN(__glewTextureStorageMem2DMultisampleEXT)
+#define glTextureStorageMem3DEXT GLEW_GET_FUN(__glewTextureStorageMem3DEXT)
+#define glTextureStorageMem3DMultisampleEXT GLEW_GET_FUN(__glewTextureStorageMem3DMultisampleEXT)
+
+#define GLEW_EXT_memory_object GLEW_GET_VAR(__GLEW_EXT_memory_object)
+
+#endif /* GL_EXT_memory_object */
+
+/* ------------------------ GL_EXT_memory_object_fd ------------------------ */
+
+#ifndef GL_EXT_memory_object_fd
+#define GL_EXT_memory_object_fd 1
+
+#define GL_HANDLE_TYPE_OPAQUE_FD_EXT 0x9586
+
+typedef void (GLAPIENTRY * PFNGLIMPORTMEMORYFDEXTPROC) (GLuint memory, GLuint64 size, GLenum handleType, GLint fd);
+
+#define glImportMemoryFdEXT GLEW_GET_FUN(__glewImportMemoryFdEXT)
+
+#define GLEW_EXT_memory_object_fd GLEW_GET_VAR(__GLEW_EXT_memory_object_fd)
+
+#endif /* GL_EXT_memory_object_fd */
+
+/* ----------------------- GL_EXT_memory_object_win32 ---------------------- */
+
+#ifndef GL_EXT_memory_object_win32
+#define GL_EXT_memory_object_win32 1
+
+#define GL_LUID_SIZE_EXT 8
+#define GL_HANDLE_TYPE_OPAQUE_WIN32_EXT 0x9587
+#define GL_HANDLE_TYPE_OPAQUE_WIN32_KMT_EXT 0x9588
+#define GL_HANDLE_TYPE_D3D12_TILEPOOL_EXT 0x9589
+#define GL_HANDLE_TYPE_D3D12_RESOURCE_EXT 0x958A
+#define GL_HANDLE_TYPE_D3D11_IMAGE_EXT 0x958B
+#define GL_HANDLE_TYPE_D3D11_IMAGE_KMT_EXT 0x958C
+#define GL_HANDLE_TYPE_D3D12_FENCE_EXT 0x9594
+#define GL_D3D12_FENCE_VALUE_EXT 0x9595
+#define GL_DEVICE_LUID_EXT 0x9599
+#define GL_DEVICE_NODE_MASK_EXT 0x959A
+
+typedef void (GLAPIENTRY * PFNGLIMPORTMEMORYWIN32HANDLEEXTPROC) (GLuint memory, GLuint64 size, GLenum handleType, void *handle);
+typedef void (GLAPIENTRY * PFNGLIMPORTMEMORYWIN32NAMEEXTPROC) (GLuint memory, GLuint64 size, GLenum handleType, const void *name);
+
+#define glImportMemoryWin32HandleEXT GLEW_GET_FUN(__glewImportMemoryWin32HandleEXT)
+#define glImportMemoryWin32NameEXT GLEW_GET_FUN(__glewImportMemoryWin32NameEXT)
+
+#define GLEW_EXT_memory_object_win32 GLEW_GET_VAR(__GLEW_EXT_memory_object_win32)
+
+#endif /* GL_EXT_memory_object_win32 */
+
 /* ------------------------- GL_EXT_misc_attribute ------------------------- */
 
 #ifndef GL_EXT_misc_attribute
@@ -9812,6 +11079,30 @@ typedef void (GLAPIENTRY * PFNGLMULTIDRAWELEMENTSEXTPROC) (GLenum mode, GLsizei*
 #define GLEW_EXT_multi_draw_arrays GLEW_GET_VAR(__GLEW_EXT_multi_draw_arrays)
 
 #endif /* GL_EXT_multi_draw_arrays */
+
+/* ----------------------- GL_EXT_multi_draw_indirect ---------------------- */
+
+#ifndef GL_EXT_multi_draw_indirect
+#define GL_EXT_multi_draw_indirect 1
+
+typedef void (GLAPIENTRY * PFNGLMULTIDRAWARRAYSINDIRECTEXTPROC) (GLenum mode, const void *indirect, GLsizei drawcount, GLsizei stride);
+typedef void (GLAPIENTRY * PFNGLMULTIDRAWELEMENTSINDIRECTEXTPROC) (GLenum mode, GLenum type, const void *indirect, GLsizei drawcount, GLsizei stride);
+
+#define glMultiDrawArraysIndirectEXT GLEW_GET_FUN(__glewMultiDrawArraysIndirectEXT)
+#define glMultiDrawElementsIndirectEXT GLEW_GET_FUN(__glewMultiDrawElementsIndirectEXT)
+
+#define GLEW_EXT_multi_draw_indirect GLEW_GET_VAR(__GLEW_EXT_multi_draw_indirect)
+
+#endif /* GL_EXT_multi_draw_indirect */
+
+/* ------------------------ GL_EXT_multiple_textures ----------------------- */
+
+#ifndef GL_EXT_multiple_textures
+#define GL_EXT_multiple_textures 1
+
+#define GLEW_EXT_multiple_textures GLEW_GET_VAR(__GLEW_EXT_multiple_textures)
+
+#endif /* GL_EXT_multiple_textures */
 
 /* --------------------------- GL_EXT_multisample -------------------------- */
 
@@ -9845,6 +11136,68 @@ typedef void (GLAPIENTRY * PFNGLSAMPLEPATTERNEXTPROC) (GLenum pattern);
 #define GLEW_EXT_multisample GLEW_GET_VAR(__GLEW_EXT_multisample)
 
 #endif /* GL_EXT_multisample */
+
+/* -------------------- GL_EXT_multisample_compatibility ------------------- */
+
+#ifndef GL_EXT_multisample_compatibility
+#define GL_EXT_multisample_compatibility 1
+
+#define GL_MULTISAMPLE_EXT 0x809D
+#define GL_SAMPLE_ALPHA_TO_ONE_EXT 0x809F
+
+#define GLEW_EXT_multisample_compatibility GLEW_GET_VAR(__GLEW_EXT_multisample_compatibility)
+
+#endif /* GL_EXT_multisample_compatibility */
+
+/* ----------------- GL_EXT_multisampled_render_to_texture ----------------- */
+
+#ifndef GL_EXT_multisampled_render_to_texture
+#define GL_EXT_multisampled_render_to_texture 1
+
+#define GL_RENDERBUFFER_SAMPLES_EXT 0x8CAB
+#define GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE_EXT 0x8D56
+#define GL_MAX_SAMPLES_EXT 0x8D57
+#define GL_FRAMEBUFFER_ATTACHMENT_TEXTURE_SAMPLES_EXT 0x8D6C
+
+typedef void (GLAPIENTRY * PFNGLFRAMEBUFFERTEXTURE2DMULTISAMPLEEXTPROC) (GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level, GLsizei samples);
+
+#define glFramebufferTexture2DMultisampleEXT GLEW_GET_FUN(__glewFramebufferTexture2DMultisampleEXT)
+
+#define GLEW_EXT_multisampled_render_to_texture GLEW_GET_VAR(__GLEW_EXT_multisampled_render_to_texture)
+
+#endif /* GL_EXT_multisampled_render_to_texture */
+
+/* ----------------- GL_EXT_multisampled_render_to_texture2 ---------------- */
+
+#ifndef GL_EXT_multisampled_render_to_texture2
+#define GL_EXT_multisampled_render_to_texture2 1
+
+#define GLEW_EXT_multisampled_render_to_texture2 GLEW_GET_VAR(__GLEW_EXT_multisampled_render_to_texture2)
+
+#endif /* GL_EXT_multisampled_render_to_texture2 */
+
+/* --------------------- GL_EXT_multiview_draw_buffers --------------------- */
+
+#ifndef GL_EXT_multiview_draw_buffers
+#define GL_EXT_multiview_draw_buffers 1
+
+#define GL_DRAW_BUFFER_EXT 0x0C01
+#define GL_READ_BUFFER_EXT 0x0C02
+#define GL_COLOR_ATTACHMENT_EXT 0x90F0
+#define GL_MULTIVIEW_EXT 0x90F1
+#define GL_MAX_MULTIVIEW_BUFFERS_EXT 0x90F2
+
+typedef void (GLAPIENTRY * PFNGLDRAWBUFFERSINDEXEDEXTPROC) (GLint n, const GLenum* location, const GLint *indices);
+typedef void (GLAPIENTRY * PFNGLGETINTEGERI_VEXTPROC) (GLenum target, GLuint index, GLint* data);
+typedef void (GLAPIENTRY * PFNGLREADBUFFERINDEXEDEXTPROC) (GLenum src, GLint index);
+
+#define glDrawBuffersIndexedEXT GLEW_GET_FUN(__glewDrawBuffersIndexedEXT)
+#define glGetIntegeri_vEXT GLEW_GET_FUN(__glewGetIntegeri_vEXT)
+#define glReadBufferIndexedEXT GLEW_GET_FUN(__glewReadBufferIndexedEXT)
+
+#define GLEW_EXT_multiview_draw_buffers GLEW_GET_VAR(__GLEW_EXT_multiview_draw_buffers)
+
+#endif /* GL_EXT_multiview_draw_buffers */
 
 /* ---------------------- GL_EXT_packed_depth_stencil ---------------------- */
 
@@ -10022,6 +11375,30 @@ typedef void (GLAPIENTRY * PFNGLPOLYGONOFFSETEXTPROC) (GLfloat factor, GLfloat b
 
 #endif /* GL_EXT_polygon_offset */
 
+/* ---------------------- GL_EXT_polygon_offset_clamp ---------------------- */
+
+#ifndef GL_EXT_polygon_offset_clamp
+#define GL_EXT_polygon_offset_clamp 1
+
+#define GL_POLYGON_OFFSET_CLAMP_EXT 0x8E1B
+
+typedef void (GLAPIENTRY * PFNGLPOLYGONOFFSETCLAMPEXTPROC) (GLfloat factor, GLfloat units, GLfloat clamp);
+
+#define glPolygonOffsetClampEXT GLEW_GET_FUN(__glewPolygonOffsetClampEXT)
+
+#define GLEW_EXT_polygon_offset_clamp GLEW_GET_VAR(__GLEW_EXT_polygon_offset_clamp)
+
+#endif /* GL_EXT_polygon_offset_clamp */
+
+/* ----------------------- GL_EXT_post_depth_coverage ---------------------- */
+
+#ifndef GL_EXT_post_depth_coverage
+#define GL_EXT_post_depth_coverage 1
+
+#define GLEW_EXT_post_depth_coverage GLEW_GET_VAR(__GLEW_EXT_post_depth_coverage)
+
+#endif /* GL_EXT_post_depth_coverage */
+
 /* ------------------------ GL_EXT_provoking_vertex ------------------------ */
 
 #ifndef GL_EXT_provoking_vertex
@@ -10040,6 +11417,85 @@ typedef void (GLAPIENTRY * PFNGLPROVOKINGVERTEXEXTPROC) (GLenum mode);
 
 #endif /* GL_EXT_provoking_vertex */
 
+/* --------------------------- GL_EXT_pvrtc_sRGB --------------------------- */
+
+#ifndef GL_EXT_pvrtc_sRGB
+#define GL_EXT_pvrtc_sRGB 1
+
+#define GL_COMPRESSED_SRGB_PVRTC_2BPPV1_EXT 0x8A54
+#define GL_COMPRESSED_SRGB_PVRTC_4BPPV1_EXT 0x8A55
+#define GL_COMPRESSED_SRGB_ALPHA_PVRTC_2BPPV1_EXT 0x8A56
+#define GL_COMPRESSED_SRGB_ALPHA_PVRTC_4BPPV1_EXT 0x8A57
+
+#define GLEW_EXT_pvrtc_sRGB GLEW_GET_VAR(__GLEW_EXT_pvrtc_sRGB)
+
+#endif /* GL_EXT_pvrtc_sRGB */
+
+/* ----------------------- GL_EXT_raster_multisample ----------------------- */
+
+#ifndef GL_EXT_raster_multisample
+#define GL_EXT_raster_multisample 1
+
+#define GL_COLOR_SAMPLES_NV 0x8E20
+#define GL_RASTER_MULTISAMPLE_EXT 0x9327
+#define GL_RASTER_SAMPLES_EXT 0x9328
+#define GL_MAX_RASTER_SAMPLES_EXT 0x9329
+#define GL_RASTER_FIXED_SAMPLE_LOCATIONS_EXT 0x932A
+#define GL_MULTISAMPLE_RASTERIZATION_ALLOWED_EXT 0x932B
+#define GL_EFFECTIVE_RASTER_SAMPLES_EXT 0x932C
+#define GL_DEPTH_SAMPLES_NV 0x932D
+#define GL_STENCIL_SAMPLES_NV 0x932E
+#define GL_MIXED_DEPTH_SAMPLES_SUPPORTED_NV 0x932F
+#define GL_MIXED_STENCIL_SAMPLES_SUPPORTED_NV 0x9330
+#define GL_COVERAGE_MODULATION_TABLE_NV 0x9331
+#define GL_COVERAGE_MODULATION_NV 0x9332
+#define GL_COVERAGE_MODULATION_TABLE_SIZE_NV 0x9333
+
+typedef void (GLAPIENTRY * PFNGLCOVERAGEMODULATIONNVPROC) (GLenum components);
+typedef void (GLAPIENTRY * PFNGLCOVERAGEMODULATIONTABLENVPROC) (GLsizei n, const GLfloat* v);
+typedef void (GLAPIENTRY * PFNGLGETCOVERAGEMODULATIONTABLENVPROC) (GLsizei bufsize, GLfloat* v);
+typedef void (GLAPIENTRY * PFNGLRASTERSAMPLESEXTPROC) (GLuint samples, GLboolean fixedsamplelocations);
+
+#define glCoverageModulationNV GLEW_GET_FUN(__glewCoverageModulationNV)
+#define glCoverageModulationTableNV GLEW_GET_FUN(__glewCoverageModulationTableNV)
+#define glGetCoverageModulationTableNV GLEW_GET_FUN(__glewGetCoverageModulationTableNV)
+#define glRasterSamplesEXT GLEW_GET_FUN(__glewRasterSamplesEXT)
+
+#define GLEW_EXT_raster_multisample GLEW_GET_VAR(__GLEW_EXT_raster_multisample)
+
+#endif /* GL_EXT_raster_multisample */
+
+/* ------------------------ GL_EXT_read_format_bgra ------------------------ */
+
+#ifndef GL_EXT_read_format_bgra
+#define GL_EXT_read_format_bgra 1
+
+#define GL_BGRA_EXT 0x80E1
+#define GL_UNSIGNED_SHORT_4_4_4_4_REV_EXT 0x8365
+#define GL_UNSIGNED_SHORT_1_5_5_5_REV_EXT 0x8366
+
+#define GLEW_EXT_read_format_bgra GLEW_GET_VAR(__GLEW_EXT_read_format_bgra)
+
+#endif /* GL_EXT_read_format_bgra */
+
+/* -------------------------- GL_EXT_render_snorm -------------------------- */
+
+#ifndef GL_EXT_render_snorm
+#define GL_EXT_render_snorm 1
+
+#define GL_BYTE 0x1400
+#define GL_SHORT 0x1402
+#define GL_R8_SNORM 0x8F94
+#define GL_RG8_SNORM 0x8F95
+#define GL_RGBA8_SNORM 0x8F97
+#define GL_R16_SNORM_EXT 0x8F98
+#define GL_RG16_SNORM_EXT 0x8F99
+#define GL_RGBA16_SNORM_EXT 0x8F9B
+
+#define GLEW_EXT_render_snorm GLEW_GET_VAR(__GLEW_EXT_render_snorm)
+
+#endif /* GL_EXT_render_snorm */
+
 /* ------------------------- GL_EXT_rescale_normal ------------------------- */
 
 #ifndef GL_EXT_rescale_normal
@@ -10050,6 +11506,31 @@ typedef void (GLAPIENTRY * PFNGLPROVOKINGVERTEXEXTPROC) (GLenum mode);
 #define GLEW_EXT_rescale_normal GLEW_GET_VAR(__GLEW_EXT_rescale_normal)
 
 #endif /* GL_EXT_rescale_normal */
+
+/* ------------------------------ GL_EXT_sRGB ------------------------------ */
+
+#ifndef GL_EXT_sRGB
+#define GL_EXT_sRGB 1
+
+#define GL_FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING_EXT 0x8210
+#define GL_SRGB_EXT 0x8C40
+#define GL_SRGB_ALPHA_EXT 0x8C42
+#define GL_SRGB8_ALPHA8_EXT 0x8C43
+
+#define GLEW_EXT_sRGB GLEW_GET_VAR(__GLEW_EXT_sRGB)
+
+#endif /* GL_EXT_sRGB */
+
+/* ----------------------- GL_EXT_sRGB_write_control ----------------------- */
+
+#ifndef GL_EXT_sRGB_write_control
+#define GL_EXT_sRGB_write_control 1
+
+#define GL_FRAMEBUFFER_SRGB_EXT 0x8DB9
+
+#define GLEW_EXT_sRGB_write_control GLEW_GET_VAR(__GLEW_EXT_sRGB_write_control)
+
+#endif /* GL_EXT_sRGB_write_control */
 
 /* -------------------------- GL_EXT_scene_marker -------------------------- */
 
@@ -10119,6 +11600,59 @@ typedef void (GLAPIENTRY * PFNGLSECONDARYCOLORPOINTEREXTPROC) (GLint size, GLenu
 
 #endif /* GL_EXT_secondary_color */
 
+/* ---------------------------- GL_EXT_semaphore --------------------------- */
+
+#ifndef GL_EXT_semaphore
+#define GL_EXT_semaphore 1
+
+typedef void (GLAPIENTRY * PFNGLDELETESEMAPHORESEXTPROC) (GLsizei n, const GLuint* semaphores);
+typedef void (GLAPIENTRY * PFNGLGENSEMAPHORESEXTPROC) (GLsizei n, GLuint* semaphores);
+typedef void (GLAPIENTRY * PFNGLGETSEMAPHOREPARAMETERUI64VEXTPROC) (GLuint semaphore, GLenum pname, GLuint64* params);
+typedef GLboolean (GLAPIENTRY * PFNGLISSEMAPHOREEXTPROC) (GLuint semaphore);
+typedef void (GLAPIENTRY * PFNGLSEMAPHOREPARAMETERUI64VEXTPROC) (GLuint semaphore, GLenum pname, const GLuint64* params);
+typedef void (GLAPIENTRY * PFNGLSIGNALSEMAPHOREEXTPROC) (GLuint semaphore, GLuint numBufferBarriers, const GLuint* buffers, GLuint numTextureBarriers, const GLuint *textures, const GLenum *dstLayouts);
+typedef void (GLAPIENTRY * PFNGLWAITSEMAPHOREEXTPROC) (GLuint semaphore, GLuint numBufferBarriers, const GLuint* buffers, GLuint numTextureBarriers, const GLuint *textures, const GLenum *srcLayouts);
+
+#define glDeleteSemaphoresEXT GLEW_GET_FUN(__glewDeleteSemaphoresEXT)
+#define glGenSemaphoresEXT GLEW_GET_FUN(__glewGenSemaphoresEXT)
+#define glGetSemaphoreParameterui64vEXT GLEW_GET_FUN(__glewGetSemaphoreParameterui64vEXT)
+#define glIsSemaphoreEXT GLEW_GET_FUN(__glewIsSemaphoreEXT)
+#define glSemaphoreParameterui64vEXT GLEW_GET_FUN(__glewSemaphoreParameterui64vEXT)
+#define glSignalSemaphoreEXT GLEW_GET_FUN(__glewSignalSemaphoreEXT)
+#define glWaitSemaphoreEXT GLEW_GET_FUN(__glewWaitSemaphoreEXT)
+
+#define GLEW_EXT_semaphore GLEW_GET_VAR(__GLEW_EXT_semaphore)
+
+#endif /* GL_EXT_semaphore */
+
+/* -------------------------- GL_EXT_semaphore_fd -------------------------- */
+
+#ifndef GL_EXT_semaphore_fd
+#define GL_EXT_semaphore_fd 1
+
+typedef void (GLAPIENTRY * PFNGLIMPORTSEMAPHOREFDEXTPROC) (GLuint semaphore, GLenum handleType, GLint fd);
+
+#define glImportSemaphoreFdEXT GLEW_GET_FUN(__glewImportSemaphoreFdEXT)
+
+#define GLEW_EXT_semaphore_fd GLEW_GET_VAR(__GLEW_EXT_semaphore_fd)
+
+#endif /* GL_EXT_semaphore_fd */
+
+/* ------------------------- GL_EXT_semaphore_win32 ------------------------ */
+
+#ifndef GL_EXT_semaphore_win32
+#define GL_EXT_semaphore_win32 1
+
+typedef void (GLAPIENTRY * PFNGLIMPORTSEMAPHOREWIN32HANDLEEXTPROC) (GLuint semaphore, GLenum handleType, void *handle);
+typedef void (GLAPIENTRY * PFNGLIMPORTSEMAPHOREWIN32NAMEEXTPROC) (GLuint semaphore, GLenum handleType, const void *name);
+
+#define glImportSemaphoreWin32HandleEXT GLEW_GET_FUN(__glewImportSemaphoreWin32HandleEXT)
+#define glImportSemaphoreWin32NameEXT GLEW_GET_FUN(__glewImportSemaphoreWin32NameEXT)
+
+#define GLEW_EXT_semaphore_win32 GLEW_GET_VAR(__GLEW_EXT_semaphore_win32)
+
+#endif /* GL_EXT_semaphore_win32 */
+
 /* --------------------- GL_EXT_separate_shader_objects -------------------- */
 
 #ifndef GL_EXT_separate_shader_objects
@@ -10150,6 +11684,26 @@ typedef void (GLAPIENTRY * PFNGLUSESHADERPROGRAMEXTPROC) (GLenum type, GLuint pr
 #define GLEW_EXT_separate_specular_color GLEW_GET_VAR(__GLEW_EXT_separate_specular_color)
 
 #endif /* GL_EXT_separate_specular_color */
+
+/* -------------------- GL_EXT_shader_framebuffer_fetch -------------------- */
+
+#ifndef GL_EXT_shader_framebuffer_fetch
+#define GL_EXT_shader_framebuffer_fetch 1
+
+#define GL_FRAGMENT_SHADER_DISCARDS_SAMPLES_EXT 0x8A52
+
+#define GLEW_EXT_shader_framebuffer_fetch GLEW_GET_VAR(__GLEW_EXT_shader_framebuffer_fetch)
+
+#endif /* GL_EXT_shader_framebuffer_fetch */
+
+/* ------------------------ GL_EXT_shader_group_vote ----------------------- */
+
+#ifndef GL_EXT_shader_group_vote
+#define GL_EXT_shader_group_vote 1
+
+#define GLEW_EXT_shader_group_vote GLEW_GET_VAR(__GLEW_EXT_shader_group_vote)
+
+#endif /* GL_EXT_shader_group_vote */
 
 /* ------------------- GL_EXT_shader_image_load_formatted ------------------ */
 
@@ -10231,6 +11785,15 @@ typedef void (GLAPIENTRY * PFNGLMEMORYBARRIEREXTPROC) (GLbitfield barriers);
 
 #endif /* GL_EXT_shader_image_load_store */
 
+/* ------------------- GL_EXT_shader_implicit_conversions ------------------ */
+
+#ifndef GL_EXT_shader_implicit_conversions
+#define GL_EXT_shader_implicit_conversions 1
+
+#define GLEW_EXT_shader_implicit_conversions GLEW_GET_VAR(__GLEW_EXT_shader_implicit_conversions)
+
+#endif /* GL_EXT_shader_implicit_conversions */
+
 /* ----------------------- GL_EXT_shader_integer_mix ----------------------- */
 
 #ifndef GL_EXT_shader_integer_mix
@@ -10240,6 +11803,67 @@ typedef void (GLAPIENTRY * PFNGLMEMORYBARRIEREXTPROC) (GLbitfield barriers);
 
 #endif /* GL_EXT_shader_integer_mix */
 
+/* ------------------------ GL_EXT_shader_io_blocks ------------------------ */
+
+#ifndef GL_EXT_shader_io_blocks
+#define GL_EXT_shader_io_blocks 1
+
+#define GLEW_EXT_shader_io_blocks GLEW_GET_VAR(__GLEW_EXT_shader_io_blocks)
+
+#endif /* GL_EXT_shader_io_blocks */
+
+/* ------------- GL_EXT_shader_non_constant_global_initializers ------------ */
+
+#ifndef GL_EXT_shader_non_constant_global_initializers
+#define GL_EXT_shader_non_constant_global_initializers 1
+
+#define GLEW_EXT_shader_non_constant_global_initializers GLEW_GET_VAR(__GLEW_EXT_shader_non_constant_global_initializers)
+
+#endif /* GL_EXT_shader_non_constant_global_initializers */
+
+/* ------------------- GL_EXT_shader_pixel_local_storage ------------------- */
+
+#ifndef GL_EXT_shader_pixel_local_storage
+#define GL_EXT_shader_pixel_local_storage 1
+
+#define GL_MAX_SHADER_PIXEL_LOCAL_STORAGE_FAST_SIZE_EXT 0x8F63
+#define GL_SHADER_PIXEL_LOCAL_STORAGE_EXT 0x8F64
+#define GL_MAX_SHADER_PIXEL_LOCAL_STORAGE_SIZE_EXT 0x8F67
+
+#define GLEW_EXT_shader_pixel_local_storage GLEW_GET_VAR(__GLEW_EXT_shader_pixel_local_storage)
+
+#endif /* GL_EXT_shader_pixel_local_storage */
+
+/* ------------------- GL_EXT_shader_pixel_local_storage2 ------------------ */
+
+#ifndef GL_EXT_shader_pixel_local_storage2
+#define GL_EXT_shader_pixel_local_storage2 1
+
+#define GL_MAX_SHADER_COMBINED_LOCAL_STORAGE_FAST_SIZE_EXT 0x9650
+#define GL_MAX_SHADER_COMBINED_LOCAL_STORAGE_SIZE_EXT 0x9651
+#define GL_FRAMEBUFFER_INCOMPLETE_INSUFFICIENT_SHADER_COMBINED_LOCAL_STORAGE_EXT 0x9652
+
+typedef void (GLAPIENTRY * PFNGLCLEARPIXELLOCALSTORAGEUIEXTPROC) (GLsizei offset, GLsizei n, const GLuint* values);
+typedef void (GLAPIENTRY * PFNGLFRAMEBUFFERPIXELLOCALSTORAGESIZEEXTPROC) (GLuint target, GLsizei size);
+typedef GLsizei (GLAPIENTRY * PFNGLGETFRAMEBUFFERPIXELLOCALSTORAGESIZEEXTPROC) (GLuint target);
+
+#define glClearPixelLocalStorageuiEXT GLEW_GET_FUN(__glewClearPixelLocalStorageuiEXT)
+#define glFramebufferPixelLocalStorageSizeEXT GLEW_GET_FUN(__glewFramebufferPixelLocalStorageSizeEXT)
+#define glGetFramebufferPixelLocalStorageSizeEXT GLEW_GET_FUN(__glewGetFramebufferPixelLocalStorageSizeEXT)
+
+#define GLEW_EXT_shader_pixel_local_storage2 GLEW_GET_VAR(__GLEW_EXT_shader_pixel_local_storage2)
+
+#endif /* GL_EXT_shader_pixel_local_storage2 */
+
+/* ----------------------- GL_EXT_shader_texture_lod ----------------------- */
+
+#ifndef GL_EXT_shader_texture_lod
+#define GL_EXT_shader_texture_lod 1
+
+#define GLEW_EXT_shader_texture_lod GLEW_GET_VAR(__GLEW_EXT_shader_texture_lod)
+
+#endif /* GL_EXT_shader_texture_lod */
+
 /* -------------------------- GL_EXT_shadow_funcs -------------------------- */
 
 #ifndef GL_EXT_shadow_funcs
@@ -10248,6 +11872,20 @@ typedef void (GLAPIENTRY * PFNGLMEMORYBARRIEREXTPROC) (GLbitfield barriers);
 #define GLEW_EXT_shadow_funcs GLEW_GET_VAR(__GLEW_EXT_shadow_funcs)
 
 #endif /* GL_EXT_shadow_funcs */
+
+/* ------------------------- GL_EXT_shadow_samplers ------------------------ */
+
+#ifndef GL_EXT_shadow_samplers
+#define GL_EXT_shadow_samplers 1
+
+#define GL_TEXTURE_COMPARE_MODE_EXT 0x884C
+#define GL_TEXTURE_COMPARE_FUNC_EXT 0x884D
+#define GL_COMPARE_REF_TO_TEXTURE_EXT 0x884E
+#define GL_SAMPLER_2D_SHADOW_EXT 0x8B62
+
+#define GLEW_EXT_shadow_samplers GLEW_GET_VAR(__GLEW_EXT_shadow_samplers)
+
+#endif /* GL_EXT_shadow_samplers */
 
 /* --------------------- GL_EXT_shared_texture_palette --------------------- */
 
@@ -10259,6 +11897,47 @@ typedef void (GLAPIENTRY * PFNGLMEMORYBARRIEREXTPROC) (GLbitfield barriers);
 #define GLEW_EXT_shared_texture_palette GLEW_GET_VAR(__GLEW_EXT_shared_texture_palette)
 
 #endif /* GL_EXT_shared_texture_palette */
+
+/* ------------------------- GL_EXT_sparse_texture ------------------------- */
+
+#ifndef GL_EXT_sparse_texture
+#define GL_EXT_sparse_texture 1
+
+#define GL_TEXTURE_2D 0x0DE1
+#define GL_TEXTURE_3D 0x806F
+#define GL_TEXTURE_CUBE_MAP 0x8513
+#define GL_TEXTURE_2D_ARRAY 0x8C1A
+#define GL_TEXTURE_CUBE_MAP_ARRAY_OES 0x9009
+#define GL_VIRTUAL_PAGE_SIZE_X_EXT 0x9195
+#define GL_VIRTUAL_PAGE_SIZE_Y_EXT 0x9196
+#define GL_VIRTUAL_PAGE_SIZE_Z_EXT 0x9197
+#define GL_MAX_SPARSE_TEXTURE_SIZE_EXT 0x9198
+#define GL_MAX_SPARSE_3D_TEXTURE_SIZE_EXT 0x9199
+#define GL_MAX_SPARSE_ARRAY_TEXTURE_LAYERS_EXT 0x919A
+#define GL_TEXTURE_SPARSE_EXT 0x91A6
+#define GL_VIRTUAL_PAGE_SIZE_INDEX_EXT 0x91A7
+#define GL_NUM_VIRTUAL_PAGE_SIZES_EXT 0x91A8
+#define GL_SPARSE_TEXTURE_FULL_ARRAY_CUBE_MIPMAPS_EXT 0x91A9
+#define GL_NUM_SPARSE_LEVELS_EXT 0x91AA
+
+typedef void (GLAPIENTRY * PFNGLTEXPAGECOMMITMENTEXTPROC) (GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width, GLsizei height, GLsizei depth, GLboolean commit);
+typedef void (GLAPIENTRY * PFNGLTEXTUREPAGECOMMITMENTEXTPROC) (GLuint texture, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width, GLsizei height, GLsizei depth, GLboolean commit);
+
+#define glTexPageCommitmentEXT GLEW_GET_FUN(__glewTexPageCommitmentEXT)
+#define glTexturePageCommitmentEXT GLEW_GET_FUN(__glewTexturePageCommitmentEXT)
+
+#define GLEW_EXT_sparse_texture GLEW_GET_VAR(__GLEW_EXT_sparse_texture)
+
+#endif /* GL_EXT_sparse_texture */
+
+/* ------------------------- GL_EXT_sparse_texture2 ------------------------ */
+
+#ifndef GL_EXT_sparse_texture2
+#define GL_EXT_sparse_texture2 1
+
+#define GLEW_EXT_sparse_texture2 GLEW_GET_VAR(__GLEW_EXT_sparse_texture2)
+
+#endif /* GL_EXT_sparse_texture2 */
 
 /* ------------------------ GL_EXT_stencil_clear_tag ----------------------- */
 
@@ -10433,6 +12112,42 @@ typedef void (GLAPIENTRY * PFNGLTEXBUFFEREXTPROC) (GLenum target, GLenum interna
 
 #endif /* GL_EXT_texture_buffer_object */
 
+/* -------------- GL_EXT_texture_compression_astc_decode_mode -------------- */
+
+#ifndef GL_EXT_texture_compression_astc_decode_mode
+#define GL_EXT_texture_compression_astc_decode_mode 1
+
+#define GL_TEXTURE_ASTC_DECODE_PRECISION_EXT 0x8F69
+
+#define GLEW_EXT_texture_compression_astc_decode_mode GLEW_GET_VAR(__GLEW_EXT_texture_compression_astc_decode_mode)
+
+#endif /* GL_EXT_texture_compression_astc_decode_mode */
+
+/* ----------- GL_EXT_texture_compression_astc_decode_mode_rgb9e5 ---------- */
+
+#ifndef GL_EXT_texture_compression_astc_decode_mode_rgb9e5
+#define GL_EXT_texture_compression_astc_decode_mode_rgb9e5 1
+
+#define GL_TEXTURE_ASTC_DECODE_PRECISION_EXT 0x8F69
+
+#define GLEW_EXT_texture_compression_astc_decode_mode_rgb9e5 GLEW_GET_VAR(__GLEW_EXT_texture_compression_astc_decode_mode_rgb9e5)
+
+#endif /* GL_EXT_texture_compression_astc_decode_mode_rgb9e5 */
+
+/* -------------------- GL_EXT_texture_compression_bptc -------------------- */
+
+#ifndef GL_EXT_texture_compression_bptc
+#define GL_EXT_texture_compression_bptc 1
+
+#define GL_COMPRESSED_RGBA_BPTC_UNORM_EXT 0x8E8C
+#define GL_COMPRESSED_SRGB_ALPHA_BPTC_UNORM_EXT 0x8E8D
+#define GL_COMPRESSED_RGB_BPTC_SIGNED_FLOAT_EXT 0x8E8E
+#define GL_COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT_EXT 0x8E8F
+
+#define GLEW_EXT_texture_compression_bptc GLEW_GET_VAR(__GLEW_EXT_texture_compression_bptc)
+
+#endif /* GL_EXT_texture_compression_bptc */
+
 /* -------------------- GL_EXT_texture_compression_dxt1 -------------------- */
 
 #ifndef GL_EXT_texture_compression_dxt1
@@ -10505,6 +12220,25 @@ typedef void (GLAPIENTRY * PFNGLTEXBUFFEREXTPROC) (GLenum target, GLenum interna
 #define GLEW_EXT_texture_cube_map GLEW_GET_VAR(__GLEW_EXT_texture_cube_map)
 
 #endif /* GL_EXT_texture_cube_map */
+
+/* --------------------- GL_EXT_texture_cube_map_array --------------------- */
+
+#ifndef GL_EXT_texture_cube_map_array
+#define GL_EXT_texture_cube_map_array 1
+
+#define GL_TEXTURE_CUBE_MAP_ARRAY_EXT 0x9009
+#define GL_TEXTURE_BINDING_CUBE_MAP_ARRAY_EXT 0x900A
+#define GL_SAMPLER_CUBE_MAP_ARRAY_EXT 0x900C
+#define GL_SAMPLER_CUBE_MAP_ARRAY_SHADOW_EXT 0x900D
+#define GL_INT_SAMPLER_CUBE_MAP_ARRAY_EXT 0x900E
+#define GL_UNSIGNED_INT_SAMPLER_CUBE_MAP_ARRAY_EXT 0x900F
+#define GL_IMAGE_CUBE_MAP_ARRAY_EXT 0x9054
+#define GL_INT_IMAGE_CUBE_MAP_ARRAY_EXT 0x905F
+#define GL_UNSIGNED_INT_IMAGE_CUBE_MAP_ARRAY_EXT 0x906A
+
+#define GLEW_EXT_texture_cube_map_array GLEW_GET_VAR(__GLEW_EXT_texture_cube_map_array)
+
+#endif /* GL_EXT_texture_cube_map_array */
 
 /* ----------------------- GL_EXT_texture_edge_clamp ----------------------- */
 
@@ -10589,6 +12323,29 @@ typedef void (GLAPIENTRY * PFNGLTEXBUFFEREXTPROC) (GLenum target, GLenum interna
 #define GLEW_EXT_texture_filter_anisotropic GLEW_GET_VAR(__GLEW_EXT_texture_filter_anisotropic)
 
 #endif /* GL_EXT_texture_filter_anisotropic */
+
+/* ---------------------- GL_EXT_texture_filter_minmax --------------------- */
+
+#ifndef GL_EXT_texture_filter_minmax
+#define GL_EXT_texture_filter_minmax 1
+
+#define GL_TEXTURE_REDUCTION_MODE_EXT 0x9366
+#define GL_WEIGHTED_AVERAGE_EXT 0x9367
+
+#define GLEW_EXT_texture_filter_minmax GLEW_GET_VAR(__GLEW_EXT_texture_filter_minmax)
+
+#endif /* GL_EXT_texture_filter_minmax */
+
+/* --------------------- GL_EXT_texture_format_BGRA8888 -------------------- */
+
+#ifndef GL_EXT_texture_format_BGRA8888
+#define GL_EXT_texture_format_BGRA8888 1
+
+#define GL_BGRA_EXT 0x80E1
+
+#define GLEW_EXT_texture_format_BGRA8888 GLEW_GET_VAR(__GLEW_EXT_texture_format_BGRA8888)
+
+#endif /* GL_EXT_texture_format_BGRA8888 */
 
 /* ------------------------- GL_EXT_texture_integer ------------------------ */
 
@@ -10687,6 +12444,24 @@ typedef void (GLAPIENTRY * PFNGLTEXPARAMETERIUIVEXTPROC) (GLenum target, GLenum 
 
 #endif /* GL_EXT_texture_mirror_clamp */
 
+/* ------------------------- GL_EXT_texture_norm16 ------------------------- */
+
+#ifndef GL_EXT_texture_norm16
+#define GL_EXT_texture_norm16 1
+
+#define GL_RGB16_EXT 0x8054
+#define GL_RGBA16_EXT 0x805B
+#define GL_R16_EXT 0x822A
+#define GL_RG16_EXT 0x822C
+#define GL_R16_SNORM_EXT 0x8F98
+#define GL_RG16_SNORM_EXT 0x8F99
+#define GL_RGB16_SNORM_EXT 0x8F9A
+#define GL_RGBA16_SNORM_EXT 0x8F9B
+
+#define GLEW_EXT_texture_norm16 GLEW_GET_VAR(__GLEW_EXT_texture_norm16)
+
+#endif /* GL_EXT_texture_norm16 */
+
 /* ------------------------- GL_EXT_texture_object ------------------------- */
 
 #ifndef GL_EXT_texture_object
@@ -10746,6 +12521,20 @@ typedef void (GLAPIENTRY * PFNGLTEXTURENORMALEXTPROC) (GLenum mode);
 
 #endif /* GL_EXT_texture_rectangle */
 
+/* --------------------------- GL_EXT_texture_rg --------------------------- */
+
+#ifndef GL_EXT_texture_rg
+#define GL_EXT_texture_rg 1
+
+#define GL_RED_EXT 0x1903
+#define GL_RG_EXT 0x8227
+#define GL_R8_EXT 0x8229
+#define GL_RG8_EXT 0x822B
+
+#define GLEW_EXT_texture_rg GLEW_GET_VAR(__GLEW_EXT_texture_rg)
+
+#endif /* GL_EXT_texture_rg */
+
 /* -------------------------- GL_EXT_texture_sRGB -------------------------- */
 
 #ifndef GL_EXT_texture_sRGB
@@ -10771,6 +12560,28 @@ typedef void (GLAPIENTRY * PFNGLTEXTURENORMALEXTPROC) (GLenum mode);
 #define GLEW_EXT_texture_sRGB GLEW_GET_VAR(__GLEW_EXT_texture_sRGB)
 
 #endif /* GL_EXT_texture_sRGB */
+
+/* ------------------------- GL_EXT_texture_sRGB_R8 ------------------------ */
+
+#ifndef GL_EXT_texture_sRGB_R8
+#define GL_EXT_texture_sRGB_R8 1
+
+#define GL_SR8_EXT 0x8FBD
+
+#define GLEW_EXT_texture_sRGB_R8 GLEW_GET_VAR(__GLEW_EXT_texture_sRGB_R8)
+
+#endif /* GL_EXT_texture_sRGB_R8 */
+
+/* ------------------------ GL_EXT_texture_sRGB_RG8 ------------------------ */
+
+#ifndef GL_EXT_texture_sRGB_RG8
+#define GL_EXT_texture_sRGB_RG8 1
+
+#define GL_SRG8_EXT 0x8FBE
+
+#define GLEW_EXT_texture_sRGB_RG8 GLEW_GET_VAR(__GLEW_EXT_texture_sRGB_RG8)
+
+#endif /* GL_EXT_texture_sRGB_RG8 */
 
 /* ----------------------- GL_EXT_texture_sRGB_decode ---------------------- */
 
@@ -10833,6 +12644,54 @@ typedef void (GLAPIENTRY * PFNGLTEXTURENORMALEXTPROC) (GLenum mode);
 
 #endif /* GL_EXT_texture_snorm */
 
+/* ------------------------- GL_EXT_texture_storage ------------------------ */
+
+#ifndef GL_EXT_texture_storage
+#define GL_EXT_texture_storage 1
+
+#define GL_ALPHA8_EXT 0x803C
+#define GL_LUMINANCE8_EXT 0x8040
+#define GL_LUMINANCE8_ALPHA8_EXT 0x8045
+#define GL_RGB10_EXT 0x8052
+#define GL_RGB10_A2_EXT 0x8059
+#define GL_R8_EXT 0x8229
+#define GL_RG8_EXT 0x822B
+#define GL_R16F_EXT 0x822D
+#define GL_R32F_EXT 0x822E
+#define GL_RG16F_EXT 0x822F
+#define GL_RG32F_EXT 0x8230
+#define GL_RGBA32F_EXT 0x8814
+#define GL_RGB32F_EXT 0x8815
+#define GL_ALPHA32F_EXT 0x8816
+#define GL_LUMINANCE32F_EXT 0x8818
+#define GL_LUMINANCE_ALPHA32F_EXT 0x8819
+#define GL_RGBA16F_EXT 0x881A
+#define GL_RGB16F_EXT 0x881B
+#define GL_ALPHA16F_EXT 0x881C
+#define GL_LUMINANCE16F_EXT 0x881E
+#define GL_LUMINANCE_ALPHA16F_EXT 0x881F
+#define GL_RGB_RAW_422_APPLE 0x8A51
+#define GL_TEXTURE_IMMUTABLE_FORMAT_EXT 0x912F
+#define GL_BGRA8_EXT 0x93A1
+
+typedef void (GLAPIENTRY * PFNGLTEXSTORAGE1DEXTPROC) (GLenum target, GLsizei levels, GLenum internalformat, GLsizei width);
+typedef void (GLAPIENTRY * PFNGLTEXSTORAGE2DEXTPROC) (GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height);
+typedef void (GLAPIENTRY * PFNGLTEXSTORAGE3DEXTPROC) (GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth);
+typedef void (GLAPIENTRY * PFNGLTEXTURESTORAGE1DEXTPROC) (GLuint texture, GLenum target, GLsizei levels, GLenum internalformat, GLsizei width);
+typedef void (GLAPIENTRY * PFNGLTEXTURESTORAGE2DEXTPROC) (GLuint texture, GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height);
+typedef void (GLAPIENTRY * PFNGLTEXTURESTORAGE3DEXTPROC) (GLuint texture, GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth);
+
+#define glTexStorage1DEXT GLEW_GET_FUN(__glewTexStorage1DEXT)
+#define glTexStorage2DEXT GLEW_GET_FUN(__glewTexStorage2DEXT)
+#define glTexStorage3DEXT GLEW_GET_FUN(__glewTexStorage3DEXT)
+#define glTextureStorage1DEXT GLEW_GET_FUN(__glewTextureStorage1DEXT)
+#define glTextureStorage2DEXT GLEW_GET_FUN(__glewTextureStorage2DEXT)
+#define glTextureStorage3DEXT GLEW_GET_FUN(__glewTextureStorage3DEXT)
+
+#define GLEW_EXT_texture_storage GLEW_GET_VAR(__GLEW_EXT_texture_storage)
+
+#endif /* GL_EXT_texture_storage */
+
 /* ------------------------- GL_EXT_texture_swizzle ------------------------ */
 
 #ifndef GL_EXT_texture_swizzle
@@ -10847,6 +12706,36 @@ typedef void (GLAPIENTRY * PFNGLTEXTURENORMALEXTPROC) (GLenum mode);
 #define GLEW_EXT_texture_swizzle GLEW_GET_VAR(__GLEW_EXT_texture_swizzle)
 
 #endif /* GL_EXT_texture_swizzle */
+
+/* ------------------- GL_EXT_texture_type_2_10_10_10_REV ------------------ */
+
+#ifndef GL_EXT_texture_type_2_10_10_10_REV
+#define GL_EXT_texture_type_2_10_10_10_REV 1
+
+#define GL_UNSIGNED_INT_2_10_10_10_REV_EXT 0x8368
+
+#define GLEW_EXT_texture_type_2_10_10_10_REV GLEW_GET_VAR(__GLEW_EXT_texture_type_2_10_10_10_REV)
+
+#endif /* GL_EXT_texture_type_2_10_10_10_REV */
+
+/* -------------------------- GL_EXT_texture_view -------------------------- */
+
+#ifndef GL_EXT_texture_view
+#define GL_EXT_texture_view 1
+
+#define GL_TEXTURE_VIEW_MIN_LEVEL_EXT 0x82DB
+#define GL_TEXTURE_VIEW_NUM_LEVELS_EXT 0x82DC
+#define GL_TEXTURE_VIEW_MIN_LAYER_EXT 0x82DD
+#define GL_TEXTURE_VIEW_NUM_LAYERS_EXT 0x82DE
+#define GL_TEXTURE_IMMUTABLE_LEVELS 0x82DF
+
+typedef void (GLAPIENTRY * PFNGLTEXTUREVIEWEXTPROC) (GLuint texture, GLenum target, GLuint origtexture, GLenum internalformat, GLuint minlevel, GLuint numlevels, GLuint minlayer, GLuint numlayers);
+
+#define glTextureViewEXT GLEW_GET_FUN(__glewTextureViewEXT)
+
+#define GLEW_EXT_texture_view GLEW_GET_VAR(__GLEW_EXT_texture_view)
+
+#endif /* GL_EXT_texture_view */
 
 /* --------------------------- GL_EXT_timer_query -------------------------- */
 
@@ -10905,6 +12794,19 @@ typedef void (GLAPIENTRY * PFNGLTRANSFORMFEEDBACKVARYINGSEXTPROC) (GLuint progra
 #define GLEW_EXT_transform_feedback GLEW_GET_VAR(__GLEW_EXT_transform_feedback)
 
 #endif /* GL_EXT_transform_feedback */
+
+/* ------------------------- GL_EXT_unpack_subimage ------------------------ */
+
+#ifndef GL_EXT_unpack_subimage
+#define GL_EXT_unpack_subimage 1
+
+#define GL_UNPACK_ROW_LENGTH_EXT 0x0CF2
+#define GL_UNPACK_SKIP_ROWS_EXT 0x0CF3
+#define GL_UNPACK_SKIP_PIXELS_EXT 0x0CF4
+
+#define GLEW_EXT_unpack_subimage GLEW_GET_VAR(__GLEW_EXT_unpack_subimage)
+
+#endif /* GL_EXT_unpack_subimage */
 
 /* -------------------------- GL_EXT_vertex_array -------------------------- */
 
@@ -10977,6 +12879,23 @@ typedef void (GLAPIENTRY * PFNGLVERTEXPOINTEREXTPROC) (GLint size, GLenum type, 
 #define GLEW_EXT_vertex_array_bgra GLEW_GET_VAR(__GLEW_EXT_vertex_array_bgra)
 
 #endif /* GL_EXT_vertex_array_bgra */
+
+/* ----------------------- GL_EXT_vertex_array_setXXX ---------------------- */
+
+#ifndef GL_EXT_vertex_array_setXXX
+#define GL_EXT_vertex_array_setXXX 1
+
+typedef void (GLAPIENTRY * PFNGLBINDARRAYSETEXTPROC) (const void *arrayset);
+typedef const void * (GLAPIENTRY * PFNGLCREATEARRAYSETEXTPROC) (void);
+typedef void (GLAPIENTRY * PFNGLDELETEARRAYSETSEXTPROC) (GLsizei n, const void *arrayset[]);
+
+#define glBindArraySetEXT GLEW_GET_FUN(__glewBindArraySetEXT)
+#define glCreateArraySetExt GLEW_GET_FUN(__glewCreateArraySetExt)
+#define glDeleteArraySetsEXT GLEW_GET_FUN(__glewDeleteArraySetsEXT)
+
+#define GLEW_EXT_vertex_array_setXXX GLEW_GET_VAR(__GLEW_EXT_vertex_array_setXXX)
+
+#endif /* GL_EXT_vertex_array_setXXX */
 
 /* ----------------------- GL_EXT_vertex_attrib_64bit ---------------------- */
 
@@ -11261,6 +13180,41 @@ typedef void (GLAPIENTRY * PFNGLVERTEXWEIGHTFVEXTPROC) (GLfloat* weight);
 
 #endif /* GL_EXT_vertex_weighting */
 
+/* ------------------------ GL_EXT_win32_keyed_mutex ----------------------- */
+
+#ifndef GL_EXT_win32_keyed_mutex
+#define GL_EXT_win32_keyed_mutex 1
+
+typedef GLboolean (GLAPIENTRY * PFNGLACQUIREKEYEDMUTEXWIN32EXTPROC) (GLuint memory, GLuint64 key, GLuint timeout);
+typedef GLboolean (GLAPIENTRY * PFNGLRELEASEKEYEDMUTEXWIN32EXTPROC) (GLuint memory, GLuint64 key);
+
+#define glAcquireKeyedMutexWin32EXT GLEW_GET_FUN(__glewAcquireKeyedMutexWin32EXT)
+#define glReleaseKeyedMutexWin32EXT GLEW_GET_FUN(__glewReleaseKeyedMutexWin32EXT)
+
+#define GLEW_EXT_win32_keyed_mutex GLEW_GET_VAR(__GLEW_EXT_win32_keyed_mutex)
+
+#endif /* GL_EXT_win32_keyed_mutex */
+
+/* ------------------------ GL_EXT_window_rectangles ----------------------- */
+
+#ifndef GL_EXT_window_rectangles
+#define GL_EXT_window_rectangles 1
+
+#define GL_INCLUSIVE_EXT 0x8F10
+#define GL_EXCLUSIVE_EXT 0x8F11
+#define GL_WINDOW_RECTANGLE_EXT 0x8F12
+#define GL_WINDOW_RECTANGLE_MODE_EXT 0x8F13
+#define GL_MAX_WINDOW_RECTANGLES_EXT 0x8F14
+#define GL_NUM_WINDOW_RECTANGLES_EXT 0x8F15
+
+typedef void (GLAPIENTRY * PFNGLWINDOWRECTANGLESEXTPROC) (GLenum mode, GLsizei count, const GLint box[]);
+
+#define glWindowRectanglesEXT GLEW_GET_FUN(__glewWindowRectanglesEXT)
+
+#define GLEW_EXT_window_rectangles GLEW_GET_VAR(__GLEW_EXT_window_rectangles)
+
+#endif /* GL_EXT_window_rectangles */
+
 /* ------------------------- GL_EXT_x11_sync_object ------------------------ */
 
 #ifndef GL_EXT_x11_sync_object
@@ -11485,6 +13439,17 @@ typedef void (GLAPIENTRY * PFNGLVERTEXPOINTERLISTIBMPROC) (GLint size, GLenum ty
 
 #endif /* GL_INGR_interlace_read */
 
+/* ------------------ GL_INTEL_conservative_rasterization ------------------ */
+
+#ifndef GL_INTEL_conservative_rasterization
+#define GL_INTEL_conservative_rasterization 1
+
+#define GL_CONSERVATIVE_RASTERIZATION_INTEL 0x83FE
+
+#define GLEW_INTEL_conservative_rasterization GLEW_GET_VAR(__GLEW_INTEL_conservative_rasterization)
+
+#endif /* GL_INTEL_conservative_rasterization */
+
 /* ------------------- GL_INTEL_fragment_shader_ordering ------------------- */
 
 #ifndef GL_INTEL_fragment_shader_ordering
@@ -11493,6 +13458,15 @@ typedef void (GLAPIENTRY * PFNGLVERTEXPOINTERLISTIBMPROC) (GLint size, GLenum ty
 #define GLEW_INTEL_fragment_shader_ordering GLEW_GET_VAR(__GLEW_INTEL_fragment_shader_ordering)
 
 #endif /* GL_INTEL_fragment_shader_ordering */
+
+/* ----------------------- GL_INTEL_framebuffer_CMAA ----------------------- */
+
+#ifndef GL_INTEL_framebuffer_CMAA
+#define GL_INTEL_framebuffer_CMAA 1
+
+#define GLEW_INTEL_framebuffer_CMAA GLEW_GET_VAR(__GLEW_INTEL_framebuffer_CMAA)
+
+#endif /* GL_INTEL_framebuffer_CMAA */
 
 /* -------------------------- GL_INTEL_map_texture ------------------------- */
 
@@ -11709,9 +13683,9 @@ typedef void (GLAPIENTRY * PFNGLDEBUGMESSAGECONTROLPROC) (GLenum source, GLenum 
 typedef void (GLAPIENTRY * PFNGLDEBUGMESSAGEINSERTPROC) (GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* buf);
 typedef GLuint (GLAPIENTRY * PFNGLGETDEBUGMESSAGELOGPROC) (GLuint count, GLsizei bufSize, GLenum* sources, GLenum* types, GLuint* ids, GLenum* severities, GLsizei* lengths, GLchar* messageLog);
 typedef void (GLAPIENTRY * PFNGLGETOBJECTLABELPROC) (GLenum identifier, GLuint name, GLsizei bufSize, GLsizei* length, GLchar *label);
-typedef void (GLAPIENTRY * PFNGLGETOBJECTPTRLABELPROC) (const void *ptr, GLsizei bufSize, GLsizei* length, GLchar *label);
+typedef void (GLAPIENTRY * PFNGLGETOBJECTPTRLABELPROC) (void* ptr, GLsizei bufSize, GLsizei* length, GLchar *label);
 typedef void (GLAPIENTRY * PFNGLOBJECTLABELPROC) (GLenum identifier, GLuint name, GLsizei length, const GLchar* label);
-typedef void (GLAPIENTRY * PFNGLOBJECTPTRLABELPROC) (const void *ptr, GLsizei length, const GLchar* label);
+typedef void (GLAPIENTRY * PFNGLOBJECTPTRLABELPROC) (void* ptr, GLsizei length, const GLchar* label);
 typedef void (GLAPIENTRY * PFNGLPOPDEBUGGROUPPROC) (void);
 typedef void (GLAPIENTRY * PFNGLPUSHDEBUGGROUPPROC) (GLenum source, GLuint id, GLsizei length, const GLchar * message);
 
@@ -11729,6 +13703,33 @@ typedef void (GLAPIENTRY * PFNGLPUSHDEBUGGROUPPROC) (GLenum source, GLuint id, G
 #define GLEW_KHR_debug GLEW_GET_VAR(__GLEW_KHR_debug)
 
 #endif /* GL_KHR_debug */
+
+/* ---------------------------- GL_KHR_no_error ---------------------------- */
+
+#ifndef GL_KHR_no_error
+#define GL_KHR_no_error 1
+
+#define GL_CONTEXT_FLAG_NO_ERROR_BIT_KHR 0x00000008
+
+#define GLEW_KHR_no_error GLEW_GET_VAR(__GLEW_KHR_no_error)
+
+#endif /* GL_KHR_no_error */
+
+/* --------------------- GL_KHR_parallel_shader_compile -------------------- */
+
+#ifndef GL_KHR_parallel_shader_compile
+#define GL_KHR_parallel_shader_compile 1
+
+#define GL_MAX_SHADER_COMPILER_THREADS_KHR 0x91B0
+#define GL_COMPLETION_STATUS_KHR 0x91B1
+
+typedef void (GLAPIENTRY * PFNGLMAXSHADERCOMPILERTHREADSKHRPROC) (GLuint count);
+
+#define glMaxShaderCompilerThreadsKHR GLEW_GET_FUN(__glewMaxShaderCompilerThreadsKHR)
+
+#define GLEW_KHR_parallel_shader_compile GLEW_GET_VAR(__GLEW_KHR_parallel_shader_compile)
+
+#endif /* GL_KHR_parallel_shader_compile */
 
 /* ------------------ GL_KHR_robust_buffer_access_behavior ----------------- */
 
@@ -11843,6 +13844,15 @@ typedef void (GLAPIENTRY * PFNGLREADNPIXELSPROC) (GLint x, GLint y, GLsizei widt
 
 #endif /* GL_KHR_texture_compression_astc_ldr */
 
+/* --------------- GL_KHR_texture_compression_astc_sliced_3d --------------- */
+
+#ifndef GL_KHR_texture_compression_astc_sliced_3d
+#define GL_KHR_texture_compression_astc_sliced_3d 1
+
+#define GLEW_KHR_texture_compression_astc_sliced_3d GLEW_GET_VAR(__GLEW_KHR_texture_compression_astc_sliced_3d)
+
+#endif /* GL_KHR_texture_compression_astc_sliced_3d */
+
 /* -------------------------- GL_KTX_buffer_region ------------------------- */
 
 #ifndef GL_KTX_buffer_region
@@ -11908,6 +13918,15 @@ typedef void (GLAPIENTRY * PFNGLRESIZEBUFFERSMESAPROC) (void);
 #define GLEW_MESA_resize_buffers GLEW_GET_VAR(__GLEW_MESA_resize_buffers)
 
 #endif /* GL_MESA_resize_buffers */
+
+/* -------------------- GL_MESA_shader_integer_functions ------------------- */
+
+#ifndef GL_MESA_shader_integer_functions
+#define GL_MESA_shader_integer_functions 1
+
+#define GLEW_MESA_shader_integer_functions GLEW_GET_VAR(__GLEW_MESA_shader_integer_functions)
+
+#endif /* GL_MESA_shader_integer_functions */
 
 /* --------------------------- GL_MESA_window_pos -------------------------- */
 
@@ -11981,6 +14000,15 @@ typedef void (GLAPIENTRY * PFNGLWINDOWPOS4SVMESAPROC) (const GLshort* p);
 
 #endif /* GL_MESA_ycbcr_texture */
 
+/* ----------- GL_NVX_blend_equation_advanced_multi_draw_buffers ----------- */
+
+#ifndef GL_NVX_blend_equation_advanced_multi_draw_buffers
+#define GL_NVX_blend_equation_advanced_multi_draw_buffers 1
+
+#define GLEW_NVX_blend_equation_advanced_multi_draw_buffers GLEW_GET_VAR(__GLEW_NVX_blend_equation_advanced_multi_draw_buffers)
+
+#endif /* GL_NVX_blend_equation_advanced_multi_draw_buffers */
+
 /* ----------------------- GL_NVX_conditional_render ----------------------- */
 
 #ifndef GL_NVX_conditional_render
@@ -12010,6 +14038,88 @@ typedef void (GLAPIENTRY * PFNGLENDCONDITIONALRENDERNVXPROC) (void);
 #define GLEW_NVX_gpu_memory_info GLEW_GET_VAR(__GLEW_NVX_gpu_memory_info)
 
 #endif /* GL_NVX_gpu_memory_info */
+
+/* ---------------------- GL_NVX_linked_gpu_multicast ---------------------- */
+
+#ifndef GL_NVX_linked_gpu_multicast
+#define GL_NVX_linked_gpu_multicast 1
+
+#define GL_LGPU_SEPARATE_STORAGE_BIT_NVX 0x0800
+#define GL_MAX_LGPU_GPUS_NVX 0x92BA
+
+typedef void (GLAPIENTRY * PFNGLLGPUCOPYIMAGESUBDATANVXPROC) (GLuint sourceGpu, GLbitfield destinationGpuMask, GLuint srcName, GLenum srcTarget, GLint srcLevel, GLint srcX, GLint srxY, GLint srcZ, GLuint dstName, GLenum dstTarget, GLint dstLevel, GLint dstX, GLint dstY, GLint dstZ, GLsizei width, GLsizei height, GLsizei depth);
+typedef void (GLAPIENTRY * PFNGLLGPUINTERLOCKNVXPROC) (void);
+typedef void (GLAPIENTRY * PFNGLLGPUNAMEDBUFFERSUBDATANVXPROC) (GLbitfield gpuMask, GLuint buffer, GLintptr offset, GLsizeiptr size, const void *data);
+
+#define glLGPUCopyImageSubDataNVX GLEW_GET_FUN(__glewLGPUCopyImageSubDataNVX)
+#define glLGPUInterlockNVX GLEW_GET_FUN(__glewLGPUInterlockNVX)
+#define glLGPUNamedBufferSubDataNVX GLEW_GET_FUN(__glewLGPUNamedBufferSubDataNVX)
+
+#define GLEW_NVX_linked_gpu_multicast GLEW_GET_VAR(__GLEW_NVX_linked_gpu_multicast)
+
+#endif /* GL_NVX_linked_gpu_multicast */
+
+/* ------------------------ GL_NV_3dvision_settings ------------------------ */
+
+#ifndef GL_NV_3dvision_settings
+#define GL_NV_3dvision_settings 1
+
+#define GL_3DVISION_STEREO_NV 0x90F4
+#define GL_STEREO_SEPARATION_NV 0x90F5
+#define GL_STEREO_CONVERGENCE_NV 0x90F6
+#define GL_STEREO_CUTOFF_NV 0x90F7
+#define GL_STEREO_PROJECTION_NV 0x90F8
+#define GL_STEREO_PROJECTION_PERSPECTIVE_NV 0x90F9
+#define GL_STEREO_PROJECTION_ORTHO_NV 0x90FA
+
+typedef void (GLAPIENTRY * PFNGLSTEREOPARAMETERFNVPROC) (GLenum pname, GLfloat param);
+typedef void (GLAPIENTRY * PFNGLSTEREOPARAMETERINVPROC) (GLenum pname, GLint param);
+
+#define glStereoParameterfNV GLEW_GET_FUN(__glewStereoParameterfNV)
+#define glStereoParameteriNV GLEW_GET_FUN(__glewStereoParameteriNV)
+
+#define GLEW_NV_3dvision_settings GLEW_GET_VAR(__GLEW_NV_3dvision_settings)
+
+#endif /* GL_NV_3dvision_settings */
+
+/* ------------------- GL_NV_EGL_stream_consumer_external ------------------ */
+
+#ifndef GL_NV_EGL_stream_consumer_external
+#define GL_NV_EGL_stream_consumer_external 1
+
+#define GL_TEXTURE_EXTERNAL_OES 0x8D65
+#define GL_SAMPLER_EXTERNAL_OES 0x8D66
+#define GL_TEXTURE_BINDING_EXTERNAL_OES 0x8D67
+#define GL_REQUIRED_TEXTURE_IMAGE_UNITS_OES 0x8D68
+
+#define GLEW_NV_EGL_stream_consumer_external GLEW_GET_VAR(__GLEW_NV_EGL_stream_consumer_external)
+
+#endif /* GL_NV_EGL_stream_consumer_external */
+
+/* ----------------- GL_NV_alpha_to_coverage_dither_control ---------------- */
+
+#ifndef GL_NV_alpha_to_coverage_dither_control
+#define GL_NV_alpha_to_coverage_dither_control 1
+
+#define GL_ALPHA_TO_COVERAGE_DITHER_MODE_NV 0x92BF
+#define GL_ALPHA_TO_COVERAGE_DITHER_DEFAULT_NV 0x934D
+#define GL_ALPHA_TO_COVERAGE_DITHER_ENABLE_NV 0x934E
+#define GL_ALPHA_TO_COVERAGE_DITHER_DISABLE_NV 0x934F
+
+#define GLEW_NV_alpha_to_coverage_dither_control GLEW_GET_VAR(__GLEW_NV_alpha_to_coverage_dither_control)
+
+#endif /* GL_NV_alpha_to_coverage_dither_control */
+
+/* ------------------------------- GL_NV_bgr ------------------------------- */
+
+#ifndef GL_NV_bgr
+#define GL_NV_bgr 1
+
+#define GL_BGR_NV 0x80E0
+
+#define GLEW_NV_bgr GLEW_GET_VAR(__GLEW_NV_bgr)
+
+#endif /* GL_NV_bgr */
 
 /* ------------------- GL_NV_bindless_multi_draw_indirect ------------------ */
 
@@ -12153,6 +14263,18 @@ typedef void (GLAPIENTRY * PFNGLBLENDPARAMETERINVPROC) (GLenum pname, GLint valu
 
 #endif /* GL_NV_blend_equation_advanced_coherent */
 
+/* ----------------------- GL_NV_blend_minmax_factor ----------------------- */
+
+#ifndef GL_NV_blend_minmax_factor
+#define GL_NV_blend_minmax_factor 1
+
+#define GL_FACTOR_MIN_AMD 0x901C
+#define GL_FACTOR_MAX_AMD 0x901D
+
+#define GLEW_NV_blend_minmax_factor GLEW_GET_VAR(__GLEW_NV_blend_minmax_factor)
+
+#endif /* GL_NV_blend_minmax_factor */
+
 /* --------------------------- GL_NV_blend_square -------------------------- */
 
 #ifndef GL_NV_blend_square
@@ -12161,6 +14283,88 @@ typedef void (GLAPIENTRY * PFNGLBLENDPARAMETERINVPROC) (GLenum pname, GLint valu
 #define GLEW_NV_blend_square GLEW_GET_VAR(__GLEW_NV_blend_square)
 
 #endif /* GL_NV_blend_square */
+
+/* ----------------------- GL_NV_clip_space_w_scaling ---------------------- */
+
+#ifndef GL_NV_clip_space_w_scaling
+#define GL_NV_clip_space_w_scaling 1
+
+#define GL_VIEWPORT_POSITION_W_SCALE_NV 0x937C
+#define GL_VIEWPORT_POSITION_W_SCALE_X_COEFF_NV 0x937D
+#define GL_VIEWPORT_POSITION_W_SCALE_Y_COEFF_NV 0x937E
+
+typedef void (GLAPIENTRY * PFNGLVIEWPORTPOSITIONWSCALENVPROC) (GLuint index, GLfloat xcoeff, GLfloat ycoeff);
+
+#define glViewportPositionWScaleNV GLEW_GET_FUN(__glewViewportPositionWScaleNV)
+
+#define GLEW_NV_clip_space_w_scaling GLEW_GET_VAR(__GLEW_NV_clip_space_w_scaling)
+
+#endif /* GL_NV_clip_space_w_scaling */
+
+/* --------------------------- GL_NV_command_list -------------------------- */
+
+#ifndef GL_NV_command_list
+#define GL_NV_command_list 1
+
+#define GL_TERMINATE_SEQUENCE_COMMAND_NV 0x0000
+#define GL_NOP_COMMAND_NV 0x0001
+#define GL_DRAW_ELEMENTS_COMMAND_NV 0x0002
+#define GL_DRAW_ARRAYS_COMMAND_NV 0x0003
+#define GL_DRAW_ELEMENTS_STRIP_COMMAND_NV 0x0004
+#define GL_DRAW_ARRAYS_STRIP_COMMAND_NV 0x0005
+#define GL_DRAW_ELEMENTS_INSTANCED_COMMAND_NV 0x0006
+#define GL_DRAW_ARRAYS_INSTANCED_COMMAND_NV 0x0007
+#define GL_ELEMENT_ADDRESS_COMMAND_NV 0x0008
+#define GL_ATTRIBUTE_ADDRESS_COMMAND_NV 0x0009
+#define GL_UNIFORM_ADDRESS_COMMAND_NV 0x000a
+#define GL_BLEND_COLOR_COMMAND_NV 0x000b
+#define GL_STENCIL_REF_COMMAND_NV 0x000c
+#define GL_LINE_WIDTH_COMMAND_NV 0x000d
+#define GL_POLYGON_OFFSET_COMMAND_NV 0x000e
+#define GL_ALPHA_REF_COMMAND_NV 0x000f
+#define GL_VIEWPORT_COMMAND_NV 0x0010
+#define GL_SCISSOR_COMMAND_NV 0x0011
+#define GL_FRONT_FACE_COMMAND_NV 0x0012
+
+typedef void (GLAPIENTRY * PFNGLCALLCOMMANDLISTNVPROC) (GLuint list);
+typedef void (GLAPIENTRY * PFNGLCOMMANDLISTSEGMENTSNVPROC) (GLuint list, GLuint segments);
+typedef void (GLAPIENTRY * PFNGLCOMPILECOMMANDLISTNVPROC) (GLuint list);
+typedef void (GLAPIENTRY * PFNGLCREATECOMMANDLISTSNVPROC) (GLsizei n, GLuint* lists);
+typedef void (GLAPIENTRY * PFNGLCREATESTATESNVPROC) (GLsizei n, GLuint* states);
+typedef void (GLAPIENTRY * PFNGLDELETECOMMANDLISTSNVPROC) (GLsizei n, const GLuint* lists);
+typedef void (GLAPIENTRY * PFNGLDELETESTATESNVPROC) (GLsizei n, const GLuint* states);
+typedef void (GLAPIENTRY * PFNGLDRAWCOMMANDSADDRESSNVPROC) (GLenum primitiveMode, const GLuint64* indirects, const GLsizei* sizes, GLuint count);
+typedef void (GLAPIENTRY * PFNGLDRAWCOMMANDSNVPROC) (GLenum primitiveMode, GLuint buffer, const GLintptr* indirects, const GLsizei* sizes, GLuint count);
+typedef void (GLAPIENTRY * PFNGLDRAWCOMMANDSSTATESADDRESSNVPROC) (const GLuint64* indirects, const GLsizei* sizes, const GLuint* states, const GLuint* fbos, GLuint count);
+typedef void (GLAPIENTRY * PFNGLDRAWCOMMANDSSTATESNVPROC) (GLuint buffer, const GLintptr* indirects, const GLsizei* sizes, const GLuint* states, const GLuint* fbos, GLuint count);
+typedef GLuint (GLAPIENTRY * PFNGLGETCOMMANDHEADERNVPROC) (GLenum tokenID, GLuint size);
+typedef GLushort (GLAPIENTRY * PFNGLGETSTAGEINDEXNVPROC) (GLenum shadertype);
+typedef GLboolean (GLAPIENTRY * PFNGLISCOMMANDLISTNVPROC) (GLuint list);
+typedef GLboolean (GLAPIENTRY * PFNGLISSTATENVPROC) (GLuint state);
+typedef void (GLAPIENTRY * PFNGLLISTDRAWCOMMANDSSTATESCLIENTNVPROC) (GLuint list, GLuint segment, const void** indirects, const GLsizei* sizes, const GLuint* states, const GLuint* fbos, GLuint count);
+typedef void (GLAPIENTRY * PFNGLSTATECAPTURENVPROC) (GLuint state, GLenum mode);
+
+#define glCallCommandListNV GLEW_GET_FUN(__glewCallCommandListNV)
+#define glCommandListSegmentsNV GLEW_GET_FUN(__glewCommandListSegmentsNV)
+#define glCompileCommandListNV GLEW_GET_FUN(__glewCompileCommandListNV)
+#define glCreateCommandListsNV GLEW_GET_FUN(__glewCreateCommandListsNV)
+#define glCreateStatesNV GLEW_GET_FUN(__glewCreateStatesNV)
+#define glDeleteCommandListsNV GLEW_GET_FUN(__glewDeleteCommandListsNV)
+#define glDeleteStatesNV GLEW_GET_FUN(__glewDeleteStatesNV)
+#define glDrawCommandsAddressNV GLEW_GET_FUN(__glewDrawCommandsAddressNV)
+#define glDrawCommandsNV GLEW_GET_FUN(__glewDrawCommandsNV)
+#define glDrawCommandsStatesAddressNV GLEW_GET_FUN(__glewDrawCommandsStatesAddressNV)
+#define glDrawCommandsStatesNV GLEW_GET_FUN(__glewDrawCommandsStatesNV)
+#define glGetCommandHeaderNV GLEW_GET_FUN(__glewGetCommandHeaderNV)
+#define glGetStageIndexNV GLEW_GET_FUN(__glewGetStageIndexNV)
+#define glIsCommandListNV GLEW_GET_FUN(__glewIsCommandListNV)
+#define glIsStateNV GLEW_GET_FUN(__glewIsStateNV)
+#define glListDrawCommandsStatesClientNV GLEW_GET_FUN(__glewListDrawCommandsStatesClientNV)
+#define glStateCaptureNV GLEW_GET_FUN(__glewStateCaptureNV)
+
+#define GLEW_NV_command_list GLEW_GET_VAR(__GLEW_NV_command_list)
+
+#endif /* GL_NV_command_list */
 
 /* ------------------------- GL_NV_compute_program5 ------------------------ */
 
@@ -12193,6 +14397,74 @@ typedef void (GLAPIENTRY * PFNGLENDCONDITIONALRENDERNVPROC) (void);
 #define GLEW_NV_conditional_render GLEW_GET_VAR(__GLEW_NV_conditional_render)
 
 #endif /* GL_NV_conditional_render */
+
+/* ----------------------- GL_NV_conservative_raster ----------------------- */
+
+#ifndef GL_NV_conservative_raster
+#define GL_NV_conservative_raster 1
+
+#define GL_CONSERVATIVE_RASTERIZATION_NV 0x9346
+#define GL_SUBPIXEL_PRECISION_BIAS_X_BITS_NV 0x9347
+#define GL_SUBPIXEL_PRECISION_BIAS_Y_BITS_NV 0x9348
+#define GL_MAX_SUBPIXEL_PRECISION_BIAS_BITS_NV 0x9349
+
+typedef void (GLAPIENTRY * PFNGLSUBPIXELPRECISIONBIASNVPROC) (GLuint xbits, GLuint ybits);
+
+#define glSubpixelPrecisionBiasNV GLEW_GET_FUN(__glewSubpixelPrecisionBiasNV)
+
+#define GLEW_NV_conservative_raster GLEW_GET_VAR(__GLEW_NV_conservative_raster)
+
+#endif /* GL_NV_conservative_raster */
+
+/* -------------------- GL_NV_conservative_raster_dilate ------------------- */
+
+#ifndef GL_NV_conservative_raster_dilate
+#define GL_NV_conservative_raster_dilate 1
+
+#define GL_CONSERVATIVE_RASTER_DILATE_NV 0x9379
+#define GL_CONSERVATIVE_RASTER_DILATE_RANGE_NV 0x937A
+#define GL_CONSERVATIVE_RASTER_DILATE_GRANULARITY_NV 0x937B
+
+typedef void (GLAPIENTRY * PFNGLCONSERVATIVERASTERPARAMETERFNVPROC) (GLenum pname, GLfloat value);
+
+#define glConservativeRasterParameterfNV GLEW_GET_FUN(__glewConservativeRasterParameterfNV)
+
+#define GLEW_NV_conservative_raster_dilate GLEW_GET_VAR(__GLEW_NV_conservative_raster_dilate)
+
+#endif /* GL_NV_conservative_raster_dilate */
+
+/* -------------- GL_NV_conservative_raster_pre_snap_triangles ------------- */
+
+#ifndef GL_NV_conservative_raster_pre_snap_triangles
+#define GL_NV_conservative_raster_pre_snap_triangles 1
+
+#define GL_CONSERVATIVE_RASTER_MODE_NV 0x954D
+#define GL_CONSERVATIVE_RASTER_MODE_POST_SNAP_NV 0x954E
+#define GL_CONSERVATIVE_RASTER_MODE_PRE_SNAP_TRIANGLES_NV 0x954F
+
+typedef void (GLAPIENTRY * PFNGLCONSERVATIVERASTERPARAMETERINVPROC) (GLenum pname, GLint param);
+
+#define glConservativeRasterParameteriNV GLEW_GET_FUN(__glewConservativeRasterParameteriNV)
+
+#define GLEW_NV_conservative_raster_pre_snap_triangles GLEW_GET_VAR(__GLEW_NV_conservative_raster_pre_snap_triangles)
+
+#endif /* GL_NV_conservative_raster_pre_snap_triangles */
+
+/* --------------------------- GL_NV_copy_buffer --------------------------- */
+
+#ifndef GL_NV_copy_buffer
+#define GL_NV_copy_buffer 1
+
+#define GL_COPY_READ_BUFFER_NV 0x8F36
+#define GL_COPY_WRITE_BUFFER_NV 0x8F37
+
+typedef void (GLAPIENTRY * PFNGLCOPYBUFFERSUBDATANVPROC) (GLenum readtarget, GLenum writetarget, GLintptr readoffset, GLintptr writeoffset, GLsizeiptr size);
+
+#define glCopyBufferSubDataNV GLEW_GET_FUN(__glewCopyBufferSubDataNV)
+
+#define GLEW_NV_copy_buffer GLEW_GET_VAR(__GLEW_NV_copy_buffer)
+
+#endif /* GL_NV_copy_buffer */
 
 /* ----------------------- GL_NV_copy_depth_to_color ----------------------- */
 
@@ -12279,6 +14551,68 @@ typedef void (GLAPIENTRY * PFNGLDEPTHRANGEDNVPROC) (GLdouble zNear, GLdouble zFa
 
 #endif /* GL_NV_depth_range_unclamped */
 
+/* --------------------------- GL_NV_draw_buffers -------------------------- */
+
+#ifndef GL_NV_draw_buffers
+#define GL_NV_draw_buffers 1
+
+#define GL_MAX_DRAW_BUFFERS_NV 0x8824
+#define GL_DRAW_BUFFER0_NV 0x8825
+#define GL_DRAW_BUFFER1_NV 0x8826
+#define GL_DRAW_BUFFER2_NV 0x8827
+#define GL_DRAW_BUFFER3_NV 0x8828
+#define GL_DRAW_BUFFER4_NV 0x8829
+#define GL_DRAW_BUFFER5_NV 0x882A
+#define GL_DRAW_BUFFER6_NV 0x882B
+#define GL_DRAW_BUFFER7_NV 0x882C
+#define GL_DRAW_BUFFER8_NV 0x882D
+#define GL_DRAW_BUFFER9_NV 0x882E
+#define GL_DRAW_BUFFER10_NV 0x882F
+#define GL_DRAW_BUFFER11_NV 0x8830
+#define GL_DRAW_BUFFER12_NV 0x8831
+#define GL_DRAW_BUFFER13_NV 0x8832
+#define GL_DRAW_BUFFER14_NV 0x8833
+#define GL_DRAW_BUFFER15_NV 0x8834
+#define GL_COLOR_ATTACHMENT0_NV 0x8CE0
+#define GL_COLOR_ATTACHMENT1_NV 0x8CE1
+#define GL_COLOR_ATTACHMENT2_NV 0x8CE2
+#define GL_COLOR_ATTACHMENT3_NV 0x8CE3
+#define GL_COLOR_ATTACHMENT4_NV 0x8CE4
+#define GL_COLOR_ATTACHMENT5_NV 0x8CE5
+#define GL_COLOR_ATTACHMENT6_NV 0x8CE6
+#define GL_COLOR_ATTACHMENT7_NV 0x8CE7
+#define GL_COLOR_ATTACHMENT8_NV 0x8CE8
+#define GL_COLOR_ATTACHMENT9_NV 0x8CE9
+#define GL_COLOR_ATTACHMENT10_NV 0x8CEA
+#define GL_COLOR_ATTACHMENT11_NV 0x8CEB
+#define GL_COLOR_ATTACHMENT12_NV 0x8CEC
+#define GL_COLOR_ATTACHMENT13_NV 0x8CED
+#define GL_COLOR_ATTACHMENT14_NV 0x8CEE
+#define GL_COLOR_ATTACHMENT15_NV 0x8CEF
+
+typedef void (GLAPIENTRY * PFNGLDRAWBUFFERSNVPROC) (GLsizei n, const GLenum* bufs);
+
+#define glDrawBuffersNV GLEW_GET_FUN(__glewDrawBuffersNV)
+
+#define GLEW_NV_draw_buffers GLEW_GET_VAR(__GLEW_NV_draw_buffers)
+
+#endif /* GL_NV_draw_buffers */
+
+/* -------------------------- GL_NV_draw_instanced ------------------------- */
+
+#ifndef GL_NV_draw_instanced
+#define GL_NV_draw_instanced 1
+
+typedef void (GLAPIENTRY * PFNGLDRAWARRAYSINSTANCEDNVPROC) (GLenum mode, GLint first, GLsizei count, GLsizei primcount);
+typedef void (GLAPIENTRY * PFNGLDRAWELEMENTSINSTANCEDNVPROC) (GLenum mode, GLsizei count, GLenum type, const void *indices, GLsizei primcount);
+
+#define glDrawArraysInstancedNV GLEW_GET_FUN(__glewDrawArraysInstancedNV)
+#define glDrawElementsInstancedNV GLEW_GET_FUN(__glewDrawElementsInstancedNV)
+
+#define GLEW_NV_draw_instanced GLEW_GET_VAR(__GLEW_NV_draw_instanced)
+
+#endif /* GL_NV_draw_instanced */
+
 /* --------------------------- GL_NV_draw_texture -------------------------- */
 
 #ifndef GL_NV_draw_texture
@@ -12291,6 +14625,29 @@ typedef void (GLAPIENTRY * PFNGLDRAWTEXTURENVPROC) (GLuint texture, GLuint sampl
 #define GLEW_NV_draw_texture GLEW_GET_VAR(__GLEW_NV_draw_texture)
 
 #endif /* GL_NV_draw_texture */
+
+/* ------------------------ GL_NV_draw_vulkan_image ------------------------ */
+
+#ifndef GL_NV_draw_vulkan_image
+#define GL_NV_draw_vulkan_image 1
+
+typedef void (APIENTRY *GLVULKANPROCNV)(void);
+
+typedef void (GLAPIENTRY * PFNGLDRAWVKIMAGENVPROC) (GLuint64 vkImage, GLuint sampler, GLfloat x0, GLfloat y0, GLfloat x1, GLfloat y1, GLfloat z, GLfloat s0, GLfloat t0, GLfloat s1, GLfloat t1);
+typedef GLVULKANPROCNV (GLAPIENTRY * PFNGLGETVKPROCADDRNVPROC) (const GLchar* name);
+typedef void (GLAPIENTRY * PFNGLSIGNALVKFENCENVPROC) (GLuint64 vkFence);
+typedef void (GLAPIENTRY * PFNGLSIGNALVKSEMAPHORENVPROC) (GLuint64 vkSemaphore);
+typedef void (GLAPIENTRY * PFNGLWAITVKSEMAPHORENVPROC) (GLuint64 vkSemaphore);
+
+#define glDrawVkImageNV GLEW_GET_FUN(__glewDrawVkImageNV)
+#define glGetVkProcAddrNV GLEW_GET_FUN(__glewGetVkProcAddrNV)
+#define glSignalVkFenceNV GLEW_GET_FUN(__glewSignalVkFenceNV)
+#define glSignalVkSemaphoreNV GLEW_GET_FUN(__glewSignalVkSemaphoreNV)
+#define glWaitVkSemaphoreNV GLEW_GET_FUN(__glewWaitVkSemaphoreNV)
+
+#define GLEW_NV_draw_vulkan_image GLEW_GET_VAR(__GLEW_NV_draw_vulkan_image)
+
+#endif /* GL_NV_draw_vulkan_image */
 
 /* ---------------------------- GL_NV_evaluators --------------------------- */
 
@@ -12346,6 +14703,15 @@ typedef void (GLAPIENTRY * PFNGLMAPPARAMETERIVNVPROC) (GLenum target, GLenum pna
 
 #endif /* GL_NV_evaluators */
 
+/* --------------------- GL_NV_explicit_attrib_location -------------------- */
+
+#ifndef GL_NV_explicit_attrib_location
+#define GL_NV_explicit_attrib_location 1
+
+#define GLEW_NV_explicit_attrib_location GLEW_GET_VAR(__GLEW_NV_explicit_attrib_location)
+
+#endif /* GL_NV_explicit_attrib_location */
+
 /* ----------------------- GL_NV_explicit_multisample ---------------------- */
 
 #ifndef GL_NV_explicit_multisample
@@ -12373,6 +14739,33 @@ typedef void (GLAPIENTRY * PFNGLTEXRENDERBUFFERNVPROC) (GLenum target, GLuint re
 #define GLEW_NV_explicit_multisample GLEW_GET_VAR(__GLEW_NV_explicit_multisample)
 
 #endif /* GL_NV_explicit_multisample */
+
+/* ---------------------- GL_NV_fbo_color_attachments ---------------------- */
+
+#ifndef GL_NV_fbo_color_attachments
+#define GL_NV_fbo_color_attachments 1
+
+#define GL_MAX_COLOR_ATTACHMENTS_NV 0x8CDF
+#define GL_COLOR_ATTACHMENT0_NV 0x8CE0
+#define GL_COLOR_ATTACHMENT1_NV 0x8CE1
+#define GL_COLOR_ATTACHMENT2_NV 0x8CE2
+#define GL_COLOR_ATTACHMENT3_NV 0x8CE3
+#define GL_COLOR_ATTACHMENT4_NV 0x8CE4
+#define GL_COLOR_ATTACHMENT5_NV 0x8CE5
+#define GL_COLOR_ATTACHMENT6_NV 0x8CE6
+#define GL_COLOR_ATTACHMENT7_NV 0x8CE7
+#define GL_COLOR_ATTACHMENT8_NV 0x8CE8
+#define GL_COLOR_ATTACHMENT9_NV 0x8CE9
+#define GL_COLOR_ATTACHMENT10_NV 0x8CEA
+#define GL_COLOR_ATTACHMENT11_NV 0x8CEB
+#define GL_COLOR_ATTACHMENT12_NV 0x8CEC
+#define GL_COLOR_ATTACHMENT13_NV 0x8CED
+#define GL_COLOR_ATTACHMENT14_NV 0x8CEE
+#define GL_COLOR_ATTACHMENT15_NV 0x8CEF
+
+#define GLEW_NV_fbo_color_attachments GLEW_GET_VAR(__GLEW_NV_fbo_color_attachments)
+
+#endif /* GL_NV_fbo_color_attachments */
 
 /* ------------------------------ GL_NV_fence ------------------------------ */
 
@@ -12402,6 +14795,17 @@ typedef GLboolean (GLAPIENTRY * PFNGLTESTFENCENVPROC) (GLuint fence);
 #define GLEW_NV_fence GLEW_GET_VAR(__GLEW_NV_fence)
 
 #endif /* GL_NV_fence */
+
+/* -------------------------- GL_NV_fill_rectangle ------------------------- */
+
+#ifndef GL_NV_fill_rectangle
+#define GL_NV_fill_rectangle 1
+
+#define GL_FILL_RECTANGLE_NV 0x933C
+
+#define GLEW_NV_fill_rectangle GLEW_GET_VAR(__GLEW_NV_fill_rectangle)
+
+#endif /* GL_NV_fill_rectangle */
 
 /* --------------------------- GL_NV_float_buffer -------------------------- */
 
@@ -12440,6 +14844,22 @@ typedef GLboolean (GLAPIENTRY * PFNGLTESTFENCENVPROC) (GLuint fence);
 #define GLEW_NV_fog_distance GLEW_GET_VAR(__GLEW_NV_fog_distance)
 
 #endif /* GL_NV_fog_distance */
+
+/* -------------------- GL_NV_fragment_coverage_to_color ------------------- */
+
+#ifndef GL_NV_fragment_coverage_to_color
+#define GL_NV_fragment_coverage_to_color 1
+
+#define GL_FRAGMENT_COVERAGE_TO_COLOR_NV 0x92DD
+#define GL_FRAGMENT_COVERAGE_COLOR_NV 0x92DE
+
+typedef void (GLAPIENTRY * PFNGLFRAGMENTCOVERAGECOLORNVPROC) (GLuint color);
+
+#define glFragmentCoverageColorNV GLEW_GET_FUN(__glewFragmentCoverageColorNV)
+
+#define GLEW_NV_fragment_coverage_to_color GLEW_GET_VAR(__GLEW_NV_fragment_coverage_to_color)
+
+#endif /* GL_NV_fragment_coverage_to_color */
 
 /* ------------------------- GL_NV_fragment_program ------------------------ */
 
@@ -12504,6 +14924,74 @@ typedef void (GLAPIENTRY * PFNGLPROGRAMNAMEDPARAMETER4FVNVPROC) (GLuint id, GLsi
 
 #endif /* GL_NV_fragment_program_option */
 
+/* -------------------- GL_NV_fragment_shader_interlock -------------------- */
+
+#ifndef GL_NV_fragment_shader_interlock
+#define GL_NV_fragment_shader_interlock 1
+
+#define GLEW_NV_fragment_shader_interlock GLEW_GET_VAR(__GLEW_NV_fragment_shader_interlock)
+
+#endif /* GL_NV_fragment_shader_interlock */
+
+/* ------------------------- GL_NV_framebuffer_blit ------------------------ */
+
+#ifndef GL_NV_framebuffer_blit
+#define GL_NV_framebuffer_blit 1
+
+#define GL_DRAW_FRAMEBUFFER_BINDING_NV 0x8CA6
+#define GL_READ_FRAMEBUFFER_NV 0x8CA8
+#define GL_DRAW_FRAMEBUFFER_NV 0x8CA9
+#define GL_READ_FRAMEBUFFER_BINDING_NV 0x8CAA
+
+typedef void (GLAPIENTRY * PFNGLBLITFRAMEBUFFERNVPROC) (GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0, GLint dstX1, GLint dstY1, GLbitfield mask, GLenum filter);
+
+#define glBlitFramebufferNV GLEW_GET_FUN(__glewBlitFramebufferNV)
+
+#define GLEW_NV_framebuffer_blit GLEW_GET_VAR(__GLEW_NV_framebuffer_blit)
+
+#endif /* GL_NV_framebuffer_blit */
+
+/* -------------------- GL_NV_framebuffer_mixed_samples -------------------- */
+
+#ifndef GL_NV_framebuffer_mixed_samples
+#define GL_NV_framebuffer_mixed_samples 1
+
+#define GL_COLOR_SAMPLES_NV 0x8E20
+#define GL_RASTER_MULTISAMPLE_EXT 0x9327
+#define GL_RASTER_SAMPLES_EXT 0x9328
+#define GL_MAX_RASTER_SAMPLES_EXT 0x9329
+#define GL_RASTER_FIXED_SAMPLE_LOCATIONS_EXT 0x932A
+#define GL_MULTISAMPLE_RASTERIZATION_ALLOWED_EXT 0x932B
+#define GL_EFFECTIVE_RASTER_SAMPLES_EXT 0x932C
+#define GL_DEPTH_SAMPLES_NV 0x932D
+#define GL_STENCIL_SAMPLES_NV 0x932E
+#define GL_MIXED_DEPTH_SAMPLES_SUPPORTED_NV 0x932F
+#define GL_MIXED_STENCIL_SAMPLES_SUPPORTED_NV 0x9330
+#define GL_COVERAGE_MODULATION_TABLE_NV 0x9331
+#define GL_COVERAGE_MODULATION_NV 0x9332
+#define GL_COVERAGE_MODULATION_TABLE_SIZE_NV 0x9333
+
+#define GLEW_NV_framebuffer_mixed_samples GLEW_GET_VAR(__GLEW_NV_framebuffer_mixed_samples)
+
+#endif /* GL_NV_framebuffer_mixed_samples */
+
+/* --------------------- GL_NV_framebuffer_multisample --------------------- */
+
+#ifndef GL_NV_framebuffer_multisample
+#define GL_NV_framebuffer_multisample 1
+
+#define GL_RENDERBUFFER_SAMPLES_NV 0x8CAB
+#define GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE_NV 0x8D56
+#define GL_MAX_SAMPLES_NV 0x8D57
+
+typedef void (GLAPIENTRY * PFNGLRENDERBUFFERSTORAGEMULTISAMPLENVPROC) (GLenum target, GLsizei samples, GLenum internalformat, GLsizei width, GLsizei height);
+
+#define glRenderbufferStorageMultisampleNV GLEW_GET_FUN(__glewRenderbufferStorageMultisampleNV)
+
+#define GLEW_NV_framebuffer_multisample GLEW_GET_VAR(__GLEW_NV_framebuffer_multisample)
+
+#endif /* GL_NV_framebuffer_multisample */
+
 /* ----------------- GL_NV_framebuffer_multisample_coverage ---------------- */
 
 #ifndef GL_NV_framebuffer_multisample_coverage
@@ -12521,6 +15009,15 @@ typedef void (GLAPIENTRY * PFNGLRENDERBUFFERSTORAGEMULTISAMPLECOVERAGENVPROC) (G
 #define GLEW_NV_framebuffer_multisample_coverage GLEW_GET_VAR(__GLEW_NV_framebuffer_multisample_coverage)
 
 #endif /* GL_NV_framebuffer_multisample_coverage */
+
+/* ----------------------- GL_NV_generate_mipmap_sRGB ---------------------- */
+
+#ifndef GL_NV_generate_mipmap_sRGB
+#define GL_NV_generate_mipmap_sRGB 1
+
+#define GLEW_NV_generate_mipmap_sRGB GLEW_GET_VAR(__GLEW_NV_generate_mipmap_sRGB)
+
+#endif /* GL_NV_generate_mipmap_sRGB */
 
 /* ------------------------ GL_NV_geometry_program4 ------------------------ */
 
@@ -12547,6 +15044,56 @@ typedef void (GLAPIENTRY * PFNGLPROGRAMVERTEXLIMITNVPROC) (GLenum target, GLint 
 #define GLEW_NV_geometry_shader4 GLEW_GET_VAR(__GLEW_NV_geometry_shader4)
 
 #endif /* GL_NV_geometry_shader4 */
+
+/* ------------------- GL_NV_geometry_shader_passthrough ------------------- */
+
+#ifndef GL_NV_geometry_shader_passthrough
+#define GL_NV_geometry_shader_passthrough 1
+
+#define GLEW_NV_geometry_shader_passthrough GLEW_GET_VAR(__GLEW_NV_geometry_shader_passthrough)
+
+#endif /* GL_NV_geometry_shader_passthrough */
+
+/* -------------------------- GL_NV_gpu_multicast -------------------------- */
+
+#ifndef GL_NV_gpu_multicast
+#define GL_NV_gpu_multicast 1
+
+#define GL_PER_GPU_STORAGE_BIT_NV 0x0800
+#define GL_MULTICAST_GPUS_NV 0x92BA
+#define GL_PER_GPU_STORAGE_NV 0x9548
+#define GL_MULTICAST_PROGRAMMABLE_SAMPLE_LOCATION_NV 0x9549
+#define GL_RENDER_GPU_MASK_NV 0x9558
+
+typedef void (GLAPIENTRY * PFNGLMULTICASTBARRIERNVPROC) (void);
+typedef void (GLAPIENTRY * PFNGLMULTICASTBLITFRAMEBUFFERNVPROC) (GLuint srcGpu, GLuint dstGpu, GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0, GLint dstX1, GLint dstY1, GLbitfield mask, GLenum filter);
+typedef void (GLAPIENTRY * PFNGLMULTICASTBUFFERSUBDATANVPROC) (GLbitfield gpuMask, GLuint buffer, GLintptr offset, GLsizeiptr size, const void *data);
+typedef void (GLAPIENTRY * PFNGLMULTICASTCOPYBUFFERSUBDATANVPROC) (GLuint readGpu, GLbitfield writeGpuMask, GLuint readBuffer, GLuint writeBuffer, GLintptr readOffset, GLintptr writeOffset, GLsizeiptr size);
+typedef void (GLAPIENTRY * PFNGLMULTICASTCOPYIMAGESUBDATANVPROC) (GLuint srcGpu, GLbitfield dstGpuMask, GLuint srcName, GLenum srcTarget, GLint srcLevel, GLint srcX, GLint srcY, GLint srcZ, GLuint dstName, GLenum dstTarget, GLint dstLevel, GLint dstX, GLint dstY, GLint dstZ, GLsizei srcWidth, GLsizei srcHeight, GLsizei srcDepth);
+typedef void (GLAPIENTRY * PFNGLMULTICASTFRAMEBUFFERSAMPLELOCATIONSFVNVPROC) (GLuint gpu, GLuint framebuffer, GLuint start, GLsizei count, const GLfloat* v);
+typedef void (GLAPIENTRY * PFNGLMULTICASTGETQUERYOBJECTI64VNVPROC) (GLuint gpu, GLuint id, GLenum pname, GLint64* params);
+typedef void (GLAPIENTRY * PFNGLMULTICASTGETQUERYOBJECTIVNVPROC) (GLuint gpu, GLuint id, GLenum pname, GLint* params);
+typedef void (GLAPIENTRY * PFNGLMULTICASTGETQUERYOBJECTUI64VNVPROC) (GLuint gpu, GLuint id, GLenum pname, GLuint64* params);
+typedef void (GLAPIENTRY * PFNGLMULTICASTGETQUERYOBJECTUIVNVPROC) (GLuint gpu, GLuint id, GLenum pname, GLuint* params);
+typedef void (GLAPIENTRY * PFNGLMULTICASTWAITSYNCNVPROC) (GLuint signalGpu, GLbitfield waitGpuMask);
+typedef void (GLAPIENTRY * PFNGLRENDERGPUMASKNVPROC) (GLbitfield mask);
+
+#define glMulticastBarrierNV GLEW_GET_FUN(__glewMulticastBarrierNV)
+#define glMulticastBlitFramebufferNV GLEW_GET_FUN(__glewMulticastBlitFramebufferNV)
+#define glMulticastBufferSubDataNV GLEW_GET_FUN(__glewMulticastBufferSubDataNV)
+#define glMulticastCopyBufferSubDataNV GLEW_GET_FUN(__glewMulticastCopyBufferSubDataNV)
+#define glMulticastCopyImageSubDataNV GLEW_GET_FUN(__glewMulticastCopyImageSubDataNV)
+#define glMulticastFramebufferSampleLocationsfvNV GLEW_GET_FUN(__glewMulticastFramebufferSampleLocationsfvNV)
+#define glMulticastGetQueryObjecti64vNV GLEW_GET_FUN(__glewMulticastGetQueryObjecti64vNV)
+#define glMulticastGetQueryObjectivNV GLEW_GET_FUN(__glewMulticastGetQueryObjectivNV)
+#define glMulticastGetQueryObjectui64vNV GLEW_GET_FUN(__glewMulticastGetQueryObjectui64vNV)
+#define glMulticastGetQueryObjectuivNV GLEW_GET_FUN(__glewMulticastGetQueryObjectuivNV)
+#define glMulticastWaitSyncNV GLEW_GET_FUN(__glewMulticastWaitSyncNV)
+#define glRenderGpuMaskNV GLEW_GET_FUN(__glewRenderGpuMaskNV)
+
+#define GLEW_NV_gpu_multicast GLEW_GET_VAR(__GLEW_NV_gpu_multicast)
+
+#endif /* GL_NV_gpu_multicast */
 
 /* --------------------------- GL_NV_gpu_program4 -------------------------- */
 
@@ -12841,6 +15388,48 @@ typedef void (GLAPIENTRY * PFNGLVERTEXWEIGHTHVNVPROC) (const GLhalf* weight);
 
 #endif /* GL_NV_half_float */
 
+/* -------------------------- GL_NV_image_formats -------------------------- */
+
+#ifndef GL_NV_image_formats
+#define GL_NV_image_formats 1
+
+#define GLEW_NV_image_formats GLEW_GET_VAR(__GLEW_NV_image_formats)
+
+#endif /* GL_NV_image_formats */
+
+/* ------------------------- GL_NV_instanced_arrays ------------------------ */
+
+#ifndef GL_NV_instanced_arrays
+#define GL_NV_instanced_arrays 1
+
+#define GL_VERTEX_ATTRIB_ARRAY_DIVISOR_NV 0x88FE
+
+typedef void (GLAPIENTRY * PFNGLVERTEXATTRIBDIVISORNVPROC) (GLuint index, GLuint divisor);
+
+#define glVertexAttribDivisorNV GLEW_GET_FUN(__glewVertexAttribDivisorNV)
+
+#define GLEW_NV_instanced_arrays GLEW_GET_VAR(__GLEW_NV_instanced_arrays)
+
+#endif /* GL_NV_instanced_arrays */
+
+/* ------------------- GL_NV_internalformat_sample_query ------------------- */
+
+#ifndef GL_NV_internalformat_sample_query
+#define GL_NV_internalformat_sample_query 1
+
+#define GL_MULTISAMPLES_NV 0x9371
+#define GL_SUPERSAMPLE_SCALE_X_NV 0x9372
+#define GL_SUPERSAMPLE_SCALE_Y_NV 0x9373
+#define GL_CONFORMANT_NV 0x9374
+
+typedef void (GLAPIENTRY * PFNGLGETINTERNALFORMATSAMPLEIVNVPROC) (GLenum target, GLenum internalformat, GLsizei samples, GLenum pname, GLsizei bufSize, GLint* params);
+
+#define glGetInternalformatSampleivNV GLEW_GET_FUN(__glewGetInternalformatSampleivNV)
+
+#define GLEW_NV_internalformat_sample_query GLEW_GET_VAR(__GLEW_NV_internalformat_sample_query)
+
+#endif /* GL_NV_internalformat_sample_query */
+
 /* ------------------------ GL_NV_light_max_exponent ----------------------- */
 
 #ifndef GL_NV_light_max_exponent
@@ -12875,6 +15464,36 @@ typedef void (GLAPIENTRY * PFNGLVERTEXWEIGHTHVNVPROC) (const GLhalf* weight);
 
 #endif /* GL_NV_multisample_filter_hint */
 
+/* ----------------------- GL_NV_non_square_matrices ----------------------- */
+
+#ifndef GL_NV_non_square_matrices
+#define GL_NV_non_square_matrices 1
+
+#define GL_FLOAT_MAT2x3_NV 0x8B65
+#define GL_FLOAT_MAT2x4_NV 0x8B66
+#define GL_FLOAT_MAT3x2_NV 0x8B67
+#define GL_FLOAT_MAT3x4_NV 0x8B68
+#define GL_FLOAT_MAT4x2_NV 0x8B69
+#define GL_FLOAT_MAT4x3_NV 0x8B6A
+
+typedef void (GLAPIENTRY * PFNGLUNIFORMMATRIX2X3FVNVPROC) (GLint location, GLsizei count, GLboolean transpose, const GLfloat* value);
+typedef void (GLAPIENTRY * PFNGLUNIFORMMATRIX2X4FVNVPROC) (GLint location, GLsizei count, GLboolean transpose, const GLfloat* value);
+typedef void (GLAPIENTRY * PFNGLUNIFORMMATRIX3X2FVNVPROC) (GLint location, GLsizei count, GLboolean transpose, const GLfloat* value);
+typedef void (GLAPIENTRY * PFNGLUNIFORMMATRIX3X4FVNVPROC) (GLint location, GLsizei count, GLboolean transpose, const GLfloat* value);
+typedef void (GLAPIENTRY * PFNGLUNIFORMMATRIX4X2FVNVPROC) (GLint location, GLsizei count, GLboolean transpose, const GLfloat* value);
+typedef void (GLAPIENTRY * PFNGLUNIFORMMATRIX4X3FVNVPROC) (GLint location, GLsizei count, GLboolean transpose, const GLfloat* value);
+
+#define glUniformMatrix2x3fvNV GLEW_GET_FUN(__glewUniformMatrix2x3fvNV)
+#define glUniformMatrix2x4fvNV GLEW_GET_FUN(__glewUniformMatrix2x4fvNV)
+#define glUniformMatrix3x2fvNV GLEW_GET_FUN(__glewUniformMatrix3x2fvNV)
+#define glUniformMatrix3x4fvNV GLEW_GET_FUN(__glewUniformMatrix3x4fvNV)
+#define glUniformMatrix4x2fvNV GLEW_GET_FUN(__glewUniformMatrix4x2fvNV)
+#define glUniformMatrix4x3fvNV GLEW_GET_FUN(__glewUniformMatrix4x3fvNV)
+
+#define GLEW_NV_non_square_matrices GLEW_GET_VAR(__GLEW_NV_non_square_matrices)
+
+#endif /* GL_NV_non_square_matrices */
+
 /* ------------------------- GL_NV_occlusion_query ------------------------- */
 
 #ifndef GL_NV_occlusion_query
@@ -12905,6 +15524,19 @@ typedef GLboolean (GLAPIENTRY * PFNGLISOCCLUSIONQUERYNVPROC) (GLuint id);
 
 #endif /* GL_NV_occlusion_query */
 
+/* -------------------------- GL_NV_pack_subimage -------------------------- */
+
+#ifndef GL_NV_pack_subimage
+#define GL_NV_pack_subimage 1
+
+#define GL_PACK_ROW_LENGTH_NV 0x0D02
+#define GL_PACK_SKIP_ROWS_NV 0x0D03
+#define GL_PACK_SKIP_PIXELS_NV 0x0D04
+
+#define GLEW_NV_pack_subimage GLEW_GET_VAR(__GLEW_NV_pack_subimage)
+
+#endif /* GL_NV_pack_subimage */
+
 /* ----------------------- GL_NV_packed_depth_stencil ---------------------- */
 
 #ifndef GL_NV_packed_depth_stencil
@@ -12916,6 +15548,30 @@ typedef GLboolean (GLAPIENTRY * PFNGLISOCCLUSIONQUERYNVPROC) (GLuint id);
 #define GLEW_NV_packed_depth_stencil GLEW_GET_VAR(__GLEW_NV_packed_depth_stencil)
 
 #endif /* GL_NV_packed_depth_stencil */
+
+/* --------------------------- GL_NV_packed_float -------------------------- */
+
+#ifndef GL_NV_packed_float
+#define GL_NV_packed_float 1
+
+#define GL_R11F_G11F_B10F_NV 0x8C3A
+#define GL_UNSIGNED_INT_10F_11F_11F_REV_NV 0x8C3B
+
+#define GLEW_NV_packed_float GLEW_GET_VAR(__GLEW_NV_packed_float)
+
+#endif /* GL_NV_packed_float */
+
+/* ----------------------- GL_NV_packed_float_linear ----------------------- */
+
+#ifndef GL_NV_packed_float_linear
+#define GL_NV_packed_float_linear 1
+
+#define GL_R11F_G11F_B10F_NV 0x8C3A
+#define GL_UNSIGNED_INT_10F_11F_11F_REV_NV 0x8C3B
+
+#define GLEW_NV_packed_float_linear GLEW_GET_VAR(__GLEW_NV_packed_float_linear)
+
+#endif /* GL_NV_packed_float_linear */
 
 /* --------------------- GL_NV_parameter_buffer_object --------------------- */
 
@@ -12986,19 +15642,32 @@ typedef void (GLAPIENTRY * PFNGLPROGRAMBUFFERPARAMETERSFVNVPROC) (GLenum target,
 #define GL_RELATIVE_LARGE_CCW_ARC_TO_NV 0x17
 #define GL_LARGE_CW_ARC_TO_NV 0x18
 #define GL_RELATIVE_LARGE_CW_ARC_TO_NV 0x19
+#define GL_CONIC_CURVE_TO_NV 0x1A
+#define GL_RELATIVE_CONIC_CURVE_TO_NV 0x1B
 #define GL_GLYPH_VERTICAL_BEARING_X_BIT_NV 0x20
 #define GL_GLYPH_VERTICAL_BEARING_Y_BIT_NV 0x40
 #define GL_GLYPH_VERTICAL_BEARING_ADVANCE_BIT_NV 0x80
+#define GL_ROUNDED_RECT_NV 0xE8
+#define GL_RELATIVE_ROUNDED_RECT_NV 0xE9
+#define GL_ROUNDED_RECT2_NV 0xEA
+#define GL_RELATIVE_ROUNDED_RECT2_NV 0xEB
+#define GL_ROUNDED_RECT4_NV 0xEC
+#define GL_RELATIVE_ROUNDED_RECT4_NV 0xED
+#define GL_ROUNDED_RECT8_NV 0xEE
+#define GL_RELATIVE_ROUNDED_RECT8_NV 0xEF
 #define GL_RESTART_PATH_NV 0xF0
 #define GL_DUP_FIRST_CUBIC_CURVE_TO_NV 0xF2
 #define GL_DUP_LAST_CUBIC_CURVE_TO_NV 0xF4
 #define GL_RECT_NV 0xF6
+#define GL_RELATIVE_RECT_NV 0xF7
 #define GL_CIRCULAR_CCW_ARC_TO_NV 0xF8
 #define GL_CIRCULAR_CW_ARC_TO_NV 0xFA
 #define GL_CIRCULAR_TANGENT_ARC_TO_NV 0xFC
 #define GL_ARC_TO_NV 0xFE
 #define GL_RELATIVE_ARC_TO_NV 0xFF
 #define GL_GLYPH_HAS_KERNING_BIT_NV 0x100
+#define GL_PRIMARY_COLOR_NV 0x852C
+#define GL_SECONDARY_COLOR_NV 0x852D
 #define GL_PRIMARY_COLOR 0x8577
 #define GL_PATH_FORMAT_SVG_NV 0x9070
 #define GL_PATH_FORMAT_PS_NV 0x9071
@@ -13021,6 +15690,7 @@ typedef void (GLAPIENTRY * PFNGLPROGRAMBUFFERPARAMETERSFVNVPROC) (GLenum target,
 #define GL_PATH_FILL_COVER_MODE_NV 0x9082
 #define GL_PATH_STROKE_COVER_MODE_NV 0x9083
 #define GL_PATH_STROKE_MASK_NV 0x9084
+#define GL_PATH_STROKE_BOUND_NV 0x9086
 #define GL_COUNT_UP_NV 0x9088
 #define GL_COUNT_DOWN_NV 0x9089
 #define GL_PATH_OBJECT_BOUNDING_BOX_NV 0x908A
@@ -13069,6 +15739,12 @@ typedef void (GLAPIENTRY * PFNGLPROGRAMBUFFERPARAMETERSFVNVPROC) (GLenum target,
 #define GL_PATH_STENCIL_DEPTH_OFFSET_FACTOR_NV 0x90BD
 #define GL_PATH_STENCIL_DEPTH_OFFSET_UNITS_NV 0x90BE
 #define GL_PATH_COVER_DEPTH_FUNC_NV 0x90BF
+#define GL_FONT_GLYPHS_AVAILABLE_NV 0x9368
+#define GL_FONT_TARGET_UNAVAILABLE_NV 0x9369
+#define GL_FONT_UNAVAILABLE_NV 0x936A
+#define GL_FONT_UNINTELLIGIBLE_NV 0x936B
+#define GL_STANDARD_FONT_FORMAT_NV 0x936C
+#define GL_FRAGMENT_INPUT_NV 0x936D
 #define GL_FONT_X_MIN_BOUNDS_BIT_NV 0x00010000
 #define GL_FONT_Y_MIN_BOUNDS_BIT_NV 0x00020000
 #define GL_FONT_X_MAX_BOUNDS_BIT_NV 0x00040000
@@ -13082,54 +15758,70 @@ typedef void (GLAPIENTRY * PFNGLPROGRAMBUFFERPARAMETERSFVNVPROC) (GLenum target,
 #define GL_FONT_UNDERLINE_POSITION_BIT_NV 0x04000000
 #define GL_FONT_UNDERLINE_THICKNESS_BIT_NV 0x08000000
 #define GL_FONT_HAS_KERNING_BIT_NV 0x10000000
+#define GL_FONT_NUM_GLYPH_INDICES_BIT_NV 0x20000000
 
 typedef void (GLAPIENTRY * PFNGLCOPYPATHNVPROC) (GLuint resultPath, GLuint srcPath);
-typedef void (GLAPIENTRY * PFNGLCOVERFILLPATHINSTANCEDNVPROC) (GLsizei numPaths, GLenum pathNameType, const void* paths, GLuint pathBase, GLenum coverMode, GLenum transformType, const GLfloat *transformValues);
+typedef void (GLAPIENTRY * PFNGLCOVERFILLPATHINSTANCEDNVPROC) (GLsizei numPaths, GLenum pathNameType, const void *paths, GLuint pathBase, GLenum coverMode, GLenum transformType, const GLfloat *transformValues);
 typedef void (GLAPIENTRY * PFNGLCOVERFILLPATHNVPROC) (GLuint path, GLenum coverMode);
-typedef void (GLAPIENTRY * PFNGLCOVERSTROKEPATHINSTANCEDNVPROC) (GLsizei numPaths, GLenum pathNameType, const void* paths, GLuint pathBase, GLenum coverMode, GLenum transformType, const GLfloat *transformValues);
-typedef void (GLAPIENTRY * PFNGLCOVERSTROKEPATHNVPROC) (GLuint name, GLenum coverMode);
+typedef void (GLAPIENTRY * PFNGLCOVERSTROKEPATHINSTANCEDNVPROC) (GLsizei numPaths, GLenum pathNameType, const void *paths, GLuint pathBase, GLenum coverMode, GLenum transformType, const GLfloat *transformValues);
+typedef void (GLAPIENTRY * PFNGLCOVERSTROKEPATHNVPROC) (GLuint path, GLenum coverMode);
 typedef void (GLAPIENTRY * PFNGLDELETEPATHSNVPROC) (GLuint path, GLsizei range);
 typedef GLuint (GLAPIENTRY * PFNGLGENPATHSNVPROC) (GLsizei range);
 typedef void (GLAPIENTRY * PFNGLGETPATHCOLORGENFVNVPROC) (GLenum color, GLenum pname, GLfloat* value);
 typedef void (GLAPIENTRY * PFNGLGETPATHCOLORGENIVNVPROC) (GLenum color, GLenum pname, GLint* value);
-typedef void (GLAPIENTRY * PFNGLGETPATHCOMMANDSNVPROC) (GLuint name, GLubyte* commands);
-typedef void (GLAPIENTRY * PFNGLGETPATHCOORDSNVPROC) (GLuint name, GLfloat* coords);
-typedef void (GLAPIENTRY * PFNGLGETPATHDASHARRAYNVPROC) (GLuint name, GLfloat* dashArray);
+typedef void (GLAPIENTRY * PFNGLGETPATHCOMMANDSNVPROC) (GLuint path, GLubyte* commands);
+typedef void (GLAPIENTRY * PFNGLGETPATHCOORDSNVPROC) (GLuint path, GLfloat* coords);
+typedef void (GLAPIENTRY * PFNGLGETPATHDASHARRAYNVPROC) (GLuint path, GLfloat* dashArray);
 typedef GLfloat (GLAPIENTRY * PFNGLGETPATHLENGTHNVPROC) (GLuint path, GLsizei startSegment, GLsizei numSegments);
-typedef void (GLAPIENTRY * PFNGLGETPATHMETRICRANGENVPROC) (GLbitfield metricQueryMask, GLuint fistPathName, GLsizei numPaths, GLsizei stride, GLfloat* metrics);
-typedef void (GLAPIENTRY * PFNGLGETPATHMETRICSNVPROC) (GLbitfield metricQueryMask, GLsizei numPaths, GLenum pathNameType, const void* paths, GLuint pathBase, GLsizei stride, GLfloat *metrics);
-typedef void (GLAPIENTRY * PFNGLGETPATHPARAMETERFVNVPROC) (GLuint name, GLenum param, GLfloat* value);
-typedef void (GLAPIENTRY * PFNGLGETPATHPARAMETERIVNVPROC) (GLuint name, GLenum param, GLint* value);
-typedef void (GLAPIENTRY * PFNGLGETPATHSPACINGNVPROC) (GLenum pathListMode, GLsizei numPaths, GLenum pathNameType, const void* paths, GLuint pathBase, GLfloat advanceScale, GLfloat kerningScale, GLenum transformType, GLfloat *returnedSpacing);
+typedef void (GLAPIENTRY * PFNGLGETPATHMETRICRANGENVPROC) (GLbitfield metricQueryMask, GLuint firstPathName, GLsizei numPaths, GLsizei stride, GLfloat* metrics);
+typedef void (GLAPIENTRY * PFNGLGETPATHMETRICSNVPROC) (GLbitfield metricQueryMask, GLsizei numPaths, GLenum pathNameType, const void *paths, GLuint pathBase, GLsizei stride, GLfloat *metrics);
+typedef void (GLAPIENTRY * PFNGLGETPATHPARAMETERFVNVPROC) (GLuint path, GLenum pname, GLfloat* value);
+typedef void (GLAPIENTRY * PFNGLGETPATHPARAMETERIVNVPROC) (GLuint path, GLenum pname, GLint* value);
+typedef void (GLAPIENTRY * PFNGLGETPATHSPACINGNVPROC) (GLenum pathListMode, GLsizei numPaths, GLenum pathNameType, const void *paths, GLuint pathBase, GLfloat advanceScale, GLfloat kerningScale, GLenum transformType, GLfloat *returnedSpacing);
 typedef void (GLAPIENTRY * PFNGLGETPATHTEXGENFVNVPROC) (GLenum texCoordSet, GLenum pname, GLfloat* value);
 typedef void (GLAPIENTRY * PFNGLGETPATHTEXGENIVNVPROC) (GLenum texCoordSet, GLenum pname, GLint* value);
+typedef void (GLAPIENTRY * PFNGLGETPROGRAMRESOURCEFVNVPROC) (GLuint program, GLenum programInterface, GLuint index, GLsizei propCount, const GLenum* props, GLsizei bufSize, GLsizei *length, GLfloat *params);
 typedef void (GLAPIENTRY * PFNGLINTERPOLATEPATHSNVPROC) (GLuint resultPath, GLuint pathA, GLuint pathB, GLfloat weight);
 typedef GLboolean (GLAPIENTRY * PFNGLISPATHNVPROC) (GLuint path);
 typedef GLboolean (GLAPIENTRY * PFNGLISPOINTINFILLPATHNVPROC) (GLuint path, GLuint mask, GLfloat x, GLfloat y);
 typedef GLboolean (GLAPIENTRY * PFNGLISPOINTINSTROKEPATHNVPROC) (GLuint path, GLfloat x, GLfloat y);
+typedef void (GLAPIENTRY * PFNGLMATRIXLOAD3X2FNVPROC) (GLenum matrixMode, const GLfloat* m);
+typedef void (GLAPIENTRY * PFNGLMATRIXLOAD3X3FNVPROC) (GLenum matrixMode, const GLfloat* m);
+typedef void (GLAPIENTRY * PFNGLMATRIXLOADTRANSPOSE3X3FNVPROC) (GLenum matrixMode, const GLfloat* m);
+typedef void (GLAPIENTRY * PFNGLMATRIXMULT3X2FNVPROC) (GLenum matrixMode, const GLfloat* m);
+typedef void (GLAPIENTRY * PFNGLMATRIXMULT3X3FNVPROC) (GLenum matrixMode, const GLfloat* m);
+typedef void (GLAPIENTRY * PFNGLMATRIXMULTTRANSPOSE3X3FNVPROC) (GLenum matrixMode, const GLfloat* m);
 typedef void (GLAPIENTRY * PFNGLPATHCOLORGENNVPROC) (GLenum color, GLenum genMode, GLenum colorFormat, const GLfloat* coeffs);
 typedef void (GLAPIENTRY * PFNGLPATHCOMMANDSNVPROC) (GLuint path, GLsizei numCommands, const GLubyte* commands, GLsizei numCoords, GLenum coordType, const void*coords);
-typedef void (GLAPIENTRY * PFNGLPATHCOORDSNVPROC) (GLuint path, GLsizei numCoords, GLenum coordType, const void* coords);
+typedef void (GLAPIENTRY * PFNGLPATHCOORDSNVPROC) (GLuint path, GLsizei numCoords, GLenum coordType, const void *coords);
 typedef void (GLAPIENTRY * PFNGLPATHCOVERDEPTHFUNCNVPROC) (GLenum zfunc);
 typedef void (GLAPIENTRY * PFNGLPATHDASHARRAYNVPROC) (GLuint path, GLsizei dashCount, const GLfloat* dashArray);
 typedef void (GLAPIENTRY * PFNGLPATHFOGGENNVPROC) (GLenum genMode);
-typedef void (GLAPIENTRY * PFNGLPATHGLYPHRANGENVPROC) (GLuint firstPathName, GLenum fontTarget, const void* fontName, GLbitfield fontStyle, GLuint firstGlyph, GLsizei numGlyphs, GLenum handleMissingGlyphs, GLuint pathParameterTemplate, GLfloat emScale);
-typedef void (GLAPIENTRY * PFNGLPATHGLYPHSNVPROC) (GLuint firstPathName, GLenum fontTarget, const void* fontName, GLbitfield fontStyle, GLsizei numGlyphs, GLenum type, const void*charcodes, GLenum handleMissingGlyphs, GLuint pathParameterTemplate, GLfloat emScale);
+typedef GLenum (GLAPIENTRY * PFNGLPATHGLYPHINDEXARRAYNVPROC) (GLuint firstPathName, GLenum fontTarget, const void *fontName, GLbitfield fontStyle, GLuint firstGlyphIndex, GLsizei numGlyphs, GLuint pathParameterTemplate, GLfloat emScale);
+typedef GLenum (GLAPIENTRY * PFNGLPATHGLYPHINDEXRANGENVPROC) (GLenum fontTarget, const void *fontName, GLbitfield fontStyle, GLuint pathParameterTemplate, GLfloat emScale, GLuint baseAndCount[2]);
+typedef void (GLAPIENTRY * PFNGLPATHGLYPHRANGENVPROC) (GLuint firstPathName, GLenum fontTarget, const void *fontName, GLbitfield fontStyle, GLuint firstGlyph, GLsizei numGlyphs, GLenum handleMissingGlyphs, GLuint pathParameterTemplate, GLfloat emScale);
+typedef void (GLAPIENTRY * PFNGLPATHGLYPHSNVPROC) (GLuint firstPathName, GLenum fontTarget, const void *fontName, GLbitfield fontStyle, GLsizei numGlyphs, GLenum type, const void*charcodes, GLenum handleMissingGlyphs, GLuint pathParameterTemplate, GLfloat emScale);
+typedef GLenum (GLAPIENTRY * PFNGLPATHMEMORYGLYPHINDEXARRAYNVPROC) (GLuint firstPathName, GLenum fontTarget, GLsizeiptr fontSize, const void *fontData, GLsizei faceIndex, GLuint firstGlyphIndex, GLsizei numGlyphs, GLuint pathParameterTemplate, GLfloat emScale);
 typedef void (GLAPIENTRY * PFNGLPATHPARAMETERFNVPROC) (GLuint path, GLenum pname, GLfloat value);
 typedef void (GLAPIENTRY * PFNGLPATHPARAMETERFVNVPROC) (GLuint path, GLenum pname, const GLfloat* value);
 typedef void (GLAPIENTRY * PFNGLPATHPARAMETERINVPROC) (GLuint path, GLenum pname, GLint value);
 typedef void (GLAPIENTRY * PFNGLPATHPARAMETERIVNVPROC) (GLuint path, GLenum pname, const GLint* value);
 typedef void (GLAPIENTRY * PFNGLPATHSTENCILDEPTHOFFSETNVPROC) (GLfloat factor, GLfloat units);
 typedef void (GLAPIENTRY * PFNGLPATHSTENCILFUNCNVPROC) (GLenum func, GLint ref, GLuint mask);
-typedef void (GLAPIENTRY * PFNGLPATHSTRINGNVPROC) (GLuint path, GLenum format, GLsizei length, const void* pathString);
+typedef void (GLAPIENTRY * PFNGLPATHSTRINGNVPROC) (GLuint path, GLenum format, GLsizei length, const void *pathString);
 typedef void (GLAPIENTRY * PFNGLPATHSUBCOMMANDSNVPROC) (GLuint path, GLsizei commandStart, GLsizei commandsToDelete, GLsizei numCommands, const GLubyte* commands, GLsizei numCoords, GLenum coordType, const void*coords);
-typedef void (GLAPIENTRY * PFNGLPATHSUBCOORDSNVPROC) (GLuint path, GLsizei coordStart, GLsizei numCoords, GLenum coordType, const void* coords);
+typedef void (GLAPIENTRY * PFNGLPATHSUBCOORDSNVPROC) (GLuint path, GLsizei coordStart, GLsizei numCoords, GLenum coordType, const void *coords);
 typedef void (GLAPIENTRY * PFNGLPATHTEXGENNVPROC) (GLenum texCoordSet, GLenum genMode, GLint components, const GLfloat* coeffs);
 typedef GLboolean (GLAPIENTRY * PFNGLPOINTALONGPATHNVPROC) (GLuint path, GLsizei startSegment, GLsizei numSegments, GLfloat distance, GLfloat* x, GLfloat *y, GLfloat *tangentX, GLfloat *tangentY);
-typedef void (GLAPIENTRY * PFNGLSTENCILFILLPATHINSTANCEDNVPROC) (GLsizei numPaths, GLenum pathNameType, const void* paths, GLuint pathBase, GLenum fillMode, GLuint mask, GLenum transformType, const GLfloat *transformValues);
+typedef void (GLAPIENTRY * PFNGLPROGRAMPATHFRAGMENTINPUTGENNVPROC) (GLuint program, GLint location, GLenum genMode, GLint components, const GLfloat* coeffs);
+typedef void (GLAPIENTRY * PFNGLSTENCILFILLPATHINSTANCEDNVPROC) (GLsizei numPaths, GLenum pathNameType, const void *paths, GLuint pathBase, GLenum fillMode, GLuint mask, GLenum transformType, const GLfloat *transformValues);
 typedef void (GLAPIENTRY * PFNGLSTENCILFILLPATHNVPROC) (GLuint path, GLenum fillMode, GLuint mask);
-typedef void (GLAPIENTRY * PFNGLSTENCILSTROKEPATHINSTANCEDNVPROC) (GLsizei numPaths, GLenum pathNameType, const void* paths, GLuint pathBase, GLint reference, GLuint mask, GLenum transformType, const GLfloat *transformValues);
+typedef void (GLAPIENTRY * PFNGLSTENCILSTROKEPATHINSTANCEDNVPROC) (GLsizei numPaths, GLenum pathNameType, const void *paths, GLuint pathBase, GLint reference, GLuint mask, GLenum transformType, const GLfloat *transformValues);
 typedef void (GLAPIENTRY * PFNGLSTENCILSTROKEPATHNVPROC) (GLuint path, GLint reference, GLuint mask);
+typedef void (GLAPIENTRY * PFNGLSTENCILTHENCOVERFILLPATHINSTANCEDNVPROC) (GLsizei numPaths, GLenum pathNameType, const void *paths, GLuint pathBase, GLenum fillMode, GLuint mask, GLenum coverMode, GLenum transformType, const GLfloat *transformValues);
+typedef void (GLAPIENTRY * PFNGLSTENCILTHENCOVERFILLPATHNVPROC) (GLuint path, GLenum fillMode, GLuint mask, GLenum coverMode);
+typedef void (GLAPIENTRY * PFNGLSTENCILTHENCOVERSTROKEPATHINSTANCEDNVPROC) (GLsizei numPaths, GLenum pathNameType, const void *paths, GLuint pathBase, GLint reference, GLuint mask, GLenum coverMode, GLenum transformType, const GLfloat *transformValues);
+typedef void (GLAPIENTRY * PFNGLSTENCILTHENCOVERSTROKEPATHNVPROC) (GLuint path, GLint reference, GLuint mask, GLenum coverMode);
 typedef void (GLAPIENTRY * PFNGLTRANSFORMPATHNVPROC) (GLuint resultPath, GLuint srcPath, GLenum transformType, const GLfloat* transformValues);
 typedef void (GLAPIENTRY * PFNGLWEIGHTPATHSNVPROC) (GLuint resultPath, GLsizei numPaths, const GLuint paths[], const GLfloat weights[]);
 
@@ -13153,18 +15845,28 @@ typedef void (GLAPIENTRY * PFNGLWEIGHTPATHSNVPROC) (GLuint resultPath, GLsizei n
 #define glGetPathSpacingNV GLEW_GET_FUN(__glewGetPathSpacingNV)
 #define glGetPathTexGenfvNV GLEW_GET_FUN(__glewGetPathTexGenfvNV)
 #define glGetPathTexGenivNV GLEW_GET_FUN(__glewGetPathTexGenivNV)
+#define glGetProgramResourcefvNV GLEW_GET_FUN(__glewGetProgramResourcefvNV)
 #define glInterpolatePathsNV GLEW_GET_FUN(__glewInterpolatePathsNV)
 #define glIsPathNV GLEW_GET_FUN(__glewIsPathNV)
 #define glIsPointInFillPathNV GLEW_GET_FUN(__glewIsPointInFillPathNV)
 #define glIsPointInStrokePathNV GLEW_GET_FUN(__glewIsPointInStrokePathNV)
+#define glMatrixLoad3x2fNV GLEW_GET_FUN(__glewMatrixLoad3x2fNV)
+#define glMatrixLoad3x3fNV GLEW_GET_FUN(__glewMatrixLoad3x3fNV)
+#define glMatrixLoadTranspose3x3fNV GLEW_GET_FUN(__glewMatrixLoadTranspose3x3fNV)
+#define glMatrixMult3x2fNV GLEW_GET_FUN(__glewMatrixMult3x2fNV)
+#define glMatrixMult3x3fNV GLEW_GET_FUN(__glewMatrixMult3x3fNV)
+#define glMatrixMultTranspose3x3fNV GLEW_GET_FUN(__glewMatrixMultTranspose3x3fNV)
 #define glPathColorGenNV GLEW_GET_FUN(__glewPathColorGenNV)
 #define glPathCommandsNV GLEW_GET_FUN(__glewPathCommandsNV)
 #define glPathCoordsNV GLEW_GET_FUN(__glewPathCoordsNV)
 #define glPathCoverDepthFuncNV GLEW_GET_FUN(__glewPathCoverDepthFuncNV)
 #define glPathDashArrayNV GLEW_GET_FUN(__glewPathDashArrayNV)
 #define glPathFogGenNV GLEW_GET_FUN(__glewPathFogGenNV)
+#define glPathGlyphIndexArrayNV GLEW_GET_FUN(__glewPathGlyphIndexArrayNV)
+#define glPathGlyphIndexRangeNV GLEW_GET_FUN(__glewPathGlyphIndexRangeNV)
 #define glPathGlyphRangeNV GLEW_GET_FUN(__glewPathGlyphRangeNV)
 #define glPathGlyphsNV GLEW_GET_FUN(__glewPathGlyphsNV)
+#define glPathMemoryGlyphIndexArrayNV GLEW_GET_FUN(__glewPathMemoryGlyphIndexArrayNV)
 #define glPathParameterfNV GLEW_GET_FUN(__glewPathParameterfNV)
 #define glPathParameterfvNV GLEW_GET_FUN(__glewPathParameterfvNV)
 #define glPathParameteriNV GLEW_GET_FUN(__glewPathParameteriNV)
@@ -13176,16 +15878,46 @@ typedef void (GLAPIENTRY * PFNGLWEIGHTPATHSNVPROC) (GLuint resultPath, GLsizei n
 #define glPathSubCoordsNV GLEW_GET_FUN(__glewPathSubCoordsNV)
 #define glPathTexGenNV GLEW_GET_FUN(__glewPathTexGenNV)
 #define glPointAlongPathNV GLEW_GET_FUN(__glewPointAlongPathNV)
+#define glProgramPathFragmentInputGenNV GLEW_GET_FUN(__glewProgramPathFragmentInputGenNV)
 #define glStencilFillPathInstancedNV GLEW_GET_FUN(__glewStencilFillPathInstancedNV)
 #define glStencilFillPathNV GLEW_GET_FUN(__glewStencilFillPathNV)
 #define glStencilStrokePathInstancedNV GLEW_GET_FUN(__glewStencilStrokePathInstancedNV)
 #define glStencilStrokePathNV GLEW_GET_FUN(__glewStencilStrokePathNV)
+#define glStencilThenCoverFillPathInstancedNV GLEW_GET_FUN(__glewStencilThenCoverFillPathInstancedNV)
+#define glStencilThenCoverFillPathNV GLEW_GET_FUN(__glewStencilThenCoverFillPathNV)
+#define glStencilThenCoverStrokePathInstancedNV GLEW_GET_FUN(__glewStencilThenCoverStrokePathInstancedNV)
+#define glStencilThenCoverStrokePathNV GLEW_GET_FUN(__glewStencilThenCoverStrokePathNV)
 #define glTransformPathNV GLEW_GET_FUN(__glewTransformPathNV)
 #define glWeightPathsNV GLEW_GET_FUN(__glewWeightPathsNV)
 
 #define GLEW_NV_path_rendering GLEW_GET_VAR(__GLEW_NV_path_rendering)
 
 #endif /* GL_NV_path_rendering */
+
+/* -------------------- GL_NV_path_rendering_shared_edge ------------------- */
+
+#ifndef GL_NV_path_rendering_shared_edge
+#define GL_NV_path_rendering_shared_edge 1
+
+#define GL_SHARED_EDGE_NV 0xC0
+
+#define GLEW_NV_path_rendering_shared_edge GLEW_GET_VAR(__GLEW_NV_path_rendering_shared_edge)
+
+#endif /* GL_NV_path_rendering_shared_edge */
+
+/* ----------------------- GL_NV_pixel_buffer_object ----------------------- */
+
+#ifndef GL_NV_pixel_buffer_object
+#define GL_NV_pixel_buffer_object 1
+
+#define GL_PIXEL_PACK_BUFFER_NV 0x88EB
+#define GL_PIXEL_UNPACK_BUFFER_NV 0x88EC
+#define GL_PIXEL_PACK_BUFFER_BINDING_NV 0x88ED
+#define GL_PIXEL_UNPACK_BUFFER_BINDING_NV 0x88EF
+
+#define GLEW_NV_pixel_buffer_object GLEW_GET_VAR(__GLEW_NV_pixel_buffer_object)
+
+#endif /* GL_NV_pixel_buffer_object */
 
 /* ------------------------- GL_NV_pixel_data_range ------------------------ */
 
@@ -13209,6 +15941,17 @@ typedef void (GLAPIENTRY * PFNGLPIXELDATARANGENVPROC) (GLenum target, GLsizei le
 
 #endif /* GL_NV_pixel_data_range */
 
+/* ------------------------- GL_NV_platform_binary ------------------------- */
+
+#ifndef GL_NV_platform_binary
+#define GL_NV_platform_binary 1
+
+#define GL_NVIDIA_PLATFORM_BINARY_NV 0x890B
+
+#define GLEW_NV_platform_binary GLEW_GET_VAR(__GLEW_NV_platform_binary)
+
+#endif /* GL_NV_platform_binary */
+
 /* --------------------------- GL_NV_point_sprite -------------------------- */
 
 #ifndef GL_NV_point_sprite
@@ -13227,6 +15970,26 @@ typedef void (GLAPIENTRY * PFNGLPOINTPARAMETERIVNVPROC) (GLenum pname, const GLi
 #define GLEW_NV_point_sprite GLEW_GET_VAR(__GLEW_NV_point_sprite)
 
 #endif /* GL_NV_point_sprite */
+
+/* --------------------------- GL_NV_polygon_mode -------------------------- */
+
+#ifndef GL_NV_polygon_mode
+#define GL_NV_polygon_mode 1
+
+#define GL_POLYGON_MODE_NV 0x0B40
+#define GL_POINT_NV 0x1B00
+#define GL_LINE_NV 0x1B01
+#define GL_FILL_NV 0x1B02
+#define GL_POLYGON_OFFSET_POINT_NV 0x2A01
+#define GL_POLYGON_OFFSET_LINE_NV 0x2A02
+
+typedef void (GLAPIENTRY * PFNGLPOLYGONMODENVPROC) (GLenum face, GLenum mode);
+
+#define glPolygonModeNV GLEW_GET_FUN(__glewPolygonModeNV)
+
+#define GLEW_NV_polygon_mode GLEW_GET_VAR(__GLEW_NV_polygon_mode)
+
+#endif /* GL_NV_polygon_mode */
 
 /* -------------------------- GL_NV_present_video -------------------------- */
 
@@ -13275,6 +16038,33 @@ typedef void (GLAPIENTRY * PFNGLPRIMITIVERESTARTNVPROC) (void);
 #define GLEW_NV_primitive_restart GLEW_GET_VAR(__GLEW_NV_primitive_restart)
 
 #endif /* GL_NV_primitive_restart */
+
+/* ---------------------------- GL_NV_read_depth --------------------------- */
+
+#ifndef GL_NV_read_depth
+#define GL_NV_read_depth 1
+
+#define GLEW_NV_read_depth GLEW_GET_VAR(__GLEW_NV_read_depth)
+
+#endif /* GL_NV_read_depth */
+
+/* ------------------------ GL_NV_read_depth_stencil ----------------------- */
+
+#ifndef GL_NV_read_depth_stencil
+#define GL_NV_read_depth_stencil 1
+
+#define GLEW_NV_read_depth_stencil GLEW_GET_VAR(__GLEW_NV_read_depth_stencil)
+
+#endif /* GL_NV_read_depth_stencil */
+
+/* --------------------------- GL_NV_read_stencil -------------------------- */
+
+#ifndef GL_NV_read_stencil
+#define GL_NV_read_stencil 1
+
+#define GLEW_NV_read_stencil GLEW_GET_VAR(__GLEW_NV_read_stencil)
+
+#endif /* GL_NV_read_stencil */
 
 /* ------------------------ GL_NV_register_combiners ----------------------- */
 
@@ -13382,6 +16172,71 @@ typedef void (GLAPIENTRY * PFNGLGETCOMBINERSTAGEPARAMETERFVNVPROC) (GLenum stage
 
 #endif /* GL_NV_register_combiners2 */
 
+/* ------------------ GL_NV_robustness_video_memory_purge ------------------ */
+
+#ifndef GL_NV_robustness_video_memory_purge
+#define GL_NV_robustness_video_memory_purge 1
+
+#define GL_EGL_GENERATE_RESET_ON_VIDEO_MEMORY_PURGE_NV 0x334C
+#define GL_PURGED_CONTEXT_RESET_NV 0x92BB
+
+#define GLEW_NV_robustness_video_memory_purge GLEW_GET_VAR(__GLEW_NV_robustness_video_memory_purge)
+
+#endif /* GL_NV_robustness_video_memory_purge */
+
+/* --------------------------- GL_NV_sRGB_formats -------------------------- */
+
+#ifndef GL_NV_sRGB_formats
+#define GL_NV_sRGB_formats 1
+
+#define GL_ETC1_SRGB8_NV 0x88EE
+#define GL_SRGB8_NV 0x8C41
+#define GL_SLUMINANCE_ALPHA_NV 0x8C44
+#define GL_SLUMINANCE8_ALPHA8_NV 0x8C45
+#define GL_SLUMINANCE_NV 0x8C46
+#define GL_SLUMINANCE8_NV 0x8C47
+#define GL_COMPRESSED_SRGB_S3TC_DXT1_NV 0x8C4C
+#define GL_COMPRESSED_SRGB_ALPHA_S3TC_DXT1_NV 0x8C4D
+#define GL_COMPRESSED_SRGB_ALPHA_S3TC_DXT3_NV 0x8C4E
+#define GL_COMPRESSED_SRGB_ALPHA_S3TC_DXT5_NV 0x8C4F
+
+#define GLEW_NV_sRGB_formats GLEW_GET_VAR(__GLEW_NV_sRGB_formats)
+
+#endif /* GL_NV_sRGB_formats */
+
+/* ------------------------- GL_NV_sample_locations ------------------------ */
+
+#ifndef GL_NV_sample_locations
+#define GL_NV_sample_locations 1
+
+#define GL_SAMPLE_LOCATION_NV 0x8E50
+#define GL_SAMPLE_LOCATION_SUBPIXEL_BITS_NV 0x933D
+#define GL_SAMPLE_LOCATION_PIXEL_GRID_WIDTH_NV 0x933E
+#define GL_SAMPLE_LOCATION_PIXEL_GRID_HEIGHT_NV 0x933F
+#define GL_PROGRAMMABLE_SAMPLE_LOCATION_TABLE_SIZE_NV 0x9340
+#define GL_PROGRAMMABLE_SAMPLE_LOCATION_NV 0x9341
+#define GL_FRAMEBUFFER_PROGRAMMABLE_SAMPLE_LOCATIONS_NV 0x9342
+#define GL_FRAMEBUFFER_SAMPLE_LOCATION_PIXEL_GRID_NV 0x9343
+
+typedef void (GLAPIENTRY * PFNGLFRAMEBUFFERSAMPLELOCATIONSFVNVPROC) (GLenum target, GLuint start, GLsizei count, const GLfloat* v);
+typedef void (GLAPIENTRY * PFNGLNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNVPROC) (GLuint framebuffer, GLuint start, GLsizei count, const GLfloat* v);
+
+#define glFramebufferSampleLocationsfvNV GLEW_GET_FUN(__glewFramebufferSampleLocationsfvNV)
+#define glNamedFramebufferSampleLocationsfvNV GLEW_GET_FUN(__glewNamedFramebufferSampleLocationsfvNV)
+
+#define GLEW_NV_sample_locations GLEW_GET_VAR(__GLEW_NV_sample_locations)
+
+#endif /* GL_NV_sample_locations */
+
+/* ------------------ GL_NV_sample_mask_override_coverage ------------------ */
+
+#ifndef GL_NV_sample_mask_override_coverage
+#define GL_NV_sample_mask_override_coverage 1
+
+#define GLEW_NV_sample_mask_override_coverage GLEW_GET_VAR(__GLEW_NV_sample_mask_override_coverage)
+
+#endif /* GL_NV_sample_mask_override_coverage */
+
 /* ---------------------- GL_NV_shader_atomic_counters --------------------- */
 
 #ifndef GL_NV_shader_atomic_counters
@@ -13399,6 +16254,24 @@ typedef void (GLAPIENTRY * PFNGLGETCOMBINERSTAGEPARAMETERFVNVPROC) (GLenum stage
 #define GLEW_NV_shader_atomic_float GLEW_GET_VAR(__GLEW_NV_shader_atomic_float)
 
 #endif /* GL_NV_shader_atomic_float */
+
+/* ---------------------- GL_NV_shader_atomic_float64 ---------------------- */
+
+#ifndef GL_NV_shader_atomic_float64
+#define GL_NV_shader_atomic_float64 1
+
+#define GLEW_NV_shader_atomic_float64 GLEW_GET_VAR(__GLEW_NV_shader_atomic_float64)
+
+#endif /* GL_NV_shader_atomic_float64 */
+
+/* -------------------- GL_NV_shader_atomic_fp16_vector -------------------- */
+
+#ifndef GL_NV_shader_atomic_fp16_vector
+#define GL_NV_shader_atomic_fp16_vector 1
+
+#define GLEW_NV_shader_atomic_fp16_vector GLEW_GET_VAR(__GLEW_NV_shader_atomic_fp16_vector)
+
+#endif /* GL_NV_shader_atomic_fp16_vector */
 
 /* ----------------------- GL_NV_shader_atomic_int64 ----------------------- */
 
@@ -13450,6 +16323,15 @@ typedef void (GLAPIENTRY * PFNGLUNIFORMUI64VNVPROC) (GLint location, GLsizei cou
 
 #endif /* GL_NV_shader_buffer_load */
 
+/* ---------------- GL_NV_shader_noperspective_interpolation --------------- */
+
+#ifndef GL_NV_shader_noperspective_interpolation
+#define GL_NV_shader_noperspective_interpolation 1
+
+#define GLEW_NV_shader_noperspective_interpolation GLEW_GET_VAR(__GLEW_NV_shader_noperspective_interpolation)
+
+#endif /* GL_NV_shader_noperspective_interpolation */
+
 /* ------------------- GL_NV_shader_storage_buffer_object ------------------ */
 
 #ifndef GL_NV_shader_storage_buffer_object
@@ -13480,6 +16362,37 @@ typedef void (GLAPIENTRY * PFNGLUNIFORMUI64VNVPROC) (GLint location, GLsizei cou
 #define GLEW_NV_shader_thread_shuffle GLEW_GET_VAR(__GLEW_NV_shader_thread_shuffle)
 
 #endif /* GL_NV_shader_thread_shuffle */
+
+/* ---------------------- GL_NV_shadow_samplers_array ---------------------- */
+
+#ifndef GL_NV_shadow_samplers_array
+#define GL_NV_shadow_samplers_array 1
+
+#define GL_SAMPLER_2D_ARRAY_SHADOW_NV 0x8DC4
+
+#define GLEW_NV_shadow_samplers_array GLEW_GET_VAR(__GLEW_NV_shadow_samplers_array)
+
+#endif /* GL_NV_shadow_samplers_array */
+
+/* ----------------------- GL_NV_shadow_samplers_cube ---------------------- */
+
+#ifndef GL_NV_shadow_samplers_cube
+#define GL_NV_shadow_samplers_cube 1
+
+#define GL_SAMPLER_CUBE_SHADOW_NV 0x8DC5
+
+#define GLEW_NV_shadow_samplers_cube GLEW_GET_VAR(__GLEW_NV_shadow_samplers_cube)
+
+#endif /* GL_NV_shadow_samplers_cube */
+
+/* ---------------------- GL_NV_stereo_view_rendering ---------------------- */
+
+#ifndef GL_NV_stereo_view_rendering
+#define GL_NV_stereo_view_rendering 1
+
+#define GLEW_NV_stereo_view_rendering GLEW_GET_VAR(__GLEW_NV_stereo_view_rendering)
+
+#endif /* GL_NV_stereo_view_rendering */
 
 /* ---------------------- GL_NV_tessellation_program5 ---------------------- */
 
@@ -13521,6 +16434,37 @@ typedef void (GLAPIENTRY * PFNGLUNIFORMUI64VNVPROC) (GLint location, GLsizei cou
 
 #endif /* GL_NV_texgen_reflection */
 
+/* -------------------------- GL_NV_texture_array -------------------------- */
+
+#ifndef GL_NV_texture_array
+#define GL_NV_texture_array 1
+
+#define GL_UNPACK_SKIP_IMAGES_NV 0x806D
+#define GL_UNPACK_IMAGE_HEIGHT_NV 0x806E
+#define GL_MAX_ARRAY_TEXTURE_LAYERS_NV 0x88FF
+#define GL_TEXTURE_2D_ARRAY_NV 0x8C1A
+#define GL_TEXTURE_BINDING_2D_ARRAY_NV 0x8C1D
+#define GL_FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER_NV 0x8CD4
+#define GL_SAMPLER_2D_ARRAY_NV 0x8DC1
+
+typedef void (GLAPIENTRY * PFNGLCOMPRESSEDTEXIMAGE3DNVPROC) (GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth, GLint border, GLsizei imageSize, const void *data);
+typedef void (GLAPIENTRY * PFNGLCOMPRESSEDTEXSUBIMAGE3DNVPROC) (GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLsizei imageSize, const void *data);
+typedef void (GLAPIENTRY * PFNGLCOPYTEXSUBIMAGE3DNVPROC) (GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLint x, GLint y, GLsizei width, GLsizei height);
+typedef void (GLAPIENTRY * PFNGLFRAMEBUFFERTEXTURELAYERNVPROC) (GLenum target, GLenum attachment, GLuint texture, GLint level, GLint layer);
+typedef void (GLAPIENTRY * PFNGLTEXIMAGE3DNVPROC) (GLenum target, GLint level, GLenum internalFormat, GLsizei width, GLsizei height, GLsizei depth, GLint border, GLenum format, GLenum type, const void *pixels);
+typedef void (GLAPIENTRY * PFNGLTEXSUBIMAGE3DNVPROC) (GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type, const void *pixels);
+
+#define glCompressedTexImage3DNV GLEW_GET_FUN(__glewCompressedTexImage3DNV)
+#define glCompressedTexSubImage3DNV GLEW_GET_FUN(__glewCompressedTexSubImage3DNV)
+#define glCopyTexSubImage3DNV GLEW_GET_FUN(__glewCopyTexSubImage3DNV)
+#define glFramebufferTextureLayerNV GLEW_GET_FUN(__glewFramebufferTextureLayerNV)
+#define glTexImage3DNV GLEW_GET_FUN(__glewTexImage3DNV)
+#define glTexSubImage3DNV GLEW_GET_FUN(__glewTexSubImage3DNV)
+
+#define GLEW_NV_texture_array GLEW_GET_VAR(__GLEW_NV_texture_array)
+
+#endif /* GL_NV_texture_array */
+
 /* ------------------------- GL_NV_texture_barrier ------------------------- */
 
 #ifndef GL_NV_texture_barrier
@@ -13533,6 +16477,55 @@ typedef void (GLAPIENTRY * PFNGLTEXTUREBARRIERNVPROC) (void);
 #define GLEW_NV_texture_barrier GLEW_GET_VAR(__GLEW_NV_texture_barrier)
 
 #endif /* GL_NV_texture_barrier */
+
+/* ----------------------- GL_NV_texture_border_clamp ---------------------- */
+
+#ifndef GL_NV_texture_border_clamp
+#define GL_NV_texture_border_clamp 1
+
+#define GL_TEXTURE_BORDER_COLOR_NV 0x1004
+#define GL_CLAMP_TO_BORDER_NV 0x812D
+
+#define GLEW_NV_texture_border_clamp GLEW_GET_VAR(__GLEW_NV_texture_border_clamp)
+
+#endif /* GL_NV_texture_border_clamp */
+
+/* --------------------- GL_NV_texture_compression_latc -------------------- */
+
+#ifndef GL_NV_texture_compression_latc
+#define GL_NV_texture_compression_latc 1
+
+#define GL_COMPRESSED_LUMINANCE_LATC1_NV 0x8C70
+#define GL_COMPRESSED_SIGNED_LUMINANCE_LATC1_NV 0x8C71
+#define GL_COMPRESSED_LUMINANCE_ALPHA_LATC2_NV 0x8C72
+#define GL_COMPRESSED_SIGNED_LUMINANCE_ALPHA_LATC2_NV 0x8C73
+
+#define GLEW_NV_texture_compression_latc GLEW_GET_VAR(__GLEW_NV_texture_compression_latc)
+
+#endif /* GL_NV_texture_compression_latc */
+
+/* --------------------- GL_NV_texture_compression_s3tc -------------------- */
+
+#ifndef GL_NV_texture_compression_s3tc
+#define GL_NV_texture_compression_s3tc 1
+
+#define GL_COMPRESSED_RGB_S3TC_DXT1_NV 0x83F0
+#define GL_COMPRESSED_RGBA_S3TC_DXT1_NV 0x83F1
+#define GL_COMPRESSED_RGBA_S3TC_DXT3_NV 0x83F2
+#define GL_COMPRESSED_RGBA_S3TC_DXT5_NV 0x83F3
+
+#define GLEW_NV_texture_compression_s3tc GLEW_GET_VAR(__GLEW_NV_texture_compression_s3tc)
+
+#endif /* GL_NV_texture_compression_s3tc */
+
+/* ----------------- GL_NV_texture_compression_s3tc_update ----------------- */
+
+#ifndef GL_NV_texture_compression_s3tc_update
+#define GL_NV_texture_compression_s3tc_update 1
+
+#define GLEW_NV_texture_compression_s3tc_update GLEW_GET_VAR(__GLEW_NV_texture_compression_s3tc_update)
+
+#endif /* GL_NV_texture_compression_s3tc_update */
 
 /* --------------------- GL_NV_texture_compression_vtc --------------------- */
 
@@ -13595,6 +16588,15 @@ typedef void (GLAPIENTRY * PFNGLTEXTUREIMAGE3DMULTISAMPLENVPROC) (GLuint texture
 
 #endif /* GL_NV_texture_multisample */
 
+/* ---------------------- GL_NV_texture_npot_2D_mipmap --------------------- */
+
+#ifndef GL_NV_texture_npot_2D_mipmap
+#define GL_NV_texture_npot_2D_mipmap 1
+
+#define GLEW_NV_texture_npot_2D_mipmap GLEW_GET_VAR(__GLEW_NV_texture_npot_2D_mipmap)
+
+#endif /* GL_NV_texture_npot_2D_mipmap */
+
 /* ------------------------ GL_NV_texture_rectangle ------------------------ */
 
 #ifndef GL_NV_texture_rectangle
@@ -13608,6 +16610,15 @@ typedef void (GLAPIENTRY * PFNGLTEXTUREIMAGE3DMULTISAMPLENVPROC) (GLuint texture
 #define GLEW_NV_texture_rectangle GLEW_GET_VAR(__GLEW_NV_texture_rectangle)
 
 #endif /* GL_NV_texture_rectangle */
+
+/* ------------------- GL_NV_texture_rectangle_compressed ------------------ */
+
+#ifndef GL_NV_texture_rectangle_compressed
+#define GL_NV_texture_rectangle_compressed 1
+
+#define GLEW_NV_texture_rectangle_compressed GLEW_GET_VAR(__GLEW_NV_texture_rectangle_compressed)
+
+#endif /* GL_NV_texture_rectangle_compressed */
 
 /* -------------------------- GL_NV_texture_shader ------------------------- */
 
@@ -13845,6 +16856,19 @@ typedef void (GLAPIENTRY * PFNGLRESUMETRANSFORMFEEDBACKNVPROC) (void);
 #define GLEW_NV_transform_feedback2 GLEW_GET_VAR(__GLEW_NV_transform_feedback2)
 
 #endif /* GL_NV_transform_feedback2 */
+
+/* ------------------ GL_NV_uniform_buffer_unified_memory ------------------ */
+
+#ifndef GL_NV_uniform_buffer_unified_memory
+#define GL_NV_uniform_buffer_unified_memory 1
+
+#define GL_UNIFORM_BUFFER_UNIFIED_NV 0x936E
+#define GL_UNIFORM_BUFFER_ADDRESS_NV 0x936F
+#define GL_UNIFORM_BUFFER_LENGTH_NV 0x9370
+
+#define GLEW_NV_uniform_buffer_unified_memory GLEW_GET_VAR(__GLEW_NV_uniform_buffer_unified_memory)
+
+#endif /* GL_NV_uniform_buffer_unified_memory */
 
 /* -------------------------- GL_NV_vdpau_interop -------------------------- */
 
@@ -14369,6 +17393,85 @@ typedef void (GLAPIENTRY * PFNGLVIDEOCAPTURESTREAMPARAMETERIVNVPROC) (GLuint vid
 
 #endif /* GL_NV_video_capture */
 
+/* -------------------------- GL_NV_viewport_array ------------------------- */
+
+#ifndef GL_NV_viewport_array
+#define GL_NV_viewport_array 1
+
+#define GL_DEPTH_RANGE 0x0B70
+#define GL_VIEWPORT 0x0BA2
+#define GL_SCISSOR_BOX 0x0C10
+#define GL_SCISSOR_TEST 0x0C11
+#define GL_MAX_VIEWPORTS_NV 0x825B
+#define GL_VIEWPORT_SUBPIXEL_BITS_NV 0x825C
+#define GL_VIEWPORT_BOUNDS_RANGE_NV 0x825D
+#define GL_VIEWPORT_INDEX_PROVOKING_VERTEX_NV 0x825F
+
+typedef void (GLAPIENTRY * PFNGLDEPTHRANGEARRAYFVNVPROC) (GLuint first, GLsizei count, const GLfloat * v);
+typedef void (GLAPIENTRY * PFNGLDEPTHRANGEINDEXEDFNVPROC) (GLuint index, GLfloat n, GLfloat f);
+typedef void (GLAPIENTRY * PFNGLDISABLEINVPROC) (GLenum target, GLuint index);
+typedef void (GLAPIENTRY * PFNGLENABLEINVPROC) (GLenum target, GLuint index);
+typedef void (GLAPIENTRY * PFNGLGETFLOATI_VNVPROC) (GLenum target, GLuint index, GLfloat* data);
+typedef GLboolean (GLAPIENTRY * PFNGLISENABLEDINVPROC) (GLenum target, GLuint index);
+typedef void (GLAPIENTRY * PFNGLSCISSORARRAYVNVPROC) (GLuint first, GLsizei count, const GLint * v);
+typedef void (GLAPIENTRY * PFNGLSCISSORINDEXEDNVPROC) (GLuint index, GLint left, GLint bottom, GLsizei width, GLsizei height);
+typedef void (GLAPIENTRY * PFNGLSCISSORINDEXEDVNVPROC) (GLuint index, const GLint * v);
+typedef void (GLAPIENTRY * PFNGLVIEWPORTARRAYVNVPROC) (GLuint first, GLsizei count, const GLfloat * v);
+typedef void (GLAPIENTRY * PFNGLVIEWPORTINDEXEDFNVPROC) (GLuint index, GLfloat x, GLfloat y, GLfloat w, GLfloat h);
+typedef void (GLAPIENTRY * PFNGLVIEWPORTINDEXEDFVNVPROC) (GLuint index, const GLfloat * v);
+
+#define glDepthRangeArrayfvNV GLEW_GET_FUN(__glewDepthRangeArrayfvNV)
+#define glDepthRangeIndexedfNV GLEW_GET_FUN(__glewDepthRangeIndexedfNV)
+#define glDisableiNV GLEW_GET_FUN(__glewDisableiNV)
+#define glEnableiNV GLEW_GET_FUN(__glewEnableiNV)
+#define glGetFloati_vNV GLEW_GET_FUN(__glewGetFloati_vNV)
+#define glIsEnablediNV GLEW_GET_FUN(__glewIsEnablediNV)
+#define glScissorArrayvNV GLEW_GET_FUN(__glewScissorArrayvNV)
+#define glScissorIndexedNV GLEW_GET_FUN(__glewScissorIndexedNV)
+#define glScissorIndexedvNV GLEW_GET_FUN(__glewScissorIndexedvNV)
+#define glViewportArrayvNV GLEW_GET_FUN(__glewViewportArrayvNV)
+#define glViewportIndexedfNV GLEW_GET_FUN(__glewViewportIndexedfNV)
+#define glViewportIndexedfvNV GLEW_GET_FUN(__glewViewportIndexedfvNV)
+
+#define GLEW_NV_viewport_array GLEW_GET_VAR(__GLEW_NV_viewport_array)
+
+#endif /* GL_NV_viewport_array */
+
+/* ------------------------- GL_NV_viewport_array2 ------------------------- */
+
+#ifndef GL_NV_viewport_array2
+#define GL_NV_viewport_array2 1
+
+#define GLEW_NV_viewport_array2 GLEW_GET_VAR(__GLEW_NV_viewport_array2)
+
+#endif /* GL_NV_viewport_array2 */
+
+/* ------------------------- GL_NV_viewport_swizzle ------------------------ */
+
+#ifndef GL_NV_viewport_swizzle
+#define GL_NV_viewport_swizzle 1
+
+#define GL_VIEWPORT_SWIZZLE_POSITIVE_X_NV 0x9350
+#define GL_VIEWPORT_SWIZZLE_NEGATIVE_X_NV 0x9351
+#define GL_VIEWPORT_SWIZZLE_POSITIVE_Y_NV 0x9352
+#define GL_VIEWPORT_SWIZZLE_NEGATIVE_Y_NV 0x9353
+#define GL_VIEWPORT_SWIZZLE_POSITIVE_Z_NV 0x9354
+#define GL_VIEWPORT_SWIZZLE_NEGATIVE_Z_NV 0x9355
+#define GL_VIEWPORT_SWIZZLE_POSITIVE_W_NV 0x9356
+#define GL_VIEWPORT_SWIZZLE_NEGATIVE_W_NV 0x9357
+#define GL_VIEWPORT_SWIZZLE_X_NV 0x9358
+#define GL_VIEWPORT_SWIZZLE_Y_NV 0x9359
+#define GL_VIEWPORT_SWIZZLE_Z_NV 0x935A
+#define GL_VIEWPORT_SWIZZLE_W_NV 0x935B
+
+typedef void (GLAPIENTRY * PFNGLVIEWPORTSWIZZLENVPROC) (GLuint index, GLenum swizzlex, GLenum swizzley, GLenum swizzlez, GLenum swizzlew);
+
+#define glViewportSwizzleNV GLEW_GET_FUN(__glewViewportSwizzleNV)
+
+#define GLEW_NV_viewport_swizzle GLEW_GET_VAR(__GLEW_NV_viewport_swizzle)
+
+#endif /* GL_NV_viewport_swizzle */
+
 /* ------------------------ GL_OES_byte_coordinates ------------------------ */
 
 #ifndef GL_OES_byte_coordinates
@@ -14377,61 +17480,6 @@ typedef void (GLAPIENTRY * PFNGLVIDEOCAPTURESTREAMPARAMETERIVNVPROC) (GLuint vid
 #define GLEW_OES_byte_coordinates GLEW_GET_VAR(__GLEW_OES_byte_coordinates)
 
 #endif /* GL_OES_byte_coordinates */
-
-/* ------------------- GL_OES_compressed_paletted_texture ------------------ */
-
-#ifndef GL_OES_compressed_paletted_texture
-#define GL_OES_compressed_paletted_texture 1
-
-#define GL_PALETTE4_RGB8_OES 0x8B90
-#define GL_PALETTE4_RGBA8_OES 0x8B91
-#define GL_PALETTE4_R5_G6_B5_OES 0x8B92
-#define GL_PALETTE4_RGBA4_OES 0x8B93
-#define GL_PALETTE4_RGB5_A1_OES 0x8B94
-#define GL_PALETTE8_RGB8_OES 0x8B95
-#define GL_PALETTE8_RGBA8_OES 0x8B96
-#define GL_PALETTE8_R5_G6_B5_OES 0x8B97
-#define GL_PALETTE8_RGBA4_OES 0x8B98
-#define GL_PALETTE8_RGB5_A1_OES 0x8B99
-
-#define GLEW_OES_compressed_paletted_texture GLEW_GET_VAR(__GLEW_OES_compressed_paletted_texture)
-
-#endif /* GL_OES_compressed_paletted_texture */
-
-/* --------------------------- GL_OES_read_format -------------------------- */
-
-#ifndef GL_OES_read_format
-#define GL_OES_read_format 1
-
-#define GL_IMPLEMENTATION_COLOR_READ_TYPE_OES 0x8B9A
-#define GL_IMPLEMENTATION_COLOR_READ_FORMAT_OES 0x8B9B
-
-#define GLEW_OES_read_format GLEW_GET_VAR(__GLEW_OES_read_format)
-
-#endif /* GL_OES_read_format */
-
-/* ------------------------ GL_OES_single_precision ------------------------ */
-
-#ifndef GL_OES_single_precision
-#define GL_OES_single_precision 1
-
-typedef void (GLAPIENTRY * PFNGLCLEARDEPTHFOESPROC) (GLclampd depth);
-typedef void (GLAPIENTRY * PFNGLCLIPPLANEFOESPROC) (GLenum plane, const GLfloat* equation);
-typedef void (GLAPIENTRY * PFNGLDEPTHRANGEFOESPROC) (GLclampf n, GLclampf f);
-typedef void (GLAPIENTRY * PFNGLFRUSTUMFOESPROC) (GLfloat l, GLfloat r, GLfloat b, GLfloat t, GLfloat n, GLfloat f);
-typedef void (GLAPIENTRY * PFNGLGETCLIPPLANEFOESPROC) (GLenum plane, GLfloat* equation);
-typedef void (GLAPIENTRY * PFNGLORTHOFOESPROC) (GLfloat l, GLfloat r, GLfloat b, GLfloat t, GLfloat n, GLfloat f);
-
-#define glClearDepthfOES GLEW_GET_FUN(__glewClearDepthfOES)
-#define glClipPlanefOES GLEW_GET_FUN(__glewClipPlanefOES)
-#define glDepthRangefOES GLEW_GET_FUN(__glewDepthRangefOES)
-#define glFrustumfOES GLEW_GET_FUN(__glewFrustumfOES)
-#define glGetClipPlanefOES GLEW_GET_FUN(__glewGetClipPlanefOES)
-#define glOrthofOES GLEW_GET_FUN(__glewOrthofOES)
-
-#define GLEW_OES_single_precision GLEW_GET_VAR(__GLEW_OES_single_precision)
-
-#endif /* GL_OES_single_precision */
 
 /* ---------------------------- GL_OML_interlace --------------------------- */
 
@@ -14472,6 +17520,46 @@ typedef void (GLAPIENTRY * PFNGLORTHOFOESPROC) (GLfloat l, GLfloat r, GLfloat b,
 #define GLEW_OML_subsample GLEW_GET_VAR(__GLEW_OML_subsample)
 
 #endif /* GL_OML_subsample */
+
+/* ---------------------------- GL_OVR_multiview --------------------------- */
+
+#ifndef GL_OVR_multiview
+#define GL_OVR_multiview 1
+
+#define GL_FRAMEBUFFER_ATTACHMENT_TEXTURE_NUM_VIEWS_OVR 0x9630
+#define GL_MAX_VIEWS_OVR 0x9631
+#define GL_FRAMEBUFFER_ATTACHMENT_TEXTURE_BASE_VIEW_INDEX_OVR 0x9632
+#define GL_FRAMEBUFFER_INCOMPLETE_VIEW_TARGETS_OVR 0x9633
+
+typedef void (GLAPIENTRY * PFNGLFRAMEBUFFERTEXTUREMULTIVIEWOVRPROC) (GLenum target, GLenum attachment, GLuint texture, GLint level, GLint baseViewIndex, GLsizei numViews);
+
+#define glFramebufferTextureMultiviewOVR GLEW_GET_FUN(__glewFramebufferTextureMultiviewOVR)
+
+#define GLEW_OVR_multiview GLEW_GET_VAR(__GLEW_OVR_multiview)
+
+#endif /* GL_OVR_multiview */
+
+/* --------------------------- GL_OVR_multiview2 --------------------------- */
+
+#ifndef GL_OVR_multiview2
+#define GL_OVR_multiview2 1
+
+#define GLEW_OVR_multiview2 GLEW_GET_VAR(__GLEW_OVR_multiview2)
+
+#endif /* GL_OVR_multiview2 */
+
+/* ------------ GL_OVR_multiview_multisampled_render_to_texture ------------ */
+
+#ifndef GL_OVR_multiview_multisampled_render_to_texture
+#define GL_OVR_multiview_multisampled_render_to_texture 1
+
+typedef void (GLAPIENTRY * PFNGLFRAMEBUFFERTEXTUREMULTISAMPLEMULTIVIEWOVRPROC) (GLenum target, GLenum attachment, GLuint texture, GLint level, GLsizei samples, GLint baseViewIndex, GLsizei numViews);
+
+#define glFramebufferTextureMultisampleMultiviewOVR GLEW_GET_FUN(__glewFramebufferTextureMultisampleMultiviewOVR)
+
+#define GLEW_OVR_multiview_multisampled_render_to_texture GLEW_GET_VAR(__GLEW_OVR_multiview_multisampled_render_to_texture)
+
+#endif /* GL_OVR_multiview_multisampled_render_to_texture */
 
 /* --------------------------- GL_PGI_misc_hints --------------------------- */
 
@@ -14534,6 +17622,218 @@ typedef void (GLAPIENTRY * PFNGLORTHOFOESPROC) (GLfloat l, GLfloat r, GLfloat b,
 #define GLEW_PGI_vertex_hints GLEW_GET_VAR(__GLEW_PGI_vertex_hints)
 
 #endif /* GL_PGI_vertex_hints */
+
+/* --------------------------- GL_QCOM_alpha_test -------------------------- */
+
+#ifndef GL_QCOM_alpha_test
+#define GL_QCOM_alpha_test 1
+
+#define GL_ALPHA_TEST_QCOM 0x0BC0
+#define GL_ALPHA_TEST_FUNC_QCOM 0x0BC1
+#define GL_ALPHA_TEST_REF_QCOM 0x0BC2
+
+typedef void (GLAPIENTRY * PFNGLALPHAFUNCQCOMPROC) (GLenum func, GLclampf ref);
+
+#define glAlphaFuncQCOM GLEW_GET_FUN(__glewAlphaFuncQCOM)
+
+#define GLEW_QCOM_alpha_test GLEW_GET_VAR(__GLEW_QCOM_alpha_test)
+
+#endif /* GL_QCOM_alpha_test */
+
+/* ------------------------ GL_QCOM_binning_control ------------------------ */
+
+#ifndef GL_QCOM_binning_control
+#define GL_QCOM_binning_control 1
+
+#define GL_DONT_CARE 0x1100
+#define GL_BINNING_CONTROL_HINT_QCOM 0x8FB0
+#define GL_CPU_OPTIMIZED_QCOM 0x8FB1
+#define GL_GPU_OPTIMIZED_QCOM 0x8FB2
+#define GL_RENDER_DIRECT_TO_FRAMEBUFFER_QCOM 0x8FB3
+
+#define GLEW_QCOM_binning_control GLEW_GET_VAR(__GLEW_QCOM_binning_control)
+
+#endif /* GL_QCOM_binning_control */
+
+/* ------------------------- GL_QCOM_driver_control ------------------------ */
+
+#ifndef GL_QCOM_driver_control
+#define GL_QCOM_driver_control 1
+
+typedef void (GLAPIENTRY * PFNGLDISABLEDRIVERCONTROLQCOMPROC) (GLuint driverControl);
+typedef void (GLAPIENTRY * PFNGLENABLEDRIVERCONTROLQCOMPROC) (GLuint driverControl);
+typedef void (GLAPIENTRY * PFNGLGETDRIVERCONTROLSTRINGQCOMPROC) (GLuint driverControl, GLsizei bufSize, GLsizei* length, GLchar *driverControlString);
+typedef void (GLAPIENTRY * PFNGLGETDRIVERCONTROLSQCOMPROC) (GLint* num, GLsizei size, GLuint *driverControls);
+
+#define glDisableDriverControlQCOM GLEW_GET_FUN(__glewDisableDriverControlQCOM)
+#define glEnableDriverControlQCOM GLEW_GET_FUN(__glewEnableDriverControlQCOM)
+#define glGetDriverControlStringQCOM GLEW_GET_FUN(__glewGetDriverControlStringQCOM)
+#define glGetDriverControlsQCOM GLEW_GET_FUN(__glewGetDriverControlsQCOM)
+
+#define GLEW_QCOM_driver_control GLEW_GET_VAR(__GLEW_QCOM_driver_control)
+
+#endif /* GL_QCOM_driver_control */
+
+/* -------------------------- GL_QCOM_extended_get ------------------------- */
+
+#ifndef GL_QCOM_extended_get
+#define GL_QCOM_extended_get 1
+
+#define GL_TEXTURE_WIDTH_QCOM 0x8BD2
+#define GL_TEXTURE_HEIGHT_QCOM 0x8BD3
+#define GL_TEXTURE_DEPTH_QCOM 0x8BD4
+#define GL_TEXTURE_INTERNAL_FORMAT_QCOM 0x8BD5
+#define GL_TEXTURE_FORMAT_QCOM 0x8BD6
+#define GL_TEXTURE_TYPE_QCOM 0x8BD7
+#define GL_TEXTURE_IMAGE_VALID_QCOM 0x8BD8
+#define GL_TEXTURE_NUM_LEVELS_QCOM 0x8BD9
+#define GL_TEXTURE_TARGET_QCOM 0x8BDA
+#define GL_TEXTURE_OBJECT_VALID_QCOM 0x8BDB
+#define GL_STATE_RESTORE 0x8BDC
+
+typedef void (GLAPIENTRY * PFNGLEXTGETBUFFERPOINTERVQCOMPROC) (GLenum target, void** params);
+typedef void (GLAPIENTRY * PFNGLEXTGETBUFFERSQCOMPROC) (GLuint* buffers, GLint maxBuffers, GLint* numBuffers);
+typedef void (GLAPIENTRY * PFNGLEXTGETFRAMEBUFFERSQCOMPROC) (GLuint* framebuffers, GLint maxFramebuffers, GLint* numFramebuffers);
+typedef void (GLAPIENTRY * PFNGLEXTGETRENDERBUFFERSQCOMPROC) (GLuint* renderbuffers, GLint maxRenderbuffers, GLint* numRenderbuffers);
+typedef void (GLAPIENTRY * PFNGLEXTGETTEXLEVELPARAMETERIVQCOMPROC) (GLuint texture, GLenum face, GLint level, GLenum pname, GLint* params);
+typedef void (GLAPIENTRY * PFNGLEXTGETTEXSUBIMAGEQCOMPROC) (GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type, void *texels);
+typedef void (GLAPIENTRY * PFNGLEXTGETTEXTURESQCOMPROC) (GLuint* textures, GLint maxTextures, GLint* numTextures);
+typedef void (GLAPIENTRY * PFNGLEXTTEXOBJECTSTATEOVERRIDEIQCOMPROC) (GLenum target, GLenum pname, GLint param);
+
+#define glExtGetBufferPointervQCOM GLEW_GET_FUN(__glewExtGetBufferPointervQCOM)
+#define glExtGetBuffersQCOM GLEW_GET_FUN(__glewExtGetBuffersQCOM)
+#define glExtGetFramebuffersQCOM GLEW_GET_FUN(__glewExtGetFramebuffersQCOM)
+#define glExtGetRenderbuffersQCOM GLEW_GET_FUN(__glewExtGetRenderbuffersQCOM)
+#define glExtGetTexLevelParameterivQCOM GLEW_GET_FUN(__glewExtGetTexLevelParameterivQCOM)
+#define glExtGetTexSubImageQCOM GLEW_GET_FUN(__glewExtGetTexSubImageQCOM)
+#define glExtGetTexturesQCOM GLEW_GET_FUN(__glewExtGetTexturesQCOM)
+#define glExtTexObjectStateOverrideiQCOM GLEW_GET_FUN(__glewExtTexObjectStateOverrideiQCOM)
+
+#define GLEW_QCOM_extended_get GLEW_GET_VAR(__GLEW_QCOM_extended_get)
+
+#endif /* GL_QCOM_extended_get */
+
+/* ------------------------- GL_QCOM_extended_get2 ------------------------- */
+
+#ifndef GL_QCOM_extended_get2
+#define GL_QCOM_extended_get2 1
+
+typedef void (GLAPIENTRY * PFNGLEXTGETPROGRAMBINARYSOURCEQCOMPROC) (GLuint program, GLenum shadertype, GLchar* source, GLint* length);
+typedef void (GLAPIENTRY * PFNGLEXTGETPROGRAMSQCOMPROC) (GLuint* programs, GLint maxPrograms, GLint* numPrograms);
+typedef void (GLAPIENTRY * PFNGLEXTGETSHADERSQCOMPROC) (GLuint* shaders, GLint maxShaders, GLint* numShaders);
+typedef GLboolean (GLAPIENTRY * PFNGLEXTISPROGRAMBINARYQCOMPROC) (GLuint program);
+
+#define glExtGetProgramBinarySourceQCOM GLEW_GET_FUN(__glewExtGetProgramBinarySourceQCOM)
+#define glExtGetProgramsQCOM GLEW_GET_FUN(__glewExtGetProgramsQCOM)
+#define glExtGetShadersQCOM GLEW_GET_FUN(__glewExtGetShadersQCOM)
+#define glExtIsProgramBinaryQCOM GLEW_GET_FUN(__glewExtIsProgramBinaryQCOM)
+
+#define GLEW_QCOM_extended_get2 GLEW_GET_VAR(__GLEW_QCOM_extended_get2)
+
+#endif /* GL_QCOM_extended_get2 */
+
+/* ---------------------- GL_QCOM_framebuffer_foveated --------------------- */
+
+#ifndef GL_QCOM_framebuffer_foveated
+#define GL_QCOM_framebuffer_foveated 1
+
+#define GL_FOVEATION_ENABLE_BIT_QCOM 0x1
+#define GL_FOVEATION_SCALED_BIN_METHOD_BIT_QCOM 0x2
+
+typedef void (GLAPIENTRY * PFNGLFRAMEBUFFERFOVEATIONCONFIGQCOMPROC) (GLuint fbo, GLuint numLayers, GLuint focalPointsPerLayer, GLuint requestedFeatures, GLuint* providedFeatures);
+typedef void (GLAPIENTRY * PFNGLFRAMEBUFFERFOVEATIONPARAMETERSQCOMPROC) (GLuint fbo, GLuint layer, GLuint focalPoint, GLfloat focalX, GLfloat focalY, GLfloat gainX, GLfloat gainY, GLfloat foveaArea);
+
+#define glFramebufferFoveationConfigQCOM GLEW_GET_FUN(__glewFramebufferFoveationConfigQCOM)
+#define glFramebufferFoveationParametersQCOM GLEW_GET_FUN(__glewFramebufferFoveationParametersQCOM)
+
+#define GLEW_QCOM_framebuffer_foveated GLEW_GET_VAR(__GLEW_QCOM_framebuffer_foveated)
+
+#endif /* GL_QCOM_framebuffer_foveated */
+
+/* ---------------------- GL_QCOM_perfmon_global_mode ---------------------- */
+
+#ifndef GL_QCOM_perfmon_global_mode
+#define GL_QCOM_perfmon_global_mode 1
+
+#define GL_PERFMON_GLOBAL_MODE_QCOM 0x8FA0
+
+#define GLEW_QCOM_perfmon_global_mode GLEW_GET_VAR(__GLEW_QCOM_perfmon_global_mode)
+
+#endif /* GL_QCOM_perfmon_global_mode */
+
+/* -------------- GL_QCOM_shader_framebuffer_fetch_noncoherent ------------- */
+
+#ifndef GL_QCOM_shader_framebuffer_fetch_noncoherent
+#define GL_QCOM_shader_framebuffer_fetch_noncoherent 1
+
+#define GL_FRAMEBUFFER_FETCH_NONCOHERENT_QCOM 0x96A2
+
+typedef void (GLAPIENTRY * PFNGLFRAMEBUFFERFETCHBARRIERQCOMPROC) (void);
+
+#define glFramebufferFetchBarrierQCOM GLEW_GET_FUN(__glewFramebufferFetchBarrierQCOM)
+
+#define GLEW_QCOM_shader_framebuffer_fetch_noncoherent GLEW_GET_VAR(__GLEW_QCOM_shader_framebuffer_fetch_noncoherent)
+
+#endif /* GL_QCOM_shader_framebuffer_fetch_noncoherent */
+
+/* ------------------------ GL_QCOM_tiled_rendering ------------------------ */
+
+#ifndef GL_QCOM_tiled_rendering
+#define GL_QCOM_tiled_rendering 1
+
+#define GL_COLOR_BUFFER_BIT0_QCOM 0x00000001
+#define GL_COLOR_BUFFER_BIT1_QCOM 0x00000002
+#define GL_COLOR_BUFFER_BIT2_QCOM 0x00000004
+#define GL_COLOR_BUFFER_BIT3_QCOM 0x00000008
+#define GL_COLOR_BUFFER_BIT4_QCOM 0x00000010
+#define GL_COLOR_BUFFER_BIT5_QCOM 0x00000020
+#define GL_COLOR_BUFFER_BIT6_QCOM 0x00000040
+#define GL_COLOR_BUFFER_BIT7_QCOM 0x00000080
+#define GL_DEPTH_BUFFER_BIT0_QCOM 0x00000100
+#define GL_DEPTH_BUFFER_BIT1_QCOM 0x00000200
+#define GL_DEPTH_BUFFER_BIT2_QCOM 0x00000400
+#define GL_DEPTH_BUFFER_BIT3_QCOM 0x00000800
+#define GL_DEPTH_BUFFER_BIT4_QCOM 0x00001000
+#define GL_DEPTH_BUFFER_BIT5_QCOM 0x00002000
+#define GL_DEPTH_BUFFER_BIT6_QCOM 0x00004000
+#define GL_DEPTH_BUFFER_BIT7_QCOM 0x00008000
+#define GL_STENCIL_BUFFER_BIT0_QCOM 0x00010000
+#define GL_STENCIL_BUFFER_BIT1_QCOM 0x00020000
+#define GL_STENCIL_BUFFER_BIT2_QCOM 0x00040000
+#define GL_STENCIL_BUFFER_BIT3_QCOM 0x00080000
+#define GL_STENCIL_BUFFER_BIT4_QCOM 0x00100000
+#define GL_STENCIL_BUFFER_BIT5_QCOM 0x00200000
+#define GL_STENCIL_BUFFER_BIT6_QCOM 0x00400000
+#define GL_STENCIL_BUFFER_BIT7_QCOM 0x00800000
+#define GL_MULTISAMPLE_BUFFER_BIT0_QCOM 0x01000000
+#define GL_MULTISAMPLE_BUFFER_BIT1_QCOM 0x02000000
+#define GL_MULTISAMPLE_BUFFER_BIT2_QCOM 0x04000000
+#define GL_MULTISAMPLE_BUFFER_BIT3_QCOM 0x08000000
+#define GL_MULTISAMPLE_BUFFER_BIT4_QCOM 0x10000000
+#define GL_MULTISAMPLE_BUFFER_BIT5_QCOM 0x20000000
+#define GL_MULTISAMPLE_BUFFER_BIT6_QCOM 0x40000000
+#define GL_MULTISAMPLE_BUFFER_BIT7_QCOM 0x80000000
+
+typedef void (GLAPIENTRY * PFNGLENDTILINGQCOMPROC) (GLbitfield preserveMask);
+typedef void (GLAPIENTRY * PFNGLSTARTTILINGQCOMPROC) (GLuint x, GLuint y, GLuint width, GLuint height, GLbitfield preserveMask);
+
+#define glEndTilingQCOM GLEW_GET_FUN(__glewEndTilingQCOM)
+#define glStartTilingQCOM GLEW_GET_FUN(__glewStartTilingQCOM)
+
+#define GLEW_QCOM_tiled_rendering GLEW_GET_VAR(__GLEW_QCOM_tiled_rendering)
+
+#endif /* GL_QCOM_tiled_rendering */
+
+/* ---------------------- GL_QCOM_writeonly_rendering ---------------------- */
+
+#ifndef GL_QCOM_writeonly_rendering
+#define GL_QCOM_writeonly_rendering 1
+
+#define GL_WRITEONLY_RENDERING_QCOM 0x8823
+
+#define GLEW_QCOM_writeonly_rendering GLEW_GET_VAR(__GLEW_QCOM_writeonly_rendering)
+
+#endif /* GL_QCOM_writeonly_rendering */
 
 /* ---------------------- GL_REGAL_ES1_0_compatibility --------------------- */
 
@@ -14761,6 +18061,15 @@ typedef void * (GLAPIENTRY * PFNGLGETPROCADDRESSREGALPROC) (const GLchar *name);
 
 #endif /* GL_S3_s3tc */
 
+/* ------------------------- GL_SGIS_clip_band_hint ------------------------ */
+
+#ifndef GL_SGIS_clip_band_hint
+#define GL_SGIS_clip_band_hint 1
+
+#define GLEW_SGIS_clip_band_hint GLEW_GET_VAR(__GLEW_SGIS_clip_band_hint)
+
+#endif /* GL_SGIS_clip_band_hint */
+
 /* -------------------------- GL_SGIS_color_range -------------------------- */
 
 #ifndef GL_SGIS_color_range
@@ -14822,6 +18131,15 @@ typedef void (GLAPIENTRY * PFNGLGETFOGFUNCSGISPROC) (GLfloat* points);
 
 #endif /* GL_SGIS_generate_mipmap */
 
+/* -------------------------- GL_SGIS_line_texgen -------------------------- */
+
+#ifndef GL_SGIS_line_texgen
+#define GL_SGIS_line_texgen 1
+
+#define GLEW_SGIS_line_texgen GLEW_GET_VAR(__GLEW_SGIS_line_texgen)
+
+#endif /* GL_SGIS_line_texgen */
+
 /* -------------------------- GL_SGIS_multisample -------------------------- */
 
 #ifndef GL_SGIS_multisample
@@ -14854,6 +18172,37 @@ typedef void (GLAPIENTRY * PFNGLSAMPLEPATTERNSGISPROC) (GLenum pattern);
 
 #endif /* GL_SGIS_multisample */
 
+/* -------------------------- GL_SGIS_multitexture ------------------------- */
+
+#ifndef GL_SGIS_multitexture
+#define GL_SGIS_multitexture 1
+
+#define GL_SELECTED_TEXTURE_SGIS 0x83C0
+#define GL_SELECTED_TEXTURE_COORD_SET_SGIS 0x83C1
+#define GL_SELECTED_TEXTURE_TRANSFORM_SGIS 0x83C2
+#define GL_MAX_TEXTURES_SGIS 0x83C3
+#define GL_MAX_TEXTURE_COORD_SETS_SGIS 0x83C4
+#define GL_TEXTURE_COORD_SET_INTERLEAVE_FACTOR_SGIS 0x83C5
+#define GL_TEXTURE_ENV_COORD_SET_SGIS 0x83C6
+#define GL_TEXTURE0_SGIS 0x83C7
+#define GL_TEXTURE1_SGIS 0x83C8
+#define GL_TEXTURE2_SGIS 0x83C9
+#define GL_TEXTURE3_SGIS 0x83CA
+
+typedef void (GLAPIENTRY * PFNGLINTERLEAVEDTEXTURECOORDSETSSGISPROC) (GLint factor);
+typedef void (GLAPIENTRY * PFNGLSELECTTEXTURECOORDSETSGISPROC) (GLenum target);
+typedef void (GLAPIENTRY * PFNGLSELECTTEXTURESGISPROC) (GLenum target);
+typedef void (GLAPIENTRY * PFNGLSELECTTEXTURETRANSFORMSGISPROC) (GLenum target);
+
+#define glInterleavedTextureCoordSetsSGIS GLEW_GET_FUN(__glewInterleavedTextureCoordSetsSGIS)
+#define glSelectTextureCoordSetSGIS GLEW_GET_FUN(__glewSelectTextureCoordSetSGIS)
+#define glSelectTextureSGIS GLEW_GET_FUN(__glewSelectTextureSGIS)
+#define glSelectTextureTransformSGIS GLEW_GET_FUN(__glewSelectTextureTransformSGIS)
+
+#define GLEW_SGIS_multitexture GLEW_GET_VAR(__GLEW_SGIS_multitexture)
+
+#endif /* GL_SGIS_multitexture */
+
 /* ------------------------- GL_SGIS_pixel_texture ------------------------- */
 
 #ifndef GL_SGIS_pixel_texture
@@ -14880,6 +18229,19 @@ typedef void (GLAPIENTRY * PFNGLSAMPLEPATTERNSGISPROC) (GLenum pattern);
 #define GLEW_SGIS_point_line_texgen GLEW_GET_VAR(__GLEW_SGIS_point_line_texgen)
 
 #endif /* GL_SGIS_point_line_texgen */
+
+/* ----------------------- GL_SGIS_shared_multisample ---------------------- */
+
+#ifndef GL_SGIS_shared_multisample
+#define GL_SGIS_shared_multisample 1
+
+typedef void (GLAPIENTRY * PFNGLMULTISAMPLESUBRECTPOSSGISPROC) (GLint x, GLint y);
+
+#define glMultisampleSubRectPosSGIS GLEW_GET_FUN(__glewMultisampleSubRectPosSGIS)
+
+#define GLEW_SGIS_shared_multisample GLEW_GET_VAR(__GLEW_SGIS_shared_multisample)
+
+#endif /* GL_SGIS_shared_multisample */
 
 /* ------------------------ GL_SGIS_sharpen_texture ------------------------ */
 
@@ -15024,6 +18386,42 @@ typedef GLint (GLAPIENTRY * PFNGLPOLLASYNCSGIXPROC) (GLuint* markerp);
 
 #endif /* GL_SGIX_async_pixel */
 
+/* ----------------------- GL_SGIX_bali_g_instruments ---------------------- */
+
+#ifndef GL_SGIX_bali_g_instruments
+#define GL_SGIX_bali_g_instruments 1
+
+#define GL_BALI_NUM_TRIS_CULLED_INSTRUMENT 0x6080
+#define GL_BALI_NUM_PRIMS_CLIPPED_INSTRUMENT 0x6081
+#define GL_BALI_NUM_PRIMS_REJECT_INSTRUMENT 0x6082
+#define GL_BALI_NUM_PRIMS_CLIP_RESULT_INSTRUMENT 0x6083
+
+#define GLEW_SGIX_bali_g_instruments GLEW_GET_VAR(__GLEW_SGIX_bali_g_instruments)
+
+#endif /* GL_SGIX_bali_g_instruments */
+
+/* ----------------------- GL_SGIX_bali_r_instruments ---------------------- */
+
+#ifndef GL_SGIX_bali_r_instruments
+#define GL_SGIX_bali_r_instruments 1
+
+#define GL_BALI_FRAGMENTS_GENERATED_INSTRUMENT 0x6090
+#define GL_BALI_DEPTH_PASS_INSTRUMENT 0x6091
+#define GL_BALI_R_CHIP_COUNT 0x6092
+
+#define GLEW_SGIX_bali_r_instruments GLEW_GET_VAR(__GLEW_SGIX_bali_r_instruments)
+
+#endif /* GL_SGIX_bali_r_instruments */
+
+/* --------------------- GL_SGIX_bali_timer_instruments -------------------- */
+
+#ifndef GL_SGIX_bali_timer_instruments
+#define GL_SGIX_bali_timer_instruments 1
+
+#define GLEW_SGIX_bali_timer_instruments GLEW_GET_VAR(__GLEW_SGIX_bali_timer_instruments)
+
+#endif /* GL_SGIX_bali_timer_instruments */
+
 /* ----------------------- GL_SGIX_blend_alpha_minmax ---------------------- */
 
 #ifndef GL_SGIX_blend_alpha_minmax
@@ -15036,6 +18434,37 @@ typedef GLint (GLAPIENTRY * PFNGLPOLLASYNCSGIXPROC) (GLuint* markerp);
 
 #endif /* GL_SGIX_blend_alpha_minmax */
 
+/* --------------------------- GL_SGIX_blend_cadd -------------------------- */
+
+#ifndef GL_SGIX_blend_cadd
+#define GL_SGIX_blend_cadd 1
+
+#define GL_FUNC_COMPLEX_ADD_EXT 0x601C
+
+#define GLEW_SGIX_blend_cadd GLEW_GET_VAR(__GLEW_SGIX_blend_cadd)
+
+#endif /* GL_SGIX_blend_cadd */
+
+/* ------------------------ GL_SGIX_blend_cmultiply ------------------------ */
+
+#ifndef GL_SGIX_blend_cmultiply
+#define GL_SGIX_blend_cmultiply 1
+
+#define GL_FUNC_COMPLEX_MULTIPLY_EXT 0x601B
+
+#define GLEW_SGIX_blend_cmultiply GLEW_GET_VAR(__GLEW_SGIX_blend_cmultiply)
+
+#endif /* GL_SGIX_blend_cmultiply */
+
+/* --------------------- GL_SGIX_calligraphic_fragment --------------------- */
+
+#ifndef GL_SGIX_calligraphic_fragment
+#define GL_SGIX_calligraphic_fragment 1
+
+#define GLEW_SGIX_calligraphic_fragment GLEW_GET_VAR(__GLEW_SGIX_calligraphic_fragment)
+
+#endif /* GL_SGIX_calligraphic_fragment */
+
 /* ---------------------------- GL_SGIX_clipmap ---------------------------- */
 
 #ifndef GL_SGIX_clipmap
@@ -15044,6 +18473,35 @@ typedef GLint (GLAPIENTRY * PFNGLPOLLASYNCSGIXPROC) (GLuint* markerp);
 #define GLEW_SGIX_clipmap GLEW_GET_VAR(__GLEW_SGIX_clipmap)
 
 #endif /* GL_SGIX_clipmap */
+
+/* --------------------- GL_SGIX_color_matrix_accuracy --------------------- */
+
+#ifndef GL_SGIX_color_matrix_accuracy
+#define GL_SGIX_color_matrix_accuracy 1
+
+#define GL_COLOR_MATRIX_HINT 0x8317
+
+#define GLEW_SGIX_color_matrix_accuracy GLEW_GET_VAR(__GLEW_SGIX_color_matrix_accuracy)
+
+#endif /* GL_SGIX_color_matrix_accuracy */
+
+/* --------------------- GL_SGIX_color_table_index_mode -------------------- */
+
+#ifndef GL_SGIX_color_table_index_mode
+#define GL_SGIX_color_table_index_mode 1
+
+#define GLEW_SGIX_color_table_index_mode GLEW_GET_VAR(__GLEW_SGIX_color_table_index_mode)
+
+#endif /* GL_SGIX_color_table_index_mode */
+
+/* ------------------------- GL_SGIX_complex_polar ------------------------- */
+
+#ifndef GL_SGIX_complex_polar
+#define GL_SGIX_complex_polar 1
+
+#define GLEW_SGIX_complex_polar GLEW_GET_VAR(__GLEW_SGIX_complex_polar)
+
+#endif /* GL_SGIX_complex_polar */
 
 /* ---------------------- GL_SGIX_convolution_accuracy --------------------- */
 
@@ -15055,6 +18513,74 @@ typedef GLint (GLAPIENTRY * PFNGLPOLLASYNCSGIXPROC) (GLuint* markerp);
 #define GLEW_SGIX_convolution_accuracy GLEW_GET_VAR(__GLEW_SGIX_convolution_accuracy)
 
 #endif /* GL_SGIX_convolution_accuracy */
+
+/* ---------------------------- GL_SGIX_cube_map --------------------------- */
+
+#ifndef GL_SGIX_cube_map
+#define GL_SGIX_cube_map 1
+
+#define GL_ENV_MAP_SGIX 0x8340
+#define GL_CUBE_MAP_SGIX 0x8341
+#define GL_CUBE_MAP_ZP_SGIX 0x8342
+#define GL_CUBE_MAP_ZN_SGIX 0x8343
+#define GL_CUBE_MAP_XN_SGIX 0x8344
+#define GL_CUBE_MAP_XP_SGIX 0x8345
+#define GL_CUBE_MAP_YN_SGIX 0x8346
+#define GL_CUBE_MAP_YP_SGIX 0x8347
+#define GL_CUBE_MAP_BINDING_SGIX 0x8348
+
+#define GLEW_SGIX_cube_map GLEW_GET_VAR(__GLEW_SGIX_cube_map)
+
+#endif /* GL_SGIX_cube_map */
+
+/* ------------------------ GL_SGIX_cylinder_texgen ------------------------ */
+
+#ifndef GL_SGIX_cylinder_texgen
+#define GL_SGIX_cylinder_texgen 1
+
+#define GLEW_SGIX_cylinder_texgen GLEW_GET_VAR(__GLEW_SGIX_cylinder_texgen)
+
+#endif /* GL_SGIX_cylinder_texgen */
+
+/* ---------------------------- GL_SGIX_datapipe --------------------------- */
+
+#ifndef GL_SGIX_datapipe
+#define GL_SGIX_datapipe 1
+
+#define GL_GEOMETRY_BIT 0x1
+#define GL_IMAGE_BIT 0x2
+
+typedef void (GLAPIENTRY * PFNGLADDRESSSPACEPROC) (GLenum space, GLbitfield mask);
+typedef GLint (GLAPIENTRY * PFNGLDATAPIPEPROC) (GLenum space);
+
+#define glAddressSpace GLEW_GET_FUN(__glewAddressSpace)
+#define glDataPipe GLEW_GET_FUN(__glewDataPipe)
+
+#define GLEW_SGIX_datapipe GLEW_GET_VAR(__GLEW_SGIX_datapipe)
+
+#endif /* GL_SGIX_datapipe */
+
+/* --------------------------- GL_SGIX_decimation -------------------------- */
+
+#ifndef GL_SGIX_decimation
+#define GL_SGIX_decimation 1
+
+#define GLEW_SGIX_decimation GLEW_GET_VAR(__GLEW_SGIX_decimation)
+
+#endif /* GL_SGIX_decimation */
+
+/* --------------------- GL_SGIX_depth_pass_instrument --------------------- */
+
+#ifndef GL_SGIX_depth_pass_instrument
+#define GL_SGIX_depth_pass_instrument 1
+
+#define GL_DEPTH_PASS_INSTRUMENT_SGIX 0x8310
+#define GL_DEPTH_PASS_INSTRUMENT_COUNTERS_SGIX 0x8311
+#define GL_DEPTH_PASS_INSTRUMENT_MAX_SGIX 0x8312
+
+#define GLEW_SGIX_depth_pass_instrument GLEW_GET_VAR(__GLEW_SGIX_depth_pass_instrument)
+
+#endif /* GL_SGIX_depth_pass_instrument */
 
 /* ------------------------- GL_SGIX_depth_texture ------------------------- */
 
@@ -15069,6 +18595,15 @@ typedef GLint (GLAPIENTRY * PFNGLPOLLASYNCSGIXPROC) (GLuint* markerp);
 
 #endif /* GL_SGIX_depth_texture */
 
+/* ------------------------------ GL_SGIX_dvc ------------------------------ */
+
+#ifndef GL_SGIX_dvc
+#define GL_SGIX_dvc 1
+
+#define GLEW_SGIX_dvc GLEW_GET_VAR(__GLEW_SGIX_dvc)
+
+#endif /* GL_SGIX_dvc */
+
 /* -------------------------- GL_SGIX_flush_raster ------------------------- */
 
 #ifndef GL_SGIX_flush_raster
@@ -15082,6 +18617,49 @@ typedef void (GLAPIENTRY * PFNGLFLUSHRASTERSGIXPROC) (void);
 
 #endif /* GL_SGIX_flush_raster */
 
+/* --------------------------- GL_SGIX_fog_blend --------------------------- */
+
+#ifndef GL_SGIX_fog_blend
+#define GL_SGIX_fog_blend 1
+
+#define GL_FOG_BLEND_ALPHA_SGIX 0x81FE
+#define GL_FOG_BLEND_COLOR_SGIX 0x81FF
+
+#define GLEW_SGIX_fog_blend GLEW_GET_VAR(__GLEW_SGIX_fog_blend)
+
+#endif /* GL_SGIX_fog_blend */
+
+/* ---------------------- GL_SGIX_fog_factor_to_alpha ---------------------- */
+
+#ifndef GL_SGIX_fog_factor_to_alpha
+#define GL_SGIX_fog_factor_to_alpha 1
+
+#define GLEW_SGIX_fog_factor_to_alpha GLEW_GET_VAR(__GLEW_SGIX_fog_factor_to_alpha)
+
+#endif /* GL_SGIX_fog_factor_to_alpha */
+
+/* --------------------------- GL_SGIX_fog_layers -------------------------- */
+
+#ifndef GL_SGIX_fog_layers
+#define GL_SGIX_fog_layers 1
+
+#define GL_FOG_TYPE_SGIX 0x8323
+#define GL_UNIFORM_SGIX 0x8324
+#define GL_LAYERED_SGIX 0x8325
+#define GL_FOG_GROUND_PLANE_SGIX 0x8326
+#define GL_FOG_LAYERS_POINTS_SGIX 0x8327
+#define GL_MAX_FOG_LAYERS_POINTS_SGIX 0x8328
+
+typedef void (GLAPIENTRY * PFNGLFOGLAYERSSGIXPROC) (GLsizei n, const GLfloat* points);
+typedef void (GLAPIENTRY * PFNGLGETFOGLAYERSSGIXPROC) (GLfloat* points);
+
+#define glFogLayersSGIX GLEW_GET_FUN(__glewFogLayersSGIX)
+#define glGetFogLayersSGIX GLEW_GET_FUN(__glewGetFogLayersSGIX)
+
+#define GLEW_SGIX_fog_layers GLEW_GET_VAR(__GLEW_SGIX_fog_layers)
+
+#endif /* GL_SGIX_fog_layers */
+
 /* --------------------------- GL_SGIX_fog_offset -------------------------- */
 
 #ifndef GL_SGIX_fog_offset
@@ -15094,14 +18672,31 @@ typedef void (GLAPIENTRY * PFNGLFLUSHRASTERSGIXPROC) (void);
 
 #endif /* GL_SGIX_fog_offset */
 
+/* --------------------------- GL_SGIX_fog_patchy -------------------------- */
+
+#ifndef GL_SGIX_fog_patchy
+#define GL_SGIX_fog_patchy 1
+
+#define GLEW_SGIX_fog_patchy GLEW_GET_VAR(__GLEW_SGIX_fog_patchy)
+
+#endif /* GL_SGIX_fog_patchy */
+
+/* --------------------------- GL_SGIX_fog_scale --------------------------- */
+
+#ifndef GL_SGIX_fog_scale
+#define GL_SGIX_fog_scale 1
+
+#define GL_FOG_SCALE_SGIX 0x81FC
+#define GL_FOG_SCALE_VALUE_SGIX 0x81FD
+
+#define GLEW_SGIX_fog_scale GLEW_GET_VAR(__GLEW_SGIX_fog_scale)
+
+#endif /* GL_SGIX_fog_scale */
+
 /* -------------------------- GL_SGIX_fog_texture -------------------------- */
 
 #ifndef GL_SGIX_fog_texture
 #define GL_SGIX_fog_texture 1
-
-#define GL_FOG_PATCHY_FACTOR_SGIX 0
-#define GL_FRAGMENT_FOG_SGIX 0
-#define GL_TEXTURE_FOG_SGIX 0
 
 typedef void (GLAPIENTRY * PFNGLTEXTUREFOGSGIXPROC) (GLenum pname);
 
@@ -15110,6 +18705,20 @@ typedef void (GLAPIENTRY * PFNGLTEXTUREFOGSGIXPROC) (GLenum pname);
 #define GLEW_SGIX_fog_texture GLEW_GET_VAR(__GLEW_SGIX_fog_texture)
 
 #endif /* GL_SGIX_fog_texture */
+
+/* -------------------- GL_SGIX_fragment_lighting_space -------------------- */
+
+#ifndef GL_SGIX_fragment_lighting_space
+#define GL_SGIX_fragment_lighting_space 1
+
+#define GL_EYE_SPACE_SGIX 0x8436
+#define GL_TANGENT_SPACE_SGIX 0x8437
+#define GL_OBJECT_SPACE_SGIX 0x8438
+#define GL_FRAGMENT_LIGHT_SPACE_SGIX 0x843D
+
+#define GLEW_SGIX_fragment_lighting_space GLEW_GET_VAR(__GLEW_SGIX_fragment_lighting_space)
+
+#endif /* GL_SGIX_fragment_lighting_space */
 
 /* ------------------- GL_SGIX_fragment_specular_lighting ------------------ */
 
@@ -15156,6 +18765,19 @@ typedef void (GLAPIENTRY * PFNGLGETFRAGMENTMATERIALIVSGIXPROC) (GLenum face, GLe
 
 #endif /* GL_SGIX_fragment_specular_lighting */
 
+/* ---------------------- GL_SGIX_fragments_instrument --------------------- */
+
+#ifndef GL_SGIX_fragments_instrument
+#define GL_SGIX_fragments_instrument 1
+
+#define GL_FRAGMENTS_INSTRUMENT_SGIX 0x8313
+#define GL_FRAGMENTS_INSTRUMENT_COUNTERS_SGIX 0x8314
+#define GL_FRAGMENTS_INSTRUMENT_MAX_SGIX 0x8315
+
+#define GLEW_SGIX_fragments_instrument GLEW_GET_VAR(__GLEW_SGIX_fragments_instrument)
+
+#endif /* GL_SGIX_fragments_instrument */
+
 /* --------------------------- GL_SGIX_framezoom --------------------------- */
 
 #ifndef GL_SGIX_framezoom
@@ -15168,6 +18790,77 @@ typedef void (GLAPIENTRY * PFNGLFRAMEZOOMSGIXPROC) (GLint factor);
 #define GLEW_SGIX_framezoom GLEW_GET_VAR(__GLEW_SGIX_framezoom)
 
 #endif /* GL_SGIX_framezoom */
+
+/* -------------------------- GL_SGIX_icc_texture -------------------------- */
+
+#ifndef GL_SGIX_icc_texture
+#define GL_SGIX_icc_texture 1
+
+#define GL_RGB_ICC_SGIX 0x8460
+#define GL_RGBA_ICC_SGIX 0x8461
+#define GL_ALPHA_ICC_SGIX 0x8462
+#define GL_LUMINANCE_ICC_SGIX 0x8463
+#define GL_INTENSITY_ICC_SGIX 0x8464
+#define GL_LUMINANCE_ALPHA_ICC_SGIX 0x8465
+#define GL_R5_G6_B5_ICC_SGIX 0x8466
+#define GL_R5_G6_B5_A8_ICC_SGIX 0x8467
+#define GL_ALPHA16_ICC_SGIX 0x8468
+#define GL_LUMINANCE16_ICC_SGIX 0x8469
+#define GL_INTENSITY16_ICC_SGIX 0x846A
+#define GL_LUMINANCE16_ALPHA8_ICC_SGIX 0x846B
+
+#define GLEW_SGIX_icc_texture GLEW_GET_VAR(__GLEW_SGIX_icc_texture)
+
+#endif /* GL_SGIX_icc_texture */
+
+/* ------------------------ GL_SGIX_igloo_interface ------------------------ */
+
+#ifndef GL_SGIX_igloo_interface
+#define GL_SGIX_igloo_interface 1
+
+#define GL_IGLOO_FULLSCREEN_SGIX 0x819E
+#define GL_IGLOO_VIEWPORT_OFFSET_SGIX 0x819F
+#define GL_IGLOO_SWAPTMESH_SGIX 0x81A0
+#define GL_IGLOO_COLORNORMAL_SGIX 0x81A1
+#define GL_IGLOO_IRISGL_MODE_SGIX 0x81A2
+#define GL_IGLOO_LMC_COLOR_SGIX 0x81A3
+#define GL_IGLOO_TMESHMODE_SGIX 0x81A4
+#define GL_LIGHT31 0xBEAD
+
+typedef void (GLAPIENTRY * PFNGLIGLOOINTERFACESGIXPROC) (GLenum pname, void *param);
+
+#define glIglooInterfaceSGIX GLEW_GET_FUN(__glewIglooInterfaceSGIX)
+
+#define GLEW_SGIX_igloo_interface GLEW_GET_VAR(__GLEW_SGIX_igloo_interface)
+
+#endif /* GL_SGIX_igloo_interface */
+
+/* ----------------------- GL_SGIX_image_compression ----------------------- */
+
+#ifndef GL_SGIX_image_compression
+#define GL_SGIX_image_compression 1
+
+#define GLEW_SGIX_image_compression GLEW_GET_VAR(__GLEW_SGIX_image_compression)
+
+#endif /* GL_SGIX_image_compression */
+
+/* ---------------------- GL_SGIX_impact_pixel_texture --------------------- */
+
+#ifndef GL_SGIX_impact_pixel_texture
+#define GL_SGIX_impact_pixel_texture 1
+
+#define GLEW_SGIX_impact_pixel_texture GLEW_GET_VAR(__GLEW_SGIX_impact_pixel_texture)
+
+#endif /* GL_SGIX_impact_pixel_texture */
+
+/* ------------------------ GL_SGIX_instrument_error ----------------------- */
+
+#ifndef GL_SGIX_instrument_error
+#define GL_SGIX_instrument_error 1
+
+#define GLEW_SGIX_instrument_error GLEW_GET_VAR(__GLEW_SGIX_instrument_error)
+
+#endif /* GL_SGIX_instrument_error */
 
 /* --------------------------- GL_SGIX_interlace --------------------------- */
 
@@ -15189,6 +18882,17 @@ typedef void (GLAPIENTRY * PFNGLFRAMEZOOMSGIXPROC) (GLint factor);
 
 #endif /* GL_SGIX_ir_instrument1 */
 
+/* ----------------------- GL_SGIX_line_quality_hint ----------------------- */
+
+#ifndef GL_SGIX_line_quality_hint
+#define GL_SGIX_line_quality_hint 1
+
+#define GL_LINE_QUALITY_HINT_SGIX 0x835B
+
+#define GLEW_SGIX_line_quality_hint GLEW_GET_VAR(__GLEW_SGIX_line_quality_hint)
+
+#endif /* GL_SGIX_line_quality_hint */
+
 /* ------------------------- GL_SGIX_list_priority ------------------------- */
 
 #ifndef GL_SGIX_list_priority
@@ -15197,6 +18901,117 @@ typedef void (GLAPIENTRY * PFNGLFRAMEZOOMSGIXPROC) (GLint factor);
 #define GLEW_SGIX_list_priority GLEW_GET_VAR(__GLEW_SGIX_list_priority)
 
 #endif /* GL_SGIX_list_priority */
+
+/* ----------------------------- GL_SGIX_mpeg1 ----------------------------- */
+
+#ifndef GL_SGIX_mpeg1
+#define GL_SGIX_mpeg1 1
+
+typedef void (GLAPIENTRY * PFNGLALLOCMPEGPREDICTORSSGIXPROC) (GLsizei width, GLsizei height, GLsizei n, GLuint* predictors);
+typedef void (GLAPIENTRY * PFNGLDELETEMPEGPREDICTORSSGIXPROC) (GLsizei n, GLuint* predictors);
+typedef void (GLAPIENTRY * PFNGLGENMPEGPREDICTORSSGIXPROC) (GLsizei n, GLuint* predictors);
+typedef void (GLAPIENTRY * PFNGLGETMPEGPARAMETERFVSGIXPROC) (GLenum target, GLenum pname, GLfloat* params);
+typedef void (GLAPIENTRY * PFNGLGETMPEGPARAMETERIVSGIXPROC) (GLenum target, GLenum pname, GLint* params);
+typedef void (GLAPIENTRY * PFNGLGETMPEGPREDICTORSGIXPROC) (GLenum target, GLenum format, GLenum type, void *pixels);
+typedef void (GLAPIENTRY * PFNGLGETMPEGQUANTTABLEUBVPROC) (GLenum target, GLubyte* values);
+typedef GLboolean (GLAPIENTRY * PFNGLISMPEGPREDICTORSGIXPROC) (GLuint predictor);
+typedef void (GLAPIENTRY * PFNGLMPEGPREDICTORSGIXPROC) (GLenum target, GLenum format, GLenum type, void *pixels);
+typedef void (GLAPIENTRY * PFNGLMPEGQUANTTABLEUBVPROC) (GLenum target, GLubyte* values);
+typedef void (GLAPIENTRY * PFNGLSWAPMPEGPREDICTORSSGIXPROC) (GLenum target0, GLenum target1);
+
+#define glAllocMPEGPredictorsSGIX GLEW_GET_FUN(__glewAllocMPEGPredictorsSGIX)
+#define glDeleteMPEGPredictorsSGIX GLEW_GET_FUN(__glewDeleteMPEGPredictorsSGIX)
+#define glGenMPEGPredictorsSGIX GLEW_GET_FUN(__glewGenMPEGPredictorsSGIX)
+#define glGetMPEGParameterfvSGIX GLEW_GET_FUN(__glewGetMPEGParameterfvSGIX)
+#define glGetMPEGParameterivSGIX GLEW_GET_FUN(__glewGetMPEGParameterivSGIX)
+#define glGetMPEGPredictorSGIX GLEW_GET_FUN(__glewGetMPEGPredictorSGIX)
+#define glGetMPEGQuantTableubv GLEW_GET_FUN(__glewGetMPEGQuantTableubv)
+#define glIsMPEGPredictorSGIX GLEW_GET_FUN(__glewIsMPEGPredictorSGIX)
+#define glMPEGPredictorSGIX GLEW_GET_FUN(__glewMPEGPredictorSGIX)
+#define glMPEGQuantTableubv GLEW_GET_FUN(__glewMPEGQuantTableubv)
+#define glSwapMPEGPredictorsSGIX GLEW_GET_FUN(__glewSwapMPEGPredictorsSGIX)
+
+#define GLEW_SGIX_mpeg1 GLEW_GET_VAR(__GLEW_SGIX_mpeg1)
+
+#endif /* GL_SGIX_mpeg1 */
+
+/* ----------------------------- GL_SGIX_mpeg2 ----------------------------- */
+
+#ifndef GL_SGIX_mpeg2
+#define GL_SGIX_mpeg2 1
+
+#define GLEW_SGIX_mpeg2 GLEW_GET_VAR(__GLEW_SGIX_mpeg2)
+
+#endif /* GL_SGIX_mpeg2 */
+
+/* ------------------ GL_SGIX_nonlinear_lighting_pervertex ----------------- */
+
+#ifndef GL_SGIX_nonlinear_lighting_pervertex
+#define GL_SGIX_nonlinear_lighting_pervertex 1
+
+typedef void (GLAPIENTRY * PFNGLGETNONLINLIGHTFVSGIXPROC) (GLenum light, GLenum pname, GLint* terms, GLfloat *data);
+typedef void (GLAPIENTRY * PFNGLGETNONLINMATERIALFVSGIXPROC) (GLenum face, GLenum pname, GLint* terms, const GLfloat *data);
+typedef void (GLAPIENTRY * PFNGLNONLINLIGHTFVSGIXPROC) (GLenum light, GLenum pname, GLint terms, GLfloat* params);
+typedef void (GLAPIENTRY * PFNGLNONLINMATERIALFVSGIXPROC) (GLenum face, GLenum pname, GLint terms, const GLfloat* params);
+
+#define glGetNonlinLightfvSGIX GLEW_GET_FUN(__glewGetNonlinLightfvSGIX)
+#define glGetNonlinMaterialfvSGIX GLEW_GET_FUN(__glewGetNonlinMaterialfvSGIX)
+#define glNonlinLightfvSGIX GLEW_GET_FUN(__glewNonlinLightfvSGIX)
+#define glNonlinMaterialfvSGIX GLEW_GET_FUN(__glewNonlinMaterialfvSGIX)
+
+#define GLEW_SGIX_nonlinear_lighting_pervertex GLEW_GET_VAR(__GLEW_SGIX_nonlinear_lighting_pervertex)
+
+#endif /* GL_SGIX_nonlinear_lighting_pervertex */
+
+/* --------------------------- GL_SGIX_nurbs_eval -------------------------- */
+
+#ifndef GL_SGIX_nurbs_eval
+#define GL_SGIX_nurbs_eval 1
+
+#define GL_MAP1_VERTEX_3_NURBS_SGIX 0x81CB
+#define GL_MAP1_VERTEX_4_NURBS_SGIX 0x81CC
+#define GL_MAP1_INDEX_NURBS_SGIX 0x81CD
+#define GL_MAP1_COLOR_4_NURBS_SGIX 0x81CE
+#define GL_MAP1_NORMAL_NURBS_SGIX 0x81CF
+#define GL_MAP1_TEXTURE_COORD_1_NURBS_SGIX 0x81E0
+#define GL_MAP1_TEXTURE_COORD_2_NURBS_SGIX 0x81E1
+#define GL_MAP1_TEXTURE_COORD_3_NURBS_SGIX 0x81E2
+#define GL_MAP1_TEXTURE_COORD_4_NURBS_SGIX 0x81E3
+#define GL_MAP2_VERTEX_3_NURBS_SGIX 0x81E4
+#define GL_MAP2_VERTEX_4_NURBS_SGIX 0x81E5
+#define GL_MAP2_INDEX_NURBS_SGIX 0x81E6
+#define GL_MAP2_COLOR_4_NURBS_SGIX 0x81E7
+#define GL_MAP2_NORMAL_NURBS_SGIX 0x81E8
+#define GL_MAP2_TEXTURE_COORD_1_NURBS_SGIX 0x81E9
+#define GL_MAP2_TEXTURE_COORD_2_NURBS_SGIX 0x81EA
+#define GL_MAP2_TEXTURE_COORD_3_NURBS_SGIX 0x81EB
+#define GL_MAP2_TEXTURE_COORD_4_NURBS_SGIX 0x81EC
+#define GL_NURBS_KNOT_COUNT_SGIX 0x81ED
+#define GL_NURBS_KNOT_VECTOR_SGIX 0x81EE
+
+#define GLEW_SGIX_nurbs_eval GLEW_GET_VAR(__GLEW_SGIX_nurbs_eval)
+
+#endif /* GL_SGIX_nurbs_eval */
+
+/* ---------------------- GL_SGIX_occlusion_instrument --------------------- */
+
+#ifndef GL_SGIX_occlusion_instrument
+#define GL_SGIX_occlusion_instrument 1
+
+#define GL_OCCLUSION_INSTRUMENT_SGIX 0x6060
+
+#define GLEW_SGIX_occlusion_instrument GLEW_GET_VAR(__GLEW_SGIX_occlusion_instrument)
+
+#endif /* GL_SGIX_occlusion_instrument */
+
+/* ------------------------- GL_SGIX_packed_6bytes ------------------------- */
+
+#ifndef GL_SGIX_packed_6bytes
+#define GL_SGIX_packed_6bytes 1
+
+#define GLEW_SGIX_packed_6bytes GLEW_GET_VAR(__GLEW_SGIX_packed_6bytes)
+
+#endif /* GL_SGIX_packed_6bytes */
 
 /* ------------------------- GL_SGIX_pixel_texture ------------------------- */
 
@@ -15219,6 +19034,57 @@ typedef void (GLAPIENTRY * PFNGLPIXELTEXGENSGIXPROC) (GLenum mode);
 #define GLEW_SGIX_pixel_texture_bits GLEW_GET_VAR(__GLEW_SGIX_pixel_texture_bits)
 
 #endif /* GL_SGIX_pixel_texture_bits */
+
+/* ----------------------- GL_SGIX_pixel_texture_lod ----------------------- */
+
+#ifndef GL_SGIX_pixel_texture_lod
+#define GL_SGIX_pixel_texture_lod 1
+
+#define GLEW_SGIX_pixel_texture_lod GLEW_GET_VAR(__GLEW_SGIX_pixel_texture_lod)
+
+#endif /* GL_SGIX_pixel_texture_lod */
+
+/* -------------------------- GL_SGIX_pixel_tiles -------------------------- */
+
+#ifndef GL_SGIX_pixel_tiles
+#define GL_SGIX_pixel_tiles 1
+
+#define GLEW_SGIX_pixel_tiles GLEW_GET_VAR(__GLEW_SGIX_pixel_tiles)
+
+#endif /* GL_SGIX_pixel_tiles */
+
+/* ------------------------- GL_SGIX_polynomial_ffd ------------------------ */
+
+#ifndef GL_SGIX_polynomial_ffd
+#define GL_SGIX_polynomial_ffd 1
+
+#define GL_TEXTURE_DEFORMATION_BIT_SGIX 0x1
+#define GL_GEOMETRY_DEFORMATION_BIT_SGIX 0x2
+
+typedef void (GLAPIENTRY * PFNGLDEFORMSGIXPROC) (GLbitfield mask);
+typedef void (GLAPIENTRY * PFNGLLOADIDENTITYDEFORMATIONMAPSGIXPROC) (GLbitfield mask);
+
+#define glDeformSGIX GLEW_GET_FUN(__glewDeformSGIX)
+#define glLoadIdentityDeformationMapSGIX GLEW_GET_FUN(__glewLoadIdentityDeformationMapSGIX)
+
+#define GLEW_SGIX_polynomial_ffd GLEW_GET_VAR(__GLEW_SGIX_polynomial_ffd)
+
+#endif /* GL_SGIX_polynomial_ffd */
+
+/* --------------------------- GL_SGIX_quad_mesh --------------------------- */
+
+#ifndef GL_SGIX_quad_mesh
+#define GL_SGIX_quad_mesh 1
+
+typedef void (GLAPIENTRY * PFNGLMESHBREADTHSGIXPROC) (GLint breadth);
+typedef void (GLAPIENTRY * PFNGLMESHSTRIDESGIXPROC) (GLint stride);
+
+#define glMeshBreadthSGIX GLEW_GET_FUN(__glewMeshBreadthSGIX)
+#define glMeshStrideSGIX GLEW_GET_FUN(__glewMeshStrideSGIX)
+
+#define GLEW_SGIX_quad_mesh GLEW_GET_VAR(__GLEW_SGIX_quad_mesh)
+
+#endif /* GL_SGIX_quad_mesh */
 
 /* ------------------------ GL_SGIX_reference_plane ------------------------ */
 
@@ -15248,6 +19114,17 @@ typedef void (GLAPIENTRY * PFNGLREFERENCEPLANESGIXPROC) (const GLdouble* equatio
 
 #endif /* GL_SGIX_resample */
 
+/* ------------------------- GL_SGIX_scalebias_hint ------------------------ */
+
+#ifndef GL_SGIX_scalebias_hint
+#define GL_SGIX_scalebias_hint 1
+
+#define GL_SCALEBIAS_HINT_SGIX 0x8322
+
+#define GLEW_SGIX_scalebias_hint GLEW_GET_VAR(__GLEW_SGIX_scalebias_hint)
+
+#endif /* GL_SGIX_scalebias_hint */
+
 /* ----------------------------- GL_SGIX_shadow ---------------------------- */
 
 #ifndef GL_SGIX_shadow
@@ -15273,6 +19150,31 @@ typedef void (GLAPIENTRY * PFNGLREFERENCEPLANESGIXPROC) (const GLdouble* equatio
 
 #endif /* GL_SGIX_shadow_ambient */
 
+/* ------------------------------ GL_SGIX_slim ----------------------------- */
+
+#ifndef GL_SGIX_slim
+#define GL_SGIX_slim 1
+
+#define GL_PACK_MAX_COMPRESSED_SIZE_SGIX 0x831B
+#define GL_SLIM8U_SGIX 0x831D
+#define GL_SLIM10U_SGIX 0x831E
+#define GL_SLIM12S_SGIX 0x831F
+
+#define GLEW_SGIX_slim GLEW_GET_VAR(__GLEW_SGIX_slim)
+
+#endif /* GL_SGIX_slim */
+
+/* ------------------------ GL_SGIX_spotlight_cutoff ----------------------- */
+
+#ifndef GL_SGIX_spotlight_cutoff
+#define GL_SGIX_spotlight_cutoff 1
+
+#define GL_SPOT_CUTOFF_DELTA_SGIX 0x8193
+
+#define GLEW_SGIX_spotlight_cutoff GLEW_GET_VAR(__GLEW_SGIX_spotlight_cutoff)
+
+#endif /* GL_SGIX_spotlight_cutoff */
+
 /* ----------------------------- GL_SGIX_sprite ---------------------------- */
 
 #ifndef GL_SGIX_sprite
@@ -15291,6 +19193,30 @@ typedef void (GLAPIENTRY * PFNGLSPRITEPARAMETERIVSGIXPROC) (GLenum pname, GLint*
 #define GLEW_SGIX_sprite GLEW_GET_VAR(__GLEW_SGIX_sprite)
 
 #endif /* GL_SGIX_sprite */
+
+/* -------------------------- GL_SGIX_subdiv_patch ------------------------- */
+
+#ifndef GL_SGIX_subdiv_patch
+#define GL_SGIX_subdiv_patch 1
+
+#define GLEW_SGIX_subdiv_patch GLEW_GET_VAR(__GLEW_SGIX_subdiv_patch)
+
+#endif /* GL_SGIX_subdiv_patch */
+
+/* --------------------------- GL_SGIX_subsample --------------------------- */
+
+#ifndef GL_SGIX_subsample
+#define GL_SGIX_subsample 1
+
+#define GL_PACK_SUBSAMPLE_RATE_SGIX 0x85A0
+#define GL_UNPACK_SUBSAMPLE_RATE_SGIX 0x85A1
+#define GL_PIXEL_SUBSAMPLE_4444_SGIX 0x85A2
+#define GL_PIXEL_SUBSAMPLE_2424_SGIX 0x85A3
+#define GL_PIXEL_SUBSAMPLE_4242_SGIX 0x85A4
+
+#define GLEW_SGIX_subsample GLEW_GET_VAR(__GLEW_SGIX_subsample)
+
+#endif /* GL_SGIX_subsample */
 
 /* ----------------------- GL_SGIX_tag_sample_buffer ----------------------- */
 
@@ -15336,6 +19262,18 @@ typedef void (GLAPIENTRY * PFNGLTAGSAMPLEBUFFERSGIXPROC) (void);
 
 #endif /* GL_SGIX_texture_lod_bias */
 
+/* ------------------- GL_SGIX_texture_mipmap_anisotropic ------------------ */
+
+#ifndef GL_SGIX_texture_mipmap_anisotropic
+#define GL_SGIX_texture_mipmap_anisotropic 1
+
+#define GL_TEXTURE_MIPMAP_ANISOTROPY_SGIX 0x832E
+#define GL_MAX_MIPMAP_ANISOTROPY_SGIX 0x832F
+
+#define GLEW_SGIX_texture_mipmap_anisotropic GLEW_GET_VAR(__GLEW_SGIX_texture_mipmap_anisotropic)
+
+#endif /* GL_SGIX_texture_mipmap_anisotropic */
+
 /* ---------------------- GL_SGIX_texture_multi_buffer --------------------- */
 
 #ifndef GL_SGIX_texture_multi_buffer
@@ -15346,6 +19284,17 @@ typedef void (GLAPIENTRY * PFNGLTAGSAMPLEBUFFERSGIXPROC) (void);
 #define GLEW_SGIX_texture_multi_buffer GLEW_GET_VAR(__GLEW_SGIX_texture_multi_buffer)
 
 #endif /* GL_SGIX_texture_multi_buffer */
+
+/* ------------------------- GL_SGIX_texture_phase ------------------------- */
+
+#ifndef GL_SGIX_texture_phase
+#define GL_SGIX_texture_phase 1
+
+#define GL_PHASE_SGIX 0x832A
+
+#define GLEW_SGIX_texture_phase GLEW_GET_VAR(__GLEW_SGIX_texture_phase)
+
+#endif /* GL_SGIX_texture_phase */
 
 /* ------------------------- GL_SGIX_texture_range ------------------------- */
 
@@ -15399,6 +19348,53 @@ typedef void (GLAPIENTRY * PFNGLTAGSAMPLEBUFFERSGIXPROC) (void);
 
 #endif /* GL_SGIX_texture_scale_bias */
 
+/* ---------------------- GL_SGIX_texture_supersample ---------------------- */
+
+#ifndef GL_SGIX_texture_supersample
+#define GL_SGIX_texture_supersample 1
+
+#define GLEW_SGIX_texture_supersample GLEW_GET_VAR(__GLEW_SGIX_texture_supersample)
+
+#endif /* GL_SGIX_texture_supersample */
+
+/* --------------------------- GL_SGIX_vector_ops -------------------------- */
+
+#ifndef GL_SGIX_vector_ops
+#define GL_SGIX_vector_ops 1
+
+typedef void (GLAPIENTRY * PFNGLGETVECTOROPERATIONSGIXPROC) (GLenum operation);
+typedef void (GLAPIENTRY * PFNGLVECTOROPERATIONSGIXPROC) (GLenum operation);
+
+#define glGetVectorOperationSGIX GLEW_GET_FUN(__glewGetVectorOperationSGIX)
+#define glVectorOperationSGIX GLEW_GET_FUN(__glewVectorOperationSGIX)
+
+#define GLEW_SGIX_vector_ops GLEW_GET_VAR(__GLEW_SGIX_vector_ops)
+
+#endif /* GL_SGIX_vector_ops */
+
+/* ---------------------- GL_SGIX_vertex_array_object ---------------------- */
+
+#ifndef GL_SGIX_vertex_array_object
+#define GL_SGIX_vertex_array_object 1
+
+typedef GLboolean (GLAPIENTRY * PFNGLAREVERTEXARRAYSRESIDENTSGIXPROC) (GLsizei n, const GLuint* arrays, GLboolean* residences);
+typedef void (GLAPIENTRY * PFNGLBINDVERTEXARRAYSGIXPROC) (GLuint array);
+typedef void (GLAPIENTRY * PFNGLDELETEVERTEXARRAYSSGIXPROC) (GLsizei n, const GLuint* arrays);
+typedef void (GLAPIENTRY * PFNGLGENVERTEXARRAYSSGIXPROC) (GLsizei n, GLuint* arrays);
+typedef GLboolean (GLAPIENTRY * PFNGLISVERTEXARRAYSGIXPROC) (GLuint array);
+typedef void (GLAPIENTRY * PFNGLPRIORITIZEVERTEXARRAYSSGIXPROC) (GLsizei n, const GLuint* arrays, const GLclampf* priorities);
+
+#define glAreVertexArraysResidentSGIX GLEW_GET_FUN(__glewAreVertexArraysResidentSGIX)
+#define glBindVertexArraySGIX GLEW_GET_FUN(__glewBindVertexArraySGIX)
+#define glDeleteVertexArraysSGIX GLEW_GET_FUN(__glewDeleteVertexArraysSGIX)
+#define glGenVertexArraysSGIX GLEW_GET_FUN(__glewGenVertexArraysSGIX)
+#define glIsVertexArraySGIX GLEW_GET_FUN(__glewIsVertexArraySGIX)
+#define glPrioritizeVertexArraysSGIX GLEW_GET_FUN(__glewPrioritizeVertexArraysSGIX)
+
+#define GLEW_SGIX_vertex_array_object GLEW_GET_VAR(__GLEW_SGIX_vertex_array_object)
+
+#endif /* GL_SGIX_vertex_array_object */
+
 /* ------------------------- GL_SGIX_vertex_preclip ------------------------ */
 
 #ifndef GL_SGIX_vertex_preclip
@@ -15431,6 +19427,27 @@ typedef void (GLAPIENTRY * PFNGLTAGSAMPLEBUFFERSGIXPROC) (void);
 #define GLEW_SGIX_ycrcb GLEW_GET_VAR(__GLEW_SGIX_ycrcb)
 
 #endif /* GL_SGIX_ycrcb */
+
+/* ------------------------ GL_SGIX_ycrcb_subsample ------------------------ */
+
+#ifndef GL_SGIX_ycrcb_subsample
+#define GL_SGIX_ycrcb_subsample 1
+
+#define GLEW_SGIX_ycrcb_subsample GLEW_GET_VAR(__GLEW_SGIX_ycrcb_subsample)
+
+#endif /* GL_SGIX_ycrcb_subsample */
+
+/* ----------------------------- GL_SGIX_ycrcba ---------------------------- */
+
+#ifndef GL_SGIX_ycrcba
+#define GL_SGIX_ycrcba 1
+
+#define GL_YCRCB_SGIX 0x8318
+#define GL_YCRCBA_SGIX 0x8319
+
+#define GLEW_SGIX_ycrcba GLEW_GET_VAR(__GLEW_SGIX_ycrcba)
+
+#endif /* GL_SGIX_ycrcba */
 
 /* -------------------------- GL_SGI_color_matrix -------------------------- */
 
@@ -15494,6 +19511,63 @@ typedef void (GLAPIENTRY * PFNGLGETCOLORTABLESGIPROC) (GLenum target, GLenum for
 #define GLEW_SGI_color_table GLEW_GET_VAR(__GLEW_SGI_color_table)
 
 #endif /* GL_SGI_color_table */
+
+/* ----------------------------- GL_SGI_complex ---------------------------- */
+
+#ifndef GL_SGI_complex
+#define GL_SGI_complex 1
+
+#define GLEW_SGI_complex GLEW_GET_VAR(__GLEW_SGI_complex)
+
+#endif /* GL_SGI_complex */
+
+/* -------------------------- GL_SGI_complex_type -------------------------- */
+
+#ifndef GL_SGI_complex_type
+#define GL_SGI_complex_type 1
+
+#define GL_COMPLEX_UNSIGNED_BYTE_SGI 0x81BD
+#define GL_COMPLEX_BYTE_SGI 0x81BE
+#define GL_COMPLEX_UNSIGNED_SHORT_SGI 0x81BF
+#define GL_COMPLEX_SHORT_SGI 0x81C0
+#define GL_COMPLEX_UNSIGNED_INT_SGI 0x81C1
+#define GL_COMPLEX_INT_SGI 0x81C2
+#define GL_COMPLEX_FLOAT_SGI 0x81C3
+
+#define GLEW_SGI_complex_type GLEW_GET_VAR(__GLEW_SGI_complex_type)
+
+#endif /* GL_SGI_complex_type */
+
+/* ------------------------------- GL_SGI_fft ------------------------------ */
+
+#ifndef GL_SGI_fft
+#define GL_SGI_fft 1
+
+#define GL_PIXEL_TRANSFORM_OPERATOR_SGI 0x81C4
+#define GL_CONVOLUTION_SGI 0x81C5
+#define GL_FFT_1D_SGI 0x81C6
+#define GL_PIXEL_TRANSFORM_SGI 0x81C7
+#define GL_MAX_FFT_WIDTH_SGI 0x81C8
+
+typedef void (GLAPIENTRY * PFNGLGETPIXELTRANSFORMPARAMETERFVSGIPROC) (GLenum target, GLenum pname, GLfloat* params);
+typedef void (GLAPIENTRY * PFNGLGETPIXELTRANSFORMPARAMETERIVSGIPROC) (GLenum target, GLenum pname, GLint* params);
+typedef void (GLAPIENTRY * PFNGLPIXELTRANSFORMPARAMETERFSGIPROC) (GLenum target, GLenum pname, GLfloat param);
+typedef void (GLAPIENTRY * PFNGLPIXELTRANSFORMPARAMETERFVSGIPROC) (GLenum target, GLenum pname, const GLfloat* params);
+typedef void (GLAPIENTRY * PFNGLPIXELTRANSFORMPARAMETERISGIPROC) (GLenum target, GLenum pname, GLint param);
+typedef void (GLAPIENTRY * PFNGLPIXELTRANSFORMPARAMETERIVSGIPROC) (GLenum target, GLenum pname, const GLint* params);
+typedef void (GLAPIENTRY * PFNGLPIXELTRANSFORMSGIPROC) (GLenum target);
+
+#define glGetPixelTransformParameterfvSGI GLEW_GET_FUN(__glewGetPixelTransformParameterfvSGI)
+#define glGetPixelTransformParameterivSGI GLEW_GET_FUN(__glewGetPixelTransformParameterivSGI)
+#define glPixelTransformParameterfSGI GLEW_GET_FUN(__glewPixelTransformParameterfSGI)
+#define glPixelTransformParameterfvSGI GLEW_GET_FUN(__glewPixelTransformParameterfvSGI)
+#define glPixelTransformParameteriSGI GLEW_GET_FUN(__glewPixelTransformParameteriSGI)
+#define glPixelTransformParameterivSGI GLEW_GET_FUN(__glewPixelTransformParameterivSGI)
+#define glPixelTransformSGI GLEW_GET_FUN(__glewPixelTransformSGI)
+
+#define GLEW_SGI_fft GLEW_GET_VAR(__GLEW_SGI_fft)
+
+#endif /* GL_SGI_fft */
 
 /* ----------------------- GL_SGI_texture_color_table ---------------------- */
 
@@ -15746,6 +19820,15 @@ typedef void (GLAPIENTRY * PFNGLTEXCOORD4FVERTEX4FVSUNPROC) (const GLfloat* tc, 
 
 #endif /* GL_WIN_phong_shading */
 
+/* ------------------------- GL_WIN_scene_markerXXX ------------------------ */
+
+#ifndef GL_WIN_scene_markerXXX
+#define GL_WIN_scene_markerXXX 1
+
+#define GLEW_WIN_scene_markerXXX GLEW_GET_VAR(__GLEW_WIN_scene_markerXXX)
+
+#endif /* GL_WIN_scene_markerXXX */
+
 /* -------------------------- GL_WIN_specular_fog -------------------------- */
 
 #ifndef GL_WIN_specular_fog
@@ -15772,22 +19855,7 @@ typedef void (GLAPIENTRY * PFNGLADDSWAPHINTRECTWINPROC) (GLint x, GLint y, GLsiz
 
 /* ------------------------------------------------------------------------- */
 
-#if defined(GLEW_MX) && defined(_WIN32)
-#define GLEW_FUN_EXPORT
-#else
-#define GLEW_FUN_EXPORT GLEWAPI
-#endif /* GLEW_MX */
 
-#if defined(GLEW_MX)
-#define GLEW_VAR_EXPORT
-#else
-#define GLEW_VAR_EXPORT GLEWAPI
-#endif /* GLEW_MX */
-
-#if defined(GLEW_MX) && defined(_WIN32)
-struct GLEWContextStruct
-{
-#endif /* GLEW_MX */
 
 GLEW_FUN_EXPORT PFNGLCOPYTEXSUBIMAGE3DPROC __glewCopyTexSubImage3D;
 GLEW_FUN_EXPORT PFNGLDRAWRANGEELEMENTSPROC __glewDrawRangeElements;
@@ -16083,6 +20151,15 @@ GLEW_FUN_EXPORT PFNGLBLENDFUNCSEPARATEIPROC __glewBlendFuncSeparatei;
 GLEW_FUN_EXPORT PFNGLBLENDFUNCIPROC __glewBlendFunci;
 GLEW_FUN_EXPORT PFNGLMINSAMPLESHADINGPROC __glewMinSampleShading;
 
+GLEW_FUN_EXPORT PFNGLGETGRAPHICSRESETSTATUSPROC __glewGetGraphicsResetStatus;
+GLEW_FUN_EXPORT PFNGLGETNCOMPRESSEDTEXIMAGEPROC __glewGetnCompressedTexImage;
+GLEW_FUN_EXPORT PFNGLGETNTEXIMAGEPROC __glewGetnTexImage;
+GLEW_FUN_EXPORT PFNGLGETNUNIFORMDVPROC __glewGetnUniformdv;
+
+GLEW_FUN_EXPORT PFNGLMULTIDRAWARRAYSINDIRECTCOUNTPROC __glewMultiDrawArraysIndirectCount;
+GLEW_FUN_EXPORT PFNGLMULTIDRAWELEMENTSINDIRECTCOUNTPROC __glewMultiDrawElementsIndirectCount;
+GLEW_FUN_EXPORT PFNGLSPECIALIZESHADERPROC __glewSpecializeShader;
+
 GLEW_FUN_EXPORT PFNGLTBUFFERMASK3DFXPROC __glewTbufferMask3DFX;
 
 GLEW_FUN_EXPORT PFNGLDEBUGMESSAGECALLBACKAMDPROC __glewDebugMessageCallbackAMD;
@@ -16094,6 +20171,11 @@ GLEW_FUN_EXPORT PFNGLBLENDEQUATIONINDEXEDAMDPROC __glewBlendEquationIndexedAMD;
 GLEW_FUN_EXPORT PFNGLBLENDEQUATIONSEPARATEINDEXEDAMDPROC __glewBlendEquationSeparateIndexedAMD;
 GLEW_FUN_EXPORT PFNGLBLENDFUNCINDEXEDAMDPROC __glewBlendFuncIndexedAMD;
 GLEW_FUN_EXPORT PFNGLBLENDFUNCSEPARATEINDEXEDAMDPROC __glewBlendFuncSeparateIndexedAMD;
+
+GLEW_FUN_EXPORT PFNGLFRAMEBUFFERSAMPLEPOSITIONSFVAMDPROC __glewFramebufferSamplePositionsfvAMD;
+GLEW_FUN_EXPORT PFNGLGETFRAMEBUFFERPARAMETERFVAMDPROC __glewGetFramebufferParameterfvAMD;
+GLEW_FUN_EXPORT PFNGLGETNAMEDFRAMEBUFFERPARAMETERFVAMDPROC __glewGetNamedFramebufferParameterfvAMD;
+GLEW_FUN_EXPORT PFNGLNAMEDFRAMEBUFFERSAMPLEPOSITIONSFVAMDPROC __glewNamedFramebufferSamplePositionsfvAMD;
 
 GLEW_FUN_EXPORT PFNGLVERTEXATTRIBPARAMETERIAMDPROC __glewVertexAttribParameteriAMD;
 
@@ -16150,6 +20232,8 @@ GLEW_FUN_EXPORT PFNGLQUERYCOUNTERANGLEPROC __glewQueryCounterANGLE;
 
 GLEW_FUN_EXPORT PFNGLGETTRANSLATEDSHADERSOURCEANGLEPROC __glewGetTranslatedShaderSourceANGLE;
 
+GLEW_FUN_EXPORT PFNGLCOPYTEXTURELEVELSAPPLEPROC __glewCopyTextureLevelsAPPLE;
+
 GLEW_FUN_EXPORT PFNGLDRAWELEMENTARRAYAPPLEPROC __glewDrawElementArrayAPPLE;
 GLEW_FUN_EXPORT PFNGLDRAWRANGEELEMENTARRAYAPPLEPROC __glewDrawRangeElementArrayAPPLE;
 GLEW_FUN_EXPORT PFNGLELEMENTPOINTERAPPLEPROC __glewElementPointerAPPLE;
@@ -16168,9 +20252,20 @@ GLEW_FUN_EXPORT PFNGLTESTOBJECTAPPLEPROC __glewTestObjectAPPLE;
 GLEW_FUN_EXPORT PFNGLBUFFERPARAMETERIAPPLEPROC __glewBufferParameteriAPPLE;
 GLEW_FUN_EXPORT PFNGLFLUSHMAPPEDBUFFERRANGEAPPLEPROC __glewFlushMappedBufferRangeAPPLE;
 
+GLEW_FUN_EXPORT PFNGLRENDERBUFFERSTORAGEMULTISAMPLEAPPLEPROC __glewRenderbufferStorageMultisampleAPPLE;
+GLEW_FUN_EXPORT PFNGLRESOLVEMULTISAMPLEFRAMEBUFFERAPPLEPROC __glewResolveMultisampleFramebufferAPPLE;
+
 GLEW_FUN_EXPORT PFNGLGETOBJECTPARAMETERIVAPPLEPROC __glewGetObjectParameterivAPPLE;
 GLEW_FUN_EXPORT PFNGLOBJECTPURGEABLEAPPLEPROC __glewObjectPurgeableAPPLE;
 GLEW_FUN_EXPORT PFNGLOBJECTUNPURGEABLEAPPLEPROC __glewObjectUnpurgeableAPPLE;
+
+GLEW_FUN_EXPORT PFNGLCLIENTWAITSYNCAPPLEPROC __glewClientWaitSyncAPPLE;
+GLEW_FUN_EXPORT PFNGLDELETESYNCAPPLEPROC __glewDeleteSyncAPPLE;
+GLEW_FUN_EXPORT PFNGLFENCESYNCAPPLEPROC __glewFenceSyncAPPLE;
+GLEW_FUN_EXPORT PFNGLGETINTEGER64VAPPLEPROC __glewGetInteger64vAPPLE;
+GLEW_FUN_EXPORT PFNGLGETSYNCIVAPPLEPROC __glewGetSyncivAPPLE;
+GLEW_FUN_EXPORT PFNGLISSYNCAPPLEPROC __glewIsSyncAPPLE;
+GLEW_FUN_EXPORT PFNGLWAITSYNCAPPLEPROC __glewWaitSyncAPPLE;
 
 GLEW_FUN_EXPORT PFNGLGETTEXPARAMETERPOINTERVAPPLEPROC __glewGetTexParameterPointervAPPLE;
 GLEW_FUN_EXPORT PFNGLTEXTURERANGEAPPLEPROC __glewTextureRangeAPPLE;
@@ -16200,6 +20295,8 @@ GLEW_FUN_EXPORT PFNGLSHADERBINARYPROC __glewShaderBinary;
 
 GLEW_FUN_EXPORT PFNGLMEMORYBARRIERBYREGIONPROC __glewMemoryBarrierByRegion;
 
+GLEW_FUN_EXPORT PFNGLPRIMITIVEBOUNDINGBOXARBPROC __glewPrimitiveBoundingBoxARB;
+
 GLEW_FUN_EXPORT PFNGLDRAWARRAYSINSTANCEDBASEINSTANCEPROC __glewDrawArraysInstancedBaseInstance;
 GLEW_FUN_EXPORT PFNGLDRAWELEMENTSINSTANCEDBASEINSTANCEPROC __glewDrawElementsInstancedBaseInstance;
 GLEW_FUN_EXPORT PFNGLDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCEPROC __glewDrawElementsInstancedBaseVertexBaseInstance;
@@ -16225,7 +20322,6 @@ GLEW_FUN_EXPORT PFNGLBINDFRAGDATALOCATIONINDEXEDPROC __glewBindFragDataLocationI
 GLEW_FUN_EXPORT PFNGLGETFRAGDATAINDEXPROC __glewGetFragDataIndex;
 
 GLEW_FUN_EXPORT PFNGLBUFFERSTORAGEPROC __glewBufferStorage;
-GLEW_FUN_EXPORT PFNGLNAMEDBUFFERSTORAGEEXTPROC __glewNamedBufferStorageEXT;
 
 GLEW_FUN_EXPORT PFNGLCREATESYNCFROMCLEVENTARBPROC __glewCreateSyncFromCLeventARB;
 
@@ -16292,6 +20388,10 @@ GLEW_FUN_EXPORT PFNGLGETNAMEDBUFFERSUBDATAPROC __glewGetNamedBufferSubData;
 GLEW_FUN_EXPORT PFNGLGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVPROC __glewGetNamedFramebufferAttachmentParameteriv;
 GLEW_FUN_EXPORT PFNGLGETNAMEDFRAMEBUFFERPARAMETERIVPROC __glewGetNamedFramebufferParameteriv;
 GLEW_FUN_EXPORT PFNGLGETNAMEDRENDERBUFFERPARAMETERIVPROC __glewGetNamedRenderbufferParameteriv;
+GLEW_FUN_EXPORT PFNGLGETQUERYBUFFEROBJECTI64VPROC __glewGetQueryBufferObjecti64v;
+GLEW_FUN_EXPORT PFNGLGETQUERYBUFFEROBJECTIVPROC __glewGetQueryBufferObjectiv;
+GLEW_FUN_EXPORT PFNGLGETQUERYBUFFEROBJECTUI64VPROC __glewGetQueryBufferObjectui64v;
+GLEW_FUN_EXPORT PFNGLGETQUERYBUFFEROBJECTUIVPROC __glewGetQueryBufferObjectuiv;
 GLEW_FUN_EXPORT PFNGLGETTEXTUREIMAGEPROC __glewGetTextureImage;
 GLEW_FUN_EXPORT PFNGLGETTEXTURELEVELPARAMETERFVPROC __glewGetTextureLevelParameterfv;
 GLEW_FUN_EXPORT PFNGLGETTEXTURELEVELPARAMETERIVPROC __glewGetTextureLevelParameteriv;
@@ -16402,6 +20502,8 @@ GLEW_FUN_EXPORT PFNGLPROGRAMPARAMETERIPROC __glewProgramParameteri;
 GLEW_FUN_EXPORT PFNGLGETCOMPRESSEDTEXTURESUBIMAGEPROC __glewGetCompressedTextureSubImage;
 GLEW_FUN_EXPORT PFNGLGETTEXTURESUBIMAGEPROC __glewGetTextureSubImage;
 
+GLEW_FUN_EXPORT PFNGLSPECIALIZESHADERARBPROC __glewSpecializeShaderARB;
+
 GLEW_FUN_EXPORT PFNGLGETUNIFORMDVPROC __glewGetUniformdv;
 GLEW_FUN_EXPORT PFNGLUNIFORM1DPROC __glewUniform1d;
 GLEW_FUN_EXPORT PFNGLUNIFORM1DVPROC __glewUniform1dv;
@@ -16420,6 +20522,43 @@ GLEW_FUN_EXPORT PFNGLUNIFORMMATRIX3X4DVPROC __glewUniformMatrix3x4dv;
 GLEW_FUN_EXPORT PFNGLUNIFORMMATRIX4DVPROC __glewUniformMatrix4dv;
 GLEW_FUN_EXPORT PFNGLUNIFORMMATRIX4X2DVPROC __glewUniformMatrix4x2dv;
 GLEW_FUN_EXPORT PFNGLUNIFORMMATRIX4X3DVPROC __glewUniformMatrix4x3dv;
+
+GLEW_FUN_EXPORT PFNGLGETUNIFORMI64VARBPROC __glewGetUniformi64vARB;
+GLEW_FUN_EXPORT PFNGLGETUNIFORMUI64VARBPROC __glewGetUniformui64vARB;
+GLEW_FUN_EXPORT PFNGLGETNUNIFORMI64VARBPROC __glewGetnUniformi64vARB;
+GLEW_FUN_EXPORT PFNGLGETNUNIFORMUI64VARBPROC __glewGetnUniformui64vARB;
+GLEW_FUN_EXPORT PFNGLPROGRAMUNIFORM1I64ARBPROC __glewProgramUniform1i64ARB;
+GLEW_FUN_EXPORT PFNGLPROGRAMUNIFORM1I64VARBPROC __glewProgramUniform1i64vARB;
+GLEW_FUN_EXPORT PFNGLPROGRAMUNIFORM1UI64ARBPROC __glewProgramUniform1ui64ARB;
+GLEW_FUN_EXPORT PFNGLPROGRAMUNIFORM1UI64VARBPROC __glewProgramUniform1ui64vARB;
+GLEW_FUN_EXPORT PFNGLPROGRAMUNIFORM2I64ARBPROC __glewProgramUniform2i64ARB;
+GLEW_FUN_EXPORT PFNGLPROGRAMUNIFORM2I64VARBPROC __glewProgramUniform2i64vARB;
+GLEW_FUN_EXPORT PFNGLPROGRAMUNIFORM2UI64ARBPROC __glewProgramUniform2ui64ARB;
+GLEW_FUN_EXPORT PFNGLPROGRAMUNIFORM2UI64VARBPROC __glewProgramUniform2ui64vARB;
+GLEW_FUN_EXPORT PFNGLPROGRAMUNIFORM3I64ARBPROC __glewProgramUniform3i64ARB;
+GLEW_FUN_EXPORT PFNGLPROGRAMUNIFORM3I64VARBPROC __glewProgramUniform3i64vARB;
+GLEW_FUN_EXPORT PFNGLPROGRAMUNIFORM3UI64ARBPROC __glewProgramUniform3ui64ARB;
+GLEW_FUN_EXPORT PFNGLPROGRAMUNIFORM3UI64VARBPROC __glewProgramUniform3ui64vARB;
+GLEW_FUN_EXPORT PFNGLPROGRAMUNIFORM4I64ARBPROC __glewProgramUniform4i64ARB;
+GLEW_FUN_EXPORT PFNGLPROGRAMUNIFORM4I64VARBPROC __glewProgramUniform4i64vARB;
+GLEW_FUN_EXPORT PFNGLPROGRAMUNIFORM4UI64ARBPROC __glewProgramUniform4ui64ARB;
+GLEW_FUN_EXPORT PFNGLPROGRAMUNIFORM4UI64VARBPROC __glewProgramUniform4ui64vARB;
+GLEW_FUN_EXPORT PFNGLUNIFORM1I64ARBPROC __glewUniform1i64ARB;
+GLEW_FUN_EXPORT PFNGLUNIFORM1I64VARBPROC __glewUniform1i64vARB;
+GLEW_FUN_EXPORT PFNGLUNIFORM1UI64ARBPROC __glewUniform1ui64ARB;
+GLEW_FUN_EXPORT PFNGLUNIFORM1UI64VARBPROC __glewUniform1ui64vARB;
+GLEW_FUN_EXPORT PFNGLUNIFORM2I64ARBPROC __glewUniform2i64ARB;
+GLEW_FUN_EXPORT PFNGLUNIFORM2I64VARBPROC __glewUniform2i64vARB;
+GLEW_FUN_EXPORT PFNGLUNIFORM2UI64ARBPROC __glewUniform2ui64ARB;
+GLEW_FUN_EXPORT PFNGLUNIFORM2UI64VARBPROC __glewUniform2ui64vARB;
+GLEW_FUN_EXPORT PFNGLUNIFORM3I64ARBPROC __glewUniform3i64ARB;
+GLEW_FUN_EXPORT PFNGLUNIFORM3I64VARBPROC __glewUniform3i64vARB;
+GLEW_FUN_EXPORT PFNGLUNIFORM3UI64ARBPROC __glewUniform3ui64ARB;
+GLEW_FUN_EXPORT PFNGLUNIFORM3UI64VARBPROC __glewUniform3ui64vARB;
+GLEW_FUN_EXPORT PFNGLUNIFORM4I64ARBPROC __glewUniform4i64ARB;
+GLEW_FUN_EXPORT PFNGLUNIFORM4I64VARBPROC __glewUniform4i64vARB;
+GLEW_FUN_EXPORT PFNGLUNIFORM4UI64ARBPROC __glewUniform4ui64ARB;
+GLEW_FUN_EXPORT PFNGLUNIFORM4UI64VARBPROC __glewUniform4ui64vARB;
 
 GLEW_FUN_EXPORT PFNGLCOLORSUBTABLEPROC __glewColorSubTable;
 GLEW_FUN_EXPORT PFNGLCOLORTABLEPROC __glewColorTable;
@@ -16537,8 +20676,12 @@ GLEW_FUN_EXPORT PFNGLGETQUERYOBJECTUIVARBPROC __glewGetQueryObjectuivARB;
 GLEW_FUN_EXPORT PFNGLGETQUERYIVARBPROC __glewGetQueryivARB;
 GLEW_FUN_EXPORT PFNGLISQUERYARBPROC __glewIsQueryARB;
 
+GLEW_FUN_EXPORT PFNGLMAXSHADERCOMPILERTHREADSARBPROC __glewMaxShaderCompilerThreadsARB;
+
 GLEW_FUN_EXPORT PFNGLPOINTPARAMETERFARBPROC __glewPointParameterfARB;
 GLEW_FUN_EXPORT PFNGLPOINTPARAMETERFVARBPROC __glewPointParameterfvARB;
+
+GLEW_FUN_EXPORT PFNGLPOLYGONOFFSETCLAMPPROC __glewPolygonOffsetClamp;
 
 GLEW_FUN_EXPORT PFNGLGETPROGRAMINTERFACEIVPROC __glewGetProgramInterfaceiv;
 GLEW_FUN_EXPORT PFNGLGETPROGRAMRESOURCEINDEXPROC __glewGetProgramResourceIndex;
@@ -16569,6 +20712,9 @@ GLEW_FUN_EXPORT PFNGLGETNUNIFORMFVARBPROC __glewGetnUniformfvARB;
 GLEW_FUN_EXPORT PFNGLGETNUNIFORMIVARBPROC __glewGetnUniformivARB;
 GLEW_FUN_EXPORT PFNGLGETNUNIFORMUIVARBPROC __glewGetnUniformuivARB;
 GLEW_FUN_EXPORT PFNGLREADNPIXELSARBPROC __glewReadnPixelsARB;
+
+GLEW_FUN_EXPORT PFNGLFRAMEBUFFERSAMPLELOCATIONSFVARBPROC __glewFramebufferSampleLocationsfvARB;
+GLEW_FUN_EXPORT PFNGLNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARBPROC __glewNamedFramebufferSampleLocationsfvARB;
 
 GLEW_FUN_EXPORT PFNGLMINSAMPLESHADINGARBPROC __glewMinSampleShadingARB;
 
@@ -16714,7 +20860,6 @@ GLEW_FUN_EXPORT PFNGLNAMEDSTRINGARBPROC __glewNamedStringARB;
 GLEW_FUN_EXPORT PFNGLBUFFERPAGECOMMITMENTARBPROC __glewBufferPageCommitmentARB;
 
 GLEW_FUN_EXPORT PFNGLTEXPAGECOMMITMENTARBPROC __glewTexPageCommitmentARB;
-GLEW_FUN_EXPORT PFNGLTEXTUREPAGECOMMITMENTEXTPROC __glewTexturePageCommitmentEXT;
 
 GLEW_FUN_EXPORT PFNGLCLIENTWAITSYNCPROC __glewClientWaitSync;
 GLEW_FUN_EXPORT PFNGLDELETESYNCPROC __glewDeleteSync;
@@ -16750,9 +20895,6 @@ GLEW_FUN_EXPORT PFNGLTEXIMAGE3DMULTISAMPLEPROC __glewTexImage3DMultisample;
 GLEW_FUN_EXPORT PFNGLTEXSTORAGE1DPROC __glewTexStorage1D;
 GLEW_FUN_EXPORT PFNGLTEXSTORAGE2DPROC __glewTexStorage2D;
 GLEW_FUN_EXPORT PFNGLTEXSTORAGE3DPROC __glewTexStorage3D;
-GLEW_FUN_EXPORT PFNGLTEXTURESTORAGE1DEXTPROC __glewTextureStorage1DEXT;
-GLEW_FUN_EXPORT PFNGLTEXTURESTORAGE2DEXTPROC __glewTextureStorage2DEXT;
-GLEW_FUN_EXPORT PFNGLTEXTURESTORAGE3DEXTPROC __glewTextureStorage3DEXT;
 
 GLEW_FUN_EXPORT PFNGLTEXSTORAGE2DMULTISAMPLEPROC __glewTexStorage2DMultisample;
 GLEW_FUN_EXPORT PFNGLTEXSTORAGE3DMULTISAMPLEPROC __glewTexStorage3DMultisample;
@@ -17081,6 +21223,10 @@ GLEW_FUN_EXPORT PFNGLVERTEXSTREAM4IVATIPROC __glewVertexStream4ivATI;
 GLEW_FUN_EXPORT PFNGLVERTEXSTREAM4SATIPROC __glewVertexStream4sATI;
 GLEW_FUN_EXPORT PFNGLVERTEXSTREAM4SVATIPROC __glewVertexStream4svATI;
 
+GLEW_FUN_EXPORT PFNGLDRAWARRAYSINSTANCEDBASEINSTANCEEXTPROC __glewDrawArraysInstancedBaseInstanceEXT;
+GLEW_FUN_EXPORT PFNGLDRAWELEMENTSINSTANCEDBASEINSTANCEEXTPROC __glewDrawElementsInstancedBaseInstanceEXT;
+GLEW_FUN_EXPORT PFNGLDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCEEXTPROC __glewDrawElementsInstancedBaseVertexBaseInstanceEXT;
+
 GLEW_FUN_EXPORT PFNGLGETUNIFORMBUFFERSIZEEXTPROC __glewGetUniformBufferSizeEXT;
 GLEW_FUN_EXPORT PFNGLGETUNIFORMOFFSETEXTPROC __glewGetUniformOffsetEXT;
 GLEW_FUN_EXPORT PFNGLUNIFORMBUFFEREXTPROC __glewUniformBufferEXT;
@@ -17089,9 +21235,19 @@ GLEW_FUN_EXPORT PFNGLBLENDCOLOREXTPROC __glewBlendColorEXT;
 
 GLEW_FUN_EXPORT PFNGLBLENDEQUATIONSEPARATEEXTPROC __glewBlendEquationSeparateEXT;
 
+GLEW_FUN_EXPORT PFNGLBINDFRAGDATALOCATIONINDEXEDEXTPROC __glewBindFragDataLocationIndexedEXT;
+GLEW_FUN_EXPORT PFNGLGETFRAGDATAINDEXEXTPROC __glewGetFragDataIndexEXT;
+GLEW_FUN_EXPORT PFNGLGETPROGRAMRESOURCELOCATIONINDEXEXTPROC __glewGetProgramResourceLocationIndexEXT;
+
 GLEW_FUN_EXPORT PFNGLBLENDFUNCSEPARATEEXTPROC __glewBlendFuncSeparateEXT;
 
 GLEW_FUN_EXPORT PFNGLBLENDEQUATIONEXTPROC __glewBlendEquationEXT;
+
+GLEW_FUN_EXPORT PFNGLBUFFERSTORAGEEXTPROC __glewBufferStorageEXT;
+GLEW_FUN_EXPORT PFNGLNAMEDBUFFERSTORAGEEXTPROC __glewNamedBufferStorageEXT;
+
+GLEW_FUN_EXPORT PFNGLCLEARTEXIMAGEEXTPROC __glewClearTexImageEXT;
+GLEW_FUN_EXPORT PFNGLCLEARTEXSUBIMAGEEXTPROC __glewClearTexSubImageEXT;
 
 GLEW_FUN_EXPORT PFNGLCOLORSUBTABLEEXTPROC __glewColorSubTableEXT;
 GLEW_FUN_EXPORT PFNGLCOPYCOLORSUBTABLEEXTPROC __glewCopyColorSubTableEXT;
@@ -17115,6 +21271,8 @@ GLEW_FUN_EXPORT PFNGLSEPARABLEFILTER2DEXTPROC __glewSeparableFilter2DEXT;
 
 GLEW_FUN_EXPORT PFNGLBINORMALPOINTEREXTPROC __glewBinormalPointerEXT;
 GLEW_FUN_EXPORT PFNGLTANGENTPOINTEREXTPROC __glewTangentPointerEXT;
+
+GLEW_FUN_EXPORT PFNGLCOPYIMAGESUBDATAEXTPROC __glewCopyImageSubDataEXT;
 
 GLEW_FUN_EXPORT PFNGLCOPYTEXIMAGE1DEXTPROC __glewCopyTexImage1DEXT;
 GLEW_FUN_EXPORT PFNGLCOPYTEXIMAGE2DEXTPROC __glewCopyTexImage2DEXT;
@@ -17349,6 +21507,10 @@ GLEW_FUN_EXPORT PFNGLVERTEXARRAYVERTEXATTRIBIOFFSETEXTPROC __glewVertexArrayVert
 GLEW_FUN_EXPORT PFNGLVERTEXARRAYVERTEXATTRIBOFFSETEXTPROC __glewVertexArrayVertexAttribOffsetEXT;
 GLEW_FUN_EXPORT PFNGLVERTEXARRAYVERTEXOFFSETEXTPROC __glewVertexArrayVertexOffsetEXT;
 
+GLEW_FUN_EXPORT PFNGLDISCARDFRAMEBUFFEREXTPROC __glewDiscardFramebufferEXT;
+
+GLEW_FUN_EXPORT PFNGLDRAWBUFFERSEXTPROC __glewDrawBuffersEXT;
+
 GLEW_FUN_EXPORT PFNGLCOLORMASKINDEXEDEXTPROC __glewColorMaskIndexedEXT;
 GLEW_FUN_EXPORT PFNGLDISABLEINDEXEDEXTPROC __glewDisableIndexedEXT;
 GLEW_FUN_EXPORT PFNGLENABLEINDEXEDEXTPROC __glewEnableIndexedEXT;
@@ -17356,10 +21518,27 @@ GLEW_FUN_EXPORT PFNGLGETBOOLEANINDEXEDVEXTPROC __glewGetBooleanIndexedvEXT;
 GLEW_FUN_EXPORT PFNGLGETINTEGERINDEXEDVEXTPROC __glewGetIntegerIndexedvEXT;
 GLEW_FUN_EXPORT PFNGLISENABLEDINDEXEDEXTPROC __glewIsEnabledIndexedEXT;
 
+GLEW_FUN_EXPORT PFNGLBLENDEQUATIONSEPARATEIEXTPROC __glewBlendEquationSeparateiEXT;
+GLEW_FUN_EXPORT PFNGLBLENDEQUATIONIEXTPROC __glewBlendEquationiEXT;
+GLEW_FUN_EXPORT PFNGLBLENDFUNCSEPARATEIEXTPROC __glewBlendFuncSeparateiEXT;
+GLEW_FUN_EXPORT PFNGLBLENDFUNCIEXTPROC __glewBlendFunciEXT;
+GLEW_FUN_EXPORT PFNGLCOLORMASKIEXTPROC __glewColorMaskiEXT;
+GLEW_FUN_EXPORT PFNGLDISABLEIEXTPROC __glewDisableiEXT;
+GLEW_FUN_EXPORT PFNGLENABLEIEXTPROC __glewEnableiEXT;
+GLEW_FUN_EXPORT PFNGLISENABLEDIEXTPROC __glewIsEnablediEXT;
+
+GLEW_FUN_EXPORT PFNGLDRAWELEMENTSBASEVERTEXEXTPROC __glewDrawElementsBaseVertexEXT;
+GLEW_FUN_EXPORT PFNGLDRAWELEMENTSINSTANCEDBASEVERTEXEXTPROC __glewDrawElementsInstancedBaseVertexEXT;
+GLEW_FUN_EXPORT PFNGLDRAWRANGEELEMENTSBASEVERTEXEXTPROC __glewDrawRangeElementsBaseVertexEXT;
+GLEW_FUN_EXPORT PFNGLMULTIDRAWELEMENTSBASEVERTEXEXTPROC __glewMultiDrawElementsBaseVertexEXT;
+
 GLEW_FUN_EXPORT PFNGLDRAWARRAYSINSTANCEDEXTPROC __glewDrawArraysInstancedEXT;
 GLEW_FUN_EXPORT PFNGLDRAWELEMENTSINSTANCEDEXTPROC __glewDrawElementsInstancedEXT;
 
 GLEW_FUN_EXPORT PFNGLDRAWRANGEELEMENTSEXTPROC __glewDrawRangeElementsEXT;
+
+GLEW_FUN_EXPORT PFNGLBUFFERSTORAGEEXTERNALEXTPROC __glewBufferStorageExternalEXT;
+GLEW_FUN_EXPORT PFNGLNAMEDBUFFERSTORAGEEXTERNALEXTPROC __glewNamedBufferStorageExternalEXT;
 
 GLEW_FUN_EXPORT PFNGLFOGCOORDPOINTEREXTPROC __glewFogCoordPointerEXT;
 GLEW_FUN_EXPORT PFNGLFOGCOORDDEXTPROC __glewFogCoorddEXT;
@@ -17465,15 +21644,54 @@ GLEW_FUN_EXPORT PFNGLINDEXFUNCEXTPROC __glewIndexFuncEXT;
 
 GLEW_FUN_EXPORT PFNGLINDEXMATERIALEXTPROC __glewIndexMaterialEXT;
 
+GLEW_FUN_EXPORT PFNGLVERTEXATTRIBDIVISOREXTPROC __glewVertexAttribDivisorEXT;
+
 GLEW_FUN_EXPORT PFNGLAPPLYTEXTUREEXTPROC __glewApplyTextureEXT;
 GLEW_FUN_EXPORT PFNGLTEXTURELIGHTEXTPROC __glewTextureLightEXT;
 GLEW_FUN_EXPORT PFNGLTEXTUREMATERIALEXTPROC __glewTextureMaterialEXT;
 
+GLEW_FUN_EXPORT PFNGLFLUSHMAPPEDBUFFERRANGEEXTPROC __glewFlushMappedBufferRangeEXT;
+GLEW_FUN_EXPORT PFNGLMAPBUFFERRANGEEXTPROC __glewMapBufferRangeEXT;
+
+GLEW_FUN_EXPORT PFNGLBUFFERSTORAGEMEMEXTPROC __glewBufferStorageMemEXT;
+GLEW_FUN_EXPORT PFNGLCREATEMEMORYOBJECTSEXTPROC __glewCreateMemoryObjectsEXT;
+GLEW_FUN_EXPORT PFNGLDELETEMEMORYOBJECTSEXTPROC __glewDeleteMemoryObjectsEXT;
+GLEW_FUN_EXPORT PFNGLGETMEMORYOBJECTPARAMETERIVEXTPROC __glewGetMemoryObjectParameterivEXT;
+GLEW_FUN_EXPORT PFNGLGETUNSIGNEDBYTEI_VEXTPROC __glewGetUnsignedBytei_vEXT;
+GLEW_FUN_EXPORT PFNGLGETUNSIGNEDBYTEVEXTPROC __glewGetUnsignedBytevEXT;
+GLEW_FUN_EXPORT PFNGLISMEMORYOBJECTEXTPROC __glewIsMemoryObjectEXT;
+GLEW_FUN_EXPORT PFNGLMEMORYOBJECTPARAMETERIVEXTPROC __glewMemoryObjectParameterivEXT;
+GLEW_FUN_EXPORT PFNGLNAMEDBUFFERSTORAGEMEMEXTPROC __glewNamedBufferStorageMemEXT;
+GLEW_FUN_EXPORT PFNGLTEXSTORAGEMEM1DEXTPROC __glewTexStorageMem1DEXT;
+GLEW_FUN_EXPORT PFNGLTEXSTORAGEMEM2DEXTPROC __glewTexStorageMem2DEXT;
+GLEW_FUN_EXPORT PFNGLTEXSTORAGEMEM2DMULTISAMPLEEXTPROC __glewTexStorageMem2DMultisampleEXT;
+GLEW_FUN_EXPORT PFNGLTEXSTORAGEMEM3DEXTPROC __glewTexStorageMem3DEXT;
+GLEW_FUN_EXPORT PFNGLTEXSTORAGEMEM3DMULTISAMPLEEXTPROC __glewTexStorageMem3DMultisampleEXT;
+GLEW_FUN_EXPORT PFNGLTEXTURESTORAGEMEM1DEXTPROC __glewTextureStorageMem1DEXT;
+GLEW_FUN_EXPORT PFNGLTEXTURESTORAGEMEM2DEXTPROC __glewTextureStorageMem2DEXT;
+GLEW_FUN_EXPORT PFNGLTEXTURESTORAGEMEM2DMULTISAMPLEEXTPROC __glewTextureStorageMem2DMultisampleEXT;
+GLEW_FUN_EXPORT PFNGLTEXTURESTORAGEMEM3DEXTPROC __glewTextureStorageMem3DEXT;
+GLEW_FUN_EXPORT PFNGLTEXTURESTORAGEMEM3DMULTISAMPLEEXTPROC __glewTextureStorageMem3DMultisampleEXT;
+
+GLEW_FUN_EXPORT PFNGLIMPORTMEMORYFDEXTPROC __glewImportMemoryFdEXT;
+
+GLEW_FUN_EXPORT PFNGLIMPORTMEMORYWIN32HANDLEEXTPROC __glewImportMemoryWin32HandleEXT;
+GLEW_FUN_EXPORT PFNGLIMPORTMEMORYWIN32NAMEEXTPROC __glewImportMemoryWin32NameEXT;
+
 GLEW_FUN_EXPORT PFNGLMULTIDRAWARRAYSEXTPROC __glewMultiDrawArraysEXT;
 GLEW_FUN_EXPORT PFNGLMULTIDRAWELEMENTSEXTPROC __glewMultiDrawElementsEXT;
 
+GLEW_FUN_EXPORT PFNGLMULTIDRAWARRAYSINDIRECTEXTPROC __glewMultiDrawArraysIndirectEXT;
+GLEW_FUN_EXPORT PFNGLMULTIDRAWELEMENTSINDIRECTEXTPROC __glewMultiDrawElementsIndirectEXT;
+
 GLEW_FUN_EXPORT PFNGLSAMPLEMASKEXTPROC __glewSampleMaskEXT;
 GLEW_FUN_EXPORT PFNGLSAMPLEPATTERNEXTPROC __glewSamplePatternEXT;
+
+GLEW_FUN_EXPORT PFNGLFRAMEBUFFERTEXTURE2DMULTISAMPLEEXTPROC __glewFramebufferTexture2DMultisampleEXT;
+
+GLEW_FUN_EXPORT PFNGLDRAWBUFFERSINDEXEDEXTPROC __glewDrawBuffersIndexedEXT;
+GLEW_FUN_EXPORT PFNGLGETINTEGERI_VEXTPROC __glewGetIntegeri_vEXT;
+GLEW_FUN_EXPORT PFNGLREADBUFFERINDEXEDEXTPROC __glewReadBufferIndexedEXT;
 
 GLEW_FUN_EXPORT PFNGLCOLORTABLEEXTPROC __glewColorTableEXT;
 GLEW_FUN_EXPORT PFNGLGETCOLORTABLEEXTPROC __glewGetColorTableEXT;
@@ -17492,7 +21710,14 @@ GLEW_FUN_EXPORT PFNGLPOINTPARAMETERFVEXTPROC __glewPointParameterfvEXT;
 
 GLEW_FUN_EXPORT PFNGLPOLYGONOFFSETEXTPROC __glewPolygonOffsetEXT;
 
+GLEW_FUN_EXPORT PFNGLPOLYGONOFFSETCLAMPEXTPROC __glewPolygonOffsetClampEXT;
+
 GLEW_FUN_EXPORT PFNGLPROVOKINGVERTEXEXTPROC __glewProvokingVertexEXT;
+
+GLEW_FUN_EXPORT PFNGLCOVERAGEMODULATIONNVPROC __glewCoverageModulationNV;
+GLEW_FUN_EXPORT PFNGLCOVERAGEMODULATIONTABLENVPROC __glewCoverageModulationTableNV;
+GLEW_FUN_EXPORT PFNGLGETCOVERAGEMODULATIONTABLENVPROC __glewGetCoverageModulationTableNV;
+GLEW_FUN_EXPORT PFNGLRASTERSAMPLESEXTPROC __glewRasterSamplesEXT;
 
 GLEW_FUN_EXPORT PFNGLBEGINSCENEEXTPROC __glewBeginSceneEXT;
 GLEW_FUN_EXPORT PFNGLENDSCENEEXTPROC __glewEndSceneEXT;
@@ -17515,12 +21740,32 @@ GLEW_FUN_EXPORT PFNGLSECONDARYCOLOR3USEXTPROC __glewSecondaryColor3usEXT;
 GLEW_FUN_EXPORT PFNGLSECONDARYCOLOR3USVEXTPROC __glewSecondaryColor3usvEXT;
 GLEW_FUN_EXPORT PFNGLSECONDARYCOLORPOINTEREXTPROC __glewSecondaryColorPointerEXT;
 
+GLEW_FUN_EXPORT PFNGLDELETESEMAPHORESEXTPROC __glewDeleteSemaphoresEXT;
+GLEW_FUN_EXPORT PFNGLGENSEMAPHORESEXTPROC __glewGenSemaphoresEXT;
+GLEW_FUN_EXPORT PFNGLGETSEMAPHOREPARAMETERUI64VEXTPROC __glewGetSemaphoreParameterui64vEXT;
+GLEW_FUN_EXPORT PFNGLISSEMAPHOREEXTPROC __glewIsSemaphoreEXT;
+GLEW_FUN_EXPORT PFNGLSEMAPHOREPARAMETERUI64VEXTPROC __glewSemaphoreParameterui64vEXT;
+GLEW_FUN_EXPORT PFNGLSIGNALSEMAPHOREEXTPROC __glewSignalSemaphoreEXT;
+GLEW_FUN_EXPORT PFNGLWAITSEMAPHOREEXTPROC __glewWaitSemaphoreEXT;
+
+GLEW_FUN_EXPORT PFNGLIMPORTSEMAPHOREFDEXTPROC __glewImportSemaphoreFdEXT;
+
+GLEW_FUN_EXPORT PFNGLIMPORTSEMAPHOREWIN32HANDLEEXTPROC __glewImportSemaphoreWin32HandleEXT;
+GLEW_FUN_EXPORT PFNGLIMPORTSEMAPHOREWIN32NAMEEXTPROC __glewImportSemaphoreWin32NameEXT;
+
 GLEW_FUN_EXPORT PFNGLACTIVEPROGRAMEXTPROC __glewActiveProgramEXT;
 GLEW_FUN_EXPORT PFNGLCREATESHADERPROGRAMEXTPROC __glewCreateShaderProgramEXT;
 GLEW_FUN_EXPORT PFNGLUSESHADERPROGRAMEXTPROC __glewUseShaderProgramEXT;
 
 GLEW_FUN_EXPORT PFNGLBINDIMAGETEXTUREEXTPROC __glewBindImageTextureEXT;
 GLEW_FUN_EXPORT PFNGLMEMORYBARRIEREXTPROC __glewMemoryBarrierEXT;
+
+GLEW_FUN_EXPORT PFNGLCLEARPIXELLOCALSTORAGEUIEXTPROC __glewClearPixelLocalStorageuiEXT;
+GLEW_FUN_EXPORT PFNGLFRAMEBUFFERPIXELLOCALSTORAGESIZEEXTPROC __glewFramebufferPixelLocalStorageSizeEXT;
+GLEW_FUN_EXPORT PFNGLGETFRAMEBUFFERPIXELLOCALSTORAGESIZEEXTPROC __glewGetFramebufferPixelLocalStorageSizeEXT;
+
+GLEW_FUN_EXPORT PFNGLTEXPAGECOMMITMENTEXTPROC __glewTexPageCommitmentEXT;
+GLEW_FUN_EXPORT PFNGLTEXTUREPAGECOMMITMENTEXTPROC __glewTexturePageCommitmentEXT;
 
 GLEW_FUN_EXPORT PFNGLACTIVESTENCILFACEEXTPROC __glewActiveStencilFaceEXT;
 
@@ -17550,6 +21795,15 @@ GLEW_FUN_EXPORT PFNGLPRIORITIZETEXTURESEXTPROC __glewPrioritizeTexturesEXT;
 
 GLEW_FUN_EXPORT PFNGLTEXTURENORMALEXTPROC __glewTextureNormalEXT;
 
+GLEW_FUN_EXPORT PFNGLTEXSTORAGE1DEXTPROC __glewTexStorage1DEXT;
+GLEW_FUN_EXPORT PFNGLTEXSTORAGE2DEXTPROC __glewTexStorage2DEXT;
+GLEW_FUN_EXPORT PFNGLTEXSTORAGE3DEXTPROC __glewTexStorage3DEXT;
+GLEW_FUN_EXPORT PFNGLTEXTURESTORAGE1DEXTPROC __glewTextureStorage1DEXT;
+GLEW_FUN_EXPORT PFNGLTEXTURESTORAGE2DEXTPROC __glewTextureStorage2DEXT;
+GLEW_FUN_EXPORT PFNGLTEXTURESTORAGE3DEXTPROC __glewTextureStorage3DEXT;
+
+GLEW_FUN_EXPORT PFNGLTEXTUREVIEWEXTPROC __glewTextureViewEXT;
+
 GLEW_FUN_EXPORT PFNGLGETQUERYOBJECTI64VEXTPROC __glewGetQueryObjecti64vEXT;
 GLEW_FUN_EXPORT PFNGLGETQUERYOBJECTUI64VEXTPROC __glewGetQueryObjectui64vEXT;
 
@@ -17569,6 +21823,10 @@ GLEW_FUN_EXPORT PFNGLINDEXPOINTEREXTPROC __glewIndexPointerEXT;
 GLEW_FUN_EXPORT PFNGLNORMALPOINTEREXTPROC __glewNormalPointerEXT;
 GLEW_FUN_EXPORT PFNGLTEXCOORDPOINTEREXTPROC __glewTexCoordPointerEXT;
 GLEW_FUN_EXPORT PFNGLVERTEXPOINTEREXTPROC __glewVertexPointerEXT;
+
+GLEW_FUN_EXPORT PFNGLBINDARRAYSETEXTPROC __glewBindArraySetEXT;
+GLEW_FUN_EXPORT PFNGLCREATEARRAYSETEXTPROC __glewCreateArraySetExt;
+GLEW_FUN_EXPORT PFNGLDELETEARRAYSETSEXTPROC __glewDeleteArraySetsEXT;
 
 GLEW_FUN_EXPORT PFNGLGETVERTEXATTRIBLDVEXTPROC __glewGetVertexAttribLdvEXT;
 GLEW_FUN_EXPORT PFNGLVERTEXARRAYVERTEXATTRIBLOFFSETEXTPROC __glewVertexArrayVertexAttribLOffsetEXT;
@@ -17628,6 +21886,11 @@ GLEW_FUN_EXPORT PFNGLWRITEMASKEXTPROC __glewWriteMaskEXT;
 GLEW_FUN_EXPORT PFNGLVERTEXWEIGHTPOINTEREXTPROC __glewVertexWeightPointerEXT;
 GLEW_FUN_EXPORT PFNGLVERTEXWEIGHTFEXTPROC __glewVertexWeightfEXT;
 GLEW_FUN_EXPORT PFNGLVERTEXWEIGHTFVEXTPROC __glewVertexWeightfvEXT;
+
+GLEW_FUN_EXPORT PFNGLACQUIREKEYEDMUTEXWIN32EXTPROC __glewAcquireKeyedMutexWin32EXT;
+GLEW_FUN_EXPORT PFNGLRELEASEKEYEDMUTEXWIN32EXTPROC __glewReleaseKeyedMutexWin32EXT;
+
+GLEW_FUN_EXPORT PFNGLWINDOWRECTANGLESEXTPROC __glewWindowRectanglesEXT;
 
 GLEW_FUN_EXPORT PFNGLIMPORTSYNCEXTPROC __glewImportSyncEXT;
 
@@ -17690,6 +21953,8 @@ GLEW_FUN_EXPORT PFNGLOBJECTPTRLABELPROC __glewObjectPtrLabel;
 GLEW_FUN_EXPORT PFNGLPOPDEBUGGROUPPROC __glewPopDebugGroup;
 GLEW_FUN_EXPORT PFNGLPUSHDEBUGGROUPPROC __glewPushDebugGroup;
 
+GLEW_FUN_EXPORT PFNGLMAXSHADERCOMPILERTHREADSKHRPROC __glewMaxShaderCompilerThreadsKHR;
+
 GLEW_FUN_EXPORT PFNGLGETNUNIFORMFVPROC __glewGetnUniformfv;
 GLEW_FUN_EXPORT PFNGLGETNUNIFORMIVPROC __glewGetnUniformiv;
 GLEW_FUN_EXPORT PFNGLGETNUNIFORMUIVPROC __glewGetnUniformuiv;
@@ -17731,6 +21996,13 @@ GLEW_FUN_EXPORT PFNGLWINDOWPOS4SVMESAPROC __glewWindowPos4svMESA;
 GLEW_FUN_EXPORT PFNGLBEGINCONDITIONALRENDERNVXPROC __glewBeginConditionalRenderNVX;
 GLEW_FUN_EXPORT PFNGLENDCONDITIONALRENDERNVXPROC __glewEndConditionalRenderNVX;
 
+GLEW_FUN_EXPORT PFNGLLGPUCOPYIMAGESUBDATANVXPROC __glewLGPUCopyImageSubDataNVX;
+GLEW_FUN_EXPORT PFNGLLGPUINTERLOCKNVXPROC __glewLGPUInterlockNVX;
+GLEW_FUN_EXPORT PFNGLLGPUNAMEDBUFFERSUBDATANVXPROC __glewLGPUNamedBufferSubDataNVX;
+
+GLEW_FUN_EXPORT PFNGLSTEREOPARAMETERFNVPROC __glewStereoParameterfNV;
+GLEW_FUN_EXPORT PFNGLSTEREOPARAMETERINVPROC __glewStereoParameteriNV;
+
 GLEW_FUN_EXPORT PFNGLMULTIDRAWARRAYSINDIRECTBINDLESSNVPROC __glewMultiDrawArraysIndirectBindlessNV;
 GLEW_FUN_EXPORT PFNGLMULTIDRAWELEMENTSINDIRECTBINDLESSNVPROC __glewMultiDrawElementsIndirectBindlessNV;
 
@@ -17754,8 +22026,36 @@ GLEW_FUN_EXPORT PFNGLUNIFORMHANDLEUI64VNVPROC __glewUniformHandleui64vNV;
 GLEW_FUN_EXPORT PFNGLBLENDBARRIERNVPROC __glewBlendBarrierNV;
 GLEW_FUN_EXPORT PFNGLBLENDPARAMETERINVPROC __glewBlendParameteriNV;
 
+GLEW_FUN_EXPORT PFNGLVIEWPORTPOSITIONWSCALENVPROC __glewViewportPositionWScaleNV;
+
+GLEW_FUN_EXPORT PFNGLCALLCOMMANDLISTNVPROC __glewCallCommandListNV;
+GLEW_FUN_EXPORT PFNGLCOMMANDLISTSEGMENTSNVPROC __glewCommandListSegmentsNV;
+GLEW_FUN_EXPORT PFNGLCOMPILECOMMANDLISTNVPROC __glewCompileCommandListNV;
+GLEW_FUN_EXPORT PFNGLCREATECOMMANDLISTSNVPROC __glewCreateCommandListsNV;
+GLEW_FUN_EXPORT PFNGLCREATESTATESNVPROC __glewCreateStatesNV;
+GLEW_FUN_EXPORT PFNGLDELETECOMMANDLISTSNVPROC __glewDeleteCommandListsNV;
+GLEW_FUN_EXPORT PFNGLDELETESTATESNVPROC __glewDeleteStatesNV;
+GLEW_FUN_EXPORT PFNGLDRAWCOMMANDSADDRESSNVPROC __glewDrawCommandsAddressNV;
+GLEW_FUN_EXPORT PFNGLDRAWCOMMANDSNVPROC __glewDrawCommandsNV;
+GLEW_FUN_EXPORT PFNGLDRAWCOMMANDSSTATESADDRESSNVPROC __glewDrawCommandsStatesAddressNV;
+GLEW_FUN_EXPORT PFNGLDRAWCOMMANDSSTATESNVPROC __glewDrawCommandsStatesNV;
+GLEW_FUN_EXPORT PFNGLGETCOMMANDHEADERNVPROC __glewGetCommandHeaderNV;
+GLEW_FUN_EXPORT PFNGLGETSTAGEINDEXNVPROC __glewGetStageIndexNV;
+GLEW_FUN_EXPORT PFNGLISCOMMANDLISTNVPROC __glewIsCommandListNV;
+GLEW_FUN_EXPORT PFNGLISSTATENVPROC __glewIsStateNV;
+GLEW_FUN_EXPORT PFNGLLISTDRAWCOMMANDSSTATESCLIENTNVPROC __glewListDrawCommandsStatesClientNV;
+GLEW_FUN_EXPORT PFNGLSTATECAPTURENVPROC __glewStateCaptureNV;
+
 GLEW_FUN_EXPORT PFNGLBEGINCONDITIONALRENDERNVPROC __glewBeginConditionalRenderNV;
 GLEW_FUN_EXPORT PFNGLENDCONDITIONALRENDERNVPROC __glewEndConditionalRenderNV;
+
+GLEW_FUN_EXPORT PFNGLSUBPIXELPRECISIONBIASNVPROC __glewSubpixelPrecisionBiasNV;
+
+GLEW_FUN_EXPORT PFNGLCONSERVATIVERASTERPARAMETERFNVPROC __glewConservativeRasterParameterfNV;
+
+GLEW_FUN_EXPORT PFNGLCONSERVATIVERASTERPARAMETERINVPROC __glewConservativeRasterParameteriNV;
+
+GLEW_FUN_EXPORT PFNGLCOPYBUFFERSUBDATANVPROC __glewCopyBufferSubDataNV;
 
 GLEW_FUN_EXPORT PFNGLCOPYIMAGESUBDATANVPROC __glewCopyImageSubDataNV;
 
@@ -17763,7 +22063,18 @@ GLEW_FUN_EXPORT PFNGLCLEARDEPTHDNVPROC __glewClearDepthdNV;
 GLEW_FUN_EXPORT PFNGLDEPTHBOUNDSDNVPROC __glewDepthBoundsdNV;
 GLEW_FUN_EXPORT PFNGLDEPTHRANGEDNVPROC __glewDepthRangedNV;
 
+GLEW_FUN_EXPORT PFNGLDRAWBUFFERSNVPROC __glewDrawBuffersNV;
+
+GLEW_FUN_EXPORT PFNGLDRAWARRAYSINSTANCEDNVPROC __glewDrawArraysInstancedNV;
+GLEW_FUN_EXPORT PFNGLDRAWELEMENTSINSTANCEDNVPROC __glewDrawElementsInstancedNV;
+
 GLEW_FUN_EXPORT PFNGLDRAWTEXTURENVPROC __glewDrawTextureNV;
+
+GLEW_FUN_EXPORT PFNGLDRAWVKIMAGENVPROC __glewDrawVkImageNV;
+GLEW_FUN_EXPORT PFNGLGETVKPROCADDRNVPROC __glewGetVkProcAddrNV;
+GLEW_FUN_EXPORT PFNGLSIGNALVKFENCENVPROC __glewSignalVkFenceNV;
+GLEW_FUN_EXPORT PFNGLSIGNALVKSEMAPHORENVPROC __glewSignalVkSemaphoreNV;
+GLEW_FUN_EXPORT PFNGLWAITVKSEMAPHORENVPROC __glewWaitVkSemaphoreNV;
 
 GLEW_FUN_EXPORT PFNGLEVALMAPSNVPROC __glewEvalMapsNV;
 GLEW_FUN_EXPORT PFNGLGETMAPATTRIBPARAMETERFVNVPROC __glewGetMapAttribParameterfvNV;
@@ -17787,6 +22098,8 @@ GLEW_FUN_EXPORT PFNGLISFENCENVPROC __glewIsFenceNV;
 GLEW_FUN_EXPORT PFNGLSETFENCENVPROC __glewSetFenceNV;
 GLEW_FUN_EXPORT PFNGLTESTFENCENVPROC __glewTestFenceNV;
 
+GLEW_FUN_EXPORT PFNGLFRAGMENTCOVERAGECOLORNVPROC __glewFragmentCoverageColorNV;
+
 GLEW_FUN_EXPORT PFNGLGETPROGRAMNAMEDPARAMETERDVNVPROC __glewGetProgramNamedParameterdvNV;
 GLEW_FUN_EXPORT PFNGLGETPROGRAMNAMEDPARAMETERFVNVPROC __glewGetProgramNamedParameterfvNV;
 GLEW_FUN_EXPORT PFNGLPROGRAMNAMEDPARAMETER4DNVPROC __glewProgramNamedParameter4dNV;
@@ -17794,9 +22107,26 @@ GLEW_FUN_EXPORT PFNGLPROGRAMNAMEDPARAMETER4DVNVPROC __glewProgramNamedParameter4
 GLEW_FUN_EXPORT PFNGLPROGRAMNAMEDPARAMETER4FNVPROC __glewProgramNamedParameter4fNV;
 GLEW_FUN_EXPORT PFNGLPROGRAMNAMEDPARAMETER4FVNVPROC __glewProgramNamedParameter4fvNV;
 
+GLEW_FUN_EXPORT PFNGLBLITFRAMEBUFFERNVPROC __glewBlitFramebufferNV;
+
+GLEW_FUN_EXPORT PFNGLRENDERBUFFERSTORAGEMULTISAMPLENVPROC __glewRenderbufferStorageMultisampleNV;
+
 GLEW_FUN_EXPORT PFNGLRENDERBUFFERSTORAGEMULTISAMPLECOVERAGENVPROC __glewRenderbufferStorageMultisampleCoverageNV;
 
 GLEW_FUN_EXPORT PFNGLPROGRAMVERTEXLIMITNVPROC __glewProgramVertexLimitNV;
+
+GLEW_FUN_EXPORT PFNGLMULTICASTBARRIERNVPROC __glewMulticastBarrierNV;
+GLEW_FUN_EXPORT PFNGLMULTICASTBLITFRAMEBUFFERNVPROC __glewMulticastBlitFramebufferNV;
+GLEW_FUN_EXPORT PFNGLMULTICASTBUFFERSUBDATANVPROC __glewMulticastBufferSubDataNV;
+GLEW_FUN_EXPORT PFNGLMULTICASTCOPYBUFFERSUBDATANVPROC __glewMulticastCopyBufferSubDataNV;
+GLEW_FUN_EXPORT PFNGLMULTICASTCOPYIMAGESUBDATANVPROC __glewMulticastCopyImageSubDataNV;
+GLEW_FUN_EXPORT PFNGLMULTICASTFRAMEBUFFERSAMPLELOCATIONSFVNVPROC __glewMulticastFramebufferSampleLocationsfvNV;
+GLEW_FUN_EXPORT PFNGLMULTICASTGETQUERYOBJECTI64VNVPROC __glewMulticastGetQueryObjecti64vNV;
+GLEW_FUN_EXPORT PFNGLMULTICASTGETQUERYOBJECTIVNVPROC __glewMulticastGetQueryObjectivNV;
+GLEW_FUN_EXPORT PFNGLMULTICASTGETQUERYOBJECTUI64VNVPROC __glewMulticastGetQueryObjectui64vNV;
+GLEW_FUN_EXPORT PFNGLMULTICASTGETQUERYOBJECTUIVNVPROC __glewMulticastGetQueryObjectuivNV;
+GLEW_FUN_EXPORT PFNGLMULTICASTWAITSYNCNVPROC __glewMulticastWaitSyncNV;
+GLEW_FUN_EXPORT PFNGLRENDERGPUMASKNVPROC __glewRenderGpuMaskNV;
 
 GLEW_FUN_EXPORT PFNGLPROGRAMENVPARAMETERI4INVPROC __glewProgramEnvParameterI4iNV;
 GLEW_FUN_EXPORT PFNGLPROGRAMENVPARAMETERI4IVNVPROC __glewProgramEnvParameterI4ivNV;
@@ -17893,6 +22223,17 @@ GLEW_FUN_EXPORT PFNGLVERTEXATTRIBS4HVNVPROC __glewVertexAttribs4hvNV;
 GLEW_FUN_EXPORT PFNGLVERTEXWEIGHTHNVPROC __glewVertexWeighthNV;
 GLEW_FUN_EXPORT PFNGLVERTEXWEIGHTHVNVPROC __glewVertexWeighthvNV;
 
+GLEW_FUN_EXPORT PFNGLVERTEXATTRIBDIVISORNVPROC __glewVertexAttribDivisorNV;
+
+GLEW_FUN_EXPORT PFNGLGETINTERNALFORMATSAMPLEIVNVPROC __glewGetInternalformatSampleivNV;
+
+GLEW_FUN_EXPORT PFNGLUNIFORMMATRIX2X3FVNVPROC __glewUniformMatrix2x3fvNV;
+GLEW_FUN_EXPORT PFNGLUNIFORMMATRIX2X4FVNVPROC __glewUniformMatrix2x4fvNV;
+GLEW_FUN_EXPORT PFNGLUNIFORMMATRIX3X2FVNVPROC __glewUniformMatrix3x2fvNV;
+GLEW_FUN_EXPORT PFNGLUNIFORMMATRIX3X4FVNVPROC __glewUniformMatrix3x4fvNV;
+GLEW_FUN_EXPORT PFNGLUNIFORMMATRIX4X2FVNVPROC __glewUniformMatrix4x2fvNV;
+GLEW_FUN_EXPORT PFNGLUNIFORMMATRIX4X3FVNVPROC __glewUniformMatrix4x3fvNV;
+
 GLEW_FUN_EXPORT PFNGLBEGINOCCLUSIONQUERYNVPROC __glewBeginOcclusionQueryNV;
 GLEW_FUN_EXPORT PFNGLDELETEOCCLUSIONQUERIESNVPROC __glewDeleteOcclusionQueriesNV;
 GLEW_FUN_EXPORT PFNGLENDOCCLUSIONQUERYNVPROC __glewEndOcclusionQueryNV;
@@ -17925,18 +22266,28 @@ GLEW_FUN_EXPORT PFNGLGETPATHPARAMETERIVNVPROC __glewGetPathParameterivNV;
 GLEW_FUN_EXPORT PFNGLGETPATHSPACINGNVPROC __glewGetPathSpacingNV;
 GLEW_FUN_EXPORT PFNGLGETPATHTEXGENFVNVPROC __glewGetPathTexGenfvNV;
 GLEW_FUN_EXPORT PFNGLGETPATHTEXGENIVNVPROC __glewGetPathTexGenivNV;
+GLEW_FUN_EXPORT PFNGLGETPROGRAMRESOURCEFVNVPROC __glewGetProgramResourcefvNV;
 GLEW_FUN_EXPORT PFNGLINTERPOLATEPATHSNVPROC __glewInterpolatePathsNV;
 GLEW_FUN_EXPORT PFNGLISPATHNVPROC __glewIsPathNV;
 GLEW_FUN_EXPORT PFNGLISPOINTINFILLPATHNVPROC __glewIsPointInFillPathNV;
 GLEW_FUN_EXPORT PFNGLISPOINTINSTROKEPATHNVPROC __glewIsPointInStrokePathNV;
+GLEW_FUN_EXPORT PFNGLMATRIXLOAD3X2FNVPROC __glewMatrixLoad3x2fNV;
+GLEW_FUN_EXPORT PFNGLMATRIXLOAD3X3FNVPROC __glewMatrixLoad3x3fNV;
+GLEW_FUN_EXPORT PFNGLMATRIXLOADTRANSPOSE3X3FNVPROC __glewMatrixLoadTranspose3x3fNV;
+GLEW_FUN_EXPORT PFNGLMATRIXMULT3X2FNVPROC __glewMatrixMult3x2fNV;
+GLEW_FUN_EXPORT PFNGLMATRIXMULT3X3FNVPROC __glewMatrixMult3x3fNV;
+GLEW_FUN_EXPORT PFNGLMATRIXMULTTRANSPOSE3X3FNVPROC __glewMatrixMultTranspose3x3fNV;
 GLEW_FUN_EXPORT PFNGLPATHCOLORGENNVPROC __glewPathColorGenNV;
 GLEW_FUN_EXPORT PFNGLPATHCOMMANDSNVPROC __glewPathCommandsNV;
 GLEW_FUN_EXPORT PFNGLPATHCOORDSNVPROC __glewPathCoordsNV;
 GLEW_FUN_EXPORT PFNGLPATHCOVERDEPTHFUNCNVPROC __glewPathCoverDepthFuncNV;
 GLEW_FUN_EXPORT PFNGLPATHDASHARRAYNVPROC __glewPathDashArrayNV;
 GLEW_FUN_EXPORT PFNGLPATHFOGGENNVPROC __glewPathFogGenNV;
+GLEW_FUN_EXPORT PFNGLPATHGLYPHINDEXARRAYNVPROC __glewPathGlyphIndexArrayNV;
+GLEW_FUN_EXPORT PFNGLPATHGLYPHINDEXRANGENVPROC __glewPathGlyphIndexRangeNV;
 GLEW_FUN_EXPORT PFNGLPATHGLYPHRANGENVPROC __glewPathGlyphRangeNV;
 GLEW_FUN_EXPORT PFNGLPATHGLYPHSNVPROC __glewPathGlyphsNV;
+GLEW_FUN_EXPORT PFNGLPATHMEMORYGLYPHINDEXARRAYNVPROC __glewPathMemoryGlyphIndexArrayNV;
 GLEW_FUN_EXPORT PFNGLPATHPARAMETERFNVPROC __glewPathParameterfNV;
 GLEW_FUN_EXPORT PFNGLPATHPARAMETERFVNVPROC __glewPathParameterfvNV;
 GLEW_FUN_EXPORT PFNGLPATHPARAMETERINVPROC __glewPathParameteriNV;
@@ -17948,10 +22299,15 @@ GLEW_FUN_EXPORT PFNGLPATHSUBCOMMANDSNVPROC __glewPathSubCommandsNV;
 GLEW_FUN_EXPORT PFNGLPATHSUBCOORDSNVPROC __glewPathSubCoordsNV;
 GLEW_FUN_EXPORT PFNGLPATHTEXGENNVPROC __glewPathTexGenNV;
 GLEW_FUN_EXPORT PFNGLPOINTALONGPATHNVPROC __glewPointAlongPathNV;
+GLEW_FUN_EXPORT PFNGLPROGRAMPATHFRAGMENTINPUTGENNVPROC __glewProgramPathFragmentInputGenNV;
 GLEW_FUN_EXPORT PFNGLSTENCILFILLPATHINSTANCEDNVPROC __glewStencilFillPathInstancedNV;
 GLEW_FUN_EXPORT PFNGLSTENCILFILLPATHNVPROC __glewStencilFillPathNV;
 GLEW_FUN_EXPORT PFNGLSTENCILSTROKEPATHINSTANCEDNVPROC __glewStencilStrokePathInstancedNV;
 GLEW_FUN_EXPORT PFNGLSTENCILSTROKEPATHNVPROC __glewStencilStrokePathNV;
+GLEW_FUN_EXPORT PFNGLSTENCILTHENCOVERFILLPATHINSTANCEDNVPROC __glewStencilThenCoverFillPathInstancedNV;
+GLEW_FUN_EXPORT PFNGLSTENCILTHENCOVERFILLPATHNVPROC __glewStencilThenCoverFillPathNV;
+GLEW_FUN_EXPORT PFNGLSTENCILTHENCOVERSTROKEPATHINSTANCEDNVPROC __glewStencilThenCoverStrokePathInstancedNV;
+GLEW_FUN_EXPORT PFNGLSTENCILTHENCOVERSTROKEPATHNVPROC __glewStencilThenCoverStrokePathNV;
 GLEW_FUN_EXPORT PFNGLTRANSFORMPATHNVPROC __glewTransformPathNV;
 GLEW_FUN_EXPORT PFNGLWEIGHTPATHSNVPROC __glewWeightPathsNV;
 
@@ -17960,6 +22316,8 @@ GLEW_FUN_EXPORT PFNGLPIXELDATARANGENVPROC __glewPixelDataRangeNV;
 
 GLEW_FUN_EXPORT PFNGLPOINTPARAMETERINVPROC __glewPointParameteriNV;
 GLEW_FUN_EXPORT PFNGLPOINTPARAMETERIVNVPROC __glewPointParameterivNV;
+
+GLEW_FUN_EXPORT PFNGLPOLYGONMODENVPROC __glewPolygonModeNV;
 
 GLEW_FUN_EXPORT PFNGLGETVIDEOI64VNVPROC __glewGetVideoi64vNV;
 GLEW_FUN_EXPORT PFNGLGETVIDEOIVNVPROC __glewGetVideoivNV;
@@ -17988,6 +22346,9 @@ GLEW_FUN_EXPORT PFNGLGETFINALCOMBINERINPUTPARAMETERIVNVPROC __glewGetFinalCombin
 GLEW_FUN_EXPORT PFNGLCOMBINERSTAGEPARAMETERFVNVPROC __glewCombinerStageParameterfvNV;
 GLEW_FUN_EXPORT PFNGLGETCOMBINERSTAGEPARAMETERFVNVPROC __glewGetCombinerStageParameterfvNV;
 
+GLEW_FUN_EXPORT PFNGLFRAMEBUFFERSAMPLELOCATIONSFVNVPROC __glewFramebufferSampleLocationsfvNV;
+GLEW_FUN_EXPORT PFNGLNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNVPROC __glewNamedFramebufferSampleLocationsfvNV;
+
 GLEW_FUN_EXPORT PFNGLGETBUFFERPARAMETERUI64VNVPROC __glewGetBufferParameterui64vNV;
 GLEW_FUN_EXPORT PFNGLGETINTEGERUI64VNVPROC __glewGetIntegerui64vNV;
 GLEW_FUN_EXPORT PFNGLGETNAMEDBUFFERPARAMETERUI64VNVPROC __glewGetNamedBufferParameterui64vNV;
@@ -18001,6 +22362,13 @@ GLEW_FUN_EXPORT PFNGLPROGRAMUNIFORMUI64NVPROC __glewProgramUniformui64NV;
 GLEW_FUN_EXPORT PFNGLPROGRAMUNIFORMUI64VNVPROC __glewProgramUniformui64vNV;
 GLEW_FUN_EXPORT PFNGLUNIFORMUI64NVPROC __glewUniformui64NV;
 GLEW_FUN_EXPORT PFNGLUNIFORMUI64VNVPROC __glewUniformui64vNV;
+
+GLEW_FUN_EXPORT PFNGLCOMPRESSEDTEXIMAGE3DNVPROC __glewCompressedTexImage3DNV;
+GLEW_FUN_EXPORT PFNGLCOMPRESSEDTEXSUBIMAGE3DNVPROC __glewCompressedTexSubImage3DNV;
+GLEW_FUN_EXPORT PFNGLCOPYTEXSUBIMAGE3DNVPROC __glewCopyTexSubImage3DNV;
+GLEW_FUN_EXPORT PFNGLFRAMEBUFFERTEXTURELAYERNVPROC __glewFramebufferTextureLayerNV;
+GLEW_FUN_EXPORT PFNGLTEXIMAGE3DNVPROC __glewTexImage3DNV;
+GLEW_FUN_EXPORT PFNGLTEXSUBIMAGE3DNVPROC __glewTexSubImage3DNV;
 
 GLEW_FUN_EXPORT PFNGLTEXTUREBARRIERNVPROC __glewTextureBarrierNV;
 
@@ -18156,12 +22524,53 @@ GLEW_FUN_EXPORT PFNGLVIDEOCAPTURESTREAMPARAMETERDVNVPROC __glewVideoCaptureStrea
 GLEW_FUN_EXPORT PFNGLVIDEOCAPTURESTREAMPARAMETERFVNVPROC __glewVideoCaptureStreamParameterfvNV;
 GLEW_FUN_EXPORT PFNGLVIDEOCAPTURESTREAMPARAMETERIVNVPROC __glewVideoCaptureStreamParameterivNV;
 
-GLEW_FUN_EXPORT PFNGLCLEARDEPTHFOESPROC __glewClearDepthfOES;
-GLEW_FUN_EXPORT PFNGLCLIPPLANEFOESPROC __glewClipPlanefOES;
-GLEW_FUN_EXPORT PFNGLDEPTHRANGEFOESPROC __glewDepthRangefOES;
-GLEW_FUN_EXPORT PFNGLFRUSTUMFOESPROC __glewFrustumfOES;
-GLEW_FUN_EXPORT PFNGLGETCLIPPLANEFOESPROC __glewGetClipPlanefOES;
-GLEW_FUN_EXPORT PFNGLORTHOFOESPROC __glewOrthofOES;
+GLEW_FUN_EXPORT PFNGLDEPTHRANGEARRAYFVNVPROC __glewDepthRangeArrayfvNV;
+GLEW_FUN_EXPORT PFNGLDEPTHRANGEINDEXEDFNVPROC __glewDepthRangeIndexedfNV;
+GLEW_FUN_EXPORT PFNGLDISABLEINVPROC __glewDisableiNV;
+GLEW_FUN_EXPORT PFNGLENABLEINVPROC __glewEnableiNV;
+GLEW_FUN_EXPORT PFNGLGETFLOATI_VNVPROC __glewGetFloati_vNV;
+GLEW_FUN_EXPORT PFNGLISENABLEDINVPROC __glewIsEnablediNV;
+GLEW_FUN_EXPORT PFNGLSCISSORARRAYVNVPROC __glewScissorArrayvNV;
+GLEW_FUN_EXPORT PFNGLSCISSORINDEXEDNVPROC __glewScissorIndexedNV;
+GLEW_FUN_EXPORT PFNGLSCISSORINDEXEDVNVPROC __glewScissorIndexedvNV;
+GLEW_FUN_EXPORT PFNGLVIEWPORTARRAYVNVPROC __glewViewportArrayvNV;
+GLEW_FUN_EXPORT PFNGLVIEWPORTINDEXEDFNVPROC __glewViewportIndexedfNV;
+GLEW_FUN_EXPORT PFNGLVIEWPORTINDEXEDFVNVPROC __glewViewportIndexedfvNV;
+
+GLEW_FUN_EXPORT PFNGLVIEWPORTSWIZZLENVPROC __glewViewportSwizzleNV;
+
+GLEW_FUN_EXPORT PFNGLFRAMEBUFFERTEXTUREMULTIVIEWOVRPROC __glewFramebufferTextureMultiviewOVR;
+
+GLEW_FUN_EXPORT PFNGLFRAMEBUFFERTEXTUREMULTISAMPLEMULTIVIEWOVRPROC __glewFramebufferTextureMultisampleMultiviewOVR;
+
+GLEW_FUN_EXPORT PFNGLALPHAFUNCQCOMPROC __glewAlphaFuncQCOM;
+
+GLEW_FUN_EXPORT PFNGLDISABLEDRIVERCONTROLQCOMPROC __glewDisableDriverControlQCOM;
+GLEW_FUN_EXPORT PFNGLENABLEDRIVERCONTROLQCOMPROC __glewEnableDriverControlQCOM;
+GLEW_FUN_EXPORT PFNGLGETDRIVERCONTROLSTRINGQCOMPROC __glewGetDriverControlStringQCOM;
+GLEW_FUN_EXPORT PFNGLGETDRIVERCONTROLSQCOMPROC __glewGetDriverControlsQCOM;
+
+GLEW_FUN_EXPORT PFNGLEXTGETBUFFERPOINTERVQCOMPROC __glewExtGetBufferPointervQCOM;
+GLEW_FUN_EXPORT PFNGLEXTGETBUFFERSQCOMPROC __glewExtGetBuffersQCOM;
+GLEW_FUN_EXPORT PFNGLEXTGETFRAMEBUFFERSQCOMPROC __glewExtGetFramebuffersQCOM;
+GLEW_FUN_EXPORT PFNGLEXTGETRENDERBUFFERSQCOMPROC __glewExtGetRenderbuffersQCOM;
+GLEW_FUN_EXPORT PFNGLEXTGETTEXLEVELPARAMETERIVQCOMPROC __glewExtGetTexLevelParameterivQCOM;
+GLEW_FUN_EXPORT PFNGLEXTGETTEXSUBIMAGEQCOMPROC __glewExtGetTexSubImageQCOM;
+GLEW_FUN_EXPORT PFNGLEXTGETTEXTURESQCOMPROC __glewExtGetTexturesQCOM;
+GLEW_FUN_EXPORT PFNGLEXTTEXOBJECTSTATEOVERRIDEIQCOMPROC __glewExtTexObjectStateOverrideiQCOM;
+
+GLEW_FUN_EXPORT PFNGLEXTGETPROGRAMBINARYSOURCEQCOMPROC __glewExtGetProgramBinarySourceQCOM;
+GLEW_FUN_EXPORT PFNGLEXTGETPROGRAMSQCOMPROC __glewExtGetProgramsQCOM;
+GLEW_FUN_EXPORT PFNGLEXTGETSHADERSQCOMPROC __glewExtGetShadersQCOM;
+GLEW_FUN_EXPORT PFNGLEXTISPROGRAMBINARYQCOMPROC __glewExtIsProgramBinaryQCOM;
+
+GLEW_FUN_EXPORT PFNGLFRAMEBUFFERFOVEATIONCONFIGQCOMPROC __glewFramebufferFoveationConfigQCOM;
+GLEW_FUN_EXPORT PFNGLFRAMEBUFFERFOVEATIONPARAMETERSQCOMPROC __glewFramebufferFoveationParametersQCOM;
+
+GLEW_FUN_EXPORT PFNGLFRAMEBUFFERFETCHBARRIERQCOMPROC __glewFramebufferFetchBarrierQCOM;
+
+GLEW_FUN_EXPORT PFNGLENDTILINGQCOMPROC __glewEndTilingQCOM;
+GLEW_FUN_EXPORT PFNGLSTARTTILINGQCOMPROC __glewStartTilingQCOM;
 
 GLEW_FUN_EXPORT PFNGLALPHAFUNCXPROC __glewAlphaFuncx;
 GLEW_FUN_EXPORT PFNGLCLEARCOLORXPROC __glewClearColorx;
@@ -18227,6 +22636,13 @@ GLEW_FUN_EXPORT PFNGLGETFOGFUNCSGISPROC __glewGetFogFuncSGIS;
 GLEW_FUN_EXPORT PFNGLSAMPLEMASKSGISPROC __glewSampleMaskSGIS;
 GLEW_FUN_EXPORT PFNGLSAMPLEPATTERNSGISPROC __glewSamplePatternSGIS;
 
+GLEW_FUN_EXPORT PFNGLINTERLEAVEDTEXTURECOORDSETSSGISPROC __glewInterleavedTextureCoordSetsSGIS;
+GLEW_FUN_EXPORT PFNGLSELECTTEXTURECOORDSETSGISPROC __glewSelectTextureCoordSetSGIS;
+GLEW_FUN_EXPORT PFNGLSELECTTEXTURESGISPROC __glewSelectTextureSGIS;
+GLEW_FUN_EXPORT PFNGLSELECTTEXTURETRANSFORMSGISPROC __glewSelectTextureTransformSGIS;
+
+GLEW_FUN_EXPORT PFNGLMULTISAMPLESUBRECTPOSSGISPROC __glewMultisampleSubRectPosSGIS;
+
 GLEW_FUN_EXPORT PFNGLGETSHARPENTEXFUNCSGISPROC __glewGetSharpenTexFuncSGIS;
 GLEW_FUN_EXPORT PFNGLSHARPENTEXFUNCSGISPROC __glewSharpenTexFuncSGIS;
 
@@ -18243,7 +22659,13 @@ GLEW_FUN_EXPORT PFNGLGENASYNCMARKERSSGIXPROC __glewGenAsyncMarkersSGIX;
 GLEW_FUN_EXPORT PFNGLISASYNCMARKERSGIXPROC __glewIsAsyncMarkerSGIX;
 GLEW_FUN_EXPORT PFNGLPOLLASYNCSGIXPROC __glewPollAsyncSGIX;
 
+GLEW_FUN_EXPORT PFNGLADDRESSSPACEPROC __glewAddressSpace;
+GLEW_FUN_EXPORT PFNGLDATAPIPEPROC __glewDataPipe;
+
 GLEW_FUN_EXPORT PFNGLFLUSHRASTERSGIXPROC __glewFlushRasterSGIX;
+
+GLEW_FUN_EXPORT PFNGLFOGLAYERSSGIXPROC __glewFogLayersSGIX;
+GLEW_FUN_EXPORT PFNGLGETFOGLAYERSSGIXPROC __glewGetFogLayersSGIX;
 
 GLEW_FUN_EXPORT PFNGLTEXTUREFOGSGIXPROC __glewTextureFogSGIX;
 
@@ -18267,7 +22689,32 @@ GLEW_FUN_EXPORT PFNGLGETFRAGMENTMATERIALIVSGIXPROC __glewGetFragmentMaterialivSG
 
 GLEW_FUN_EXPORT PFNGLFRAMEZOOMSGIXPROC __glewFrameZoomSGIX;
 
+GLEW_FUN_EXPORT PFNGLIGLOOINTERFACESGIXPROC __glewIglooInterfaceSGIX;
+
+GLEW_FUN_EXPORT PFNGLALLOCMPEGPREDICTORSSGIXPROC __glewAllocMPEGPredictorsSGIX;
+GLEW_FUN_EXPORT PFNGLDELETEMPEGPREDICTORSSGIXPROC __glewDeleteMPEGPredictorsSGIX;
+GLEW_FUN_EXPORT PFNGLGENMPEGPREDICTORSSGIXPROC __glewGenMPEGPredictorsSGIX;
+GLEW_FUN_EXPORT PFNGLGETMPEGPARAMETERFVSGIXPROC __glewGetMPEGParameterfvSGIX;
+GLEW_FUN_EXPORT PFNGLGETMPEGPARAMETERIVSGIXPROC __glewGetMPEGParameterivSGIX;
+GLEW_FUN_EXPORT PFNGLGETMPEGPREDICTORSGIXPROC __glewGetMPEGPredictorSGIX;
+GLEW_FUN_EXPORT PFNGLGETMPEGQUANTTABLEUBVPROC __glewGetMPEGQuantTableubv;
+GLEW_FUN_EXPORT PFNGLISMPEGPREDICTORSGIXPROC __glewIsMPEGPredictorSGIX;
+GLEW_FUN_EXPORT PFNGLMPEGPREDICTORSGIXPROC __glewMPEGPredictorSGIX;
+GLEW_FUN_EXPORT PFNGLMPEGQUANTTABLEUBVPROC __glewMPEGQuantTableubv;
+GLEW_FUN_EXPORT PFNGLSWAPMPEGPREDICTORSSGIXPROC __glewSwapMPEGPredictorsSGIX;
+
+GLEW_FUN_EXPORT PFNGLGETNONLINLIGHTFVSGIXPROC __glewGetNonlinLightfvSGIX;
+GLEW_FUN_EXPORT PFNGLGETNONLINMATERIALFVSGIXPROC __glewGetNonlinMaterialfvSGIX;
+GLEW_FUN_EXPORT PFNGLNONLINLIGHTFVSGIXPROC __glewNonlinLightfvSGIX;
+GLEW_FUN_EXPORT PFNGLNONLINMATERIALFVSGIXPROC __glewNonlinMaterialfvSGIX;
+
 GLEW_FUN_EXPORT PFNGLPIXELTEXGENSGIXPROC __glewPixelTexGenSGIX;
+
+GLEW_FUN_EXPORT PFNGLDEFORMSGIXPROC __glewDeformSGIX;
+GLEW_FUN_EXPORT PFNGLLOADIDENTITYDEFORMATIONMAPSGIXPROC __glewLoadIdentityDeformationMapSGIX;
+
+GLEW_FUN_EXPORT PFNGLMESHBREADTHSGIXPROC __glewMeshBreadthSGIX;
+GLEW_FUN_EXPORT PFNGLMESHSTRIDESGIXPROC __glewMeshStrideSGIX;
 
 GLEW_FUN_EXPORT PFNGLREFERENCEPLANESGIXPROC __glewReferencePlaneSGIX;
 
@@ -18278,6 +22725,16 @@ GLEW_FUN_EXPORT PFNGLSPRITEPARAMETERIVSGIXPROC __glewSpriteParameterivSGIX;
 
 GLEW_FUN_EXPORT PFNGLTAGSAMPLEBUFFERSGIXPROC __glewTagSampleBufferSGIX;
 
+GLEW_FUN_EXPORT PFNGLGETVECTOROPERATIONSGIXPROC __glewGetVectorOperationSGIX;
+GLEW_FUN_EXPORT PFNGLVECTOROPERATIONSGIXPROC __glewVectorOperationSGIX;
+
+GLEW_FUN_EXPORT PFNGLAREVERTEXARRAYSRESIDENTSGIXPROC __glewAreVertexArraysResidentSGIX;
+GLEW_FUN_EXPORT PFNGLBINDVERTEXARRAYSGIXPROC __glewBindVertexArraySGIX;
+GLEW_FUN_EXPORT PFNGLDELETEVERTEXARRAYSSGIXPROC __glewDeleteVertexArraysSGIX;
+GLEW_FUN_EXPORT PFNGLGENVERTEXARRAYSSGIXPROC __glewGenVertexArraysSGIX;
+GLEW_FUN_EXPORT PFNGLISVERTEXARRAYSGIXPROC __glewIsVertexArraySGIX;
+GLEW_FUN_EXPORT PFNGLPRIORITIZEVERTEXARRAYSSGIXPROC __glewPrioritizeVertexArraysSGIX;
+
 GLEW_FUN_EXPORT PFNGLCOLORTABLEPARAMETERFVSGIPROC __glewColorTableParameterfvSGI;
 GLEW_FUN_EXPORT PFNGLCOLORTABLEPARAMETERIVSGIPROC __glewColorTableParameterivSGI;
 GLEW_FUN_EXPORT PFNGLCOLORTABLESGIPROC __glewColorTableSGI;
@@ -18285,6 +22742,14 @@ GLEW_FUN_EXPORT PFNGLCOPYCOLORTABLESGIPROC __glewCopyColorTableSGI;
 GLEW_FUN_EXPORT PFNGLGETCOLORTABLEPARAMETERFVSGIPROC __glewGetColorTableParameterfvSGI;
 GLEW_FUN_EXPORT PFNGLGETCOLORTABLEPARAMETERIVSGIPROC __glewGetColorTableParameterivSGI;
 GLEW_FUN_EXPORT PFNGLGETCOLORTABLESGIPROC __glewGetColorTableSGI;
+
+GLEW_FUN_EXPORT PFNGLGETPIXELTRANSFORMPARAMETERFVSGIPROC __glewGetPixelTransformParameterfvSGI;
+GLEW_FUN_EXPORT PFNGLGETPIXELTRANSFORMPARAMETERIVSGIPROC __glewGetPixelTransformParameterivSGI;
+GLEW_FUN_EXPORT PFNGLPIXELTRANSFORMPARAMETERFSGIPROC __glewPixelTransformParameterfSGI;
+GLEW_FUN_EXPORT PFNGLPIXELTRANSFORMPARAMETERFVSGIPROC __glewPixelTransformParameterfvSGI;
+GLEW_FUN_EXPORT PFNGLPIXELTRANSFORMPARAMETERISGIPROC __glewPixelTransformParameteriSGI;
+GLEW_FUN_EXPORT PFNGLPIXELTRANSFORMPARAMETERIVSGIPROC __glewPixelTransformParameterivSGI;
+GLEW_FUN_EXPORT PFNGLPIXELTRANSFORMSGIPROC __glewPixelTransformSGI;
 
 GLEW_FUN_EXPORT PFNGLFINISHTEXTURESUNXPROC __glewFinishTextureSUNX;
 
@@ -18349,12 +22814,6 @@ GLEW_FUN_EXPORT PFNGLTEXCOORD4FVERTEX4FSUNPROC __glewTexCoord4fVertex4fSUN;
 GLEW_FUN_EXPORT PFNGLTEXCOORD4FVERTEX4FVSUNPROC __glewTexCoord4fVertex4fvSUN;
 
 GLEW_FUN_EXPORT PFNGLADDSWAPHINTRECTWINPROC __glewAddSwapHintRectWIN;
-
-#if defined(GLEW_MX) && !defined(_WIN32)
-struct GLEWContextStruct
-{
-#endif /* GLEW_MX */
-
 GLEW_VAR_EXPORT GLboolean __GLEW_VERSION_1_1;
 GLEW_VAR_EXPORT GLboolean __GLEW_VERSION_1_2;
 GLEW_VAR_EXPORT GLboolean __GLEW_VERSION_1_2_1;
@@ -18373,15 +22832,21 @@ GLEW_VAR_EXPORT GLboolean __GLEW_VERSION_4_2;
 GLEW_VAR_EXPORT GLboolean __GLEW_VERSION_4_3;
 GLEW_VAR_EXPORT GLboolean __GLEW_VERSION_4_4;
 GLEW_VAR_EXPORT GLboolean __GLEW_VERSION_4_5;
+GLEW_VAR_EXPORT GLboolean __GLEW_VERSION_4_6;
 GLEW_VAR_EXPORT GLboolean __GLEW_3DFX_multisample;
 GLEW_VAR_EXPORT GLboolean __GLEW_3DFX_tbuffer;
 GLEW_VAR_EXPORT GLboolean __GLEW_3DFX_texture_compression_FXT1;
 GLEW_VAR_EXPORT GLboolean __GLEW_AMD_blend_minmax_factor;
+GLEW_VAR_EXPORT GLboolean __GLEW_AMD_compressed_3DC_texture;
+GLEW_VAR_EXPORT GLboolean __GLEW_AMD_compressed_ATC_texture;
 GLEW_VAR_EXPORT GLboolean __GLEW_AMD_conservative_depth;
 GLEW_VAR_EXPORT GLboolean __GLEW_AMD_debug_output;
 GLEW_VAR_EXPORT GLboolean __GLEW_AMD_depth_clamp_separate;
 GLEW_VAR_EXPORT GLboolean __GLEW_AMD_draw_buffers_blend;
+GLEW_VAR_EXPORT GLboolean __GLEW_AMD_framebuffer_sample_positions;
 GLEW_VAR_EXPORT GLboolean __GLEW_AMD_gcn_shader;
+GLEW_VAR_EXPORT GLboolean __GLEW_AMD_gpu_shader_half_float;
+GLEW_VAR_EXPORT GLboolean __GLEW_AMD_gpu_shader_int16;
 GLEW_VAR_EXPORT GLboolean __GLEW_AMD_gpu_shader_int64;
 GLEW_VAR_EXPORT GLboolean __GLEW_AMD_interleaved_elements;
 GLEW_VAR_EXPORT GLboolean __GLEW_AMD_multi_draw_indirect;
@@ -18389,21 +22854,26 @@ GLEW_VAR_EXPORT GLboolean __GLEW_AMD_name_gen_delete;
 GLEW_VAR_EXPORT GLboolean __GLEW_AMD_occlusion_query_event;
 GLEW_VAR_EXPORT GLboolean __GLEW_AMD_performance_monitor;
 GLEW_VAR_EXPORT GLboolean __GLEW_AMD_pinned_memory;
+GLEW_VAR_EXPORT GLboolean __GLEW_AMD_program_binary_Z400;
 GLEW_VAR_EXPORT GLboolean __GLEW_AMD_query_buffer_object;
 GLEW_VAR_EXPORT GLboolean __GLEW_AMD_sample_positions;
 GLEW_VAR_EXPORT GLboolean __GLEW_AMD_seamless_cubemap_per_texture;
 GLEW_VAR_EXPORT GLboolean __GLEW_AMD_shader_atomic_counter_ops;
+GLEW_VAR_EXPORT GLboolean __GLEW_AMD_shader_ballot;
+GLEW_VAR_EXPORT GLboolean __GLEW_AMD_shader_explicit_vertex_parameter;
 GLEW_VAR_EXPORT GLboolean __GLEW_AMD_shader_stencil_export;
 GLEW_VAR_EXPORT GLboolean __GLEW_AMD_shader_stencil_value_export;
 GLEW_VAR_EXPORT GLboolean __GLEW_AMD_shader_trinary_minmax;
 GLEW_VAR_EXPORT GLboolean __GLEW_AMD_sparse_texture;
 GLEW_VAR_EXPORT GLboolean __GLEW_AMD_stencil_operation_extended;
+GLEW_VAR_EXPORT GLboolean __GLEW_AMD_texture_gather_bias_lod;
 GLEW_VAR_EXPORT GLboolean __GLEW_AMD_texture_texture4;
 GLEW_VAR_EXPORT GLboolean __GLEW_AMD_transform_feedback3_lines_triangles;
 GLEW_VAR_EXPORT GLboolean __GLEW_AMD_transform_feedback4;
 GLEW_VAR_EXPORT GLboolean __GLEW_AMD_vertex_shader_layer;
 GLEW_VAR_EXPORT GLboolean __GLEW_AMD_vertex_shader_tessellator;
 GLEW_VAR_EXPORT GLboolean __GLEW_AMD_vertex_shader_viewport_index;
+GLEW_VAR_EXPORT GLboolean __GLEW_ANDROID_extension_pack_es31a;
 GLEW_VAR_EXPORT GLboolean __GLEW_ANGLE_depth_texture;
 GLEW_VAR_EXPORT GLboolean __GLEW_ANGLE_framebuffer_blit;
 GLEW_VAR_EXPORT GLboolean __GLEW_ANGLE_framebuffer_multisample;
@@ -18418,15 +22888,24 @@ GLEW_VAR_EXPORT GLboolean __GLEW_ANGLE_timer_query;
 GLEW_VAR_EXPORT GLboolean __GLEW_ANGLE_translated_shader_source;
 GLEW_VAR_EXPORT GLboolean __GLEW_APPLE_aux_depth_stencil;
 GLEW_VAR_EXPORT GLboolean __GLEW_APPLE_client_storage;
+GLEW_VAR_EXPORT GLboolean __GLEW_APPLE_clip_distance;
+GLEW_VAR_EXPORT GLboolean __GLEW_APPLE_color_buffer_packed_float;
+GLEW_VAR_EXPORT GLboolean __GLEW_APPLE_copy_texture_levels;
 GLEW_VAR_EXPORT GLboolean __GLEW_APPLE_element_array;
 GLEW_VAR_EXPORT GLboolean __GLEW_APPLE_fence;
 GLEW_VAR_EXPORT GLboolean __GLEW_APPLE_float_pixels;
 GLEW_VAR_EXPORT GLboolean __GLEW_APPLE_flush_buffer_range;
+GLEW_VAR_EXPORT GLboolean __GLEW_APPLE_framebuffer_multisample;
 GLEW_VAR_EXPORT GLboolean __GLEW_APPLE_object_purgeable;
 GLEW_VAR_EXPORT GLboolean __GLEW_APPLE_pixel_buffer;
 GLEW_VAR_EXPORT GLboolean __GLEW_APPLE_rgb_422;
 GLEW_VAR_EXPORT GLboolean __GLEW_APPLE_row_bytes;
 GLEW_VAR_EXPORT GLboolean __GLEW_APPLE_specular_vector;
+GLEW_VAR_EXPORT GLboolean __GLEW_APPLE_sync;
+GLEW_VAR_EXPORT GLboolean __GLEW_APPLE_texture_2D_limited_npot;
+GLEW_VAR_EXPORT GLboolean __GLEW_APPLE_texture_format_BGRA8888;
+GLEW_VAR_EXPORT GLboolean __GLEW_APPLE_texture_max_level;
+GLEW_VAR_EXPORT GLboolean __GLEW_APPLE_texture_packed_float;
 GLEW_VAR_EXPORT GLboolean __GLEW_APPLE_texture_range;
 GLEW_VAR_EXPORT GLboolean __GLEW_APPLE_transform_hint;
 GLEW_VAR_EXPORT GLboolean __GLEW_APPLE_vertex_array_object;
@@ -18435,6 +22914,7 @@ GLEW_VAR_EXPORT GLboolean __GLEW_APPLE_vertex_program_evaluators;
 GLEW_VAR_EXPORT GLboolean __GLEW_APPLE_ycbcr_422;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_ES2_compatibility;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_ES3_1_compatibility;
+GLEW_VAR_EXPORT GLboolean __GLEW_ARB_ES3_2_compatibility;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_ES3_compatibility;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_arrays_of_arrays;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_base_instance;
@@ -18474,14 +22954,17 @@ GLEW_VAR_EXPORT GLboolean __GLEW_ARB_fragment_layer_viewport;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_fragment_program;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_fragment_program_shadow;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_fragment_shader;
+GLEW_VAR_EXPORT GLboolean __GLEW_ARB_fragment_shader_interlock;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_framebuffer_no_attachments;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_framebuffer_object;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_framebuffer_sRGB;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_geometry_shader4;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_get_program_binary;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_get_texture_sub_image;
+GLEW_VAR_EXPORT GLboolean __GLEW_ARB_gl_spirv;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_gpu_shader5;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_gpu_shader_fp64;
+GLEW_VAR_EXPORT GLboolean __GLEW_ARB_gpu_shader_int64;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_half_float_pixel;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_half_float_vertex;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_imaging;
@@ -18499,10 +22982,13 @@ GLEW_VAR_EXPORT GLboolean __GLEW_ARB_multisample;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_multitexture;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_occlusion_query;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_occlusion_query2;
+GLEW_VAR_EXPORT GLboolean __GLEW_ARB_parallel_shader_compile;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_pipeline_statistics_query;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_pixel_buffer_object;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_point_parameters;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_point_sprite;
+GLEW_VAR_EXPORT GLboolean __GLEW_ARB_polygon_offset_clamp;
+GLEW_VAR_EXPORT GLboolean __GLEW_ARB_post_depth_coverage;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_program_interface_query;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_provoking_vertex;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_query_buffer_object;
@@ -18510,13 +22996,17 @@ GLEW_VAR_EXPORT GLboolean __GLEW_ARB_robust_buffer_access_behavior;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_robustness;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_robustness_application_isolation;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_robustness_share_group_isolation;
+GLEW_VAR_EXPORT GLboolean __GLEW_ARB_sample_locations;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_sample_shading;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_sampler_objects;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_seamless_cube_map;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_seamless_cubemap_per_texture;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_separate_shader_objects;
+GLEW_VAR_EXPORT GLboolean __GLEW_ARB_shader_atomic_counter_ops;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_shader_atomic_counters;
+GLEW_VAR_EXPORT GLboolean __GLEW_ARB_shader_ballot;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_shader_bit_encoding;
+GLEW_VAR_EXPORT GLboolean __GLEW_ARB_shader_clock;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_shader_draw_parameters;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_shader_group_vote;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_shader_image_load_store;
@@ -18528,6 +23018,7 @@ GLEW_VAR_EXPORT GLboolean __GLEW_ARB_shader_storage_buffer_object;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_shader_subroutine;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_shader_texture_image_samples;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_shader_texture_lod;
+GLEW_VAR_EXPORT GLboolean __GLEW_ARB_shader_viewport_layer_array;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_shading_language_100;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_shading_language_420pack;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_shading_language_include;
@@ -18536,6 +23027,9 @@ GLEW_VAR_EXPORT GLboolean __GLEW_ARB_shadow;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_shadow_ambient;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_sparse_buffer;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_sparse_texture;
+GLEW_VAR_EXPORT GLboolean __GLEW_ARB_sparse_texture2;
+GLEW_VAR_EXPORT GLboolean __GLEW_ARB_sparse_texture_clamp;
+GLEW_VAR_EXPORT GLboolean __GLEW_ARB_spirv_extensions;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_stencil_texturing;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_sync;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_tessellation_shader;
@@ -18553,6 +23047,8 @@ GLEW_VAR_EXPORT GLboolean __GLEW_ARB_texture_env_add;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_texture_env_combine;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_texture_env_crossbar;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_texture_env_dot3;
+GLEW_VAR_EXPORT GLboolean __GLEW_ARB_texture_filter_anisotropic;
+GLEW_VAR_EXPORT GLboolean __GLEW_ARB_texture_filter_minmax;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_texture_float;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_texture_gather;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_texture_mirror_clamp_to_edge;
@@ -18588,6 +23084,11 @@ GLEW_VAR_EXPORT GLboolean __GLEW_ARB_vertex_type_10f_11f_11f_rev;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_vertex_type_2_10_10_10_rev;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_viewport_array;
 GLEW_VAR_EXPORT GLboolean __GLEW_ARB_window_pos;
+GLEW_VAR_EXPORT GLboolean __GLEW_ARM_mali_program_binary;
+GLEW_VAR_EXPORT GLboolean __GLEW_ARM_mali_shader_binary;
+GLEW_VAR_EXPORT GLboolean __GLEW_ARM_rgba8;
+GLEW_VAR_EXPORT GLboolean __GLEW_ARM_shader_framebuffer_fetch;
+GLEW_VAR_EXPORT GLboolean __GLEW_ARM_shader_framebuffer_fetch_depth_stencil;
 GLEW_VAR_EXPORT GLboolean __GLEW_ATIX_point_sprites;
 GLEW_VAR_EXPORT GLboolean __GLEW_ATIX_texture_env_combine3;
 GLEW_VAR_EXPORT GLboolean __GLEW_ATIX_texture_env_route;
@@ -18609,51 +23110,86 @@ GLEW_VAR_EXPORT GLboolean __GLEW_ATI_texture_mirror_once;
 GLEW_VAR_EXPORT GLboolean __GLEW_ATI_vertex_array_object;
 GLEW_VAR_EXPORT GLboolean __GLEW_ATI_vertex_attrib_array_object;
 GLEW_VAR_EXPORT GLboolean __GLEW_ATI_vertex_streams;
+GLEW_VAR_EXPORT GLboolean __GLEW_EGL_KHR_context_flush_control;
+GLEW_VAR_EXPORT GLboolean __GLEW_EGL_NV_robustness_video_memory_purge;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_422_pixels;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_Cg_shader;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_EGL_image_array;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_YUV_target;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_abgr;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_base_instance;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_bgra;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_bindable_uniform;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_blend_color;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_blend_equation_separate;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_blend_func_extended;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_blend_func_separate;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_blend_logic_op;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_blend_minmax;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_blend_subtract;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_buffer_storage;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_clear_texture;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_clip_cull_distance;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_clip_volume_hint;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_cmyka;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_color_buffer_float;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_color_buffer_half_float;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_color_subtable;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_compiled_vertex_array;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_compressed_ETC1_RGB8_sub_texture;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_conservative_depth;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_convolution;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_coordinate_frame;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_copy_image;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_copy_texture;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_cull_vertex;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_debug_label;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_debug_marker;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_depth_bounds_test;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_direct_state_access;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_discard_framebuffer;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_draw_buffers;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_draw_buffers2;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_draw_buffers_indexed;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_draw_elements_base_vertex;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_draw_instanced;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_draw_range_elements;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_external_buffer;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_float_blend;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_fog_coord;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_frag_depth;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_fragment_lighting;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_framebuffer_blit;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_framebuffer_multisample;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_framebuffer_multisample_blit_scaled;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_framebuffer_object;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_framebuffer_sRGB;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_geometry_point_size;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_geometry_shader;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_geometry_shader4;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_gpu_program_parameters;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_gpu_shader4;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_gpu_shader5;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_histogram;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_index_array_formats;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_index_func;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_index_material;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_index_texture;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_instanced_arrays;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_light_texture;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_map_buffer_range;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_memory_object;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_memory_object_fd;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_memory_object_win32;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_misc_attribute;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_multi_draw_arrays;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_multi_draw_indirect;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_multiple_textures;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_multisample;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_multisample_compatibility;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_multisampled_render_to_texture;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_multisampled_render_to_texture2;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_multiview_draw_buffers;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_packed_depth_stencil;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_packed_float;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_packed_pixels;
@@ -18663,17 +23199,39 @@ GLEW_VAR_EXPORT GLboolean __GLEW_EXT_pixel_transform;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_pixel_transform_color_table;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_point_parameters;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_polygon_offset;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_polygon_offset_clamp;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_post_depth_coverage;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_provoking_vertex;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_pvrtc_sRGB;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_raster_multisample;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_read_format_bgra;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_render_snorm;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_rescale_normal;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_sRGB;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_sRGB_write_control;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_scene_marker;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_secondary_color;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_semaphore;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_semaphore_fd;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_semaphore_win32;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_separate_shader_objects;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_separate_specular_color;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_shader_framebuffer_fetch;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_shader_group_vote;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_shader_image_load_formatted;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_shader_image_load_store;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_shader_implicit_conversions;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_shader_integer_mix;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_shader_io_blocks;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_shader_non_constant_global_initializers;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_shader_pixel_local_storage;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_shader_pixel_local_storage2;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_shader_texture_lod;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_shadow_funcs;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_shadow_samplers;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_shared_texture_palette;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_sparse_texture;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_sparse_texture2;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_stencil_clear_tag;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_stencil_two_side;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_stencil_wrap;
@@ -18682,35 +23240,52 @@ GLEW_VAR_EXPORT GLboolean __GLEW_EXT_texture;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_texture3D;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_texture_array;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_texture_buffer_object;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_texture_compression_astc_decode_mode;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_texture_compression_astc_decode_mode_rgb9e5;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_texture_compression_bptc;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_texture_compression_dxt1;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_texture_compression_latc;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_texture_compression_rgtc;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_texture_compression_s3tc;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_texture_cube_map;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_texture_cube_map_array;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_texture_edge_clamp;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_texture_env;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_texture_env_add;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_texture_env_combine;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_texture_env_dot3;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_texture_filter_anisotropic;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_texture_filter_minmax;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_texture_format_BGRA8888;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_texture_integer;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_texture_lod_bias;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_texture_mirror_clamp;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_texture_norm16;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_texture_object;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_texture_perturb_normal;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_texture_rectangle;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_texture_rg;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_texture_sRGB;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_texture_sRGB_R8;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_texture_sRGB_RG8;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_texture_sRGB_decode;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_texture_shared_exponent;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_texture_snorm;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_texture_storage;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_texture_swizzle;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_texture_type_2_10_10_10_REV;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_texture_view;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_timer_query;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_transform_feedback;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_unpack_subimage;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_vertex_array;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_vertex_array_bgra;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_vertex_array_setXXX;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_vertex_attrib_64bit;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_vertex_shader;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_vertex_weighting;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_win32_keyed_mutex;
+GLEW_VAR_EXPORT GLboolean __GLEW_EXT_window_rectangles;
 GLEW_VAR_EXPORT GLboolean __GLEW_EXT_x11_sync_object;
 GLEW_VAR_EXPORT GLboolean __GLEW_GREMEDY_frame_terminator;
 GLEW_VAR_EXPORT GLboolean __GLEW_GREMEDY_string_marker;
@@ -18726,7 +23301,9 @@ GLEW_VAR_EXPORT GLboolean __GLEW_IBM_texture_mirrored_repeat;
 GLEW_VAR_EXPORT GLboolean __GLEW_IBM_vertex_array_lists;
 GLEW_VAR_EXPORT GLboolean __GLEW_INGR_color_clamp;
 GLEW_VAR_EXPORT GLboolean __GLEW_INGR_interlace_read;
+GLEW_VAR_EXPORT GLboolean __GLEW_INTEL_conservative_rasterization;
 GLEW_VAR_EXPORT GLboolean __GLEW_INTEL_fragment_shader_ordering;
+GLEW_VAR_EXPORT GLboolean __GLEW_INTEL_framebuffer_CMAA;
 GLEW_VAR_EXPORT GLboolean __GLEW_INTEL_map_texture;
 GLEW_VAR_EXPORT GLboolean __GLEW_INTEL_parallel_arrays;
 GLEW_VAR_EXPORT GLboolean __GLEW_INTEL_performance_query;
@@ -18735,86 +23312,149 @@ GLEW_VAR_EXPORT GLboolean __GLEW_KHR_blend_equation_advanced;
 GLEW_VAR_EXPORT GLboolean __GLEW_KHR_blend_equation_advanced_coherent;
 GLEW_VAR_EXPORT GLboolean __GLEW_KHR_context_flush_control;
 GLEW_VAR_EXPORT GLboolean __GLEW_KHR_debug;
+GLEW_VAR_EXPORT GLboolean __GLEW_KHR_no_error;
+GLEW_VAR_EXPORT GLboolean __GLEW_KHR_parallel_shader_compile;
 GLEW_VAR_EXPORT GLboolean __GLEW_KHR_robust_buffer_access_behavior;
 GLEW_VAR_EXPORT GLboolean __GLEW_KHR_robustness;
 GLEW_VAR_EXPORT GLboolean __GLEW_KHR_texture_compression_astc_hdr;
 GLEW_VAR_EXPORT GLboolean __GLEW_KHR_texture_compression_astc_ldr;
+GLEW_VAR_EXPORT GLboolean __GLEW_KHR_texture_compression_astc_sliced_3d;
 GLEW_VAR_EXPORT GLboolean __GLEW_KTX_buffer_region;
 GLEW_VAR_EXPORT GLboolean __GLEW_MESAX_texture_stack;
 GLEW_VAR_EXPORT GLboolean __GLEW_MESA_pack_invert;
 GLEW_VAR_EXPORT GLboolean __GLEW_MESA_resize_buffers;
+GLEW_VAR_EXPORT GLboolean __GLEW_MESA_shader_integer_functions;
 GLEW_VAR_EXPORT GLboolean __GLEW_MESA_window_pos;
 GLEW_VAR_EXPORT GLboolean __GLEW_MESA_ycbcr_texture;
+GLEW_VAR_EXPORT GLboolean __GLEW_NVX_blend_equation_advanced_multi_draw_buffers;
 GLEW_VAR_EXPORT GLboolean __GLEW_NVX_conditional_render;
 GLEW_VAR_EXPORT GLboolean __GLEW_NVX_gpu_memory_info;
+GLEW_VAR_EXPORT GLboolean __GLEW_NVX_linked_gpu_multicast;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_3dvision_settings;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_EGL_stream_consumer_external;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_alpha_to_coverage_dither_control;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_bgr;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_bindless_multi_draw_indirect;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_bindless_multi_draw_indirect_count;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_bindless_texture;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_blend_equation_advanced;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_blend_equation_advanced_coherent;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_blend_minmax_factor;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_blend_square;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_clip_space_w_scaling;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_command_list;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_compute_program5;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_conditional_render;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_conservative_raster;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_conservative_raster_dilate;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_conservative_raster_pre_snap_triangles;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_copy_buffer;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_copy_depth_to_color;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_copy_image;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_deep_texture3D;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_depth_buffer_float;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_depth_clamp;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_depth_range_unclamped;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_draw_buffers;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_draw_instanced;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_draw_texture;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_draw_vulkan_image;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_evaluators;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_explicit_attrib_location;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_explicit_multisample;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_fbo_color_attachments;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_fence;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_fill_rectangle;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_float_buffer;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_fog_distance;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_fragment_coverage_to_color;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_fragment_program;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_fragment_program2;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_fragment_program4;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_fragment_program_option;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_fragment_shader_interlock;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_framebuffer_blit;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_framebuffer_mixed_samples;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_framebuffer_multisample;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_framebuffer_multisample_coverage;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_generate_mipmap_sRGB;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_geometry_program4;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_geometry_shader4;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_geometry_shader_passthrough;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_gpu_multicast;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_gpu_program4;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_gpu_program5;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_gpu_program5_mem_extended;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_gpu_program_fp64;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_gpu_shader5;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_half_float;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_image_formats;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_instanced_arrays;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_internalformat_sample_query;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_light_max_exponent;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_multisample_coverage;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_multisample_filter_hint;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_non_square_matrices;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_occlusion_query;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_pack_subimage;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_packed_depth_stencil;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_packed_float;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_packed_float_linear;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_parameter_buffer_object;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_parameter_buffer_object2;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_path_rendering;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_path_rendering_shared_edge;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_pixel_buffer_object;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_pixel_data_range;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_platform_binary;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_point_sprite;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_polygon_mode;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_present_video;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_primitive_restart;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_read_depth;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_read_depth_stencil;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_read_stencil;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_register_combiners;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_register_combiners2;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_robustness_video_memory_purge;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_sRGB_formats;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_sample_locations;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_sample_mask_override_coverage;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_shader_atomic_counters;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_shader_atomic_float;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_shader_atomic_float64;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_shader_atomic_fp16_vector;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_shader_atomic_int64;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_shader_buffer_load;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_shader_noperspective_interpolation;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_shader_storage_buffer_object;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_shader_thread_group;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_shader_thread_shuffle;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_shadow_samplers_array;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_shadow_samplers_cube;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_stereo_view_rendering;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_tessellation_program5;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_texgen_emboss;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_texgen_reflection;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_texture_array;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_texture_barrier;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_texture_border_clamp;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_texture_compression_latc;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_texture_compression_s3tc;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_texture_compression_s3tc_update;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_texture_compression_vtc;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_texture_env_combine4;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_texture_expand_normal;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_texture_multisample;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_texture_npot_2D_mipmap;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_texture_rectangle;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_texture_rectangle_compressed;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_texture_shader;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_texture_shader2;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_texture_shader3;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_transform_feedback;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_transform_feedback2;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_uniform_buffer_unified_memory;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_vdpau_interop;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_vertex_array_range;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_vertex_array_range2;
@@ -18827,15 +23467,28 @@ GLEW_VAR_EXPORT GLboolean __GLEW_NV_vertex_program2_option;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_vertex_program3;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_vertex_program4;
 GLEW_VAR_EXPORT GLboolean __GLEW_NV_video_capture;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_viewport_array;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_viewport_array2;
+GLEW_VAR_EXPORT GLboolean __GLEW_NV_viewport_swizzle;
 GLEW_VAR_EXPORT GLboolean __GLEW_OES_byte_coordinates;
-GLEW_VAR_EXPORT GLboolean __GLEW_OES_compressed_paletted_texture;
-GLEW_VAR_EXPORT GLboolean __GLEW_OES_read_format;
-GLEW_VAR_EXPORT GLboolean __GLEW_OES_single_precision;
 GLEW_VAR_EXPORT GLboolean __GLEW_OML_interlace;
 GLEW_VAR_EXPORT GLboolean __GLEW_OML_resample;
 GLEW_VAR_EXPORT GLboolean __GLEW_OML_subsample;
+GLEW_VAR_EXPORT GLboolean __GLEW_OVR_multiview;
+GLEW_VAR_EXPORT GLboolean __GLEW_OVR_multiview2;
+GLEW_VAR_EXPORT GLboolean __GLEW_OVR_multiview_multisampled_render_to_texture;
 GLEW_VAR_EXPORT GLboolean __GLEW_PGI_misc_hints;
 GLEW_VAR_EXPORT GLboolean __GLEW_PGI_vertex_hints;
+GLEW_VAR_EXPORT GLboolean __GLEW_QCOM_alpha_test;
+GLEW_VAR_EXPORT GLboolean __GLEW_QCOM_binning_control;
+GLEW_VAR_EXPORT GLboolean __GLEW_QCOM_driver_control;
+GLEW_VAR_EXPORT GLboolean __GLEW_QCOM_extended_get;
+GLEW_VAR_EXPORT GLboolean __GLEW_QCOM_extended_get2;
+GLEW_VAR_EXPORT GLboolean __GLEW_QCOM_framebuffer_foveated;
+GLEW_VAR_EXPORT GLboolean __GLEW_QCOM_perfmon_global_mode;
+GLEW_VAR_EXPORT GLboolean __GLEW_QCOM_shader_framebuffer_fetch_noncoherent;
+GLEW_VAR_EXPORT GLboolean __GLEW_QCOM_tiled_rendering;
+GLEW_VAR_EXPORT GLboolean __GLEW_QCOM_writeonly_rendering;
 GLEW_VAR_EXPORT GLboolean __GLEW_REGAL_ES1_0_compatibility;
 GLEW_VAR_EXPORT GLboolean __GLEW_REGAL_ES1_1_compatibility;
 GLEW_VAR_EXPORT GLboolean __GLEW_REGAL_enable;
@@ -18845,13 +23498,17 @@ GLEW_VAR_EXPORT GLboolean __GLEW_REGAL_log;
 GLEW_VAR_EXPORT GLboolean __GLEW_REGAL_proc_address;
 GLEW_VAR_EXPORT GLboolean __GLEW_REND_screen_coordinates;
 GLEW_VAR_EXPORT GLboolean __GLEW_S3_s3tc;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIS_clip_band_hint;
 GLEW_VAR_EXPORT GLboolean __GLEW_SGIS_color_range;
 GLEW_VAR_EXPORT GLboolean __GLEW_SGIS_detail_texture;
 GLEW_VAR_EXPORT GLboolean __GLEW_SGIS_fog_function;
 GLEW_VAR_EXPORT GLboolean __GLEW_SGIS_generate_mipmap;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIS_line_texgen;
 GLEW_VAR_EXPORT GLboolean __GLEW_SGIS_multisample;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIS_multitexture;
 GLEW_VAR_EXPORT GLboolean __GLEW_SGIS_pixel_texture;
 GLEW_VAR_EXPORT GLboolean __GLEW_SGIS_point_line_texgen;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIS_shared_multisample;
 GLEW_VAR_EXPORT GLboolean __GLEW_SGIS_sharpen_texture;
 GLEW_VAR_EXPORT GLboolean __GLEW_SGIS_texture4D;
 GLEW_VAR_EXPORT GLboolean __GLEW_SGIS_texture_border_clamp;
@@ -18862,37 +23519,90 @@ GLEW_VAR_EXPORT GLboolean __GLEW_SGIS_texture_select;
 GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_async;
 GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_async_histogram;
 GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_async_pixel;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_bali_g_instruments;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_bali_r_instruments;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_bali_timer_instruments;
 GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_blend_alpha_minmax;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_blend_cadd;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_blend_cmultiply;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_calligraphic_fragment;
 GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_clipmap;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_color_matrix_accuracy;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_color_table_index_mode;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_complex_polar;
 GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_convolution_accuracy;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_cube_map;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_cylinder_texgen;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_datapipe;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_decimation;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_depth_pass_instrument;
 GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_depth_texture;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_dvc;
 GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_flush_raster;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_fog_blend;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_fog_factor_to_alpha;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_fog_layers;
 GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_fog_offset;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_fog_patchy;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_fog_scale;
 GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_fog_texture;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_fragment_lighting_space;
 GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_fragment_specular_lighting;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_fragments_instrument;
 GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_framezoom;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_icc_texture;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_igloo_interface;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_image_compression;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_impact_pixel_texture;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_instrument_error;
 GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_interlace;
 GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_ir_instrument1;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_line_quality_hint;
 GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_list_priority;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_mpeg1;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_mpeg2;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_nonlinear_lighting_pervertex;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_nurbs_eval;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_occlusion_instrument;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_packed_6bytes;
 GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_pixel_texture;
 GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_pixel_texture_bits;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_pixel_texture_lod;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_pixel_tiles;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_polynomial_ffd;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_quad_mesh;
 GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_reference_plane;
 GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_resample;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_scalebias_hint;
 GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_shadow;
 GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_shadow_ambient;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_slim;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_spotlight_cutoff;
 GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_sprite;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_subdiv_patch;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_subsample;
 GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_tag_sample_buffer;
 GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_texture_add_env;
 GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_texture_coordinate_clamp;
 GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_texture_lod_bias;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_texture_mipmap_anisotropic;
 GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_texture_multi_buffer;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_texture_phase;
 GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_texture_range;
 GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_texture_scale_bias;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_texture_supersample;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_vector_ops;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_vertex_array_object;
 GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_vertex_preclip;
 GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_vertex_preclip_hint;
 GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_ycrcb;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_ycrcb_subsample;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGIX_ycrcba;
 GLEW_VAR_EXPORT GLboolean __GLEW_SGI_color_matrix;
 GLEW_VAR_EXPORT GLboolean __GLEW_SGI_color_table;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGI_complex;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGI_complex_type;
+GLEW_VAR_EXPORT GLboolean __GLEW_SGI_fft;
 GLEW_VAR_EXPORT GLboolean __GLEW_SGI_texture_color_table;
 GLEW_VAR_EXPORT GLboolean __GLEW_SUNX_constant_data;
 GLEW_VAR_EXPORT GLboolean __GLEW_SUN_convolution_border_modes;
@@ -18903,13 +23613,9 @@ GLEW_VAR_EXPORT GLboolean __GLEW_SUN_slice_accum;
 GLEW_VAR_EXPORT GLboolean __GLEW_SUN_triangle_list;
 GLEW_VAR_EXPORT GLboolean __GLEW_SUN_vertex;
 GLEW_VAR_EXPORT GLboolean __GLEW_WIN_phong_shading;
+GLEW_VAR_EXPORT GLboolean __GLEW_WIN_scene_markerXXX;
 GLEW_VAR_EXPORT GLboolean __GLEW_WIN_specular_fog;
 GLEW_VAR_EXPORT GLboolean __GLEW_WIN_swap_hint;
-
-#ifdef GLEW_MX
-}; /* GLEWContextStruct */
-#endif /* GLEW_MX */
-
 /* ------------------------------------------------------------------------- */
 
 /* error codes */
@@ -18918,6 +23624,7 @@ GLEW_VAR_EXPORT GLboolean __GLEW_WIN_swap_hint;
 #define GLEW_ERROR_NO_GL_VERSION 1  /* missing GL version */
 #define GLEW_ERROR_GL_VERSION_10_ONLY 2  /* Need at least OpenGL 1.1 */
 #define GLEW_ERROR_GLX_VERSION_11_ONLY 3  /* Need at least GLX 1.2 */
+#define GLEW_ERROR_NO_GLX_DISPLAY 4  /* Need GLX display for GLX support */
 
 /* string codes */
 #define GLEW_VERSION 1
@@ -18925,34 +23632,29 @@ GLEW_VAR_EXPORT GLboolean __GLEW_WIN_swap_hint;
 #define GLEW_VERSION_MINOR 3
 #define GLEW_VERSION_MICRO 4
 
+/* ------------------------------------------------------------------------- */
+
+/* GLEW version info */
+
+/*
+VERSION 2.1.0
+VERSION_MAJOR 2
+VERSION_MINOR 1
+VERSION_MICRO 0
+*/
+
 /* API */
-#ifdef GLEW_MX
-
-typedef struct GLEWContextStruct GLEWContext;
-GLEWAPI GLenum GLEWAPIENTRY glewContextInit (GLEWContext *ctx);
-GLEWAPI GLboolean GLEWAPIENTRY glewContextIsSupported (const GLEWContext *ctx, const char *name);
-
-#define glewInit() glewContextInit(glewGetContext())
-#define glewIsSupported(x) glewContextIsSupported(glewGetContext(), x)
-#define glewIsExtensionSupported(x) glewIsSupported(x)
-
-#define GLEW_GET_VAR(x) (*(const GLboolean*)&(glewGetContext()->x))
-#ifdef _WIN32
-#  define GLEW_GET_FUN(x) glewGetContext()->x
-#else
-#  define GLEW_GET_FUN(x) x
-#endif
-
-#else /* GLEW_MX */
-
 GLEWAPI GLenum GLEWAPIENTRY glewInit (void);
 GLEWAPI GLboolean GLEWAPIENTRY glewIsSupported (const char *name);
 #define glewIsExtensionSupported(x) glewIsSupported(x)
 
+#ifndef GLEW_GET_VAR
 #define GLEW_GET_VAR(x) (*(const GLboolean*)&x)
-#define GLEW_GET_FUN(x) x
+#endif
 
-#endif /* GLEW_MX */
+#ifndef GLEW_GET_FUN
+#define GLEW_GET_FUN(x) x
+#endif
 
 GLEWAPI GLboolean glewExperimental;
 GLEWAPI GLboolean GLEWAPIENTRY glewGetExtension (const char *name);

--- a/lib/glew/include/GL/glxew.h
+++ b/lib/glew/include/GL/glxew.h
@@ -1,6 +1,6 @@
 /*
 ** The OpenGL Extension Wrangler Library
-** Copyright (C) 2008-2014, Nigel Stewart <nigels[]users sourceforge net>
+** Copyright (C) 2008-2017, Nigel Stewart <nigels[]users sourceforge net>
 ** Copyright (C) 2002-2008, Milan Ikits <milan ikits[]ieee org>
 ** Copyright (C) 2002-2008, Marcelo E. Magallon <mmagallo[]debian org>
 ** Copyright (C) 2002, Lev Povalahev
@@ -415,6 +415,15 @@ typedef GLXContext ( * PFNGLXCREATECONTEXTATTRIBSARBPROC) (Display* dpy, GLXFBCo
 
 #endif /* GLX_ARB_create_context */
 
+/* -------------------- GLX_ARB_create_context_no_error -------------------- */
+
+#ifndef GLX_ARB_create_context_no_error
+#define GLX_ARB_create_context_no_error 1
+
+#define GLXEW_ARB_create_context_no_error GLXEW_GET_VAR(__GLXEW_ARB_create_context_no_error)
+
+#endif /* GLX_ARB_create_context_no_error */
+
 /* --------------------- GLX_ARB_create_context_profile -------------------- */
 
 #ifndef GLX_ARB_create_context_profile
@@ -447,8 +456,8 @@ typedef GLXContext ( * PFNGLXCREATECONTEXTATTRIBSARBPROC) (Display* dpy, GLXFBCo
 #ifndef GLX_ARB_fbconfig_float
 #define GLX_ARB_fbconfig_float 1
 
-#define GLX_RGBA_FLOAT_BIT 0x00000004
-#define GLX_RGBA_FLOAT_TYPE 0x20B9
+#define GLX_RGBA_FLOAT_BIT_ARB 0x00000004
+#define GLX_RGBA_FLOAT_TYPE_ARB 0x20B9
 
 #define GLXEW_ARB_fbconfig_float GLXEW_GET_VAR(__GLXEW_ARB_fbconfig_float)
 
@@ -665,6 +674,17 @@ typedef int ( * PFNGLXQUERYCONTEXTINFOEXTPROC) (Display* dpy, GLXContext context
 #define GLXEW_EXT_import_context GLXEW_GET_VAR(__GLXEW_EXT_import_context)
 
 #endif /* GLX_EXT_import_context */
+
+/* ---------------------------- GLX_EXT_libglvnd --------------------------- */
+
+#ifndef GLX_EXT_libglvnd
+#define GLX_EXT_libglvnd 1
+
+#define GLX_VENDOR_NAMES_EXT 0x20F6
+
+#define GLXEW_EXT_libglvnd GLXEW_GET_VAR(__GLXEW_EXT_libglvnd)
+
+#endif /* GLX_EXT_libglvnd */
 
 /* -------------------------- GLX_EXT_scene_marker ------------------------- */
 
@@ -1010,6 +1030,17 @@ typedef unsigned int* ( * PFNGLXENUMERATEVIDEODEVICESNVPROC) (Display *dpy, int 
 #define GLXEW_NV_present_video GLXEW_GET_VAR(__GLXEW_NV_present_video)
 
 #endif /* GLX_NV_present_video */
+
+/* ------------------ GLX_NV_robustness_video_memory_purge ----------------- */
+
+#ifndef GLX_NV_robustness_video_memory_purge
+#define GLX_NV_robustness_video_memory_purge 1
+
+#define GLX_GENERATE_RESET_ON_VIDEO_MEMORY_PURGE_NV 0x20F7
+
+#define GLXEW_NV_robustness_video_memory_purge GLXEW_GET_VAR(__GLXEW_NV_robustness_video_memory_purge)
+
+#endif /* GLX_NV_robustness_video_memory_purge */
 
 /* --------------------------- GLX_NV_swap_group --------------------------- */
 
@@ -1496,13 +1527,8 @@ typedef int ( * PFNGLXVIDEORESIZESUNPROC) (Display* display, GLXDrawable window,
 
 /* ------------------------------------------------------------------------- */
 
-#ifdef GLEW_MX
-#define GLXEW_FUN_EXPORT GLEW_FUN_EXPORT
-#define GLXEW_VAR_EXPORT
-#else
 #define GLXEW_FUN_EXPORT GLEW_FUN_EXPORT
 #define GLXEW_VAR_EXPORT GLEW_VAR_EXPORT
-#endif /* GLEW_MX */
 
 GLXEW_FUN_EXPORT PFNGLXGETCURRENTDISPLAYPROC __glewXGetCurrentDisplay;
 
@@ -1654,12 +1680,6 @@ GLXEW_FUN_EXPORT PFNGLXGETTRANSPARENTINDEXSUNPROC __glewXGetTransparentIndexSUN;
 
 GLXEW_FUN_EXPORT PFNGLXGETVIDEORESIZESUNPROC __glewXGetVideoResizeSUN;
 GLXEW_FUN_EXPORT PFNGLXVIDEORESIZESUNPROC __glewXVideoResizeSUN;
-
-#if defined(GLEW_MX)
-struct GLXEWContextStruct
-{
-#endif /* GLEW_MX */
-
 GLXEW_VAR_EXPORT GLboolean __GLXEW_VERSION_1_0;
 GLXEW_VAR_EXPORT GLboolean __GLXEW_VERSION_1_1;
 GLXEW_VAR_EXPORT GLboolean __GLXEW_VERSION_1_2;
@@ -1669,6 +1689,7 @@ GLXEW_VAR_EXPORT GLboolean __GLXEW_3DFX_multisample;
 GLXEW_VAR_EXPORT GLboolean __GLXEW_AMD_gpu_association;
 GLXEW_VAR_EXPORT GLboolean __GLXEW_ARB_context_flush_control;
 GLXEW_VAR_EXPORT GLboolean __GLXEW_ARB_create_context;
+GLXEW_VAR_EXPORT GLboolean __GLXEW_ARB_create_context_no_error;
 GLXEW_VAR_EXPORT GLboolean __GLXEW_ARB_create_context_profile;
 GLXEW_VAR_EXPORT GLboolean __GLXEW_ARB_create_context_robustness;
 GLXEW_VAR_EXPORT GLboolean __GLXEW_ARB_fbconfig_float;
@@ -1686,6 +1707,7 @@ GLXEW_VAR_EXPORT GLboolean __GLXEW_EXT_create_context_es_profile;
 GLXEW_VAR_EXPORT GLboolean __GLXEW_EXT_fbconfig_packed_float;
 GLXEW_VAR_EXPORT GLboolean __GLXEW_EXT_framebuffer_sRGB;
 GLXEW_VAR_EXPORT GLboolean __GLXEW_EXT_import_context;
+GLXEW_VAR_EXPORT GLboolean __GLXEW_EXT_libglvnd;
 GLXEW_VAR_EXPORT GLboolean __GLXEW_EXT_scene_marker;
 GLXEW_VAR_EXPORT GLboolean __GLXEW_EXT_stereo_tree;
 GLXEW_VAR_EXPORT GLboolean __GLXEW_EXT_swap_control;
@@ -1707,6 +1729,7 @@ GLXEW_VAR_EXPORT GLboolean __GLXEW_NV_delay_before_swap;
 GLXEW_VAR_EXPORT GLboolean __GLXEW_NV_float_buffer;
 GLXEW_VAR_EXPORT GLboolean __GLXEW_NV_multisample_coverage;
 GLXEW_VAR_EXPORT GLboolean __GLXEW_NV_present_video;
+GLXEW_VAR_EXPORT GLboolean __GLXEW_NV_robustness_video_memory_purge;
 GLXEW_VAR_EXPORT GLboolean __GLXEW_NV_swap_group;
 GLXEW_VAR_EXPORT GLboolean __GLXEW_NV_vertex_array_range;
 GLXEW_VAR_EXPORT GLboolean __GLXEW_NV_video_capture;
@@ -1730,33 +1753,18 @@ GLXEW_VAR_EXPORT GLboolean __GLXEW_SGI_swap_control;
 GLXEW_VAR_EXPORT GLboolean __GLXEW_SGI_video_sync;
 GLXEW_VAR_EXPORT GLboolean __GLXEW_SUN_get_transparent_index;
 GLXEW_VAR_EXPORT GLboolean __GLXEW_SUN_video_resize;
-
-#ifdef GLEW_MX
-}; /* GLXEWContextStruct */
-#endif /* GLEW_MX */
-
 /* ------------------------------------------------------------------------ */
 
-#ifdef GLEW_MX
-
-typedef struct GLXEWContextStruct GLXEWContext;
-GLEWAPI GLenum GLEWAPIENTRY glxewContextInit (GLXEWContext *ctx);
-GLEWAPI GLboolean GLEWAPIENTRY glxewContextIsSupported (const GLXEWContext *ctx, const char *name);
-
-#define glxewInit() glxewContextInit(glxewGetContext())
-#define glxewIsSupported(x) glxewContextIsSupported(glxewGetContext(), x)
-
-#define GLXEW_GET_VAR(x) (*(const GLboolean*)&(glxewGetContext()->x))
-#define GLXEW_GET_FUN(x) x
-
-#else /* GLEW_MX */
-
-#define GLXEW_GET_VAR(x) (*(const GLboolean*)&x)
-#define GLXEW_GET_FUN(x) x
-
+GLEWAPI GLenum GLEWAPIENTRY glxewInit ();
 GLEWAPI GLboolean GLEWAPIENTRY glxewIsSupported (const char *name);
 
-#endif /* GLEW_MX */
+#ifndef GLXEW_GET_VAR
+#define GLXEW_GET_VAR(x) (*(const GLboolean*)&x)
+#endif
+
+#ifndef GLXEW_GET_FUN
+#define GLXEW_GET_FUN(x) x
+#endif
 
 GLEWAPI GLboolean GLEWAPIENTRY glxewGetExtension (const char *name);
 

--- a/lib/glew/include/GL/wglew.h
+++ b/lib/glew/include/GL/wglew.h
@@ -1,6 +1,6 @@
 /*
 ** The OpenGL Extension Wrangler Library
-** Copyright (C) 2008-2014, Nigel Stewart <nigels[]users sourceforge net>
+** Copyright (C) 2008-2017, Nigel Stewart <nigels[]users sourceforge net>
 ** Copyright (C) 2002-2008, Milan Ikits <milan ikits[]ieee org>
 ** Copyright (C) 2002-2008, Marcelo E. Magallon <mmagallo[]debian org>
 ** Copyright (C) 2002, Lev Povalahev
@@ -213,6 +213,15 @@ typedef HGLRC (WINAPI * PFNWGLCREATECONTEXTATTRIBSARBPROC) (HDC hDC, HGLRC hShar
 #define WGLEW_ARB_create_context WGLEW_GET_VAR(__WGLEW_ARB_create_context)
 
 #endif /* WGL_ARB_create_context */
+
+/* -------------------- WGL_ARB_create_context_no_error -------------------- */
+
+#ifndef WGL_ARB_create_context_no_error
+#define WGL_ARB_create_context_no_error 1
+
+#define WGLEW_ARB_create_context_no_error WGLEW_GET_VAR(__WGLEW_ARB_create_context_no_error)
+
+#endif /* WGL_ARB_create_context_no_error */
 
 /* --------------------- WGL_ARB_create_context_profile -------------------- */
 
@@ -501,6 +510,19 @@ typedef BOOL (WINAPI * PFNWGLSETPBUFFERATTRIBARBPROC) (HPBUFFERARB hPbuffer, con
 #define WGLEW_ATI_render_texture_rectangle WGLEW_GET_VAR(__WGLEW_ATI_render_texture_rectangle)
 
 #endif /* WGL_ATI_render_texture_rectangle */
+
+/* --------------------------- WGL_EXT_colorspace -------------------------- */
+
+#ifndef WGL_EXT_colorspace
+#define WGL_EXT_colorspace 1
+
+#define WGL_COLORSPACE_SRGB_EXT 0x3089
+#define WGL_COLORSPACE_LINEAR_EXT 0x308A
+#define WGL_COLORSPACE_EXT 0x309D
+
+#define WGLEW_EXT_colorspace WGLEW_GET_VAR(__WGLEW_EXT_colorspace)
+
+#endif /* WGL_EXT_colorspace */
 
 /* ------------------- WGL_EXT_create_context_es2_profile ------------------ */
 
@@ -1193,18 +1215,8 @@ typedef BOOL (WINAPI * PFNWGLWAITFORSBCOMLPROC) (HDC hdc, INT64 target_sbc, INT6
 
 /* ------------------------------------------------------------------------- */
 
-#ifdef GLEW_MX
-#define WGLEW_FUN_EXPORT
-#define WGLEW_VAR_EXPORT
-#else
 #define WGLEW_FUN_EXPORT GLEW_FUN_EXPORT
 #define WGLEW_VAR_EXPORT GLEW_VAR_EXPORT
-#endif /* GLEW_MX */
-
-#ifdef GLEW_MX
-struct WGLEWContextStruct
-{
-#endif /* GLEW_MX */
 
 WGLEW_FUN_EXPORT PFNWGLSETSTEREOEMITTERSTATE3DLPROC __wglewSetStereoEmitterState3DL;
 
@@ -1361,6 +1373,7 @@ WGLEW_VAR_EXPORT GLboolean __WGLEW_AMD_gpu_association;
 WGLEW_VAR_EXPORT GLboolean __WGLEW_ARB_buffer_region;
 WGLEW_VAR_EXPORT GLboolean __WGLEW_ARB_context_flush_control;
 WGLEW_VAR_EXPORT GLboolean __WGLEW_ARB_create_context;
+WGLEW_VAR_EXPORT GLboolean __WGLEW_ARB_create_context_no_error;
 WGLEW_VAR_EXPORT GLboolean __WGLEW_ARB_create_context_profile;
 WGLEW_VAR_EXPORT GLboolean __WGLEW_ARB_create_context_robustness;
 WGLEW_VAR_EXPORT GLboolean __WGLEW_ARB_extensions_string;
@@ -1375,6 +1388,7 @@ WGLEW_VAR_EXPORT GLboolean __WGLEW_ARB_robustness_application_isolation;
 WGLEW_VAR_EXPORT GLboolean __WGLEW_ARB_robustness_share_group_isolation;
 WGLEW_VAR_EXPORT GLboolean __WGLEW_ATI_pixel_format_float;
 WGLEW_VAR_EXPORT GLboolean __WGLEW_ATI_render_texture_rectangle;
+WGLEW_VAR_EXPORT GLboolean __WGLEW_EXT_colorspace;
 WGLEW_VAR_EXPORT GLboolean __WGLEW_EXT_create_context_es2_profile;
 WGLEW_VAR_EXPORT GLboolean __WGLEW_EXT_create_context_es_profile;
 WGLEW_VAR_EXPORT GLboolean __WGLEW_EXT_depth_float;
@@ -1409,33 +1423,18 @@ WGLEW_VAR_EXPORT GLboolean __WGLEW_NV_vertex_array_range;
 WGLEW_VAR_EXPORT GLboolean __WGLEW_NV_video_capture;
 WGLEW_VAR_EXPORT GLboolean __WGLEW_NV_video_output;
 WGLEW_VAR_EXPORT GLboolean __WGLEW_OML_sync_control;
-
-#ifdef GLEW_MX
-}; /* WGLEWContextStruct */
-#endif /* GLEW_MX */
-
 /* ------------------------------------------------------------------------- */
 
-#ifdef GLEW_MX
-
-typedef struct WGLEWContextStruct WGLEWContext;
-GLEWAPI GLenum GLEWAPIENTRY wglewContextInit (WGLEWContext *ctx);
-GLEWAPI GLboolean GLEWAPIENTRY wglewContextIsSupported (const WGLEWContext *ctx, const char *name);
-
-#define wglewInit() wglewContextInit(wglewGetContext())
-#define wglewIsSupported(x) wglewContextIsSupported(wglewGetContext(), x)
-
-#define WGLEW_GET_VAR(x) (*(const GLboolean*)&(wglewGetContext()->x))
-#define WGLEW_GET_FUN(x) wglewGetContext()->x
-
-#else /* GLEW_MX */
-
-#define WGLEW_GET_VAR(x) (*(const GLboolean*)&x)
-#define WGLEW_GET_FUN(x) x
-
+GLEWAPI GLenum GLEWAPIENTRY wglewInit ();
 GLEWAPI GLboolean GLEWAPIENTRY wglewIsSupported (const char *name);
 
-#endif /* GLEW_MX */
+#ifndef WGLEW_GET_VAR
+#define WGLEW_GET_VAR(x) (*(const GLboolean*)&x)
+#endif
+
+#ifndef WGLEW_GET_FUN
+#define WGLEW_GET_FUN(x) x
+#endif
 
 GLEWAPI GLboolean GLEWAPIENTRY wglewGetExtension (const char *name);
 

--- a/lib/glew/src/glew.c
+++ b/lib/glew/src/glew.c
@@ -1,6 +1,6 @@
 /*
 ** The OpenGL Extension Wrangler Library
-** Copyright (C) 2008-2014, Nigel Stewart <nigels[]users sourceforge net>
+** Copyright (C) 2008-2017, Nigel Stewart <nigels[]users sourceforge net>
 ** Copyright (C) 2002-2008, Milan Ikits <milan ikits[]ieee org>
 ** Copyright (C) 2002-2008, Marcelo E. Magallon <mmagallo[]debian org>
 ** Copyright (C) 2002, Lev Povalahev
@@ -30,9 +30,26 @@
 ** THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+#ifndef GLEW_INCLUDE
 #include <GL/glew.h>
+#else
+#include GLEW_INCLUDE
+#endif
 
-#if defined(_WIN32)
+#if defined(GLEW_OSMESA)
+#  define GLAPI extern
+#  include <GL/osmesa.h>
+#elif defined(GLEW_EGL)
+#  include <GL/eglew.h>
+#elif defined(_WIN32)
+/*
+ * If NOGDI is defined, wingdi.h won't be included by windows.h, and thus
+ * wglGetProcAddress won't be declared. It will instead be implicitly declared,
+ * potentially incorrectly, which we don't want.
+ */
+#  if defined(NOGDI)
+#    undef NOGDI
+#  endif
 #  include <GL/wglew.h>
 #elif !defined(__ANDROID__) && !defined(__native_client__) && !defined(__HAIKU__) && (!defined(__APPLE__) || defined(GLEW_APPLE_GLX))
 #  include <GL/glxew.h>
@@ -40,36 +57,8 @@
 
 #include <stddef.h>  /* For size_t */
 
-/*
- * Define glewGetContext and related helper macros.
- */
-#ifdef GLEW_MX
-#  define glewGetContext() ctx
-#  ifdef _WIN32
-#    define GLEW_CONTEXT_ARG_DEF_INIT GLEWContext* ctx
-#    define GLEW_CONTEXT_ARG_VAR_INIT ctx
-#    define wglewGetContext() ctx
-#    define WGLEW_CONTEXT_ARG_DEF_INIT WGLEWContext* ctx
-#    define WGLEW_CONTEXT_ARG_DEF_LIST WGLEWContext* ctx
-#  else /* _WIN32 */
-#    define GLEW_CONTEXT_ARG_DEF_INIT void
-#    define GLEW_CONTEXT_ARG_VAR_INIT
-#    define glxewGetContext() ctx
-#    define GLXEW_CONTEXT_ARG_DEF_INIT void
-#    define GLXEW_CONTEXT_ARG_DEF_LIST GLXEWContext* ctx
-#  endif /* _WIN32 */
-#  define GLEW_CONTEXT_ARG_DEF_LIST GLEWContext* ctx
-#else /* GLEW_MX */
-#  define GLEW_CONTEXT_ARG_DEF_INIT void
-#  define GLEW_CONTEXT_ARG_VAR_INIT
-#  define GLEW_CONTEXT_ARG_DEF_LIST void
-#  define WGLEW_CONTEXT_ARG_DEF_INIT void
-#  define WGLEW_CONTEXT_ARG_DEF_LIST void
-#  define GLXEW_CONTEXT_ARG_DEF_INIT void
-#  define GLXEW_CONTEXT_ARG_DEF_LIST void
-#endif /* GLEW_MX */
-
-#if defined(GLEW_REGAL)
+#if defined(GLEW_EGL)
+#elif defined(GLEW_REGAL)
 
 /* In GLEW_REGAL mode we call direcly into the linked
    libRegal.so glGetProcAddressREGAL for looking up
@@ -121,7 +110,7 @@ void* NSGLGetProcAddress (const GLubyte *name)
 {
   static void* image = NULL;
   void* addr;
-  if (NULL == image) 
+  if (NULL == image)
   {
     image = dlopen("/System/Library/Frameworks/OpenGL.framework/Versions/Current/OpenGL", RTLD_LAZY);
   }
@@ -170,7 +159,11 @@ void* NSGLGetProcAddress (const GLubyte *name)
  * Define glewGetProcAddress.
  */
 #if defined(GLEW_REGAL)
-#  define glewGetProcAddress(name) regalGetProcAddress((const GLchar *) name)
+#  define glewGetProcAddress(name) regalGetProcAddress((const GLchar *)name)
+#elif defined(GLEW_OSMESA)
+#  define glewGetProcAddress(name) OSMesaGetProcAddress((const char *)name)
+#elif defined(GLEW_EGL)
+#  define glewGetProcAddress(name) eglGetProcAddress((const char *)name)
 #elif defined(_WIN32)
 #  define glewGetProcAddress(name) wglGetProcAddress((LPCSTR)name)
 #elif defined(__APPLE__) && !defined(GLEW_APPLE_GLX)
@@ -190,34 +183,28 @@ void* NSGLGetProcAddress (const GLubyte *name)
  */
 
 #undef GLEW_GET_VAR
-#ifdef GLEW_MX
-# define GLEW_GET_VAR(x) (glewGetContext()->x)
-#else /* GLEW_MX */
 # define GLEW_GET_VAR(x) (x)
-#endif /* GLEW_MX */
 
 #ifdef WGLEW_GET_VAR
 # undef WGLEW_GET_VAR
-# ifdef GLEW_MX
-#  define WGLEW_GET_VAR(x) (wglewGetContext()->x)
-# else /* GLEW_MX */
-#  define WGLEW_GET_VAR(x) (x)
-# endif /* GLEW_MX */
+# define WGLEW_GET_VAR(x) (x)
 #endif /* WGLEW_GET_VAR */
 
 #ifdef GLXEW_GET_VAR
 # undef GLXEW_GET_VAR
-# ifdef GLEW_MX
-#  define GLXEW_GET_VAR(x) (glxewGetContext()->x)
-# else /* GLEW_MX */
-#  define GLXEW_GET_VAR(x) (x)
-# endif /* GLEW_MX */
+# define GLXEW_GET_VAR(x) (x)
 #endif /* GLXEW_GET_VAR */
+
+#ifdef EGLEW_GET_VAR
+# undef EGLEW_GET_VAR
+# define EGLEW_GET_VAR(x) (x)
+#endif /* EGLEW_GET_VAR */
 
 /*
  * GLEW, just like OpenGL or GLU, does not rely on the standard C library.
  * These functions implement the functionality required in this file.
  */
+
 static GLuint _glewStrLen (const GLubyte* s)
 {
   GLuint i=0;
@@ -231,9 +218,20 @@ static GLuint _glewStrCLen (const GLubyte* s, GLubyte c)
   GLuint i=0;
   if (s == NULL) return 0;
   while (s[i] != '\0' && s[i] != c) i++;
-  return (s[i] == '\0' || s[i] == c) ? i : 0;
+  return i;
 }
 
+static GLuint _glewStrCopy(char *d, const char *s, char c)
+{
+  GLuint i=0;
+  if (s == NULL) return 0;
+  while (s[i] != '\0' && s[i] != c) { d[i] = s[i]; i++; }
+  d[i] = '\0';
+  return i;
+}
+
+#if !defined(GLEW_OSMESA)
+#if !defined(__APPLE__) || defined(GLEW_APPLE_GLX)
 static GLboolean _glewStrSame (const GLubyte* a, const GLubyte* b, GLuint n)
 {
   GLuint i=0;
@@ -242,8 +240,10 @@ static GLboolean _glewStrSame (const GLubyte* a, const GLubyte* b, GLuint n)
   while (i < n && a[i] != '\0' && b[i] != '\0' && a[i] == b[i]) i++;
   return i == n ? GL_TRUE : GL_FALSE;
 }
+#endif
+#endif
 
-static GLboolean _glewStrSame1 (GLubyte** a, GLuint* na, const GLubyte* b, GLuint nb)
+static GLboolean _glewStrSame1 (const GLubyte** a, GLuint* na, const GLubyte* b, GLuint nb)
 {
   while (*na > 0 && (**a == ' ' || **a == '\n' || **a == '\r' || **a == '\t'))
   {
@@ -264,7 +264,7 @@ static GLboolean _glewStrSame1 (GLubyte** a, GLuint* na, const GLubyte* b, GLuin
   return GL_FALSE;
 }
 
-static GLboolean _glewStrSame2 (GLubyte** a, GLuint* na, const GLubyte* b, GLuint nb)
+static GLboolean _glewStrSame2 (const GLubyte** a, GLuint* na, const GLubyte* b, GLuint nb)
 {
   if(*na >= nb)
   {
@@ -280,7 +280,7 @@ static GLboolean _glewStrSame2 (GLubyte** a, GLuint* na, const GLubyte* b, GLuin
   return GL_FALSE;
 }
 
-static GLboolean _glewStrSame3 (GLubyte** a, GLuint* na, const GLubyte* b, GLuint nb)
+static GLboolean _glewStrSame3 (const GLubyte** a, GLuint* na, const GLubyte* b, GLuint nb)
 {
   if(*na >= nb)
   {
@@ -296,74 +296,29 @@ static GLboolean _glewStrSame3 (GLubyte** a, GLuint* na, const GLubyte* b, GLuin
   return GL_FALSE;
 }
 
-#include <string.h>
-#include <stdlib.h>
-
-/* A simple open addressing hashset for extensions on OpenGL 3+. */
-static const char ** ext_hashset = NULL;
-size_t ext_hashset_size = 0;
-
-static unsigned hash_string(const char * key)
-{
-  unsigned hash = 0;
-  unsigned i = 0;
-  for (; i < strlen(key); ++i)
-  {
-    hash += key[i];
-    hash += (hash << 10);
-    hash ^= (hash >> 6);
-  }
-  hash += (hash << 3);
-  hash ^= (hash >> 11);
-  hash += (hash << 15);
-
-  return hash;
-}
-
 /*
  * Search for name in the extensions string. Use of strstr()
  * is not sufficient because extension names can be prefixes of
  * other extension names. Could use strtok() but the constant
  * string returned by glGetString might be in read-only memory.
  */
+#if !defined(GLEW_OSMESA)
+#if !defined(__APPLE__) || defined(GLEW_APPLE_GLX)
 static GLboolean _glewSearchExtension (const char* name, const GLubyte *start, const GLubyte *end)
 {
-  if (ext_hashset != NULL)
+  const GLubyte* p;
+  GLuint len = _glewStrLen((const GLubyte*)name);
+  p = start;
+  while (p < end)
   {
-    unsigned hash = hash_string(name);
-
-    /*
-     * As the hashset is bigger than the number of extensions
-     * this will eventually break.
-     */
-    while(1)
-    {
-        unsigned index = hash % ext_hashset_size;
-        if (ext_hashset[index] == NULL)
-            break;
-
-        if (!strcmp(ext_hashset[index], name))
-            return GL_TRUE;
-
-        hash++;
-    }
-  }
-  else
-  {
-    const GLubyte* p;
-    GLuint len = _glewStrLen((const GLubyte*)name);
-    p = start;
-    while (p < end)
-    {
-      GLuint n = _glewStrCLen(p, ' ');
-      if (len == n && _glewStrSame((const GLubyte*)name, p, n)) return GL_TRUE;
-      p += n+1;
-    }
+    GLuint n = _glewStrCLen(p, ' ');
+    if (len == n && _glewStrSame((const GLubyte*)name, p, n)) return GL_TRUE;
+    p += n+1;
   }
   return GL_FALSE;
 }
-
-#if !defined(_WIN32) || !defined(GLEW_MX)
+#endif
+#endif
 
 PFNGLCOPYTEXSUBIMAGE3DPROC __glewCopyTexSubImage3D = NULL;
 PFNGLDRAWRANGEELEMENTSPROC __glewDrawRangeElements = NULL;
@@ -659,6 +614,15 @@ PFNGLBLENDFUNCSEPARATEIPROC __glewBlendFuncSeparatei = NULL;
 PFNGLBLENDFUNCIPROC __glewBlendFunci = NULL;
 PFNGLMINSAMPLESHADINGPROC __glewMinSampleShading = NULL;
 
+PFNGLGETGRAPHICSRESETSTATUSPROC __glewGetGraphicsResetStatus = NULL;
+PFNGLGETNCOMPRESSEDTEXIMAGEPROC __glewGetnCompressedTexImage = NULL;
+PFNGLGETNTEXIMAGEPROC __glewGetnTexImage = NULL;
+PFNGLGETNUNIFORMDVPROC __glewGetnUniformdv = NULL;
+
+PFNGLMULTIDRAWARRAYSINDIRECTCOUNTPROC __glewMultiDrawArraysIndirectCount = NULL;
+PFNGLMULTIDRAWELEMENTSINDIRECTCOUNTPROC __glewMultiDrawElementsIndirectCount = NULL;
+PFNGLSPECIALIZESHADERPROC __glewSpecializeShader = NULL;
+
 PFNGLTBUFFERMASK3DFXPROC __glewTbufferMask3DFX = NULL;
 
 PFNGLDEBUGMESSAGECALLBACKAMDPROC __glewDebugMessageCallbackAMD = NULL;
@@ -670,6 +634,11 @@ PFNGLBLENDEQUATIONINDEXEDAMDPROC __glewBlendEquationIndexedAMD = NULL;
 PFNGLBLENDEQUATIONSEPARATEINDEXEDAMDPROC __glewBlendEquationSeparateIndexedAMD = NULL;
 PFNGLBLENDFUNCINDEXEDAMDPROC __glewBlendFuncIndexedAMD = NULL;
 PFNGLBLENDFUNCSEPARATEINDEXEDAMDPROC __glewBlendFuncSeparateIndexedAMD = NULL;
+
+PFNGLFRAMEBUFFERSAMPLEPOSITIONSFVAMDPROC __glewFramebufferSamplePositionsfvAMD = NULL;
+PFNGLGETFRAMEBUFFERPARAMETERFVAMDPROC __glewGetFramebufferParameterfvAMD = NULL;
+PFNGLGETNAMEDFRAMEBUFFERPARAMETERFVAMDPROC __glewGetNamedFramebufferParameterfvAMD = NULL;
+PFNGLNAMEDFRAMEBUFFERSAMPLEPOSITIONSFVAMDPROC __glewNamedFramebufferSamplePositionsfvAMD = NULL;
 
 PFNGLVERTEXATTRIBPARAMETERIAMDPROC __glewVertexAttribParameteriAMD = NULL;
 
@@ -726,6 +695,8 @@ PFNGLQUERYCOUNTERANGLEPROC __glewQueryCounterANGLE = NULL;
 
 PFNGLGETTRANSLATEDSHADERSOURCEANGLEPROC __glewGetTranslatedShaderSourceANGLE = NULL;
 
+PFNGLCOPYTEXTURELEVELSAPPLEPROC __glewCopyTextureLevelsAPPLE = NULL;
+
 PFNGLDRAWELEMENTARRAYAPPLEPROC __glewDrawElementArrayAPPLE = NULL;
 PFNGLDRAWRANGEELEMENTARRAYAPPLEPROC __glewDrawRangeElementArrayAPPLE = NULL;
 PFNGLELEMENTPOINTERAPPLEPROC __glewElementPointerAPPLE = NULL;
@@ -744,9 +715,20 @@ PFNGLTESTOBJECTAPPLEPROC __glewTestObjectAPPLE = NULL;
 PFNGLBUFFERPARAMETERIAPPLEPROC __glewBufferParameteriAPPLE = NULL;
 PFNGLFLUSHMAPPEDBUFFERRANGEAPPLEPROC __glewFlushMappedBufferRangeAPPLE = NULL;
 
+PFNGLRENDERBUFFERSTORAGEMULTISAMPLEAPPLEPROC __glewRenderbufferStorageMultisampleAPPLE = NULL;
+PFNGLRESOLVEMULTISAMPLEFRAMEBUFFERAPPLEPROC __glewResolveMultisampleFramebufferAPPLE = NULL;
+
 PFNGLGETOBJECTPARAMETERIVAPPLEPROC __glewGetObjectParameterivAPPLE = NULL;
 PFNGLOBJECTPURGEABLEAPPLEPROC __glewObjectPurgeableAPPLE = NULL;
 PFNGLOBJECTUNPURGEABLEAPPLEPROC __glewObjectUnpurgeableAPPLE = NULL;
+
+PFNGLCLIENTWAITSYNCAPPLEPROC __glewClientWaitSyncAPPLE = NULL;
+PFNGLDELETESYNCAPPLEPROC __glewDeleteSyncAPPLE = NULL;
+PFNGLFENCESYNCAPPLEPROC __glewFenceSyncAPPLE = NULL;
+PFNGLGETINTEGER64VAPPLEPROC __glewGetInteger64vAPPLE = NULL;
+PFNGLGETSYNCIVAPPLEPROC __glewGetSyncivAPPLE = NULL;
+PFNGLISSYNCAPPLEPROC __glewIsSyncAPPLE = NULL;
+PFNGLWAITSYNCAPPLEPROC __glewWaitSyncAPPLE = NULL;
 
 PFNGLGETTEXPARAMETERPOINTERVAPPLEPROC __glewGetTexParameterPointervAPPLE = NULL;
 PFNGLTEXTURERANGEAPPLEPROC __glewTextureRangeAPPLE = NULL;
@@ -776,6 +758,8 @@ PFNGLSHADERBINARYPROC __glewShaderBinary = NULL;
 
 PFNGLMEMORYBARRIERBYREGIONPROC __glewMemoryBarrierByRegion = NULL;
 
+PFNGLPRIMITIVEBOUNDINGBOXARBPROC __glewPrimitiveBoundingBoxARB = NULL;
+
 PFNGLDRAWARRAYSINSTANCEDBASEINSTANCEPROC __glewDrawArraysInstancedBaseInstance = NULL;
 PFNGLDRAWELEMENTSINSTANCEDBASEINSTANCEPROC __glewDrawElementsInstancedBaseInstance = NULL;
 PFNGLDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCEPROC __glewDrawElementsInstancedBaseVertexBaseInstance = NULL;
@@ -801,7 +785,6 @@ PFNGLBINDFRAGDATALOCATIONINDEXEDPROC __glewBindFragDataLocationIndexed = NULL;
 PFNGLGETFRAGDATAINDEXPROC __glewGetFragDataIndex = NULL;
 
 PFNGLBUFFERSTORAGEPROC __glewBufferStorage = NULL;
-PFNGLNAMEDBUFFERSTORAGEEXTPROC __glewNamedBufferStorageEXT = NULL;
 
 PFNGLCREATESYNCFROMCLEVENTARBPROC __glewCreateSyncFromCLeventARB = NULL;
 
@@ -868,6 +851,10 @@ PFNGLGETNAMEDBUFFERSUBDATAPROC __glewGetNamedBufferSubData = NULL;
 PFNGLGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVPROC __glewGetNamedFramebufferAttachmentParameteriv = NULL;
 PFNGLGETNAMEDFRAMEBUFFERPARAMETERIVPROC __glewGetNamedFramebufferParameteriv = NULL;
 PFNGLGETNAMEDRENDERBUFFERPARAMETERIVPROC __glewGetNamedRenderbufferParameteriv = NULL;
+PFNGLGETQUERYBUFFEROBJECTI64VPROC __glewGetQueryBufferObjecti64v = NULL;
+PFNGLGETQUERYBUFFEROBJECTIVPROC __glewGetQueryBufferObjectiv = NULL;
+PFNGLGETQUERYBUFFEROBJECTUI64VPROC __glewGetQueryBufferObjectui64v = NULL;
+PFNGLGETQUERYBUFFEROBJECTUIVPROC __glewGetQueryBufferObjectuiv = NULL;
 PFNGLGETTEXTUREIMAGEPROC __glewGetTextureImage = NULL;
 PFNGLGETTEXTURELEVELPARAMETERFVPROC __glewGetTextureLevelParameterfv = NULL;
 PFNGLGETTEXTURELEVELPARAMETERIVPROC __glewGetTextureLevelParameteriv = NULL;
@@ -978,6 +965,8 @@ PFNGLPROGRAMPARAMETERIPROC __glewProgramParameteri = NULL;
 PFNGLGETCOMPRESSEDTEXTURESUBIMAGEPROC __glewGetCompressedTextureSubImage = NULL;
 PFNGLGETTEXTURESUBIMAGEPROC __glewGetTextureSubImage = NULL;
 
+PFNGLSPECIALIZESHADERARBPROC __glewSpecializeShaderARB = NULL;
+
 PFNGLGETUNIFORMDVPROC __glewGetUniformdv = NULL;
 PFNGLUNIFORM1DPROC __glewUniform1d = NULL;
 PFNGLUNIFORM1DVPROC __glewUniform1dv = NULL;
@@ -996,6 +985,43 @@ PFNGLUNIFORMMATRIX3X4DVPROC __glewUniformMatrix3x4dv = NULL;
 PFNGLUNIFORMMATRIX4DVPROC __glewUniformMatrix4dv = NULL;
 PFNGLUNIFORMMATRIX4X2DVPROC __glewUniformMatrix4x2dv = NULL;
 PFNGLUNIFORMMATRIX4X3DVPROC __glewUniformMatrix4x3dv = NULL;
+
+PFNGLGETUNIFORMI64VARBPROC __glewGetUniformi64vARB = NULL;
+PFNGLGETUNIFORMUI64VARBPROC __glewGetUniformui64vARB = NULL;
+PFNGLGETNUNIFORMI64VARBPROC __glewGetnUniformi64vARB = NULL;
+PFNGLGETNUNIFORMUI64VARBPROC __glewGetnUniformui64vARB = NULL;
+PFNGLPROGRAMUNIFORM1I64ARBPROC __glewProgramUniform1i64ARB = NULL;
+PFNGLPROGRAMUNIFORM1I64VARBPROC __glewProgramUniform1i64vARB = NULL;
+PFNGLPROGRAMUNIFORM1UI64ARBPROC __glewProgramUniform1ui64ARB = NULL;
+PFNGLPROGRAMUNIFORM1UI64VARBPROC __glewProgramUniform1ui64vARB = NULL;
+PFNGLPROGRAMUNIFORM2I64ARBPROC __glewProgramUniform2i64ARB = NULL;
+PFNGLPROGRAMUNIFORM2I64VARBPROC __glewProgramUniform2i64vARB = NULL;
+PFNGLPROGRAMUNIFORM2UI64ARBPROC __glewProgramUniform2ui64ARB = NULL;
+PFNGLPROGRAMUNIFORM2UI64VARBPROC __glewProgramUniform2ui64vARB = NULL;
+PFNGLPROGRAMUNIFORM3I64ARBPROC __glewProgramUniform3i64ARB = NULL;
+PFNGLPROGRAMUNIFORM3I64VARBPROC __glewProgramUniform3i64vARB = NULL;
+PFNGLPROGRAMUNIFORM3UI64ARBPROC __glewProgramUniform3ui64ARB = NULL;
+PFNGLPROGRAMUNIFORM3UI64VARBPROC __glewProgramUniform3ui64vARB = NULL;
+PFNGLPROGRAMUNIFORM4I64ARBPROC __glewProgramUniform4i64ARB = NULL;
+PFNGLPROGRAMUNIFORM4I64VARBPROC __glewProgramUniform4i64vARB = NULL;
+PFNGLPROGRAMUNIFORM4UI64ARBPROC __glewProgramUniform4ui64ARB = NULL;
+PFNGLPROGRAMUNIFORM4UI64VARBPROC __glewProgramUniform4ui64vARB = NULL;
+PFNGLUNIFORM1I64ARBPROC __glewUniform1i64ARB = NULL;
+PFNGLUNIFORM1I64VARBPROC __glewUniform1i64vARB = NULL;
+PFNGLUNIFORM1UI64ARBPROC __glewUniform1ui64ARB = NULL;
+PFNGLUNIFORM1UI64VARBPROC __glewUniform1ui64vARB = NULL;
+PFNGLUNIFORM2I64ARBPROC __glewUniform2i64ARB = NULL;
+PFNGLUNIFORM2I64VARBPROC __glewUniform2i64vARB = NULL;
+PFNGLUNIFORM2UI64ARBPROC __glewUniform2ui64ARB = NULL;
+PFNGLUNIFORM2UI64VARBPROC __glewUniform2ui64vARB = NULL;
+PFNGLUNIFORM3I64ARBPROC __glewUniform3i64ARB = NULL;
+PFNGLUNIFORM3I64VARBPROC __glewUniform3i64vARB = NULL;
+PFNGLUNIFORM3UI64ARBPROC __glewUniform3ui64ARB = NULL;
+PFNGLUNIFORM3UI64VARBPROC __glewUniform3ui64vARB = NULL;
+PFNGLUNIFORM4I64ARBPROC __glewUniform4i64ARB = NULL;
+PFNGLUNIFORM4I64VARBPROC __glewUniform4i64vARB = NULL;
+PFNGLUNIFORM4UI64ARBPROC __glewUniform4ui64ARB = NULL;
+PFNGLUNIFORM4UI64VARBPROC __glewUniform4ui64vARB = NULL;
 
 PFNGLCOLORSUBTABLEPROC __glewColorSubTable = NULL;
 PFNGLCOLORTABLEPROC __glewColorTable = NULL;
@@ -1113,8 +1139,12 @@ PFNGLGETQUERYOBJECTUIVARBPROC __glewGetQueryObjectuivARB = NULL;
 PFNGLGETQUERYIVARBPROC __glewGetQueryivARB = NULL;
 PFNGLISQUERYARBPROC __glewIsQueryARB = NULL;
 
+PFNGLMAXSHADERCOMPILERTHREADSARBPROC __glewMaxShaderCompilerThreadsARB = NULL;
+
 PFNGLPOINTPARAMETERFARBPROC __glewPointParameterfARB = NULL;
 PFNGLPOINTPARAMETERFVARBPROC __glewPointParameterfvARB = NULL;
+
+PFNGLPOLYGONOFFSETCLAMPPROC __glewPolygonOffsetClamp = NULL;
 
 PFNGLGETPROGRAMINTERFACEIVPROC __glewGetProgramInterfaceiv = NULL;
 PFNGLGETPROGRAMRESOURCEINDEXPROC __glewGetProgramResourceIndex = NULL;
@@ -1145,6 +1175,9 @@ PFNGLGETNUNIFORMFVARBPROC __glewGetnUniformfvARB = NULL;
 PFNGLGETNUNIFORMIVARBPROC __glewGetnUniformivARB = NULL;
 PFNGLGETNUNIFORMUIVARBPROC __glewGetnUniformuivARB = NULL;
 PFNGLREADNPIXELSARBPROC __glewReadnPixelsARB = NULL;
+
+PFNGLFRAMEBUFFERSAMPLELOCATIONSFVARBPROC __glewFramebufferSampleLocationsfvARB = NULL;
+PFNGLNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARBPROC __glewNamedFramebufferSampleLocationsfvARB = NULL;
 
 PFNGLMINSAMPLESHADINGARBPROC __glewMinSampleShadingARB = NULL;
 
@@ -1290,7 +1323,6 @@ PFNGLNAMEDSTRINGARBPROC __glewNamedStringARB = NULL;
 PFNGLBUFFERPAGECOMMITMENTARBPROC __glewBufferPageCommitmentARB = NULL;
 
 PFNGLTEXPAGECOMMITMENTARBPROC __glewTexPageCommitmentARB = NULL;
-PFNGLTEXTUREPAGECOMMITMENTEXTPROC __glewTexturePageCommitmentEXT = NULL;
 
 PFNGLCLIENTWAITSYNCPROC __glewClientWaitSync = NULL;
 PFNGLDELETESYNCPROC __glewDeleteSync = NULL;
@@ -1326,9 +1358,6 @@ PFNGLTEXIMAGE3DMULTISAMPLEPROC __glewTexImage3DMultisample = NULL;
 PFNGLTEXSTORAGE1DPROC __glewTexStorage1D = NULL;
 PFNGLTEXSTORAGE2DPROC __glewTexStorage2D = NULL;
 PFNGLTEXSTORAGE3DPROC __glewTexStorage3D = NULL;
-PFNGLTEXTURESTORAGE1DEXTPROC __glewTextureStorage1DEXT = NULL;
-PFNGLTEXTURESTORAGE2DEXTPROC __glewTextureStorage2DEXT = NULL;
-PFNGLTEXTURESTORAGE3DEXTPROC __glewTextureStorage3DEXT = NULL;
 
 PFNGLTEXSTORAGE2DMULTISAMPLEPROC __glewTexStorage2DMultisample = NULL;
 PFNGLTEXSTORAGE3DMULTISAMPLEPROC __glewTexStorage3DMultisample = NULL;
@@ -1657,6 +1686,10 @@ PFNGLVERTEXSTREAM4IVATIPROC __glewVertexStream4ivATI = NULL;
 PFNGLVERTEXSTREAM4SATIPROC __glewVertexStream4sATI = NULL;
 PFNGLVERTEXSTREAM4SVATIPROC __glewVertexStream4svATI = NULL;
 
+PFNGLDRAWARRAYSINSTANCEDBASEINSTANCEEXTPROC __glewDrawArraysInstancedBaseInstanceEXT = NULL;
+PFNGLDRAWELEMENTSINSTANCEDBASEINSTANCEEXTPROC __glewDrawElementsInstancedBaseInstanceEXT = NULL;
+PFNGLDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCEEXTPROC __glewDrawElementsInstancedBaseVertexBaseInstanceEXT = NULL;
+
 PFNGLGETUNIFORMBUFFERSIZEEXTPROC __glewGetUniformBufferSizeEXT = NULL;
 PFNGLGETUNIFORMOFFSETEXTPROC __glewGetUniformOffsetEXT = NULL;
 PFNGLUNIFORMBUFFEREXTPROC __glewUniformBufferEXT = NULL;
@@ -1665,9 +1698,19 @@ PFNGLBLENDCOLOREXTPROC __glewBlendColorEXT = NULL;
 
 PFNGLBLENDEQUATIONSEPARATEEXTPROC __glewBlendEquationSeparateEXT = NULL;
 
+PFNGLBINDFRAGDATALOCATIONINDEXEDEXTPROC __glewBindFragDataLocationIndexedEXT = NULL;
+PFNGLGETFRAGDATAINDEXEXTPROC __glewGetFragDataIndexEXT = NULL;
+PFNGLGETPROGRAMRESOURCELOCATIONINDEXEXTPROC __glewGetProgramResourceLocationIndexEXT = NULL;
+
 PFNGLBLENDFUNCSEPARATEEXTPROC __glewBlendFuncSeparateEXT = NULL;
 
 PFNGLBLENDEQUATIONEXTPROC __glewBlendEquationEXT = NULL;
+
+PFNGLBUFFERSTORAGEEXTPROC __glewBufferStorageEXT = NULL;
+PFNGLNAMEDBUFFERSTORAGEEXTPROC __glewNamedBufferStorageEXT = NULL;
+
+PFNGLCLEARTEXIMAGEEXTPROC __glewClearTexImageEXT = NULL;
+PFNGLCLEARTEXSUBIMAGEEXTPROC __glewClearTexSubImageEXT = NULL;
 
 PFNGLCOLORSUBTABLEEXTPROC __glewColorSubTableEXT = NULL;
 PFNGLCOPYCOLORSUBTABLEEXTPROC __glewCopyColorSubTableEXT = NULL;
@@ -1691,6 +1734,8 @@ PFNGLSEPARABLEFILTER2DEXTPROC __glewSeparableFilter2DEXT = NULL;
 
 PFNGLBINORMALPOINTEREXTPROC __glewBinormalPointerEXT = NULL;
 PFNGLTANGENTPOINTEREXTPROC __glewTangentPointerEXT = NULL;
+
+PFNGLCOPYIMAGESUBDATAEXTPROC __glewCopyImageSubDataEXT = NULL;
 
 PFNGLCOPYTEXIMAGE1DEXTPROC __glewCopyTexImage1DEXT = NULL;
 PFNGLCOPYTEXIMAGE2DEXTPROC __glewCopyTexImage2DEXT = NULL;
@@ -1925,6 +1970,10 @@ PFNGLVERTEXARRAYVERTEXATTRIBIOFFSETEXTPROC __glewVertexArrayVertexAttribIOffsetE
 PFNGLVERTEXARRAYVERTEXATTRIBOFFSETEXTPROC __glewVertexArrayVertexAttribOffsetEXT = NULL;
 PFNGLVERTEXARRAYVERTEXOFFSETEXTPROC __glewVertexArrayVertexOffsetEXT = NULL;
 
+PFNGLDISCARDFRAMEBUFFEREXTPROC __glewDiscardFramebufferEXT = NULL;
+
+PFNGLDRAWBUFFERSEXTPROC __glewDrawBuffersEXT = NULL;
+
 PFNGLCOLORMASKINDEXEDEXTPROC __glewColorMaskIndexedEXT = NULL;
 PFNGLDISABLEINDEXEDEXTPROC __glewDisableIndexedEXT = NULL;
 PFNGLENABLEINDEXEDEXTPROC __glewEnableIndexedEXT = NULL;
@@ -1932,10 +1981,27 @@ PFNGLGETBOOLEANINDEXEDVEXTPROC __glewGetBooleanIndexedvEXT = NULL;
 PFNGLGETINTEGERINDEXEDVEXTPROC __glewGetIntegerIndexedvEXT = NULL;
 PFNGLISENABLEDINDEXEDEXTPROC __glewIsEnabledIndexedEXT = NULL;
 
+PFNGLBLENDEQUATIONSEPARATEIEXTPROC __glewBlendEquationSeparateiEXT = NULL;
+PFNGLBLENDEQUATIONIEXTPROC __glewBlendEquationiEXT = NULL;
+PFNGLBLENDFUNCSEPARATEIEXTPROC __glewBlendFuncSeparateiEXT = NULL;
+PFNGLBLENDFUNCIEXTPROC __glewBlendFunciEXT = NULL;
+PFNGLCOLORMASKIEXTPROC __glewColorMaskiEXT = NULL;
+PFNGLDISABLEIEXTPROC __glewDisableiEXT = NULL;
+PFNGLENABLEIEXTPROC __glewEnableiEXT = NULL;
+PFNGLISENABLEDIEXTPROC __glewIsEnablediEXT = NULL;
+
+PFNGLDRAWELEMENTSBASEVERTEXEXTPROC __glewDrawElementsBaseVertexEXT = NULL;
+PFNGLDRAWELEMENTSINSTANCEDBASEVERTEXEXTPROC __glewDrawElementsInstancedBaseVertexEXT = NULL;
+PFNGLDRAWRANGEELEMENTSBASEVERTEXEXTPROC __glewDrawRangeElementsBaseVertexEXT = NULL;
+PFNGLMULTIDRAWELEMENTSBASEVERTEXEXTPROC __glewMultiDrawElementsBaseVertexEXT = NULL;
+
 PFNGLDRAWARRAYSINSTANCEDEXTPROC __glewDrawArraysInstancedEXT = NULL;
 PFNGLDRAWELEMENTSINSTANCEDEXTPROC __glewDrawElementsInstancedEXT = NULL;
 
 PFNGLDRAWRANGEELEMENTSEXTPROC __glewDrawRangeElementsEXT = NULL;
+
+PFNGLBUFFERSTORAGEEXTERNALEXTPROC __glewBufferStorageExternalEXT = NULL;
+PFNGLNAMEDBUFFERSTORAGEEXTERNALEXTPROC __glewNamedBufferStorageExternalEXT = NULL;
 
 PFNGLFOGCOORDPOINTEREXTPROC __glewFogCoordPointerEXT = NULL;
 PFNGLFOGCOORDDEXTPROC __glewFogCoorddEXT = NULL;
@@ -2041,15 +2107,54 @@ PFNGLINDEXFUNCEXTPROC __glewIndexFuncEXT = NULL;
 
 PFNGLINDEXMATERIALEXTPROC __glewIndexMaterialEXT = NULL;
 
+PFNGLVERTEXATTRIBDIVISOREXTPROC __glewVertexAttribDivisorEXT = NULL;
+
 PFNGLAPPLYTEXTUREEXTPROC __glewApplyTextureEXT = NULL;
 PFNGLTEXTURELIGHTEXTPROC __glewTextureLightEXT = NULL;
 PFNGLTEXTUREMATERIALEXTPROC __glewTextureMaterialEXT = NULL;
 
+PFNGLFLUSHMAPPEDBUFFERRANGEEXTPROC __glewFlushMappedBufferRangeEXT = NULL;
+PFNGLMAPBUFFERRANGEEXTPROC __glewMapBufferRangeEXT = NULL;
+
+PFNGLBUFFERSTORAGEMEMEXTPROC __glewBufferStorageMemEXT = NULL;
+PFNGLCREATEMEMORYOBJECTSEXTPROC __glewCreateMemoryObjectsEXT = NULL;
+PFNGLDELETEMEMORYOBJECTSEXTPROC __glewDeleteMemoryObjectsEXT = NULL;
+PFNGLGETMEMORYOBJECTPARAMETERIVEXTPROC __glewGetMemoryObjectParameterivEXT = NULL;
+PFNGLGETUNSIGNEDBYTEI_VEXTPROC __glewGetUnsignedBytei_vEXT = NULL;
+PFNGLGETUNSIGNEDBYTEVEXTPROC __glewGetUnsignedBytevEXT = NULL;
+PFNGLISMEMORYOBJECTEXTPROC __glewIsMemoryObjectEXT = NULL;
+PFNGLMEMORYOBJECTPARAMETERIVEXTPROC __glewMemoryObjectParameterivEXT = NULL;
+PFNGLNAMEDBUFFERSTORAGEMEMEXTPROC __glewNamedBufferStorageMemEXT = NULL;
+PFNGLTEXSTORAGEMEM1DEXTPROC __glewTexStorageMem1DEXT = NULL;
+PFNGLTEXSTORAGEMEM2DEXTPROC __glewTexStorageMem2DEXT = NULL;
+PFNGLTEXSTORAGEMEM2DMULTISAMPLEEXTPROC __glewTexStorageMem2DMultisampleEXT = NULL;
+PFNGLTEXSTORAGEMEM3DEXTPROC __glewTexStorageMem3DEXT = NULL;
+PFNGLTEXSTORAGEMEM3DMULTISAMPLEEXTPROC __glewTexStorageMem3DMultisampleEXT = NULL;
+PFNGLTEXTURESTORAGEMEM1DEXTPROC __glewTextureStorageMem1DEXT = NULL;
+PFNGLTEXTURESTORAGEMEM2DEXTPROC __glewTextureStorageMem2DEXT = NULL;
+PFNGLTEXTURESTORAGEMEM2DMULTISAMPLEEXTPROC __glewTextureStorageMem2DMultisampleEXT = NULL;
+PFNGLTEXTURESTORAGEMEM3DEXTPROC __glewTextureStorageMem3DEXT = NULL;
+PFNGLTEXTURESTORAGEMEM3DMULTISAMPLEEXTPROC __glewTextureStorageMem3DMultisampleEXT = NULL;
+
+PFNGLIMPORTMEMORYFDEXTPROC __glewImportMemoryFdEXT = NULL;
+
+PFNGLIMPORTMEMORYWIN32HANDLEEXTPROC __glewImportMemoryWin32HandleEXT = NULL;
+PFNGLIMPORTMEMORYWIN32NAMEEXTPROC __glewImportMemoryWin32NameEXT = NULL;
+
 PFNGLMULTIDRAWARRAYSEXTPROC __glewMultiDrawArraysEXT = NULL;
 PFNGLMULTIDRAWELEMENTSEXTPROC __glewMultiDrawElementsEXT = NULL;
 
+PFNGLMULTIDRAWARRAYSINDIRECTEXTPROC __glewMultiDrawArraysIndirectEXT = NULL;
+PFNGLMULTIDRAWELEMENTSINDIRECTEXTPROC __glewMultiDrawElementsIndirectEXT = NULL;
+
 PFNGLSAMPLEMASKEXTPROC __glewSampleMaskEXT = NULL;
 PFNGLSAMPLEPATTERNEXTPROC __glewSamplePatternEXT = NULL;
+
+PFNGLFRAMEBUFFERTEXTURE2DMULTISAMPLEEXTPROC __glewFramebufferTexture2DMultisampleEXT = NULL;
+
+PFNGLDRAWBUFFERSINDEXEDEXTPROC __glewDrawBuffersIndexedEXT = NULL;
+PFNGLGETINTEGERI_VEXTPROC __glewGetIntegeri_vEXT = NULL;
+PFNGLREADBUFFERINDEXEDEXTPROC __glewReadBufferIndexedEXT = NULL;
 
 PFNGLCOLORTABLEEXTPROC __glewColorTableEXT = NULL;
 PFNGLGETCOLORTABLEEXTPROC __glewGetColorTableEXT = NULL;
@@ -2068,7 +2173,14 @@ PFNGLPOINTPARAMETERFVEXTPROC __glewPointParameterfvEXT = NULL;
 
 PFNGLPOLYGONOFFSETEXTPROC __glewPolygonOffsetEXT = NULL;
 
+PFNGLPOLYGONOFFSETCLAMPEXTPROC __glewPolygonOffsetClampEXT = NULL;
+
 PFNGLPROVOKINGVERTEXEXTPROC __glewProvokingVertexEXT = NULL;
+
+PFNGLCOVERAGEMODULATIONNVPROC __glewCoverageModulationNV = NULL;
+PFNGLCOVERAGEMODULATIONTABLENVPROC __glewCoverageModulationTableNV = NULL;
+PFNGLGETCOVERAGEMODULATIONTABLENVPROC __glewGetCoverageModulationTableNV = NULL;
+PFNGLRASTERSAMPLESEXTPROC __glewRasterSamplesEXT = NULL;
 
 PFNGLBEGINSCENEEXTPROC __glewBeginSceneEXT = NULL;
 PFNGLENDSCENEEXTPROC __glewEndSceneEXT = NULL;
@@ -2091,12 +2203,32 @@ PFNGLSECONDARYCOLOR3USEXTPROC __glewSecondaryColor3usEXT = NULL;
 PFNGLSECONDARYCOLOR3USVEXTPROC __glewSecondaryColor3usvEXT = NULL;
 PFNGLSECONDARYCOLORPOINTEREXTPROC __glewSecondaryColorPointerEXT = NULL;
 
+PFNGLDELETESEMAPHORESEXTPROC __glewDeleteSemaphoresEXT = NULL;
+PFNGLGENSEMAPHORESEXTPROC __glewGenSemaphoresEXT = NULL;
+PFNGLGETSEMAPHOREPARAMETERUI64VEXTPROC __glewGetSemaphoreParameterui64vEXT = NULL;
+PFNGLISSEMAPHOREEXTPROC __glewIsSemaphoreEXT = NULL;
+PFNGLSEMAPHOREPARAMETERUI64VEXTPROC __glewSemaphoreParameterui64vEXT = NULL;
+PFNGLSIGNALSEMAPHOREEXTPROC __glewSignalSemaphoreEXT = NULL;
+PFNGLWAITSEMAPHOREEXTPROC __glewWaitSemaphoreEXT = NULL;
+
+PFNGLIMPORTSEMAPHOREFDEXTPROC __glewImportSemaphoreFdEXT = NULL;
+
+PFNGLIMPORTSEMAPHOREWIN32HANDLEEXTPROC __glewImportSemaphoreWin32HandleEXT = NULL;
+PFNGLIMPORTSEMAPHOREWIN32NAMEEXTPROC __glewImportSemaphoreWin32NameEXT = NULL;
+
 PFNGLACTIVEPROGRAMEXTPROC __glewActiveProgramEXT = NULL;
 PFNGLCREATESHADERPROGRAMEXTPROC __glewCreateShaderProgramEXT = NULL;
 PFNGLUSESHADERPROGRAMEXTPROC __glewUseShaderProgramEXT = NULL;
 
 PFNGLBINDIMAGETEXTUREEXTPROC __glewBindImageTextureEXT = NULL;
 PFNGLMEMORYBARRIEREXTPROC __glewMemoryBarrierEXT = NULL;
+
+PFNGLCLEARPIXELLOCALSTORAGEUIEXTPROC __glewClearPixelLocalStorageuiEXT = NULL;
+PFNGLFRAMEBUFFERPIXELLOCALSTORAGESIZEEXTPROC __glewFramebufferPixelLocalStorageSizeEXT = NULL;
+PFNGLGETFRAMEBUFFERPIXELLOCALSTORAGESIZEEXTPROC __glewGetFramebufferPixelLocalStorageSizeEXT = NULL;
+
+PFNGLTEXPAGECOMMITMENTEXTPROC __glewTexPageCommitmentEXT = NULL;
+PFNGLTEXTUREPAGECOMMITMENTEXTPROC __glewTexturePageCommitmentEXT = NULL;
 
 PFNGLACTIVESTENCILFACEEXTPROC __glewActiveStencilFaceEXT = NULL;
 
@@ -2126,6 +2258,15 @@ PFNGLPRIORITIZETEXTURESEXTPROC __glewPrioritizeTexturesEXT = NULL;
 
 PFNGLTEXTURENORMALEXTPROC __glewTextureNormalEXT = NULL;
 
+PFNGLTEXSTORAGE1DEXTPROC __glewTexStorage1DEXT = NULL;
+PFNGLTEXSTORAGE2DEXTPROC __glewTexStorage2DEXT = NULL;
+PFNGLTEXSTORAGE3DEXTPROC __glewTexStorage3DEXT = NULL;
+PFNGLTEXTURESTORAGE1DEXTPROC __glewTextureStorage1DEXT = NULL;
+PFNGLTEXTURESTORAGE2DEXTPROC __glewTextureStorage2DEXT = NULL;
+PFNGLTEXTURESTORAGE3DEXTPROC __glewTextureStorage3DEXT = NULL;
+
+PFNGLTEXTUREVIEWEXTPROC __glewTextureViewEXT = NULL;
+
 PFNGLGETQUERYOBJECTI64VEXTPROC __glewGetQueryObjecti64vEXT = NULL;
 PFNGLGETQUERYOBJECTUI64VEXTPROC __glewGetQueryObjectui64vEXT = NULL;
 
@@ -2145,6 +2286,10 @@ PFNGLINDEXPOINTEREXTPROC __glewIndexPointerEXT = NULL;
 PFNGLNORMALPOINTEREXTPROC __glewNormalPointerEXT = NULL;
 PFNGLTEXCOORDPOINTEREXTPROC __glewTexCoordPointerEXT = NULL;
 PFNGLVERTEXPOINTEREXTPROC __glewVertexPointerEXT = NULL;
+
+PFNGLBINDARRAYSETEXTPROC __glewBindArraySetEXT = NULL;
+PFNGLCREATEARRAYSETEXTPROC __glewCreateArraySetExt = NULL;
+PFNGLDELETEARRAYSETSEXTPROC __glewDeleteArraySetsEXT = NULL;
 
 PFNGLGETVERTEXATTRIBLDVEXTPROC __glewGetVertexAttribLdvEXT = NULL;
 PFNGLVERTEXARRAYVERTEXATTRIBLOFFSETEXTPROC __glewVertexArrayVertexAttribLOffsetEXT = NULL;
@@ -2204,6 +2349,11 @@ PFNGLWRITEMASKEXTPROC __glewWriteMaskEXT = NULL;
 PFNGLVERTEXWEIGHTPOINTEREXTPROC __glewVertexWeightPointerEXT = NULL;
 PFNGLVERTEXWEIGHTFEXTPROC __glewVertexWeightfEXT = NULL;
 PFNGLVERTEXWEIGHTFVEXTPROC __glewVertexWeightfvEXT = NULL;
+
+PFNGLACQUIREKEYEDMUTEXWIN32EXTPROC __glewAcquireKeyedMutexWin32EXT = NULL;
+PFNGLRELEASEKEYEDMUTEXWIN32EXTPROC __glewReleaseKeyedMutexWin32EXT = NULL;
+
+PFNGLWINDOWRECTANGLESEXTPROC __glewWindowRectanglesEXT = NULL;
 
 PFNGLIMPORTSYNCEXTPROC __glewImportSyncEXT = NULL;
 
@@ -2266,6 +2416,8 @@ PFNGLOBJECTPTRLABELPROC __glewObjectPtrLabel = NULL;
 PFNGLPOPDEBUGGROUPPROC __glewPopDebugGroup = NULL;
 PFNGLPUSHDEBUGGROUPPROC __glewPushDebugGroup = NULL;
 
+PFNGLMAXSHADERCOMPILERTHREADSKHRPROC __glewMaxShaderCompilerThreadsKHR = NULL;
+
 PFNGLGETNUNIFORMFVPROC __glewGetnUniformfv = NULL;
 PFNGLGETNUNIFORMIVPROC __glewGetnUniformiv = NULL;
 PFNGLGETNUNIFORMUIVPROC __glewGetnUniformuiv = NULL;
@@ -2307,6 +2459,13 @@ PFNGLWINDOWPOS4SVMESAPROC __glewWindowPos4svMESA = NULL;
 PFNGLBEGINCONDITIONALRENDERNVXPROC __glewBeginConditionalRenderNVX = NULL;
 PFNGLENDCONDITIONALRENDERNVXPROC __glewEndConditionalRenderNVX = NULL;
 
+PFNGLLGPUCOPYIMAGESUBDATANVXPROC __glewLGPUCopyImageSubDataNVX = NULL;
+PFNGLLGPUINTERLOCKNVXPROC __glewLGPUInterlockNVX = NULL;
+PFNGLLGPUNAMEDBUFFERSUBDATANVXPROC __glewLGPUNamedBufferSubDataNVX = NULL;
+
+PFNGLSTEREOPARAMETERFNVPROC __glewStereoParameterfNV = NULL;
+PFNGLSTEREOPARAMETERINVPROC __glewStereoParameteriNV = NULL;
+
 PFNGLMULTIDRAWARRAYSINDIRECTBINDLESSNVPROC __glewMultiDrawArraysIndirectBindlessNV = NULL;
 PFNGLMULTIDRAWELEMENTSINDIRECTBINDLESSNVPROC __glewMultiDrawElementsIndirectBindlessNV = NULL;
 
@@ -2330,8 +2489,36 @@ PFNGLUNIFORMHANDLEUI64VNVPROC __glewUniformHandleui64vNV = NULL;
 PFNGLBLENDBARRIERNVPROC __glewBlendBarrierNV = NULL;
 PFNGLBLENDPARAMETERINVPROC __glewBlendParameteriNV = NULL;
 
+PFNGLVIEWPORTPOSITIONWSCALENVPROC __glewViewportPositionWScaleNV = NULL;
+
+PFNGLCALLCOMMANDLISTNVPROC __glewCallCommandListNV = NULL;
+PFNGLCOMMANDLISTSEGMENTSNVPROC __glewCommandListSegmentsNV = NULL;
+PFNGLCOMPILECOMMANDLISTNVPROC __glewCompileCommandListNV = NULL;
+PFNGLCREATECOMMANDLISTSNVPROC __glewCreateCommandListsNV = NULL;
+PFNGLCREATESTATESNVPROC __glewCreateStatesNV = NULL;
+PFNGLDELETECOMMANDLISTSNVPROC __glewDeleteCommandListsNV = NULL;
+PFNGLDELETESTATESNVPROC __glewDeleteStatesNV = NULL;
+PFNGLDRAWCOMMANDSADDRESSNVPROC __glewDrawCommandsAddressNV = NULL;
+PFNGLDRAWCOMMANDSNVPROC __glewDrawCommandsNV = NULL;
+PFNGLDRAWCOMMANDSSTATESADDRESSNVPROC __glewDrawCommandsStatesAddressNV = NULL;
+PFNGLDRAWCOMMANDSSTATESNVPROC __glewDrawCommandsStatesNV = NULL;
+PFNGLGETCOMMANDHEADERNVPROC __glewGetCommandHeaderNV = NULL;
+PFNGLGETSTAGEINDEXNVPROC __glewGetStageIndexNV = NULL;
+PFNGLISCOMMANDLISTNVPROC __glewIsCommandListNV = NULL;
+PFNGLISSTATENVPROC __glewIsStateNV = NULL;
+PFNGLLISTDRAWCOMMANDSSTATESCLIENTNVPROC __glewListDrawCommandsStatesClientNV = NULL;
+PFNGLSTATECAPTURENVPROC __glewStateCaptureNV = NULL;
+
 PFNGLBEGINCONDITIONALRENDERNVPROC __glewBeginConditionalRenderNV = NULL;
 PFNGLENDCONDITIONALRENDERNVPROC __glewEndConditionalRenderNV = NULL;
+
+PFNGLSUBPIXELPRECISIONBIASNVPROC __glewSubpixelPrecisionBiasNV = NULL;
+
+PFNGLCONSERVATIVERASTERPARAMETERFNVPROC __glewConservativeRasterParameterfNV = NULL;
+
+PFNGLCONSERVATIVERASTERPARAMETERINVPROC __glewConservativeRasterParameteriNV = NULL;
+
+PFNGLCOPYBUFFERSUBDATANVPROC __glewCopyBufferSubDataNV = NULL;
 
 PFNGLCOPYIMAGESUBDATANVPROC __glewCopyImageSubDataNV = NULL;
 
@@ -2339,7 +2526,18 @@ PFNGLCLEARDEPTHDNVPROC __glewClearDepthdNV = NULL;
 PFNGLDEPTHBOUNDSDNVPROC __glewDepthBoundsdNV = NULL;
 PFNGLDEPTHRANGEDNVPROC __glewDepthRangedNV = NULL;
 
+PFNGLDRAWBUFFERSNVPROC __glewDrawBuffersNV = NULL;
+
+PFNGLDRAWARRAYSINSTANCEDNVPROC __glewDrawArraysInstancedNV = NULL;
+PFNGLDRAWELEMENTSINSTANCEDNVPROC __glewDrawElementsInstancedNV = NULL;
+
 PFNGLDRAWTEXTURENVPROC __glewDrawTextureNV = NULL;
+
+PFNGLDRAWVKIMAGENVPROC __glewDrawVkImageNV = NULL;
+PFNGLGETVKPROCADDRNVPROC __glewGetVkProcAddrNV = NULL;
+PFNGLSIGNALVKFENCENVPROC __glewSignalVkFenceNV = NULL;
+PFNGLSIGNALVKSEMAPHORENVPROC __glewSignalVkSemaphoreNV = NULL;
+PFNGLWAITVKSEMAPHORENVPROC __glewWaitVkSemaphoreNV = NULL;
 
 PFNGLEVALMAPSNVPROC __glewEvalMapsNV = NULL;
 PFNGLGETMAPATTRIBPARAMETERFVNVPROC __glewGetMapAttribParameterfvNV = NULL;
@@ -2363,6 +2561,8 @@ PFNGLISFENCENVPROC __glewIsFenceNV = NULL;
 PFNGLSETFENCENVPROC __glewSetFenceNV = NULL;
 PFNGLTESTFENCENVPROC __glewTestFenceNV = NULL;
 
+PFNGLFRAGMENTCOVERAGECOLORNVPROC __glewFragmentCoverageColorNV = NULL;
+
 PFNGLGETPROGRAMNAMEDPARAMETERDVNVPROC __glewGetProgramNamedParameterdvNV = NULL;
 PFNGLGETPROGRAMNAMEDPARAMETERFVNVPROC __glewGetProgramNamedParameterfvNV = NULL;
 PFNGLPROGRAMNAMEDPARAMETER4DNVPROC __glewProgramNamedParameter4dNV = NULL;
@@ -2370,9 +2570,26 @@ PFNGLPROGRAMNAMEDPARAMETER4DVNVPROC __glewProgramNamedParameter4dvNV = NULL;
 PFNGLPROGRAMNAMEDPARAMETER4FNVPROC __glewProgramNamedParameter4fNV = NULL;
 PFNGLPROGRAMNAMEDPARAMETER4FVNVPROC __glewProgramNamedParameter4fvNV = NULL;
 
+PFNGLBLITFRAMEBUFFERNVPROC __glewBlitFramebufferNV = NULL;
+
+PFNGLRENDERBUFFERSTORAGEMULTISAMPLENVPROC __glewRenderbufferStorageMultisampleNV = NULL;
+
 PFNGLRENDERBUFFERSTORAGEMULTISAMPLECOVERAGENVPROC __glewRenderbufferStorageMultisampleCoverageNV = NULL;
 
 PFNGLPROGRAMVERTEXLIMITNVPROC __glewProgramVertexLimitNV = NULL;
+
+PFNGLMULTICASTBARRIERNVPROC __glewMulticastBarrierNV = NULL;
+PFNGLMULTICASTBLITFRAMEBUFFERNVPROC __glewMulticastBlitFramebufferNV = NULL;
+PFNGLMULTICASTBUFFERSUBDATANVPROC __glewMulticastBufferSubDataNV = NULL;
+PFNGLMULTICASTCOPYBUFFERSUBDATANVPROC __glewMulticastCopyBufferSubDataNV = NULL;
+PFNGLMULTICASTCOPYIMAGESUBDATANVPROC __glewMulticastCopyImageSubDataNV = NULL;
+PFNGLMULTICASTFRAMEBUFFERSAMPLELOCATIONSFVNVPROC __glewMulticastFramebufferSampleLocationsfvNV = NULL;
+PFNGLMULTICASTGETQUERYOBJECTI64VNVPROC __glewMulticastGetQueryObjecti64vNV = NULL;
+PFNGLMULTICASTGETQUERYOBJECTIVNVPROC __glewMulticastGetQueryObjectivNV = NULL;
+PFNGLMULTICASTGETQUERYOBJECTUI64VNVPROC __glewMulticastGetQueryObjectui64vNV = NULL;
+PFNGLMULTICASTGETQUERYOBJECTUIVNVPROC __glewMulticastGetQueryObjectuivNV = NULL;
+PFNGLMULTICASTWAITSYNCNVPROC __glewMulticastWaitSyncNV = NULL;
+PFNGLRENDERGPUMASKNVPROC __glewRenderGpuMaskNV = NULL;
 
 PFNGLPROGRAMENVPARAMETERI4INVPROC __glewProgramEnvParameterI4iNV = NULL;
 PFNGLPROGRAMENVPARAMETERI4IVNVPROC __glewProgramEnvParameterI4ivNV = NULL;
@@ -2469,6 +2686,17 @@ PFNGLVERTEXATTRIBS4HVNVPROC __glewVertexAttribs4hvNV = NULL;
 PFNGLVERTEXWEIGHTHNVPROC __glewVertexWeighthNV = NULL;
 PFNGLVERTEXWEIGHTHVNVPROC __glewVertexWeighthvNV = NULL;
 
+PFNGLVERTEXATTRIBDIVISORNVPROC __glewVertexAttribDivisorNV = NULL;
+
+PFNGLGETINTERNALFORMATSAMPLEIVNVPROC __glewGetInternalformatSampleivNV = NULL;
+
+PFNGLUNIFORMMATRIX2X3FVNVPROC __glewUniformMatrix2x3fvNV = NULL;
+PFNGLUNIFORMMATRIX2X4FVNVPROC __glewUniformMatrix2x4fvNV = NULL;
+PFNGLUNIFORMMATRIX3X2FVNVPROC __glewUniformMatrix3x2fvNV = NULL;
+PFNGLUNIFORMMATRIX3X4FVNVPROC __glewUniformMatrix3x4fvNV = NULL;
+PFNGLUNIFORMMATRIX4X2FVNVPROC __glewUniformMatrix4x2fvNV = NULL;
+PFNGLUNIFORMMATRIX4X3FVNVPROC __glewUniformMatrix4x3fvNV = NULL;
+
 PFNGLBEGINOCCLUSIONQUERYNVPROC __glewBeginOcclusionQueryNV = NULL;
 PFNGLDELETEOCCLUSIONQUERIESNVPROC __glewDeleteOcclusionQueriesNV = NULL;
 PFNGLENDOCCLUSIONQUERYNVPROC __glewEndOcclusionQueryNV = NULL;
@@ -2501,18 +2729,28 @@ PFNGLGETPATHPARAMETERIVNVPROC __glewGetPathParameterivNV = NULL;
 PFNGLGETPATHSPACINGNVPROC __glewGetPathSpacingNV = NULL;
 PFNGLGETPATHTEXGENFVNVPROC __glewGetPathTexGenfvNV = NULL;
 PFNGLGETPATHTEXGENIVNVPROC __glewGetPathTexGenivNV = NULL;
+PFNGLGETPROGRAMRESOURCEFVNVPROC __glewGetProgramResourcefvNV = NULL;
 PFNGLINTERPOLATEPATHSNVPROC __glewInterpolatePathsNV = NULL;
 PFNGLISPATHNVPROC __glewIsPathNV = NULL;
 PFNGLISPOINTINFILLPATHNVPROC __glewIsPointInFillPathNV = NULL;
 PFNGLISPOINTINSTROKEPATHNVPROC __glewIsPointInStrokePathNV = NULL;
+PFNGLMATRIXLOAD3X2FNVPROC __glewMatrixLoad3x2fNV = NULL;
+PFNGLMATRIXLOAD3X3FNVPROC __glewMatrixLoad3x3fNV = NULL;
+PFNGLMATRIXLOADTRANSPOSE3X3FNVPROC __glewMatrixLoadTranspose3x3fNV = NULL;
+PFNGLMATRIXMULT3X2FNVPROC __glewMatrixMult3x2fNV = NULL;
+PFNGLMATRIXMULT3X3FNVPROC __glewMatrixMult3x3fNV = NULL;
+PFNGLMATRIXMULTTRANSPOSE3X3FNVPROC __glewMatrixMultTranspose3x3fNV = NULL;
 PFNGLPATHCOLORGENNVPROC __glewPathColorGenNV = NULL;
 PFNGLPATHCOMMANDSNVPROC __glewPathCommandsNV = NULL;
 PFNGLPATHCOORDSNVPROC __glewPathCoordsNV = NULL;
 PFNGLPATHCOVERDEPTHFUNCNVPROC __glewPathCoverDepthFuncNV = NULL;
 PFNGLPATHDASHARRAYNVPROC __glewPathDashArrayNV = NULL;
 PFNGLPATHFOGGENNVPROC __glewPathFogGenNV = NULL;
+PFNGLPATHGLYPHINDEXARRAYNVPROC __glewPathGlyphIndexArrayNV = NULL;
+PFNGLPATHGLYPHINDEXRANGENVPROC __glewPathGlyphIndexRangeNV = NULL;
 PFNGLPATHGLYPHRANGENVPROC __glewPathGlyphRangeNV = NULL;
 PFNGLPATHGLYPHSNVPROC __glewPathGlyphsNV = NULL;
+PFNGLPATHMEMORYGLYPHINDEXARRAYNVPROC __glewPathMemoryGlyphIndexArrayNV = NULL;
 PFNGLPATHPARAMETERFNVPROC __glewPathParameterfNV = NULL;
 PFNGLPATHPARAMETERFVNVPROC __glewPathParameterfvNV = NULL;
 PFNGLPATHPARAMETERINVPROC __glewPathParameteriNV = NULL;
@@ -2524,10 +2762,15 @@ PFNGLPATHSUBCOMMANDSNVPROC __glewPathSubCommandsNV = NULL;
 PFNGLPATHSUBCOORDSNVPROC __glewPathSubCoordsNV = NULL;
 PFNGLPATHTEXGENNVPROC __glewPathTexGenNV = NULL;
 PFNGLPOINTALONGPATHNVPROC __glewPointAlongPathNV = NULL;
+PFNGLPROGRAMPATHFRAGMENTINPUTGENNVPROC __glewProgramPathFragmentInputGenNV = NULL;
 PFNGLSTENCILFILLPATHINSTANCEDNVPROC __glewStencilFillPathInstancedNV = NULL;
 PFNGLSTENCILFILLPATHNVPROC __glewStencilFillPathNV = NULL;
 PFNGLSTENCILSTROKEPATHINSTANCEDNVPROC __glewStencilStrokePathInstancedNV = NULL;
 PFNGLSTENCILSTROKEPATHNVPROC __glewStencilStrokePathNV = NULL;
+PFNGLSTENCILTHENCOVERFILLPATHINSTANCEDNVPROC __glewStencilThenCoverFillPathInstancedNV = NULL;
+PFNGLSTENCILTHENCOVERFILLPATHNVPROC __glewStencilThenCoverFillPathNV = NULL;
+PFNGLSTENCILTHENCOVERSTROKEPATHINSTANCEDNVPROC __glewStencilThenCoverStrokePathInstancedNV = NULL;
+PFNGLSTENCILTHENCOVERSTROKEPATHNVPROC __glewStencilThenCoverStrokePathNV = NULL;
 PFNGLTRANSFORMPATHNVPROC __glewTransformPathNV = NULL;
 PFNGLWEIGHTPATHSNVPROC __glewWeightPathsNV = NULL;
 
@@ -2536,6 +2779,8 @@ PFNGLPIXELDATARANGENVPROC __glewPixelDataRangeNV = NULL;
 
 PFNGLPOINTPARAMETERINVPROC __glewPointParameteriNV = NULL;
 PFNGLPOINTPARAMETERIVNVPROC __glewPointParameterivNV = NULL;
+
+PFNGLPOLYGONMODENVPROC __glewPolygonModeNV = NULL;
 
 PFNGLGETVIDEOI64VNVPROC __glewGetVideoi64vNV = NULL;
 PFNGLGETVIDEOIVNVPROC __glewGetVideoivNV = NULL;
@@ -2564,6 +2809,9 @@ PFNGLGETFINALCOMBINERINPUTPARAMETERIVNVPROC __glewGetFinalCombinerInputParameter
 PFNGLCOMBINERSTAGEPARAMETERFVNVPROC __glewCombinerStageParameterfvNV = NULL;
 PFNGLGETCOMBINERSTAGEPARAMETERFVNVPROC __glewGetCombinerStageParameterfvNV = NULL;
 
+PFNGLFRAMEBUFFERSAMPLELOCATIONSFVNVPROC __glewFramebufferSampleLocationsfvNV = NULL;
+PFNGLNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNVPROC __glewNamedFramebufferSampleLocationsfvNV = NULL;
+
 PFNGLGETBUFFERPARAMETERUI64VNVPROC __glewGetBufferParameterui64vNV = NULL;
 PFNGLGETINTEGERUI64VNVPROC __glewGetIntegerui64vNV = NULL;
 PFNGLGETNAMEDBUFFERPARAMETERUI64VNVPROC __glewGetNamedBufferParameterui64vNV = NULL;
@@ -2577,6 +2825,13 @@ PFNGLPROGRAMUNIFORMUI64NVPROC __glewProgramUniformui64NV = NULL;
 PFNGLPROGRAMUNIFORMUI64VNVPROC __glewProgramUniformui64vNV = NULL;
 PFNGLUNIFORMUI64NVPROC __glewUniformui64NV = NULL;
 PFNGLUNIFORMUI64VNVPROC __glewUniformui64vNV = NULL;
+
+PFNGLCOMPRESSEDTEXIMAGE3DNVPROC __glewCompressedTexImage3DNV = NULL;
+PFNGLCOMPRESSEDTEXSUBIMAGE3DNVPROC __glewCompressedTexSubImage3DNV = NULL;
+PFNGLCOPYTEXSUBIMAGE3DNVPROC __glewCopyTexSubImage3DNV = NULL;
+PFNGLFRAMEBUFFERTEXTURELAYERNVPROC __glewFramebufferTextureLayerNV = NULL;
+PFNGLTEXIMAGE3DNVPROC __glewTexImage3DNV = NULL;
+PFNGLTEXSUBIMAGE3DNVPROC __glewTexSubImage3DNV = NULL;
 
 PFNGLTEXTUREBARRIERNVPROC __glewTextureBarrierNV = NULL;
 
@@ -2732,12 +2987,53 @@ PFNGLVIDEOCAPTURESTREAMPARAMETERDVNVPROC __glewVideoCaptureStreamParameterdvNV =
 PFNGLVIDEOCAPTURESTREAMPARAMETERFVNVPROC __glewVideoCaptureStreamParameterfvNV = NULL;
 PFNGLVIDEOCAPTURESTREAMPARAMETERIVNVPROC __glewVideoCaptureStreamParameterivNV = NULL;
 
-PFNGLCLEARDEPTHFOESPROC __glewClearDepthfOES = NULL;
-PFNGLCLIPPLANEFOESPROC __glewClipPlanefOES = NULL;
-PFNGLDEPTHRANGEFOESPROC __glewDepthRangefOES = NULL;
-PFNGLFRUSTUMFOESPROC __glewFrustumfOES = NULL;
-PFNGLGETCLIPPLANEFOESPROC __glewGetClipPlanefOES = NULL;
-PFNGLORTHOFOESPROC __glewOrthofOES = NULL;
+PFNGLDEPTHRANGEARRAYFVNVPROC __glewDepthRangeArrayfvNV = NULL;
+PFNGLDEPTHRANGEINDEXEDFNVPROC __glewDepthRangeIndexedfNV = NULL;
+PFNGLDISABLEINVPROC __glewDisableiNV = NULL;
+PFNGLENABLEINVPROC __glewEnableiNV = NULL;
+PFNGLGETFLOATI_VNVPROC __glewGetFloati_vNV = NULL;
+PFNGLISENABLEDINVPROC __glewIsEnablediNV = NULL;
+PFNGLSCISSORARRAYVNVPROC __glewScissorArrayvNV = NULL;
+PFNGLSCISSORINDEXEDNVPROC __glewScissorIndexedNV = NULL;
+PFNGLSCISSORINDEXEDVNVPROC __glewScissorIndexedvNV = NULL;
+PFNGLVIEWPORTARRAYVNVPROC __glewViewportArrayvNV = NULL;
+PFNGLVIEWPORTINDEXEDFNVPROC __glewViewportIndexedfNV = NULL;
+PFNGLVIEWPORTINDEXEDFVNVPROC __glewViewportIndexedfvNV = NULL;
+
+PFNGLVIEWPORTSWIZZLENVPROC __glewViewportSwizzleNV = NULL;
+
+PFNGLFRAMEBUFFERTEXTUREMULTIVIEWOVRPROC __glewFramebufferTextureMultiviewOVR = NULL;
+
+PFNGLFRAMEBUFFERTEXTUREMULTISAMPLEMULTIVIEWOVRPROC __glewFramebufferTextureMultisampleMultiviewOVR = NULL;
+
+PFNGLALPHAFUNCQCOMPROC __glewAlphaFuncQCOM = NULL;
+
+PFNGLDISABLEDRIVERCONTROLQCOMPROC __glewDisableDriverControlQCOM = NULL;
+PFNGLENABLEDRIVERCONTROLQCOMPROC __glewEnableDriverControlQCOM = NULL;
+PFNGLGETDRIVERCONTROLSTRINGQCOMPROC __glewGetDriverControlStringQCOM = NULL;
+PFNGLGETDRIVERCONTROLSQCOMPROC __glewGetDriverControlsQCOM = NULL;
+
+PFNGLEXTGETBUFFERPOINTERVQCOMPROC __glewExtGetBufferPointervQCOM = NULL;
+PFNGLEXTGETBUFFERSQCOMPROC __glewExtGetBuffersQCOM = NULL;
+PFNGLEXTGETFRAMEBUFFERSQCOMPROC __glewExtGetFramebuffersQCOM = NULL;
+PFNGLEXTGETRENDERBUFFERSQCOMPROC __glewExtGetRenderbuffersQCOM = NULL;
+PFNGLEXTGETTEXLEVELPARAMETERIVQCOMPROC __glewExtGetTexLevelParameterivQCOM = NULL;
+PFNGLEXTGETTEXSUBIMAGEQCOMPROC __glewExtGetTexSubImageQCOM = NULL;
+PFNGLEXTGETTEXTURESQCOMPROC __glewExtGetTexturesQCOM = NULL;
+PFNGLEXTTEXOBJECTSTATEOVERRIDEIQCOMPROC __glewExtTexObjectStateOverrideiQCOM = NULL;
+
+PFNGLEXTGETPROGRAMBINARYSOURCEQCOMPROC __glewExtGetProgramBinarySourceQCOM = NULL;
+PFNGLEXTGETPROGRAMSQCOMPROC __glewExtGetProgramsQCOM = NULL;
+PFNGLEXTGETSHADERSQCOMPROC __glewExtGetShadersQCOM = NULL;
+PFNGLEXTISPROGRAMBINARYQCOMPROC __glewExtIsProgramBinaryQCOM = NULL;
+
+PFNGLFRAMEBUFFERFOVEATIONCONFIGQCOMPROC __glewFramebufferFoveationConfigQCOM = NULL;
+PFNGLFRAMEBUFFERFOVEATIONPARAMETERSQCOMPROC __glewFramebufferFoveationParametersQCOM = NULL;
+
+PFNGLFRAMEBUFFERFETCHBARRIERQCOMPROC __glewFramebufferFetchBarrierQCOM = NULL;
+
+PFNGLENDTILINGQCOMPROC __glewEndTilingQCOM = NULL;
+PFNGLSTARTTILINGQCOMPROC __glewStartTilingQCOM = NULL;
 
 PFNGLALPHAFUNCXPROC __glewAlphaFuncx = NULL;
 PFNGLCLEARCOLORXPROC __glewClearColorx = NULL;
@@ -2803,6 +3099,13 @@ PFNGLGETFOGFUNCSGISPROC __glewGetFogFuncSGIS = NULL;
 PFNGLSAMPLEMASKSGISPROC __glewSampleMaskSGIS = NULL;
 PFNGLSAMPLEPATTERNSGISPROC __glewSamplePatternSGIS = NULL;
 
+PFNGLINTERLEAVEDTEXTURECOORDSETSSGISPROC __glewInterleavedTextureCoordSetsSGIS = NULL;
+PFNGLSELECTTEXTURECOORDSETSGISPROC __glewSelectTextureCoordSetSGIS = NULL;
+PFNGLSELECTTEXTURESGISPROC __glewSelectTextureSGIS = NULL;
+PFNGLSELECTTEXTURETRANSFORMSGISPROC __glewSelectTextureTransformSGIS = NULL;
+
+PFNGLMULTISAMPLESUBRECTPOSSGISPROC __glewMultisampleSubRectPosSGIS = NULL;
+
 PFNGLGETSHARPENTEXFUNCSGISPROC __glewGetSharpenTexFuncSGIS = NULL;
 PFNGLSHARPENTEXFUNCSGISPROC __glewSharpenTexFuncSGIS = NULL;
 
@@ -2819,7 +3122,13 @@ PFNGLGENASYNCMARKERSSGIXPROC __glewGenAsyncMarkersSGIX = NULL;
 PFNGLISASYNCMARKERSGIXPROC __glewIsAsyncMarkerSGIX = NULL;
 PFNGLPOLLASYNCSGIXPROC __glewPollAsyncSGIX = NULL;
 
+PFNGLADDRESSSPACEPROC __glewAddressSpace = NULL;
+PFNGLDATAPIPEPROC __glewDataPipe = NULL;
+
 PFNGLFLUSHRASTERSGIXPROC __glewFlushRasterSGIX = NULL;
+
+PFNGLFOGLAYERSSGIXPROC __glewFogLayersSGIX = NULL;
+PFNGLGETFOGLAYERSSGIXPROC __glewGetFogLayersSGIX = NULL;
 
 PFNGLTEXTUREFOGSGIXPROC __glewTextureFogSGIX = NULL;
 
@@ -2843,7 +3152,32 @@ PFNGLGETFRAGMENTMATERIALIVSGIXPROC __glewGetFragmentMaterialivSGIX = NULL;
 
 PFNGLFRAMEZOOMSGIXPROC __glewFrameZoomSGIX = NULL;
 
+PFNGLIGLOOINTERFACESGIXPROC __glewIglooInterfaceSGIX = NULL;
+
+PFNGLALLOCMPEGPREDICTORSSGIXPROC __glewAllocMPEGPredictorsSGIX = NULL;
+PFNGLDELETEMPEGPREDICTORSSGIXPROC __glewDeleteMPEGPredictorsSGIX = NULL;
+PFNGLGENMPEGPREDICTORSSGIXPROC __glewGenMPEGPredictorsSGIX = NULL;
+PFNGLGETMPEGPARAMETERFVSGIXPROC __glewGetMPEGParameterfvSGIX = NULL;
+PFNGLGETMPEGPARAMETERIVSGIXPROC __glewGetMPEGParameterivSGIX = NULL;
+PFNGLGETMPEGPREDICTORSGIXPROC __glewGetMPEGPredictorSGIX = NULL;
+PFNGLGETMPEGQUANTTABLEUBVPROC __glewGetMPEGQuantTableubv = NULL;
+PFNGLISMPEGPREDICTORSGIXPROC __glewIsMPEGPredictorSGIX = NULL;
+PFNGLMPEGPREDICTORSGIXPROC __glewMPEGPredictorSGIX = NULL;
+PFNGLMPEGQUANTTABLEUBVPROC __glewMPEGQuantTableubv = NULL;
+PFNGLSWAPMPEGPREDICTORSSGIXPROC __glewSwapMPEGPredictorsSGIX = NULL;
+
+PFNGLGETNONLINLIGHTFVSGIXPROC __glewGetNonlinLightfvSGIX = NULL;
+PFNGLGETNONLINMATERIALFVSGIXPROC __glewGetNonlinMaterialfvSGIX = NULL;
+PFNGLNONLINLIGHTFVSGIXPROC __glewNonlinLightfvSGIX = NULL;
+PFNGLNONLINMATERIALFVSGIXPROC __glewNonlinMaterialfvSGIX = NULL;
+
 PFNGLPIXELTEXGENSGIXPROC __glewPixelTexGenSGIX = NULL;
+
+PFNGLDEFORMSGIXPROC __glewDeformSGIX = NULL;
+PFNGLLOADIDENTITYDEFORMATIONMAPSGIXPROC __glewLoadIdentityDeformationMapSGIX = NULL;
+
+PFNGLMESHBREADTHSGIXPROC __glewMeshBreadthSGIX = NULL;
+PFNGLMESHSTRIDESGIXPROC __glewMeshStrideSGIX = NULL;
 
 PFNGLREFERENCEPLANESGIXPROC __glewReferencePlaneSGIX = NULL;
 
@@ -2854,6 +3188,16 @@ PFNGLSPRITEPARAMETERIVSGIXPROC __glewSpriteParameterivSGIX = NULL;
 
 PFNGLTAGSAMPLEBUFFERSGIXPROC __glewTagSampleBufferSGIX = NULL;
 
+PFNGLGETVECTOROPERATIONSGIXPROC __glewGetVectorOperationSGIX = NULL;
+PFNGLVECTOROPERATIONSGIXPROC __glewVectorOperationSGIX = NULL;
+
+PFNGLAREVERTEXARRAYSRESIDENTSGIXPROC __glewAreVertexArraysResidentSGIX = NULL;
+PFNGLBINDVERTEXARRAYSGIXPROC __glewBindVertexArraySGIX = NULL;
+PFNGLDELETEVERTEXARRAYSSGIXPROC __glewDeleteVertexArraysSGIX = NULL;
+PFNGLGENVERTEXARRAYSSGIXPROC __glewGenVertexArraysSGIX = NULL;
+PFNGLISVERTEXARRAYSGIXPROC __glewIsVertexArraySGIX = NULL;
+PFNGLPRIORITIZEVERTEXARRAYSSGIXPROC __glewPrioritizeVertexArraysSGIX = NULL;
+
 PFNGLCOLORTABLEPARAMETERFVSGIPROC __glewColorTableParameterfvSGI = NULL;
 PFNGLCOLORTABLEPARAMETERIVSGIPROC __glewColorTableParameterivSGI = NULL;
 PFNGLCOLORTABLESGIPROC __glewColorTableSGI = NULL;
@@ -2861,6 +3205,14 @@ PFNGLCOPYCOLORTABLESGIPROC __glewCopyColorTableSGI = NULL;
 PFNGLGETCOLORTABLEPARAMETERFVSGIPROC __glewGetColorTableParameterfvSGI = NULL;
 PFNGLGETCOLORTABLEPARAMETERIVSGIPROC __glewGetColorTableParameterivSGI = NULL;
 PFNGLGETCOLORTABLESGIPROC __glewGetColorTableSGI = NULL;
+
+PFNGLGETPIXELTRANSFORMPARAMETERFVSGIPROC __glewGetPixelTransformParameterfvSGI = NULL;
+PFNGLGETPIXELTRANSFORMPARAMETERIVSGIPROC __glewGetPixelTransformParameterivSGI = NULL;
+PFNGLPIXELTRANSFORMPARAMETERFSGIPROC __glewPixelTransformParameterfSGI = NULL;
+PFNGLPIXELTRANSFORMPARAMETERFVSGIPROC __glewPixelTransformParameterfvSGI = NULL;
+PFNGLPIXELTRANSFORMPARAMETERISGIPROC __glewPixelTransformParameteriSGI = NULL;
+PFNGLPIXELTRANSFORMPARAMETERIVSGIPROC __glewPixelTransformParameterivSGI = NULL;
+PFNGLPIXELTRANSFORMSGIPROC __glewPixelTransformSGI = NULL;
 
 PFNGLFINISHTEXTURESUNXPROC __glewFinishTextureSUNX = NULL;
 
@@ -2926,10 +3278,6 @@ PFNGLTEXCOORD4FVERTEX4FVSUNPROC __glewTexCoord4fVertex4fvSUN = NULL;
 
 PFNGLADDSWAPHINTRECTWINPROC __glewAddSwapHintRectWIN = NULL;
 
-#endif /* !WIN32 || !GLEW_MX */
-
-#if !defined(GLEW_MX)
-
 GLboolean __GLEW_VERSION_1_1 = GL_FALSE;
 GLboolean __GLEW_VERSION_1_2 = GL_FALSE;
 GLboolean __GLEW_VERSION_1_2_1 = GL_FALSE;
@@ -2948,15 +3296,21 @@ GLboolean __GLEW_VERSION_4_2 = GL_FALSE;
 GLboolean __GLEW_VERSION_4_3 = GL_FALSE;
 GLboolean __GLEW_VERSION_4_4 = GL_FALSE;
 GLboolean __GLEW_VERSION_4_5 = GL_FALSE;
+GLboolean __GLEW_VERSION_4_6 = GL_FALSE;
 GLboolean __GLEW_3DFX_multisample = GL_FALSE;
 GLboolean __GLEW_3DFX_tbuffer = GL_FALSE;
 GLboolean __GLEW_3DFX_texture_compression_FXT1 = GL_FALSE;
 GLboolean __GLEW_AMD_blend_minmax_factor = GL_FALSE;
+GLboolean __GLEW_AMD_compressed_3DC_texture = GL_FALSE;
+GLboolean __GLEW_AMD_compressed_ATC_texture = GL_FALSE;
 GLboolean __GLEW_AMD_conservative_depth = GL_FALSE;
 GLboolean __GLEW_AMD_debug_output = GL_FALSE;
 GLboolean __GLEW_AMD_depth_clamp_separate = GL_FALSE;
 GLboolean __GLEW_AMD_draw_buffers_blend = GL_FALSE;
+GLboolean __GLEW_AMD_framebuffer_sample_positions = GL_FALSE;
 GLboolean __GLEW_AMD_gcn_shader = GL_FALSE;
+GLboolean __GLEW_AMD_gpu_shader_half_float = GL_FALSE;
+GLboolean __GLEW_AMD_gpu_shader_int16 = GL_FALSE;
 GLboolean __GLEW_AMD_gpu_shader_int64 = GL_FALSE;
 GLboolean __GLEW_AMD_interleaved_elements = GL_FALSE;
 GLboolean __GLEW_AMD_multi_draw_indirect = GL_FALSE;
@@ -2964,21 +3318,26 @@ GLboolean __GLEW_AMD_name_gen_delete = GL_FALSE;
 GLboolean __GLEW_AMD_occlusion_query_event = GL_FALSE;
 GLboolean __GLEW_AMD_performance_monitor = GL_FALSE;
 GLboolean __GLEW_AMD_pinned_memory = GL_FALSE;
+GLboolean __GLEW_AMD_program_binary_Z400 = GL_FALSE;
 GLboolean __GLEW_AMD_query_buffer_object = GL_FALSE;
 GLboolean __GLEW_AMD_sample_positions = GL_FALSE;
 GLboolean __GLEW_AMD_seamless_cubemap_per_texture = GL_FALSE;
 GLboolean __GLEW_AMD_shader_atomic_counter_ops = GL_FALSE;
+GLboolean __GLEW_AMD_shader_ballot = GL_FALSE;
+GLboolean __GLEW_AMD_shader_explicit_vertex_parameter = GL_FALSE;
 GLboolean __GLEW_AMD_shader_stencil_export = GL_FALSE;
 GLboolean __GLEW_AMD_shader_stencil_value_export = GL_FALSE;
 GLboolean __GLEW_AMD_shader_trinary_minmax = GL_FALSE;
 GLboolean __GLEW_AMD_sparse_texture = GL_FALSE;
 GLboolean __GLEW_AMD_stencil_operation_extended = GL_FALSE;
+GLboolean __GLEW_AMD_texture_gather_bias_lod = GL_FALSE;
 GLboolean __GLEW_AMD_texture_texture4 = GL_FALSE;
 GLboolean __GLEW_AMD_transform_feedback3_lines_triangles = GL_FALSE;
 GLboolean __GLEW_AMD_transform_feedback4 = GL_FALSE;
 GLboolean __GLEW_AMD_vertex_shader_layer = GL_FALSE;
 GLboolean __GLEW_AMD_vertex_shader_tessellator = GL_FALSE;
 GLboolean __GLEW_AMD_vertex_shader_viewport_index = GL_FALSE;
+GLboolean __GLEW_ANDROID_extension_pack_es31a = GL_FALSE;
 GLboolean __GLEW_ANGLE_depth_texture = GL_FALSE;
 GLboolean __GLEW_ANGLE_framebuffer_blit = GL_FALSE;
 GLboolean __GLEW_ANGLE_framebuffer_multisample = GL_FALSE;
@@ -2993,15 +3352,24 @@ GLboolean __GLEW_ANGLE_timer_query = GL_FALSE;
 GLboolean __GLEW_ANGLE_translated_shader_source = GL_FALSE;
 GLboolean __GLEW_APPLE_aux_depth_stencil = GL_FALSE;
 GLboolean __GLEW_APPLE_client_storage = GL_FALSE;
+GLboolean __GLEW_APPLE_clip_distance = GL_FALSE;
+GLboolean __GLEW_APPLE_color_buffer_packed_float = GL_FALSE;
+GLboolean __GLEW_APPLE_copy_texture_levels = GL_FALSE;
 GLboolean __GLEW_APPLE_element_array = GL_FALSE;
 GLboolean __GLEW_APPLE_fence = GL_FALSE;
 GLboolean __GLEW_APPLE_float_pixels = GL_FALSE;
 GLboolean __GLEW_APPLE_flush_buffer_range = GL_FALSE;
+GLboolean __GLEW_APPLE_framebuffer_multisample = GL_FALSE;
 GLboolean __GLEW_APPLE_object_purgeable = GL_FALSE;
 GLboolean __GLEW_APPLE_pixel_buffer = GL_FALSE;
 GLboolean __GLEW_APPLE_rgb_422 = GL_FALSE;
 GLboolean __GLEW_APPLE_row_bytes = GL_FALSE;
 GLboolean __GLEW_APPLE_specular_vector = GL_FALSE;
+GLboolean __GLEW_APPLE_sync = GL_FALSE;
+GLboolean __GLEW_APPLE_texture_2D_limited_npot = GL_FALSE;
+GLboolean __GLEW_APPLE_texture_format_BGRA8888 = GL_FALSE;
+GLboolean __GLEW_APPLE_texture_max_level = GL_FALSE;
+GLboolean __GLEW_APPLE_texture_packed_float = GL_FALSE;
 GLboolean __GLEW_APPLE_texture_range = GL_FALSE;
 GLboolean __GLEW_APPLE_transform_hint = GL_FALSE;
 GLboolean __GLEW_APPLE_vertex_array_object = GL_FALSE;
@@ -3010,6 +3378,7 @@ GLboolean __GLEW_APPLE_vertex_program_evaluators = GL_FALSE;
 GLboolean __GLEW_APPLE_ycbcr_422 = GL_FALSE;
 GLboolean __GLEW_ARB_ES2_compatibility = GL_FALSE;
 GLboolean __GLEW_ARB_ES3_1_compatibility = GL_FALSE;
+GLboolean __GLEW_ARB_ES3_2_compatibility = GL_FALSE;
 GLboolean __GLEW_ARB_ES3_compatibility = GL_FALSE;
 GLboolean __GLEW_ARB_arrays_of_arrays = GL_FALSE;
 GLboolean __GLEW_ARB_base_instance = GL_FALSE;
@@ -3049,14 +3418,17 @@ GLboolean __GLEW_ARB_fragment_layer_viewport = GL_FALSE;
 GLboolean __GLEW_ARB_fragment_program = GL_FALSE;
 GLboolean __GLEW_ARB_fragment_program_shadow = GL_FALSE;
 GLboolean __GLEW_ARB_fragment_shader = GL_FALSE;
+GLboolean __GLEW_ARB_fragment_shader_interlock = GL_FALSE;
 GLboolean __GLEW_ARB_framebuffer_no_attachments = GL_FALSE;
 GLboolean __GLEW_ARB_framebuffer_object = GL_FALSE;
 GLboolean __GLEW_ARB_framebuffer_sRGB = GL_FALSE;
 GLboolean __GLEW_ARB_geometry_shader4 = GL_FALSE;
 GLboolean __GLEW_ARB_get_program_binary = GL_FALSE;
 GLboolean __GLEW_ARB_get_texture_sub_image = GL_FALSE;
+GLboolean __GLEW_ARB_gl_spirv = GL_FALSE;
 GLboolean __GLEW_ARB_gpu_shader5 = GL_FALSE;
 GLboolean __GLEW_ARB_gpu_shader_fp64 = GL_FALSE;
+GLboolean __GLEW_ARB_gpu_shader_int64 = GL_FALSE;
 GLboolean __GLEW_ARB_half_float_pixel = GL_FALSE;
 GLboolean __GLEW_ARB_half_float_vertex = GL_FALSE;
 GLboolean __GLEW_ARB_imaging = GL_FALSE;
@@ -3074,10 +3446,13 @@ GLboolean __GLEW_ARB_multisample = GL_FALSE;
 GLboolean __GLEW_ARB_multitexture = GL_FALSE;
 GLboolean __GLEW_ARB_occlusion_query = GL_FALSE;
 GLboolean __GLEW_ARB_occlusion_query2 = GL_FALSE;
+GLboolean __GLEW_ARB_parallel_shader_compile = GL_FALSE;
 GLboolean __GLEW_ARB_pipeline_statistics_query = GL_FALSE;
 GLboolean __GLEW_ARB_pixel_buffer_object = GL_FALSE;
 GLboolean __GLEW_ARB_point_parameters = GL_FALSE;
 GLboolean __GLEW_ARB_point_sprite = GL_FALSE;
+GLboolean __GLEW_ARB_polygon_offset_clamp = GL_FALSE;
+GLboolean __GLEW_ARB_post_depth_coverage = GL_FALSE;
 GLboolean __GLEW_ARB_program_interface_query = GL_FALSE;
 GLboolean __GLEW_ARB_provoking_vertex = GL_FALSE;
 GLboolean __GLEW_ARB_query_buffer_object = GL_FALSE;
@@ -3085,13 +3460,17 @@ GLboolean __GLEW_ARB_robust_buffer_access_behavior = GL_FALSE;
 GLboolean __GLEW_ARB_robustness = GL_FALSE;
 GLboolean __GLEW_ARB_robustness_application_isolation = GL_FALSE;
 GLboolean __GLEW_ARB_robustness_share_group_isolation = GL_FALSE;
+GLboolean __GLEW_ARB_sample_locations = GL_FALSE;
 GLboolean __GLEW_ARB_sample_shading = GL_FALSE;
 GLboolean __GLEW_ARB_sampler_objects = GL_FALSE;
 GLboolean __GLEW_ARB_seamless_cube_map = GL_FALSE;
 GLboolean __GLEW_ARB_seamless_cubemap_per_texture = GL_FALSE;
 GLboolean __GLEW_ARB_separate_shader_objects = GL_FALSE;
+GLboolean __GLEW_ARB_shader_atomic_counter_ops = GL_FALSE;
 GLboolean __GLEW_ARB_shader_atomic_counters = GL_FALSE;
+GLboolean __GLEW_ARB_shader_ballot = GL_FALSE;
 GLboolean __GLEW_ARB_shader_bit_encoding = GL_FALSE;
+GLboolean __GLEW_ARB_shader_clock = GL_FALSE;
 GLboolean __GLEW_ARB_shader_draw_parameters = GL_FALSE;
 GLboolean __GLEW_ARB_shader_group_vote = GL_FALSE;
 GLboolean __GLEW_ARB_shader_image_load_store = GL_FALSE;
@@ -3103,6 +3482,7 @@ GLboolean __GLEW_ARB_shader_storage_buffer_object = GL_FALSE;
 GLboolean __GLEW_ARB_shader_subroutine = GL_FALSE;
 GLboolean __GLEW_ARB_shader_texture_image_samples = GL_FALSE;
 GLboolean __GLEW_ARB_shader_texture_lod = GL_FALSE;
+GLboolean __GLEW_ARB_shader_viewport_layer_array = GL_FALSE;
 GLboolean __GLEW_ARB_shading_language_100 = GL_FALSE;
 GLboolean __GLEW_ARB_shading_language_420pack = GL_FALSE;
 GLboolean __GLEW_ARB_shading_language_include = GL_FALSE;
@@ -3111,6 +3491,9 @@ GLboolean __GLEW_ARB_shadow = GL_FALSE;
 GLboolean __GLEW_ARB_shadow_ambient = GL_FALSE;
 GLboolean __GLEW_ARB_sparse_buffer = GL_FALSE;
 GLboolean __GLEW_ARB_sparse_texture = GL_FALSE;
+GLboolean __GLEW_ARB_sparse_texture2 = GL_FALSE;
+GLboolean __GLEW_ARB_sparse_texture_clamp = GL_FALSE;
+GLboolean __GLEW_ARB_spirv_extensions = GL_FALSE;
 GLboolean __GLEW_ARB_stencil_texturing = GL_FALSE;
 GLboolean __GLEW_ARB_sync = GL_FALSE;
 GLboolean __GLEW_ARB_tessellation_shader = GL_FALSE;
@@ -3128,6 +3511,8 @@ GLboolean __GLEW_ARB_texture_env_add = GL_FALSE;
 GLboolean __GLEW_ARB_texture_env_combine = GL_FALSE;
 GLboolean __GLEW_ARB_texture_env_crossbar = GL_FALSE;
 GLboolean __GLEW_ARB_texture_env_dot3 = GL_FALSE;
+GLboolean __GLEW_ARB_texture_filter_anisotropic = GL_FALSE;
+GLboolean __GLEW_ARB_texture_filter_minmax = GL_FALSE;
 GLboolean __GLEW_ARB_texture_float = GL_FALSE;
 GLboolean __GLEW_ARB_texture_gather = GL_FALSE;
 GLboolean __GLEW_ARB_texture_mirror_clamp_to_edge = GL_FALSE;
@@ -3163,6 +3548,11 @@ GLboolean __GLEW_ARB_vertex_type_10f_11f_11f_rev = GL_FALSE;
 GLboolean __GLEW_ARB_vertex_type_2_10_10_10_rev = GL_FALSE;
 GLboolean __GLEW_ARB_viewport_array = GL_FALSE;
 GLboolean __GLEW_ARB_window_pos = GL_FALSE;
+GLboolean __GLEW_ARM_mali_program_binary = GL_FALSE;
+GLboolean __GLEW_ARM_mali_shader_binary = GL_FALSE;
+GLboolean __GLEW_ARM_rgba8 = GL_FALSE;
+GLboolean __GLEW_ARM_shader_framebuffer_fetch = GL_FALSE;
+GLboolean __GLEW_ARM_shader_framebuffer_fetch_depth_stencil = GL_FALSE;
 GLboolean __GLEW_ATIX_point_sprites = GL_FALSE;
 GLboolean __GLEW_ATIX_texture_env_combine3 = GL_FALSE;
 GLboolean __GLEW_ATIX_texture_env_route = GL_FALSE;
@@ -3184,51 +3574,86 @@ GLboolean __GLEW_ATI_texture_mirror_once = GL_FALSE;
 GLboolean __GLEW_ATI_vertex_array_object = GL_FALSE;
 GLboolean __GLEW_ATI_vertex_attrib_array_object = GL_FALSE;
 GLboolean __GLEW_ATI_vertex_streams = GL_FALSE;
+GLboolean __GLEW_EGL_KHR_context_flush_control = GL_FALSE;
+GLboolean __GLEW_EGL_NV_robustness_video_memory_purge = GL_FALSE;
 GLboolean __GLEW_EXT_422_pixels = GL_FALSE;
 GLboolean __GLEW_EXT_Cg_shader = GL_FALSE;
+GLboolean __GLEW_EXT_EGL_image_array = GL_FALSE;
+GLboolean __GLEW_EXT_YUV_target = GL_FALSE;
 GLboolean __GLEW_EXT_abgr = GL_FALSE;
+GLboolean __GLEW_EXT_base_instance = GL_FALSE;
 GLboolean __GLEW_EXT_bgra = GL_FALSE;
 GLboolean __GLEW_EXT_bindable_uniform = GL_FALSE;
 GLboolean __GLEW_EXT_blend_color = GL_FALSE;
 GLboolean __GLEW_EXT_blend_equation_separate = GL_FALSE;
+GLboolean __GLEW_EXT_blend_func_extended = GL_FALSE;
 GLboolean __GLEW_EXT_blend_func_separate = GL_FALSE;
 GLboolean __GLEW_EXT_blend_logic_op = GL_FALSE;
 GLboolean __GLEW_EXT_blend_minmax = GL_FALSE;
 GLboolean __GLEW_EXT_blend_subtract = GL_FALSE;
+GLboolean __GLEW_EXT_buffer_storage = GL_FALSE;
+GLboolean __GLEW_EXT_clear_texture = GL_FALSE;
+GLboolean __GLEW_EXT_clip_cull_distance = GL_FALSE;
 GLboolean __GLEW_EXT_clip_volume_hint = GL_FALSE;
 GLboolean __GLEW_EXT_cmyka = GL_FALSE;
+GLboolean __GLEW_EXT_color_buffer_float = GL_FALSE;
+GLboolean __GLEW_EXT_color_buffer_half_float = GL_FALSE;
 GLboolean __GLEW_EXT_color_subtable = GL_FALSE;
 GLboolean __GLEW_EXT_compiled_vertex_array = GL_FALSE;
+GLboolean __GLEW_EXT_compressed_ETC1_RGB8_sub_texture = GL_FALSE;
+GLboolean __GLEW_EXT_conservative_depth = GL_FALSE;
 GLboolean __GLEW_EXT_convolution = GL_FALSE;
 GLboolean __GLEW_EXT_coordinate_frame = GL_FALSE;
+GLboolean __GLEW_EXT_copy_image = GL_FALSE;
 GLboolean __GLEW_EXT_copy_texture = GL_FALSE;
 GLboolean __GLEW_EXT_cull_vertex = GL_FALSE;
 GLboolean __GLEW_EXT_debug_label = GL_FALSE;
 GLboolean __GLEW_EXT_debug_marker = GL_FALSE;
 GLboolean __GLEW_EXT_depth_bounds_test = GL_FALSE;
 GLboolean __GLEW_EXT_direct_state_access = GL_FALSE;
+GLboolean __GLEW_EXT_discard_framebuffer = GL_FALSE;
+GLboolean __GLEW_EXT_draw_buffers = GL_FALSE;
 GLboolean __GLEW_EXT_draw_buffers2 = GL_FALSE;
+GLboolean __GLEW_EXT_draw_buffers_indexed = GL_FALSE;
+GLboolean __GLEW_EXT_draw_elements_base_vertex = GL_FALSE;
 GLboolean __GLEW_EXT_draw_instanced = GL_FALSE;
 GLboolean __GLEW_EXT_draw_range_elements = GL_FALSE;
+GLboolean __GLEW_EXT_external_buffer = GL_FALSE;
+GLboolean __GLEW_EXT_float_blend = GL_FALSE;
 GLboolean __GLEW_EXT_fog_coord = GL_FALSE;
+GLboolean __GLEW_EXT_frag_depth = GL_FALSE;
 GLboolean __GLEW_EXT_fragment_lighting = GL_FALSE;
 GLboolean __GLEW_EXT_framebuffer_blit = GL_FALSE;
 GLboolean __GLEW_EXT_framebuffer_multisample = GL_FALSE;
 GLboolean __GLEW_EXT_framebuffer_multisample_blit_scaled = GL_FALSE;
 GLboolean __GLEW_EXT_framebuffer_object = GL_FALSE;
 GLboolean __GLEW_EXT_framebuffer_sRGB = GL_FALSE;
+GLboolean __GLEW_EXT_geometry_point_size = GL_FALSE;
+GLboolean __GLEW_EXT_geometry_shader = GL_FALSE;
 GLboolean __GLEW_EXT_geometry_shader4 = GL_FALSE;
 GLboolean __GLEW_EXT_gpu_program_parameters = GL_FALSE;
 GLboolean __GLEW_EXT_gpu_shader4 = GL_FALSE;
+GLboolean __GLEW_EXT_gpu_shader5 = GL_FALSE;
 GLboolean __GLEW_EXT_histogram = GL_FALSE;
 GLboolean __GLEW_EXT_index_array_formats = GL_FALSE;
 GLboolean __GLEW_EXT_index_func = GL_FALSE;
 GLboolean __GLEW_EXT_index_material = GL_FALSE;
 GLboolean __GLEW_EXT_index_texture = GL_FALSE;
+GLboolean __GLEW_EXT_instanced_arrays = GL_FALSE;
 GLboolean __GLEW_EXT_light_texture = GL_FALSE;
+GLboolean __GLEW_EXT_map_buffer_range = GL_FALSE;
+GLboolean __GLEW_EXT_memory_object = GL_FALSE;
+GLboolean __GLEW_EXT_memory_object_fd = GL_FALSE;
+GLboolean __GLEW_EXT_memory_object_win32 = GL_FALSE;
 GLboolean __GLEW_EXT_misc_attribute = GL_FALSE;
 GLboolean __GLEW_EXT_multi_draw_arrays = GL_FALSE;
+GLboolean __GLEW_EXT_multi_draw_indirect = GL_FALSE;
+GLboolean __GLEW_EXT_multiple_textures = GL_FALSE;
 GLboolean __GLEW_EXT_multisample = GL_FALSE;
+GLboolean __GLEW_EXT_multisample_compatibility = GL_FALSE;
+GLboolean __GLEW_EXT_multisampled_render_to_texture = GL_FALSE;
+GLboolean __GLEW_EXT_multisampled_render_to_texture2 = GL_FALSE;
+GLboolean __GLEW_EXT_multiview_draw_buffers = GL_FALSE;
 GLboolean __GLEW_EXT_packed_depth_stencil = GL_FALSE;
 GLboolean __GLEW_EXT_packed_float = GL_FALSE;
 GLboolean __GLEW_EXT_packed_pixels = GL_FALSE;
@@ -3238,17 +3663,39 @@ GLboolean __GLEW_EXT_pixel_transform = GL_FALSE;
 GLboolean __GLEW_EXT_pixel_transform_color_table = GL_FALSE;
 GLboolean __GLEW_EXT_point_parameters = GL_FALSE;
 GLboolean __GLEW_EXT_polygon_offset = GL_FALSE;
+GLboolean __GLEW_EXT_polygon_offset_clamp = GL_FALSE;
+GLboolean __GLEW_EXT_post_depth_coverage = GL_FALSE;
 GLboolean __GLEW_EXT_provoking_vertex = GL_FALSE;
+GLboolean __GLEW_EXT_pvrtc_sRGB = GL_FALSE;
+GLboolean __GLEW_EXT_raster_multisample = GL_FALSE;
+GLboolean __GLEW_EXT_read_format_bgra = GL_FALSE;
+GLboolean __GLEW_EXT_render_snorm = GL_FALSE;
 GLboolean __GLEW_EXT_rescale_normal = GL_FALSE;
+GLboolean __GLEW_EXT_sRGB = GL_FALSE;
+GLboolean __GLEW_EXT_sRGB_write_control = GL_FALSE;
 GLboolean __GLEW_EXT_scene_marker = GL_FALSE;
 GLboolean __GLEW_EXT_secondary_color = GL_FALSE;
+GLboolean __GLEW_EXT_semaphore = GL_FALSE;
+GLboolean __GLEW_EXT_semaphore_fd = GL_FALSE;
+GLboolean __GLEW_EXT_semaphore_win32 = GL_FALSE;
 GLboolean __GLEW_EXT_separate_shader_objects = GL_FALSE;
 GLboolean __GLEW_EXT_separate_specular_color = GL_FALSE;
+GLboolean __GLEW_EXT_shader_framebuffer_fetch = GL_FALSE;
+GLboolean __GLEW_EXT_shader_group_vote = GL_FALSE;
 GLboolean __GLEW_EXT_shader_image_load_formatted = GL_FALSE;
 GLboolean __GLEW_EXT_shader_image_load_store = GL_FALSE;
+GLboolean __GLEW_EXT_shader_implicit_conversions = GL_FALSE;
 GLboolean __GLEW_EXT_shader_integer_mix = GL_FALSE;
+GLboolean __GLEW_EXT_shader_io_blocks = GL_FALSE;
+GLboolean __GLEW_EXT_shader_non_constant_global_initializers = GL_FALSE;
+GLboolean __GLEW_EXT_shader_pixel_local_storage = GL_FALSE;
+GLboolean __GLEW_EXT_shader_pixel_local_storage2 = GL_FALSE;
+GLboolean __GLEW_EXT_shader_texture_lod = GL_FALSE;
 GLboolean __GLEW_EXT_shadow_funcs = GL_FALSE;
+GLboolean __GLEW_EXT_shadow_samplers = GL_FALSE;
 GLboolean __GLEW_EXT_shared_texture_palette = GL_FALSE;
+GLboolean __GLEW_EXT_sparse_texture = GL_FALSE;
+GLboolean __GLEW_EXT_sparse_texture2 = GL_FALSE;
 GLboolean __GLEW_EXT_stencil_clear_tag = GL_FALSE;
 GLboolean __GLEW_EXT_stencil_two_side = GL_FALSE;
 GLboolean __GLEW_EXT_stencil_wrap = GL_FALSE;
@@ -3257,35 +3704,52 @@ GLboolean __GLEW_EXT_texture = GL_FALSE;
 GLboolean __GLEW_EXT_texture3D = GL_FALSE;
 GLboolean __GLEW_EXT_texture_array = GL_FALSE;
 GLboolean __GLEW_EXT_texture_buffer_object = GL_FALSE;
+GLboolean __GLEW_EXT_texture_compression_astc_decode_mode = GL_FALSE;
+GLboolean __GLEW_EXT_texture_compression_astc_decode_mode_rgb9e5 = GL_FALSE;
+GLboolean __GLEW_EXT_texture_compression_bptc = GL_FALSE;
 GLboolean __GLEW_EXT_texture_compression_dxt1 = GL_FALSE;
 GLboolean __GLEW_EXT_texture_compression_latc = GL_FALSE;
 GLboolean __GLEW_EXT_texture_compression_rgtc = GL_FALSE;
 GLboolean __GLEW_EXT_texture_compression_s3tc = GL_FALSE;
 GLboolean __GLEW_EXT_texture_cube_map = GL_FALSE;
+GLboolean __GLEW_EXT_texture_cube_map_array = GL_FALSE;
 GLboolean __GLEW_EXT_texture_edge_clamp = GL_FALSE;
 GLboolean __GLEW_EXT_texture_env = GL_FALSE;
 GLboolean __GLEW_EXT_texture_env_add = GL_FALSE;
 GLboolean __GLEW_EXT_texture_env_combine = GL_FALSE;
 GLboolean __GLEW_EXT_texture_env_dot3 = GL_FALSE;
 GLboolean __GLEW_EXT_texture_filter_anisotropic = GL_FALSE;
+GLboolean __GLEW_EXT_texture_filter_minmax = GL_FALSE;
+GLboolean __GLEW_EXT_texture_format_BGRA8888 = GL_FALSE;
 GLboolean __GLEW_EXT_texture_integer = GL_FALSE;
 GLboolean __GLEW_EXT_texture_lod_bias = GL_FALSE;
 GLboolean __GLEW_EXT_texture_mirror_clamp = GL_FALSE;
+GLboolean __GLEW_EXT_texture_norm16 = GL_FALSE;
 GLboolean __GLEW_EXT_texture_object = GL_FALSE;
 GLboolean __GLEW_EXT_texture_perturb_normal = GL_FALSE;
 GLboolean __GLEW_EXT_texture_rectangle = GL_FALSE;
+GLboolean __GLEW_EXT_texture_rg = GL_FALSE;
 GLboolean __GLEW_EXT_texture_sRGB = GL_FALSE;
+GLboolean __GLEW_EXT_texture_sRGB_R8 = GL_FALSE;
+GLboolean __GLEW_EXT_texture_sRGB_RG8 = GL_FALSE;
 GLboolean __GLEW_EXT_texture_sRGB_decode = GL_FALSE;
 GLboolean __GLEW_EXT_texture_shared_exponent = GL_FALSE;
 GLboolean __GLEW_EXT_texture_snorm = GL_FALSE;
+GLboolean __GLEW_EXT_texture_storage = GL_FALSE;
 GLboolean __GLEW_EXT_texture_swizzle = GL_FALSE;
+GLboolean __GLEW_EXT_texture_type_2_10_10_10_REV = GL_FALSE;
+GLboolean __GLEW_EXT_texture_view = GL_FALSE;
 GLboolean __GLEW_EXT_timer_query = GL_FALSE;
 GLboolean __GLEW_EXT_transform_feedback = GL_FALSE;
+GLboolean __GLEW_EXT_unpack_subimage = GL_FALSE;
 GLboolean __GLEW_EXT_vertex_array = GL_FALSE;
 GLboolean __GLEW_EXT_vertex_array_bgra = GL_FALSE;
+GLboolean __GLEW_EXT_vertex_array_setXXX = GL_FALSE;
 GLboolean __GLEW_EXT_vertex_attrib_64bit = GL_FALSE;
 GLboolean __GLEW_EXT_vertex_shader = GL_FALSE;
 GLboolean __GLEW_EXT_vertex_weighting = GL_FALSE;
+GLboolean __GLEW_EXT_win32_keyed_mutex = GL_FALSE;
+GLboolean __GLEW_EXT_window_rectangles = GL_FALSE;
 GLboolean __GLEW_EXT_x11_sync_object = GL_FALSE;
 GLboolean __GLEW_GREMEDY_frame_terminator = GL_FALSE;
 GLboolean __GLEW_GREMEDY_string_marker = GL_FALSE;
@@ -3301,7 +3765,9 @@ GLboolean __GLEW_IBM_texture_mirrored_repeat = GL_FALSE;
 GLboolean __GLEW_IBM_vertex_array_lists = GL_FALSE;
 GLboolean __GLEW_INGR_color_clamp = GL_FALSE;
 GLboolean __GLEW_INGR_interlace_read = GL_FALSE;
+GLboolean __GLEW_INTEL_conservative_rasterization = GL_FALSE;
 GLboolean __GLEW_INTEL_fragment_shader_ordering = GL_FALSE;
+GLboolean __GLEW_INTEL_framebuffer_CMAA = GL_FALSE;
 GLboolean __GLEW_INTEL_map_texture = GL_FALSE;
 GLboolean __GLEW_INTEL_parallel_arrays = GL_FALSE;
 GLboolean __GLEW_INTEL_performance_query = GL_FALSE;
@@ -3310,86 +3776,149 @@ GLboolean __GLEW_KHR_blend_equation_advanced = GL_FALSE;
 GLboolean __GLEW_KHR_blend_equation_advanced_coherent = GL_FALSE;
 GLboolean __GLEW_KHR_context_flush_control = GL_FALSE;
 GLboolean __GLEW_KHR_debug = GL_FALSE;
+GLboolean __GLEW_KHR_no_error = GL_FALSE;
+GLboolean __GLEW_KHR_parallel_shader_compile = GL_FALSE;
 GLboolean __GLEW_KHR_robust_buffer_access_behavior = GL_FALSE;
 GLboolean __GLEW_KHR_robustness = GL_FALSE;
 GLboolean __GLEW_KHR_texture_compression_astc_hdr = GL_FALSE;
 GLboolean __GLEW_KHR_texture_compression_astc_ldr = GL_FALSE;
+GLboolean __GLEW_KHR_texture_compression_astc_sliced_3d = GL_FALSE;
 GLboolean __GLEW_KTX_buffer_region = GL_FALSE;
 GLboolean __GLEW_MESAX_texture_stack = GL_FALSE;
 GLboolean __GLEW_MESA_pack_invert = GL_FALSE;
 GLboolean __GLEW_MESA_resize_buffers = GL_FALSE;
+GLboolean __GLEW_MESA_shader_integer_functions = GL_FALSE;
 GLboolean __GLEW_MESA_window_pos = GL_FALSE;
 GLboolean __GLEW_MESA_ycbcr_texture = GL_FALSE;
+GLboolean __GLEW_NVX_blend_equation_advanced_multi_draw_buffers = GL_FALSE;
 GLboolean __GLEW_NVX_conditional_render = GL_FALSE;
 GLboolean __GLEW_NVX_gpu_memory_info = GL_FALSE;
+GLboolean __GLEW_NVX_linked_gpu_multicast = GL_FALSE;
+GLboolean __GLEW_NV_3dvision_settings = GL_FALSE;
+GLboolean __GLEW_NV_EGL_stream_consumer_external = GL_FALSE;
+GLboolean __GLEW_NV_alpha_to_coverage_dither_control = GL_FALSE;
+GLboolean __GLEW_NV_bgr = GL_FALSE;
 GLboolean __GLEW_NV_bindless_multi_draw_indirect = GL_FALSE;
 GLboolean __GLEW_NV_bindless_multi_draw_indirect_count = GL_FALSE;
 GLboolean __GLEW_NV_bindless_texture = GL_FALSE;
 GLboolean __GLEW_NV_blend_equation_advanced = GL_FALSE;
 GLboolean __GLEW_NV_blend_equation_advanced_coherent = GL_FALSE;
+GLboolean __GLEW_NV_blend_minmax_factor = GL_FALSE;
 GLboolean __GLEW_NV_blend_square = GL_FALSE;
+GLboolean __GLEW_NV_clip_space_w_scaling = GL_FALSE;
+GLboolean __GLEW_NV_command_list = GL_FALSE;
 GLboolean __GLEW_NV_compute_program5 = GL_FALSE;
 GLboolean __GLEW_NV_conditional_render = GL_FALSE;
+GLboolean __GLEW_NV_conservative_raster = GL_FALSE;
+GLboolean __GLEW_NV_conservative_raster_dilate = GL_FALSE;
+GLboolean __GLEW_NV_conservative_raster_pre_snap_triangles = GL_FALSE;
+GLboolean __GLEW_NV_copy_buffer = GL_FALSE;
 GLboolean __GLEW_NV_copy_depth_to_color = GL_FALSE;
 GLboolean __GLEW_NV_copy_image = GL_FALSE;
 GLboolean __GLEW_NV_deep_texture3D = GL_FALSE;
 GLboolean __GLEW_NV_depth_buffer_float = GL_FALSE;
 GLboolean __GLEW_NV_depth_clamp = GL_FALSE;
 GLboolean __GLEW_NV_depth_range_unclamped = GL_FALSE;
+GLboolean __GLEW_NV_draw_buffers = GL_FALSE;
+GLboolean __GLEW_NV_draw_instanced = GL_FALSE;
 GLboolean __GLEW_NV_draw_texture = GL_FALSE;
+GLboolean __GLEW_NV_draw_vulkan_image = GL_FALSE;
 GLboolean __GLEW_NV_evaluators = GL_FALSE;
+GLboolean __GLEW_NV_explicit_attrib_location = GL_FALSE;
 GLboolean __GLEW_NV_explicit_multisample = GL_FALSE;
+GLboolean __GLEW_NV_fbo_color_attachments = GL_FALSE;
 GLboolean __GLEW_NV_fence = GL_FALSE;
+GLboolean __GLEW_NV_fill_rectangle = GL_FALSE;
 GLboolean __GLEW_NV_float_buffer = GL_FALSE;
 GLboolean __GLEW_NV_fog_distance = GL_FALSE;
+GLboolean __GLEW_NV_fragment_coverage_to_color = GL_FALSE;
 GLboolean __GLEW_NV_fragment_program = GL_FALSE;
 GLboolean __GLEW_NV_fragment_program2 = GL_FALSE;
 GLboolean __GLEW_NV_fragment_program4 = GL_FALSE;
 GLboolean __GLEW_NV_fragment_program_option = GL_FALSE;
+GLboolean __GLEW_NV_fragment_shader_interlock = GL_FALSE;
+GLboolean __GLEW_NV_framebuffer_blit = GL_FALSE;
+GLboolean __GLEW_NV_framebuffer_mixed_samples = GL_FALSE;
+GLboolean __GLEW_NV_framebuffer_multisample = GL_FALSE;
 GLboolean __GLEW_NV_framebuffer_multisample_coverage = GL_FALSE;
+GLboolean __GLEW_NV_generate_mipmap_sRGB = GL_FALSE;
 GLboolean __GLEW_NV_geometry_program4 = GL_FALSE;
 GLboolean __GLEW_NV_geometry_shader4 = GL_FALSE;
+GLboolean __GLEW_NV_geometry_shader_passthrough = GL_FALSE;
+GLboolean __GLEW_NV_gpu_multicast = GL_FALSE;
 GLboolean __GLEW_NV_gpu_program4 = GL_FALSE;
 GLboolean __GLEW_NV_gpu_program5 = GL_FALSE;
 GLboolean __GLEW_NV_gpu_program5_mem_extended = GL_FALSE;
 GLboolean __GLEW_NV_gpu_program_fp64 = GL_FALSE;
 GLboolean __GLEW_NV_gpu_shader5 = GL_FALSE;
 GLboolean __GLEW_NV_half_float = GL_FALSE;
+GLboolean __GLEW_NV_image_formats = GL_FALSE;
+GLboolean __GLEW_NV_instanced_arrays = GL_FALSE;
+GLboolean __GLEW_NV_internalformat_sample_query = GL_FALSE;
 GLboolean __GLEW_NV_light_max_exponent = GL_FALSE;
 GLboolean __GLEW_NV_multisample_coverage = GL_FALSE;
 GLboolean __GLEW_NV_multisample_filter_hint = GL_FALSE;
+GLboolean __GLEW_NV_non_square_matrices = GL_FALSE;
 GLboolean __GLEW_NV_occlusion_query = GL_FALSE;
+GLboolean __GLEW_NV_pack_subimage = GL_FALSE;
 GLboolean __GLEW_NV_packed_depth_stencil = GL_FALSE;
+GLboolean __GLEW_NV_packed_float = GL_FALSE;
+GLboolean __GLEW_NV_packed_float_linear = GL_FALSE;
 GLboolean __GLEW_NV_parameter_buffer_object = GL_FALSE;
 GLboolean __GLEW_NV_parameter_buffer_object2 = GL_FALSE;
 GLboolean __GLEW_NV_path_rendering = GL_FALSE;
+GLboolean __GLEW_NV_path_rendering_shared_edge = GL_FALSE;
+GLboolean __GLEW_NV_pixel_buffer_object = GL_FALSE;
 GLboolean __GLEW_NV_pixel_data_range = GL_FALSE;
+GLboolean __GLEW_NV_platform_binary = GL_FALSE;
 GLboolean __GLEW_NV_point_sprite = GL_FALSE;
+GLboolean __GLEW_NV_polygon_mode = GL_FALSE;
 GLboolean __GLEW_NV_present_video = GL_FALSE;
 GLboolean __GLEW_NV_primitive_restart = GL_FALSE;
+GLboolean __GLEW_NV_read_depth = GL_FALSE;
+GLboolean __GLEW_NV_read_depth_stencil = GL_FALSE;
+GLboolean __GLEW_NV_read_stencil = GL_FALSE;
 GLboolean __GLEW_NV_register_combiners = GL_FALSE;
 GLboolean __GLEW_NV_register_combiners2 = GL_FALSE;
+GLboolean __GLEW_NV_robustness_video_memory_purge = GL_FALSE;
+GLboolean __GLEW_NV_sRGB_formats = GL_FALSE;
+GLboolean __GLEW_NV_sample_locations = GL_FALSE;
+GLboolean __GLEW_NV_sample_mask_override_coverage = GL_FALSE;
 GLboolean __GLEW_NV_shader_atomic_counters = GL_FALSE;
 GLboolean __GLEW_NV_shader_atomic_float = GL_FALSE;
+GLboolean __GLEW_NV_shader_atomic_float64 = GL_FALSE;
+GLboolean __GLEW_NV_shader_atomic_fp16_vector = GL_FALSE;
 GLboolean __GLEW_NV_shader_atomic_int64 = GL_FALSE;
 GLboolean __GLEW_NV_shader_buffer_load = GL_FALSE;
+GLboolean __GLEW_NV_shader_noperspective_interpolation = GL_FALSE;
 GLboolean __GLEW_NV_shader_storage_buffer_object = GL_FALSE;
 GLboolean __GLEW_NV_shader_thread_group = GL_FALSE;
 GLboolean __GLEW_NV_shader_thread_shuffle = GL_FALSE;
+GLboolean __GLEW_NV_shadow_samplers_array = GL_FALSE;
+GLboolean __GLEW_NV_shadow_samplers_cube = GL_FALSE;
+GLboolean __GLEW_NV_stereo_view_rendering = GL_FALSE;
 GLboolean __GLEW_NV_tessellation_program5 = GL_FALSE;
 GLboolean __GLEW_NV_texgen_emboss = GL_FALSE;
 GLboolean __GLEW_NV_texgen_reflection = GL_FALSE;
+GLboolean __GLEW_NV_texture_array = GL_FALSE;
 GLboolean __GLEW_NV_texture_barrier = GL_FALSE;
+GLboolean __GLEW_NV_texture_border_clamp = GL_FALSE;
+GLboolean __GLEW_NV_texture_compression_latc = GL_FALSE;
+GLboolean __GLEW_NV_texture_compression_s3tc = GL_FALSE;
+GLboolean __GLEW_NV_texture_compression_s3tc_update = GL_FALSE;
 GLboolean __GLEW_NV_texture_compression_vtc = GL_FALSE;
 GLboolean __GLEW_NV_texture_env_combine4 = GL_FALSE;
 GLboolean __GLEW_NV_texture_expand_normal = GL_FALSE;
 GLboolean __GLEW_NV_texture_multisample = GL_FALSE;
+GLboolean __GLEW_NV_texture_npot_2D_mipmap = GL_FALSE;
 GLboolean __GLEW_NV_texture_rectangle = GL_FALSE;
+GLboolean __GLEW_NV_texture_rectangle_compressed = GL_FALSE;
 GLboolean __GLEW_NV_texture_shader = GL_FALSE;
 GLboolean __GLEW_NV_texture_shader2 = GL_FALSE;
 GLboolean __GLEW_NV_texture_shader3 = GL_FALSE;
 GLboolean __GLEW_NV_transform_feedback = GL_FALSE;
 GLboolean __GLEW_NV_transform_feedback2 = GL_FALSE;
+GLboolean __GLEW_NV_uniform_buffer_unified_memory = GL_FALSE;
 GLboolean __GLEW_NV_vdpau_interop = GL_FALSE;
 GLboolean __GLEW_NV_vertex_array_range = GL_FALSE;
 GLboolean __GLEW_NV_vertex_array_range2 = GL_FALSE;
@@ -3402,15 +3931,28 @@ GLboolean __GLEW_NV_vertex_program2_option = GL_FALSE;
 GLboolean __GLEW_NV_vertex_program3 = GL_FALSE;
 GLboolean __GLEW_NV_vertex_program4 = GL_FALSE;
 GLboolean __GLEW_NV_video_capture = GL_FALSE;
+GLboolean __GLEW_NV_viewport_array = GL_FALSE;
+GLboolean __GLEW_NV_viewport_array2 = GL_FALSE;
+GLboolean __GLEW_NV_viewport_swizzle = GL_FALSE;
 GLboolean __GLEW_OES_byte_coordinates = GL_FALSE;
-GLboolean __GLEW_OES_compressed_paletted_texture = GL_FALSE;
-GLboolean __GLEW_OES_read_format = GL_FALSE;
-GLboolean __GLEW_OES_single_precision = GL_FALSE;
 GLboolean __GLEW_OML_interlace = GL_FALSE;
 GLboolean __GLEW_OML_resample = GL_FALSE;
 GLboolean __GLEW_OML_subsample = GL_FALSE;
+GLboolean __GLEW_OVR_multiview = GL_FALSE;
+GLboolean __GLEW_OVR_multiview2 = GL_FALSE;
+GLboolean __GLEW_OVR_multiview_multisampled_render_to_texture = GL_FALSE;
 GLboolean __GLEW_PGI_misc_hints = GL_FALSE;
 GLboolean __GLEW_PGI_vertex_hints = GL_FALSE;
+GLboolean __GLEW_QCOM_alpha_test = GL_FALSE;
+GLboolean __GLEW_QCOM_binning_control = GL_FALSE;
+GLboolean __GLEW_QCOM_driver_control = GL_FALSE;
+GLboolean __GLEW_QCOM_extended_get = GL_FALSE;
+GLboolean __GLEW_QCOM_extended_get2 = GL_FALSE;
+GLboolean __GLEW_QCOM_framebuffer_foveated = GL_FALSE;
+GLboolean __GLEW_QCOM_perfmon_global_mode = GL_FALSE;
+GLboolean __GLEW_QCOM_shader_framebuffer_fetch_noncoherent = GL_FALSE;
+GLboolean __GLEW_QCOM_tiled_rendering = GL_FALSE;
+GLboolean __GLEW_QCOM_writeonly_rendering = GL_FALSE;
 GLboolean __GLEW_REGAL_ES1_0_compatibility = GL_FALSE;
 GLboolean __GLEW_REGAL_ES1_1_compatibility = GL_FALSE;
 GLboolean __GLEW_REGAL_enable = GL_FALSE;
@@ -3420,13 +3962,17 @@ GLboolean __GLEW_REGAL_log = GL_FALSE;
 GLboolean __GLEW_REGAL_proc_address = GL_FALSE;
 GLboolean __GLEW_REND_screen_coordinates = GL_FALSE;
 GLboolean __GLEW_S3_s3tc = GL_FALSE;
+GLboolean __GLEW_SGIS_clip_band_hint = GL_FALSE;
 GLboolean __GLEW_SGIS_color_range = GL_FALSE;
 GLboolean __GLEW_SGIS_detail_texture = GL_FALSE;
 GLboolean __GLEW_SGIS_fog_function = GL_FALSE;
 GLboolean __GLEW_SGIS_generate_mipmap = GL_FALSE;
+GLboolean __GLEW_SGIS_line_texgen = GL_FALSE;
 GLboolean __GLEW_SGIS_multisample = GL_FALSE;
+GLboolean __GLEW_SGIS_multitexture = GL_FALSE;
 GLboolean __GLEW_SGIS_pixel_texture = GL_FALSE;
 GLboolean __GLEW_SGIS_point_line_texgen = GL_FALSE;
+GLboolean __GLEW_SGIS_shared_multisample = GL_FALSE;
 GLboolean __GLEW_SGIS_sharpen_texture = GL_FALSE;
 GLboolean __GLEW_SGIS_texture4D = GL_FALSE;
 GLboolean __GLEW_SGIS_texture_border_clamp = GL_FALSE;
@@ -3437,37 +3983,90 @@ GLboolean __GLEW_SGIS_texture_select = GL_FALSE;
 GLboolean __GLEW_SGIX_async = GL_FALSE;
 GLboolean __GLEW_SGIX_async_histogram = GL_FALSE;
 GLboolean __GLEW_SGIX_async_pixel = GL_FALSE;
+GLboolean __GLEW_SGIX_bali_g_instruments = GL_FALSE;
+GLboolean __GLEW_SGIX_bali_r_instruments = GL_FALSE;
+GLboolean __GLEW_SGIX_bali_timer_instruments = GL_FALSE;
 GLboolean __GLEW_SGIX_blend_alpha_minmax = GL_FALSE;
+GLboolean __GLEW_SGIX_blend_cadd = GL_FALSE;
+GLboolean __GLEW_SGIX_blend_cmultiply = GL_FALSE;
+GLboolean __GLEW_SGIX_calligraphic_fragment = GL_FALSE;
 GLboolean __GLEW_SGIX_clipmap = GL_FALSE;
+GLboolean __GLEW_SGIX_color_matrix_accuracy = GL_FALSE;
+GLboolean __GLEW_SGIX_color_table_index_mode = GL_FALSE;
+GLboolean __GLEW_SGIX_complex_polar = GL_FALSE;
 GLboolean __GLEW_SGIX_convolution_accuracy = GL_FALSE;
+GLboolean __GLEW_SGIX_cube_map = GL_FALSE;
+GLboolean __GLEW_SGIX_cylinder_texgen = GL_FALSE;
+GLboolean __GLEW_SGIX_datapipe = GL_FALSE;
+GLboolean __GLEW_SGIX_decimation = GL_FALSE;
+GLboolean __GLEW_SGIX_depth_pass_instrument = GL_FALSE;
 GLboolean __GLEW_SGIX_depth_texture = GL_FALSE;
+GLboolean __GLEW_SGIX_dvc = GL_FALSE;
 GLboolean __GLEW_SGIX_flush_raster = GL_FALSE;
+GLboolean __GLEW_SGIX_fog_blend = GL_FALSE;
+GLboolean __GLEW_SGIX_fog_factor_to_alpha = GL_FALSE;
+GLboolean __GLEW_SGIX_fog_layers = GL_FALSE;
 GLboolean __GLEW_SGIX_fog_offset = GL_FALSE;
+GLboolean __GLEW_SGIX_fog_patchy = GL_FALSE;
+GLboolean __GLEW_SGIX_fog_scale = GL_FALSE;
 GLboolean __GLEW_SGIX_fog_texture = GL_FALSE;
+GLboolean __GLEW_SGIX_fragment_lighting_space = GL_FALSE;
 GLboolean __GLEW_SGIX_fragment_specular_lighting = GL_FALSE;
+GLboolean __GLEW_SGIX_fragments_instrument = GL_FALSE;
 GLboolean __GLEW_SGIX_framezoom = GL_FALSE;
+GLboolean __GLEW_SGIX_icc_texture = GL_FALSE;
+GLboolean __GLEW_SGIX_igloo_interface = GL_FALSE;
+GLboolean __GLEW_SGIX_image_compression = GL_FALSE;
+GLboolean __GLEW_SGIX_impact_pixel_texture = GL_FALSE;
+GLboolean __GLEW_SGIX_instrument_error = GL_FALSE;
 GLboolean __GLEW_SGIX_interlace = GL_FALSE;
 GLboolean __GLEW_SGIX_ir_instrument1 = GL_FALSE;
+GLboolean __GLEW_SGIX_line_quality_hint = GL_FALSE;
 GLboolean __GLEW_SGIX_list_priority = GL_FALSE;
+GLboolean __GLEW_SGIX_mpeg1 = GL_FALSE;
+GLboolean __GLEW_SGIX_mpeg2 = GL_FALSE;
+GLboolean __GLEW_SGIX_nonlinear_lighting_pervertex = GL_FALSE;
+GLboolean __GLEW_SGIX_nurbs_eval = GL_FALSE;
+GLboolean __GLEW_SGIX_occlusion_instrument = GL_FALSE;
+GLboolean __GLEW_SGIX_packed_6bytes = GL_FALSE;
 GLboolean __GLEW_SGIX_pixel_texture = GL_FALSE;
 GLboolean __GLEW_SGIX_pixel_texture_bits = GL_FALSE;
+GLboolean __GLEW_SGIX_pixel_texture_lod = GL_FALSE;
+GLboolean __GLEW_SGIX_pixel_tiles = GL_FALSE;
+GLboolean __GLEW_SGIX_polynomial_ffd = GL_FALSE;
+GLboolean __GLEW_SGIX_quad_mesh = GL_FALSE;
 GLboolean __GLEW_SGIX_reference_plane = GL_FALSE;
 GLboolean __GLEW_SGIX_resample = GL_FALSE;
+GLboolean __GLEW_SGIX_scalebias_hint = GL_FALSE;
 GLboolean __GLEW_SGIX_shadow = GL_FALSE;
 GLboolean __GLEW_SGIX_shadow_ambient = GL_FALSE;
+GLboolean __GLEW_SGIX_slim = GL_FALSE;
+GLboolean __GLEW_SGIX_spotlight_cutoff = GL_FALSE;
 GLboolean __GLEW_SGIX_sprite = GL_FALSE;
+GLboolean __GLEW_SGIX_subdiv_patch = GL_FALSE;
+GLboolean __GLEW_SGIX_subsample = GL_FALSE;
 GLboolean __GLEW_SGIX_tag_sample_buffer = GL_FALSE;
 GLboolean __GLEW_SGIX_texture_add_env = GL_FALSE;
 GLboolean __GLEW_SGIX_texture_coordinate_clamp = GL_FALSE;
 GLboolean __GLEW_SGIX_texture_lod_bias = GL_FALSE;
+GLboolean __GLEW_SGIX_texture_mipmap_anisotropic = GL_FALSE;
 GLboolean __GLEW_SGIX_texture_multi_buffer = GL_FALSE;
+GLboolean __GLEW_SGIX_texture_phase = GL_FALSE;
 GLboolean __GLEW_SGIX_texture_range = GL_FALSE;
 GLboolean __GLEW_SGIX_texture_scale_bias = GL_FALSE;
+GLboolean __GLEW_SGIX_texture_supersample = GL_FALSE;
+GLboolean __GLEW_SGIX_vector_ops = GL_FALSE;
+GLboolean __GLEW_SGIX_vertex_array_object = GL_FALSE;
 GLboolean __GLEW_SGIX_vertex_preclip = GL_FALSE;
 GLboolean __GLEW_SGIX_vertex_preclip_hint = GL_FALSE;
 GLboolean __GLEW_SGIX_ycrcb = GL_FALSE;
+GLboolean __GLEW_SGIX_ycrcb_subsample = GL_FALSE;
+GLboolean __GLEW_SGIX_ycrcba = GL_FALSE;
 GLboolean __GLEW_SGI_color_matrix = GL_FALSE;
 GLboolean __GLEW_SGI_color_table = GL_FALSE;
+GLboolean __GLEW_SGI_complex = GL_FALSE;
+GLboolean __GLEW_SGI_complex_type = GL_FALSE;
+GLboolean __GLEW_SGI_fft = GL_FALSE;
 GLboolean __GLEW_SGI_texture_color_table = GL_FALSE;
 GLboolean __GLEW_SUNX_constant_data = GL_FALSE;
 GLboolean __GLEW_SUN_convolution_border_modes = GL_FALSE;
@@ -3478,14 +4077,5181 @@ GLboolean __GLEW_SUN_slice_accum = GL_FALSE;
 GLboolean __GLEW_SUN_triangle_list = GL_FALSE;
 GLboolean __GLEW_SUN_vertex = GL_FALSE;
 GLboolean __GLEW_WIN_phong_shading = GL_FALSE;
+GLboolean __GLEW_WIN_scene_markerXXX = GL_FALSE;
 GLboolean __GLEW_WIN_specular_fog = GL_FALSE;
 GLboolean __GLEW_WIN_swap_hint = GL_FALSE;
 
-#endif /* !GLEW_MX */
+static const char * _glewExtensionLookup[] = {
+#ifdef GL_VERSION_1_2
+  "GL_VERSION_1_2",
+#endif
+#ifdef GL_VERSION_1_2_1
+  "GL_VERSION_1_2_1",
+#endif
+#ifdef GL_VERSION_1_3
+  "GL_VERSION_1_3",
+#endif
+#ifdef GL_VERSION_1_4
+  "GL_VERSION_1_4",
+#endif
+#ifdef GL_VERSION_1_5
+  "GL_VERSION_1_5",
+#endif
+#ifdef GL_VERSION_2_0
+  "GL_VERSION_2_0",
+#endif
+#ifdef GL_VERSION_2_1
+  "GL_VERSION_2_1",
+#endif
+#ifdef GL_VERSION_3_0
+  "GL_VERSION_3_0",
+#endif
+#ifdef GL_VERSION_3_1
+  "GL_VERSION_3_1",
+#endif
+#ifdef GL_VERSION_3_2
+  "GL_VERSION_3_2",
+#endif
+#ifdef GL_VERSION_3_3
+  "GL_VERSION_3_3",
+#endif
+#ifdef GL_VERSION_4_0
+  "GL_VERSION_4_0",
+#endif
+#ifdef GL_VERSION_4_1
+  "GL_VERSION_4_1",
+#endif
+#ifdef GL_VERSION_4_2
+  "GL_VERSION_4_2",
+#endif
+#ifdef GL_VERSION_4_3
+  "GL_VERSION_4_3",
+#endif
+#ifdef GL_VERSION_4_4
+  "GL_VERSION_4_4",
+#endif
+#ifdef GL_VERSION_4_5
+  "GL_VERSION_4_5",
+#endif
+#ifdef GL_VERSION_4_6
+  "GL_VERSION_4_6",
+#endif
+#ifdef GL_3DFX_multisample
+  "GL_3DFX_multisample",
+#endif
+#ifdef GL_3DFX_tbuffer
+  "GL_3DFX_tbuffer",
+#endif
+#ifdef GL_3DFX_texture_compression_FXT1
+  "GL_3DFX_texture_compression_FXT1",
+#endif
+#ifdef GL_AMD_blend_minmax_factor
+  "GL_AMD_blend_minmax_factor",
+#endif
+#ifdef GL_AMD_compressed_3DC_texture
+  "GL_AMD_compressed_3DC_texture",
+#endif
+#ifdef GL_AMD_compressed_ATC_texture
+  "GL_AMD_compressed_ATC_texture",
+#endif
+#ifdef GL_AMD_conservative_depth
+  "GL_AMD_conservative_depth",
+#endif
+#ifdef GL_AMD_debug_output
+  "GL_AMD_debug_output",
+#endif
+#ifdef GL_AMD_depth_clamp_separate
+  "GL_AMD_depth_clamp_separate",
+#endif
+#ifdef GL_AMD_draw_buffers_blend
+  "GL_AMD_draw_buffers_blend",
+#endif
+#ifdef GL_AMD_framebuffer_sample_positions
+  "GL_AMD_framebuffer_sample_positions",
+#endif
+#ifdef GL_AMD_gcn_shader
+  "GL_AMD_gcn_shader",
+#endif
+#ifdef GL_AMD_gpu_shader_half_float
+  "GL_AMD_gpu_shader_half_float",
+#endif
+#ifdef GL_AMD_gpu_shader_int16
+  "GL_AMD_gpu_shader_int16",
+#endif
+#ifdef GL_AMD_gpu_shader_int64
+  "GL_AMD_gpu_shader_int64",
+#endif
+#ifdef GL_AMD_interleaved_elements
+  "GL_AMD_interleaved_elements",
+#endif
+#ifdef GL_AMD_multi_draw_indirect
+  "GL_AMD_multi_draw_indirect",
+#endif
+#ifdef GL_AMD_name_gen_delete
+  "GL_AMD_name_gen_delete",
+#endif
+#ifdef GL_AMD_occlusion_query_event
+  "GL_AMD_occlusion_query_event",
+#endif
+#ifdef GL_AMD_performance_monitor
+  "GL_AMD_performance_monitor",
+#endif
+#ifdef GL_AMD_pinned_memory
+  "GL_AMD_pinned_memory",
+#endif
+#ifdef GL_AMD_program_binary_Z400
+  "GL_AMD_program_binary_Z400",
+#endif
+#ifdef GL_AMD_query_buffer_object
+  "GL_AMD_query_buffer_object",
+#endif
+#ifdef GL_AMD_sample_positions
+  "GL_AMD_sample_positions",
+#endif
+#ifdef GL_AMD_seamless_cubemap_per_texture
+  "GL_AMD_seamless_cubemap_per_texture",
+#endif
+#ifdef GL_AMD_shader_atomic_counter_ops
+  "GL_AMD_shader_atomic_counter_ops",
+#endif
+#ifdef GL_AMD_shader_ballot
+  "GL_AMD_shader_ballot",
+#endif
+#ifdef GL_AMD_shader_explicit_vertex_parameter
+  "GL_AMD_shader_explicit_vertex_parameter",
+#endif
+#ifdef GL_AMD_shader_stencil_export
+  "GL_AMD_shader_stencil_export",
+#endif
+#ifdef GL_AMD_shader_stencil_value_export
+  "GL_AMD_shader_stencil_value_export",
+#endif
+#ifdef GL_AMD_shader_trinary_minmax
+  "GL_AMD_shader_trinary_minmax",
+#endif
+#ifdef GL_AMD_sparse_texture
+  "GL_AMD_sparse_texture",
+#endif
+#ifdef GL_AMD_stencil_operation_extended
+  "GL_AMD_stencil_operation_extended",
+#endif
+#ifdef GL_AMD_texture_gather_bias_lod
+  "GL_AMD_texture_gather_bias_lod",
+#endif
+#ifdef GL_AMD_texture_texture4
+  "GL_AMD_texture_texture4",
+#endif
+#ifdef GL_AMD_transform_feedback3_lines_triangles
+  "GL_AMD_transform_feedback3_lines_triangles",
+#endif
+#ifdef GL_AMD_transform_feedback4
+  "GL_AMD_transform_feedback4",
+#endif
+#ifdef GL_AMD_vertex_shader_layer
+  "GL_AMD_vertex_shader_layer",
+#endif
+#ifdef GL_AMD_vertex_shader_tessellator
+  "GL_AMD_vertex_shader_tessellator",
+#endif
+#ifdef GL_AMD_vertex_shader_viewport_index
+  "GL_AMD_vertex_shader_viewport_index",
+#endif
+#ifdef GL_ANDROID_extension_pack_es31a
+  "GL_ANDROID_extension_pack_es31a",
+#endif
+#ifdef GL_ANGLE_depth_texture
+  "GL_ANGLE_depth_texture",
+#endif
+#ifdef GL_ANGLE_framebuffer_blit
+  "GL_ANGLE_framebuffer_blit",
+#endif
+#ifdef GL_ANGLE_framebuffer_multisample
+  "GL_ANGLE_framebuffer_multisample",
+#endif
+#ifdef GL_ANGLE_instanced_arrays
+  "GL_ANGLE_instanced_arrays",
+#endif
+#ifdef GL_ANGLE_pack_reverse_row_order
+  "GL_ANGLE_pack_reverse_row_order",
+#endif
+#ifdef GL_ANGLE_program_binary
+  "GL_ANGLE_program_binary",
+#endif
+#ifdef GL_ANGLE_texture_compression_dxt1
+  "GL_ANGLE_texture_compression_dxt1",
+#endif
+#ifdef GL_ANGLE_texture_compression_dxt3
+  "GL_ANGLE_texture_compression_dxt3",
+#endif
+#ifdef GL_ANGLE_texture_compression_dxt5
+  "GL_ANGLE_texture_compression_dxt5",
+#endif
+#ifdef GL_ANGLE_texture_usage
+  "GL_ANGLE_texture_usage",
+#endif
+#ifdef GL_ANGLE_timer_query
+  "GL_ANGLE_timer_query",
+#endif
+#ifdef GL_ANGLE_translated_shader_source
+  "GL_ANGLE_translated_shader_source",
+#endif
+#ifdef GL_APPLE_aux_depth_stencil
+  "GL_APPLE_aux_depth_stencil",
+#endif
+#ifdef GL_APPLE_client_storage
+  "GL_APPLE_client_storage",
+#endif
+#ifdef GL_APPLE_clip_distance
+  "GL_APPLE_clip_distance",
+#endif
+#ifdef GL_APPLE_color_buffer_packed_float
+  "GL_APPLE_color_buffer_packed_float",
+#endif
+#ifdef GL_APPLE_copy_texture_levels
+  "GL_APPLE_copy_texture_levels",
+#endif
+#ifdef GL_APPLE_element_array
+  "GL_APPLE_element_array",
+#endif
+#ifdef GL_APPLE_fence
+  "GL_APPLE_fence",
+#endif
+#ifdef GL_APPLE_float_pixels
+  "GL_APPLE_float_pixels",
+#endif
+#ifdef GL_APPLE_flush_buffer_range
+  "GL_APPLE_flush_buffer_range",
+#endif
+#ifdef GL_APPLE_framebuffer_multisample
+  "GL_APPLE_framebuffer_multisample",
+#endif
+#ifdef GL_APPLE_object_purgeable
+  "GL_APPLE_object_purgeable",
+#endif
+#ifdef GL_APPLE_pixel_buffer
+  "GL_APPLE_pixel_buffer",
+#endif
+#ifdef GL_APPLE_rgb_422
+  "GL_APPLE_rgb_422",
+#endif
+#ifdef GL_APPLE_row_bytes
+  "GL_APPLE_row_bytes",
+#endif
+#ifdef GL_APPLE_specular_vector
+  "GL_APPLE_specular_vector",
+#endif
+#ifdef GL_APPLE_sync
+  "GL_APPLE_sync",
+#endif
+#ifdef GL_APPLE_texture_2D_limited_npot
+  "GL_APPLE_texture_2D_limited_npot",
+#endif
+#ifdef GL_APPLE_texture_format_BGRA8888
+  "GL_APPLE_texture_format_BGRA8888",
+#endif
+#ifdef GL_APPLE_texture_max_level
+  "GL_APPLE_texture_max_level",
+#endif
+#ifdef GL_APPLE_texture_packed_float
+  "GL_APPLE_texture_packed_float",
+#endif
+#ifdef GL_APPLE_texture_range
+  "GL_APPLE_texture_range",
+#endif
+#ifdef GL_APPLE_transform_hint
+  "GL_APPLE_transform_hint",
+#endif
+#ifdef GL_APPLE_vertex_array_object
+  "GL_APPLE_vertex_array_object",
+#endif
+#ifdef GL_APPLE_vertex_array_range
+  "GL_APPLE_vertex_array_range",
+#endif
+#ifdef GL_APPLE_vertex_program_evaluators
+  "GL_APPLE_vertex_program_evaluators",
+#endif
+#ifdef GL_APPLE_ycbcr_422
+  "GL_APPLE_ycbcr_422",
+#endif
+#ifdef GL_ARB_ES2_compatibility
+  "GL_ARB_ES2_compatibility",
+#endif
+#ifdef GL_ARB_ES3_1_compatibility
+  "GL_ARB_ES3_1_compatibility",
+#endif
+#ifdef GL_ARB_ES3_2_compatibility
+  "GL_ARB_ES3_2_compatibility",
+#endif
+#ifdef GL_ARB_ES3_compatibility
+  "GL_ARB_ES3_compatibility",
+#endif
+#ifdef GL_ARB_arrays_of_arrays
+  "GL_ARB_arrays_of_arrays",
+#endif
+#ifdef GL_ARB_base_instance
+  "GL_ARB_base_instance",
+#endif
+#ifdef GL_ARB_bindless_texture
+  "GL_ARB_bindless_texture",
+#endif
+#ifdef GL_ARB_blend_func_extended
+  "GL_ARB_blend_func_extended",
+#endif
+#ifdef GL_ARB_buffer_storage
+  "GL_ARB_buffer_storage",
+#endif
+#ifdef GL_ARB_cl_event
+  "GL_ARB_cl_event",
+#endif
+#ifdef GL_ARB_clear_buffer_object
+  "GL_ARB_clear_buffer_object",
+#endif
+#ifdef GL_ARB_clear_texture
+  "GL_ARB_clear_texture",
+#endif
+#ifdef GL_ARB_clip_control
+  "GL_ARB_clip_control",
+#endif
+#ifdef GL_ARB_color_buffer_float
+  "GL_ARB_color_buffer_float",
+#endif
+#ifdef GL_ARB_compatibility
+  "GL_ARB_compatibility",
+#endif
+#ifdef GL_ARB_compressed_texture_pixel_storage
+  "GL_ARB_compressed_texture_pixel_storage",
+#endif
+#ifdef GL_ARB_compute_shader
+  "GL_ARB_compute_shader",
+#endif
+#ifdef GL_ARB_compute_variable_group_size
+  "GL_ARB_compute_variable_group_size",
+#endif
+#ifdef GL_ARB_conditional_render_inverted
+  "GL_ARB_conditional_render_inverted",
+#endif
+#ifdef GL_ARB_conservative_depth
+  "GL_ARB_conservative_depth",
+#endif
+#ifdef GL_ARB_copy_buffer
+  "GL_ARB_copy_buffer",
+#endif
+#ifdef GL_ARB_copy_image
+  "GL_ARB_copy_image",
+#endif
+#ifdef GL_ARB_cull_distance
+  "GL_ARB_cull_distance",
+#endif
+#ifdef GL_ARB_debug_output
+  "GL_ARB_debug_output",
+#endif
+#ifdef GL_ARB_depth_buffer_float
+  "GL_ARB_depth_buffer_float",
+#endif
+#ifdef GL_ARB_depth_clamp
+  "GL_ARB_depth_clamp",
+#endif
+#ifdef GL_ARB_depth_texture
+  "GL_ARB_depth_texture",
+#endif
+#ifdef GL_ARB_derivative_control
+  "GL_ARB_derivative_control",
+#endif
+#ifdef GL_ARB_direct_state_access
+  "GL_ARB_direct_state_access",
+#endif
+#ifdef GL_ARB_draw_buffers
+  "GL_ARB_draw_buffers",
+#endif
+#ifdef GL_ARB_draw_buffers_blend
+  "GL_ARB_draw_buffers_blend",
+#endif
+#ifdef GL_ARB_draw_elements_base_vertex
+  "GL_ARB_draw_elements_base_vertex",
+#endif
+#ifdef GL_ARB_draw_indirect
+  "GL_ARB_draw_indirect",
+#endif
+#ifdef GL_ARB_draw_instanced
+  "GL_ARB_draw_instanced",
+#endif
+#ifdef GL_ARB_enhanced_layouts
+  "GL_ARB_enhanced_layouts",
+#endif
+#ifdef GL_ARB_explicit_attrib_location
+  "GL_ARB_explicit_attrib_location",
+#endif
+#ifdef GL_ARB_explicit_uniform_location
+  "GL_ARB_explicit_uniform_location",
+#endif
+#ifdef GL_ARB_fragment_coord_conventions
+  "GL_ARB_fragment_coord_conventions",
+#endif
+#ifdef GL_ARB_fragment_layer_viewport
+  "GL_ARB_fragment_layer_viewport",
+#endif
+#ifdef GL_ARB_fragment_program
+  "GL_ARB_fragment_program",
+#endif
+#ifdef GL_ARB_fragment_program_shadow
+  "GL_ARB_fragment_program_shadow",
+#endif
+#ifdef GL_ARB_fragment_shader
+  "GL_ARB_fragment_shader",
+#endif
+#ifdef GL_ARB_fragment_shader_interlock
+  "GL_ARB_fragment_shader_interlock",
+#endif
+#ifdef GL_ARB_framebuffer_no_attachments
+  "GL_ARB_framebuffer_no_attachments",
+#endif
+#ifdef GL_ARB_framebuffer_object
+  "GL_ARB_framebuffer_object",
+#endif
+#ifdef GL_ARB_framebuffer_sRGB
+  "GL_ARB_framebuffer_sRGB",
+#endif
+#ifdef GL_ARB_geometry_shader4
+  "GL_ARB_geometry_shader4",
+#endif
+#ifdef GL_ARB_get_program_binary
+  "GL_ARB_get_program_binary",
+#endif
+#ifdef GL_ARB_get_texture_sub_image
+  "GL_ARB_get_texture_sub_image",
+#endif
+#ifdef GL_ARB_gl_spirv
+  "GL_ARB_gl_spirv",
+#endif
+#ifdef GL_ARB_gpu_shader5
+  "GL_ARB_gpu_shader5",
+#endif
+#ifdef GL_ARB_gpu_shader_fp64
+  "GL_ARB_gpu_shader_fp64",
+#endif
+#ifdef GL_ARB_gpu_shader_int64
+  "GL_ARB_gpu_shader_int64",
+#endif
+#ifdef GL_ARB_half_float_pixel
+  "GL_ARB_half_float_pixel",
+#endif
+#ifdef GL_ARB_half_float_vertex
+  "GL_ARB_half_float_vertex",
+#endif
+#ifdef GL_ARB_imaging
+  "GL_ARB_imaging",
+#endif
+#ifdef GL_ARB_indirect_parameters
+  "GL_ARB_indirect_parameters",
+#endif
+#ifdef GL_ARB_instanced_arrays
+  "GL_ARB_instanced_arrays",
+#endif
+#ifdef GL_ARB_internalformat_query
+  "GL_ARB_internalformat_query",
+#endif
+#ifdef GL_ARB_internalformat_query2
+  "GL_ARB_internalformat_query2",
+#endif
+#ifdef GL_ARB_invalidate_subdata
+  "GL_ARB_invalidate_subdata",
+#endif
+#ifdef GL_ARB_map_buffer_alignment
+  "GL_ARB_map_buffer_alignment",
+#endif
+#ifdef GL_ARB_map_buffer_range
+  "GL_ARB_map_buffer_range",
+#endif
+#ifdef GL_ARB_matrix_palette
+  "GL_ARB_matrix_palette",
+#endif
+#ifdef GL_ARB_multi_bind
+  "GL_ARB_multi_bind",
+#endif
+#ifdef GL_ARB_multi_draw_indirect
+  "GL_ARB_multi_draw_indirect",
+#endif
+#ifdef GL_ARB_multisample
+  "GL_ARB_multisample",
+#endif
+#ifdef GL_ARB_multitexture
+  "GL_ARB_multitexture",
+#endif
+#ifdef GL_ARB_occlusion_query
+  "GL_ARB_occlusion_query",
+#endif
+#ifdef GL_ARB_occlusion_query2
+  "GL_ARB_occlusion_query2",
+#endif
+#ifdef GL_ARB_parallel_shader_compile
+  "GL_ARB_parallel_shader_compile",
+#endif
+#ifdef GL_ARB_pipeline_statistics_query
+  "GL_ARB_pipeline_statistics_query",
+#endif
+#ifdef GL_ARB_pixel_buffer_object
+  "GL_ARB_pixel_buffer_object",
+#endif
+#ifdef GL_ARB_point_parameters
+  "GL_ARB_point_parameters",
+#endif
+#ifdef GL_ARB_point_sprite
+  "GL_ARB_point_sprite",
+#endif
+#ifdef GL_ARB_polygon_offset_clamp
+  "GL_ARB_polygon_offset_clamp",
+#endif
+#ifdef GL_ARB_post_depth_coverage
+  "GL_ARB_post_depth_coverage",
+#endif
+#ifdef GL_ARB_program_interface_query
+  "GL_ARB_program_interface_query",
+#endif
+#ifdef GL_ARB_provoking_vertex
+  "GL_ARB_provoking_vertex",
+#endif
+#ifdef GL_ARB_query_buffer_object
+  "GL_ARB_query_buffer_object",
+#endif
+#ifdef GL_ARB_robust_buffer_access_behavior
+  "GL_ARB_robust_buffer_access_behavior",
+#endif
+#ifdef GL_ARB_robustness
+  "GL_ARB_robustness",
+#endif
+#ifdef GL_ARB_robustness_application_isolation
+  "GL_ARB_robustness_application_isolation",
+#endif
+#ifdef GL_ARB_robustness_share_group_isolation
+  "GL_ARB_robustness_share_group_isolation",
+#endif
+#ifdef GL_ARB_sample_locations
+  "GL_ARB_sample_locations",
+#endif
+#ifdef GL_ARB_sample_shading
+  "GL_ARB_sample_shading",
+#endif
+#ifdef GL_ARB_sampler_objects
+  "GL_ARB_sampler_objects",
+#endif
+#ifdef GL_ARB_seamless_cube_map
+  "GL_ARB_seamless_cube_map",
+#endif
+#ifdef GL_ARB_seamless_cubemap_per_texture
+  "GL_ARB_seamless_cubemap_per_texture",
+#endif
+#ifdef GL_ARB_separate_shader_objects
+  "GL_ARB_separate_shader_objects",
+#endif
+#ifdef GL_ARB_shader_atomic_counter_ops
+  "GL_ARB_shader_atomic_counter_ops",
+#endif
+#ifdef GL_ARB_shader_atomic_counters
+  "GL_ARB_shader_atomic_counters",
+#endif
+#ifdef GL_ARB_shader_ballot
+  "GL_ARB_shader_ballot",
+#endif
+#ifdef GL_ARB_shader_bit_encoding
+  "GL_ARB_shader_bit_encoding",
+#endif
+#ifdef GL_ARB_shader_clock
+  "GL_ARB_shader_clock",
+#endif
+#ifdef GL_ARB_shader_draw_parameters
+  "GL_ARB_shader_draw_parameters",
+#endif
+#ifdef GL_ARB_shader_group_vote
+  "GL_ARB_shader_group_vote",
+#endif
+#ifdef GL_ARB_shader_image_load_store
+  "GL_ARB_shader_image_load_store",
+#endif
+#ifdef GL_ARB_shader_image_size
+  "GL_ARB_shader_image_size",
+#endif
+#ifdef GL_ARB_shader_objects
+  "GL_ARB_shader_objects",
+#endif
+#ifdef GL_ARB_shader_precision
+  "GL_ARB_shader_precision",
+#endif
+#ifdef GL_ARB_shader_stencil_export
+  "GL_ARB_shader_stencil_export",
+#endif
+#ifdef GL_ARB_shader_storage_buffer_object
+  "GL_ARB_shader_storage_buffer_object",
+#endif
+#ifdef GL_ARB_shader_subroutine
+  "GL_ARB_shader_subroutine",
+#endif
+#ifdef GL_ARB_shader_texture_image_samples
+  "GL_ARB_shader_texture_image_samples",
+#endif
+#ifdef GL_ARB_shader_texture_lod
+  "GL_ARB_shader_texture_lod",
+#endif
+#ifdef GL_ARB_shader_viewport_layer_array
+  "GL_ARB_shader_viewport_layer_array",
+#endif
+#ifdef GL_ARB_shading_language_100
+  "GL_ARB_shading_language_100",
+#endif
+#ifdef GL_ARB_shading_language_420pack
+  "GL_ARB_shading_language_420pack",
+#endif
+#ifdef GL_ARB_shading_language_include
+  "GL_ARB_shading_language_include",
+#endif
+#ifdef GL_ARB_shading_language_packing
+  "GL_ARB_shading_language_packing",
+#endif
+#ifdef GL_ARB_shadow
+  "GL_ARB_shadow",
+#endif
+#ifdef GL_ARB_shadow_ambient
+  "GL_ARB_shadow_ambient",
+#endif
+#ifdef GL_ARB_sparse_buffer
+  "GL_ARB_sparse_buffer",
+#endif
+#ifdef GL_ARB_sparse_texture
+  "GL_ARB_sparse_texture",
+#endif
+#ifdef GL_ARB_sparse_texture2
+  "GL_ARB_sparse_texture2",
+#endif
+#ifdef GL_ARB_sparse_texture_clamp
+  "GL_ARB_sparse_texture_clamp",
+#endif
+#ifdef GL_ARB_spirv_extensions
+  "GL_ARB_spirv_extensions",
+#endif
+#ifdef GL_ARB_stencil_texturing
+  "GL_ARB_stencil_texturing",
+#endif
+#ifdef GL_ARB_sync
+  "GL_ARB_sync",
+#endif
+#ifdef GL_ARB_tessellation_shader
+  "GL_ARB_tessellation_shader",
+#endif
+#ifdef GL_ARB_texture_barrier
+  "GL_ARB_texture_barrier",
+#endif
+#ifdef GL_ARB_texture_border_clamp
+  "GL_ARB_texture_border_clamp",
+#endif
+#ifdef GL_ARB_texture_buffer_object
+  "GL_ARB_texture_buffer_object",
+#endif
+#ifdef GL_ARB_texture_buffer_object_rgb32
+  "GL_ARB_texture_buffer_object_rgb32",
+#endif
+#ifdef GL_ARB_texture_buffer_range
+  "GL_ARB_texture_buffer_range",
+#endif
+#ifdef GL_ARB_texture_compression
+  "GL_ARB_texture_compression",
+#endif
+#ifdef GL_ARB_texture_compression_bptc
+  "GL_ARB_texture_compression_bptc",
+#endif
+#ifdef GL_ARB_texture_compression_rgtc
+  "GL_ARB_texture_compression_rgtc",
+#endif
+#ifdef GL_ARB_texture_cube_map
+  "GL_ARB_texture_cube_map",
+#endif
+#ifdef GL_ARB_texture_cube_map_array
+  "GL_ARB_texture_cube_map_array",
+#endif
+#ifdef GL_ARB_texture_env_add
+  "GL_ARB_texture_env_add",
+#endif
+#ifdef GL_ARB_texture_env_combine
+  "GL_ARB_texture_env_combine",
+#endif
+#ifdef GL_ARB_texture_env_crossbar
+  "GL_ARB_texture_env_crossbar",
+#endif
+#ifdef GL_ARB_texture_env_dot3
+  "GL_ARB_texture_env_dot3",
+#endif
+#ifdef GL_ARB_texture_filter_anisotropic
+  "GL_ARB_texture_filter_anisotropic",
+#endif
+#ifdef GL_ARB_texture_filter_minmax
+  "GL_ARB_texture_filter_minmax",
+#endif
+#ifdef GL_ARB_texture_float
+  "GL_ARB_texture_float",
+#endif
+#ifdef GL_ARB_texture_gather
+  "GL_ARB_texture_gather",
+#endif
+#ifdef GL_ARB_texture_mirror_clamp_to_edge
+  "GL_ARB_texture_mirror_clamp_to_edge",
+#endif
+#ifdef GL_ARB_texture_mirrored_repeat
+  "GL_ARB_texture_mirrored_repeat",
+#endif
+#ifdef GL_ARB_texture_multisample
+  "GL_ARB_texture_multisample",
+#endif
+#ifdef GL_ARB_texture_non_power_of_two
+  "GL_ARB_texture_non_power_of_two",
+#endif
+#ifdef GL_ARB_texture_query_levels
+  "GL_ARB_texture_query_levels",
+#endif
+#ifdef GL_ARB_texture_query_lod
+  "GL_ARB_texture_query_lod",
+#endif
+#ifdef GL_ARB_texture_rectangle
+  "GL_ARB_texture_rectangle",
+#endif
+#ifdef GL_ARB_texture_rg
+  "GL_ARB_texture_rg",
+#endif
+#ifdef GL_ARB_texture_rgb10_a2ui
+  "GL_ARB_texture_rgb10_a2ui",
+#endif
+#ifdef GL_ARB_texture_stencil8
+  "GL_ARB_texture_stencil8",
+#endif
+#ifdef GL_ARB_texture_storage
+  "GL_ARB_texture_storage",
+#endif
+#ifdef GL_ARB_texture_storage_multisample
+  "GL_ARB_texture_storage_multisample",
+#endif
+#ifdef GL_ARB_texture_swizzle
+  "GL_ARB_texture_swizzle",
+#endif
+#ifdef GL_ARB_texture_view
+  "GL_ARB_texture_view",
+#endif
+#ifdef GL_ARB_timer_query
+  "GL_ARB_timer_query",
+#endif
+#ifdef GL_ARB_transform_feedback2
+  "GL_ARB_transform_feedback2",
+#endif
+#ifdef GL_ARB_transform_feedback3
+  "GL_ARB_transform_feedback3",
+#endif
+#ifdef GL_ARB_transform_feedback_instanced
+  "GL_ARB_transform_feedback_instanced",
+#endif
+#ifdef GL_ARB_transform_feedback_overflow_query
+  "GL_ARB_transform_feedback_overflow_query",
+#endif
+#ifdef GL_ARB_transpose_matrix
+  "GL_ARB_transpose_matrix",
+#endif
+#ifdef GL_ARB_uniform_buffer_object
+  "GL_ARB_uniform_buffer_object",
+#endif
+#ifdef GL_ARB_vertex_array_bgra
+  "GL_ARB_vertex_array_bgra",
+#endif
+#ifdef GL_ARB_vertex_array_object
+  "GL_ARB_vertex_array_object",
+#endif
+#ifdef GL_ARB_vertex_attrib_64bit
+  "GL_ARB_vertex_attrib_64bit",
+#endif
+#ifdef GL_ARB_vertex_attrib_binding
+  "GL_ARB_vertex_attrib_binding",
+#endif
+#ifdef GL_ARB_vertex_blend
+  "GL_ARB_vertex_blend",
+#endif
+#ifdef GL_ARB_vertex_buffer_object
+  "GL_ARB_vertex_buffer_object",
+#endif
+#ifdef GL_ARB_vertex_program
+  "GL_ARB_vertex_program",
+#endif
+#ifdef GL_ARB_vertex_shader
+  "GL_ARB_vertex_shader",
+#endif
+#ifdef GL_ARB_vertex_type_10f_11f_11f_rev
+  "GL_ARB_vertex_type_10f_11f_11f_rev",
+#endif
+#ifdef GL_ARB_vertex_type_2_10_10_10_rev
+  "GL_ARB_vertex_type_2_10_10_10_rev",
+#endif
+#ifdef GL_ARB_viewport_array
+  "GL_ARB_viewport_array",
+#endif
+#ifdef GL_ARB_window_pos
+  "GL_ARB_window_pos",
+#endif
+#ifdef GL_ARM_mali_program_binary
+  "GL_ARM_mali_program_binary",
+#endif
+#ifdef GL_ARM_mali_shader_binary
+  "GL_ARM_mali_shader_binary",
+#endif
+#ifdef GL_ARM_rgba8
+  "GL_ARM_rgba8",
+#endif
+#ifdef GL_ARM_shader_framebuffer_fetch
+  "GL_ARM_shader_framebuffer_fetch",
+#endif
+#ifdef GL_ARM_shader_framebuffer_fetch_depth_stencil
+  "GL_ARM_shader_framebuffer_fetch_depth_stencil",
+#endif
+#ifdef GL_ATIX_point_sprites
+  "GL_ATIX_point_sprites",
+#endif
+#ifdef GL_ATIX_texture_env_combine3
+  "GL_ATIX_texture_env_combine3",
+#endif
+#ifdef GL_ATIX_texture_env_route
+  "GL_ATIX_texture_env_route",
+#endif
+#ifdef GL_ATIX_vertex_shader_output_point_size
+  "GL_ATIX_vertex_shader_output_point_size",
+#endif
+#ifdef GL_ATI_draw_buffers
+  "GL_ATI_draw_buffers",
+#endif
+#ifdef GL_ATI_element_array
+  "GL_ATI_element_array",
+#endif
+#ifdef GL_ATI_envmap_bumpmap
+  "GL_ATI_envmap_bumpmap",
+#endif
+#ifdef GL_ATI_fragment_shader
+  "GL_ATI_fragment_shader",
+#endif
+#ifdef GL_ATI_map_object_buffer
+  "GL_ATI_map_object_buffer",
+#endif
+#ifdef GL_ATI_meminfo
+  "GL_ATI_meminfo",
+#endif
+#ifdef GL_ATI_pn_triangles
+  "GL_ATI_pn_triangles",
+#endif
+#ifdef GL_ATI_separate_stencil
+  "GL_ATI_separate_stencil",
+#endif
+#ifdef GL_ATI_shader_texture_lod
+  "GL_ATI_shader_texture_lod",
+#endif
+#ifdef GL_ATI_text_fragment_shader
+  "GL_ATI_text_fragment_shader",
+#endif
+#ifdef GL_ATI_texture_compression_3dc
+  "GL_ATI_texture_compression_3dc",
+#endif
+#ifdef GL_ATI_texture_env_combine3
+  "GL_ATI_texture_env_combine3",
+#endif
+#ifdef GL_ATI_texture_float
+  "GL_ATI_texture_float",
+#endif
+#ifdef GL_ATI_texture_mirror_once
+  "GL_ATI_texture_mirror_once",
+#endif
+#ifdef GL_ATI_vertex_array_object
+  "GL_ATI_vertex_array_object",
+#endif
+#ifdef GL_ATI_vertex_attrib_array_object
+  "GL_ATI_vertex_attrib_array_object",
+#endif
+#ifdef GL_ATI_vertex_streams
+  "GL_ATI_vertex_streams",
+#endif
+#ifdef GL_EGL_KHR_context_flush_control
+  "GL_EGL_KHR_context_flush_control",
+#endif
+#ifdef GL_EGL_NV_robustness_video_memory_purge
+  "GL_EGL_NV_robustness_video_memory_purge",
+#endif
+#ifdef GL_EXT_422_pixels
+  "GL_EXT_422_pixels",
+#endif
+#ifdef GL_EXT_Cg_shader
+  "GL_EXT_Cg_shader",
+#endif
+#ifdef GL_EXT_EGL_image_array
+  "GL_EXT_EGL_image_array",
+#endif
+#ifdef GL_EXT_YUV_target
+  "GL_EXT_YUV_target",
+#endif
+#ifdef GL_EXT_abgr
+  "GL_EXT_abgr",
+#endif
+#ifdef GL_EXT_base_instance
+  "GL_EXT_base_instance",
+#endif
+#ifdef GL_EXT_bgra
+  "GL_EXT_bgra",
+#endif
+#ifdef GL_EXT_bindable_uniform
+  "GL_EXT_bindable_uniform",
+#endif
+#ifdef GL_EXT_blend_color
+  "GL_EXT_blend_color",
+#endif
+#ifdef GL_EXT_blend_equation_separate
+  "GL_EXT_blend_equation_separate",
+#endif
+#ifdef GL_EXT_blend_func_extended
+  "GL_EXT_blend_func_extended",
+#endif
+#ifdef GL_EXT_blend_func_separate
+  "GL_EXT_blend_func_separate",
+#endif
+#ifdef GL_EXT_blend_logic_op
+  "GL_EXT_blend_logic_op",
+#endif
+#ifdef GL_EXT_blend_minmax
+  "GL_EXT_blend_minmax",
+#endif
+#ifdef GL_EXT_blend_subtract
+  "GL_EXT_blend_subtract",
+#endif
+#ifdef GL_EXT_buffer_storage
+  "GL_EXT_buffer_storage",
+#endif
+#ifdef GL_EXT_clear_texture
+  "GL_EXT_clear_texture",
+#endif
+#ifdef GL_EXT_clip_cull_distance
+  "GL_EXT_clip_cull_distance",
+#endif
+#ifdef GL_EXT_clip_volume_hint
+  "GL_EXT_clip_volume_hint",
+#endif
+#ifdef GL_EXT_cmyka
+  "GL_EXT_cmyka",
+#endif
+#ifdef GL_EXT_color_buffer_float
+  "GL_EXT_color_buffer_float",
+#endif
+#ifdef GL_EXT_color_buffer_half_float
+  "GL_EXT_color_buffer_half_float",
+#endif
+#ifdef GL_EXT_color_subtable
+  "GL_EXT_color_subtable",
+#endif
+#ifdef GL_EXT_compiled_vertex_array
+  "GL_EXT_compiled_vertex_array",
+#endif
+#ifdef GL_EXT_compressed_ETC1_RGB8_sub_texture
+  "GL_EXT_compressed_ETC1_RGB8_sub_texture",
+#endif
+#ifdef GL_EXT_conservative_depth
+  "GL_EXT_conservative_depth",
+#endif
+#ifdef GL_EXT_convolution
+  "GL_EXT_convolution",
+#endif
+#ifdef GL_EXT_coordinate_frame
+  "GL_EXT_coordinate_frame",
+#endif
+#ifdef GL_EXT_copy_image
+  "GL_EXT_copy_image",
+#endif
+#ifdef GL_EXT_copy_texture
+  "GL_EXT_copy_texture",
+#endif
+#ifdef GL_EXT_cull_vertex
+  "GL_EXT_cull_vertex",
+#endif
+#ifdef GL_EXT_debug_label
+  "GL_EXT_debug_label",
+#endif
+#ifdef GL_EXT_debug_marker
+  "GL_EXT_debug_marker",
+#endif
+#ifdef GL_EXT_depth_bounds_test
+  "GL_EXT_depth_bounds_test",
+#endif
+#ifdef GL_EXT_direct_state_access
+  "GL_EXT_direct_state_access",
+#endif
+#ifdef GL_EXT_discard_framebuffer
+  "GL_EXT_discard_framebuffer",
+#endif
+#ifdef GL_EXT_draw_buffers
+  "GL_EXT_draw_buffers",
+#endif
+#ifdef GL_EXT_draw_buffers2
+  "GL_EXT_draw_buffers2",
+#endif
+#ifdef GL_EXT_draw_buffers_indexed
+  "GL_EXT_draw_buffers_indexed",
+#endif
+#ifdef GL_EXT_draw_elements_base_vertex
+  "GL_EXT_draw_elements_base_vertex",
+#endif
+#ifdef GL_EXT_draw_instanced
+  "GL_EXT_draw_instanced",
+#endif
+#ifdef GL_EXT_draw_range_elements
+  "GL_EXT_draw_range_elements",
+#endif
+#ifdef GL_EXT_external_buffer
+  "GL_EXT_external_buffer",
+#endif
+#ifdef GL_EXT_float_blend
+  "GL_EXT_float_blend",
+#endif
+#ifdef GL_EXT_fog_coord
+  "GL_EXT_fog_coord",
+#endif
+#ifdef GL_EXT_frag_depth
+  "GL_EXT_frag_depth",
+#endif
+#ifdef GL_EXT_fragment_lighting
+  "GL_EXT_fragment_lighting",
+#endif
+#ifdef GL_EXT_framebuffer_blit
+  "GL_EXT_framebuffer_blit",
+#endif
+#ifdef GL_EXT_framebuffer_multisample
+  "GL_EXT_framebuffer_multisample",
+#endif
+#ifdef GL_EXT_framebuffer_multisample_blit_scaled
+  "GL_EXT_framebuffer_multisample_blit_scaled",
+#endif
+#ifdef GL_EXT_framebuffer_object
+  "GL_EXT_framebuffer_object",
+#endif
+#ifdef GL_EXT_framebuffer_sRGB
+  "GL_EXT_framebuffer_sRGB",
+#endif
+#ifdef GL_EXT_geometry_point_size
+  "GL_EXT_geometry_point_size",
+#endif
+#ifdef GL_EXT_geometry_shader
+  "GL_EXT_geometry_shader",
+#endif
+#ifdef GL_EXT_geometry_shader4
+  "GL_EXT_geometry_shader4",
+#endif
+#ifdef GL_EXT_gpu_program_parameters
+  "GL_EXT_gpu_program_parameters",
+#endif
+#ifdef GL_EXT_gpu_shader4
+  "GL_EXT_gpu_shader4",
+#endif
+#ifdef GL_EXT_gpu_shader5
+  "GL_EXT_gpu_shader5",
+#endif
+#ifdef GL_EXT_histogram
+  "GL_EXT_histogram",
+#endif
+#ifdef GL_EXT_index_array_formats
+  "GL_EXT_index_array_formats",
+#endif
+#ifdef GL_EXT_index_func
+  "GL_EXT_index_func",
+#endif
+#ifdef GL_EXT_index_material
+  "GL_EXT_index_material",
+#endif
+#ifdef GL_EXT_index_texture
+  "GL_EXT_index_texture",
+#endif
+#ifdef GL_EXT_instanced_arrays
+  "GL_EXT_instanced_arrays",
+#endif
+#ifdef GL_EXT_light_texture
+  "GL_EXT_light_texture",
+#endif
+#ifdef GL_EXT_map_buffer_range
+  "GL_EXT_map_buffer_range",
+#endif
+#ifdef GL_EXT_memory_object
+  "GL_EXT_memory_object",
+#endif
+#ifdef GL_EXT_memory_object_fd
+  "GL_EXT_memory_object_fd",
+#endif
+#ifdef GL_EXT_memory_object_win32
+  "GL_EXT_memory_object_win32",
+#endif
+#ifdef GL_EXT_misc_attribute
+  "GL_EXT_misc_attribute",
+#endif
+#ifdef GL_EXT_multi_draw_arrays
+  "GL_EXT_multi_draw_arrays",
+#endif
+#ifdef GL_EXT_multi_draw_indirect
+  "GL_EXT_multi_draw_indirect",
+#endif
+#ifdef GL_EXT_multiple_textures
+  "GL_EXT_multiple_textures",
+#endif
+#ifdef GL_EXT_multisample
+  "GL_EXT_multisample",
+#endif
+#ifdef GL_EXT_multisample_compatibility
+  "GL_EXT_multisample_compatibility",
+#endif
+#ifdef GL_EXT_multisampled_render_to_texture
+  "GL_EXT_multisampled_render_to_texture",
+#endif
+#ifdef GL_EXT_multisampled_render_to_texture2
+  "GL_EXT_multisampled_render_to_texture2",
+#endif
+#ifdef GL_EXT_multiview_draw_buffers
+  "GL_EXT_multiview_draw_buffers",
+#endif
+#ifdef GL_EXT_packed_depth_stencil
+  "GL_EXT_packed_depth_stencil",
+#endif
+#ifdef GL_EXT_packed_float
+  "GL_EXT_packed_float",
+#endif
+#ifdef GL_EXT_packed_pixels
+  "GL_EXT_packed_pixels",
+#endif
+#ifdef GL_EXT_paletted_texture
+  "GL_EXT_paletted_texture",
+#endif
+#ifdef GL_EXT_pixel_buffer_object
+  "GL_EXT_pixel_buffer_object",
+#endif
+#ifdef GL_EXT_pixel_transform
+  "GL_EXT_pixel_transform",
+#endif
+#ifdef GL_EXT_pixel_transform_color_table
+  "GL_EXT_pixel_transform_color_table",
+#endif
+#ifdef GL_EXT_point_parameters
+  "GL_EXT_point_parameters",
+#endif
+#ifdef GL_EXT_polygon_offset
+  "GL_EXT_polygon_offset",
+#endif
+#ifdef GL_EXT_polygon_offset_clamp
+  "GL_EXT_polygon_offset_clamp",
+#endif
+#ifdef GL_EXT_post_depth_coverage
+  "GL_EXT_post_depth_coverage",
+#endif
+#ifdef GL_EXT_provoking_vertex
+  "GL_EXT_provoking_vertex",
+#endif
+#ifdef GL_EXT_pvrtc_sRGB
+  "GL_EXT_pvrtc_sRGB",
+#endif
+#ifdef GL_EXT_raster_multisample
+  "GL_EXT_raster_multisample",
+#endif
+#ifdef GL_EXT_read_format_bgra
+  "GL_EXT_read_format_bgra",
+#endif
+#ifdef GL_EXT_render_snorm
+  "GL_EXT_render_snorm",
+#endif
+#ifdef GL_EXT_rescale_normal
+  "GL_EXT_rescale_normal",
+#endif
+#ifdef GL_EXT_sRGB
+  "GL_EXT_sRGB",
+#endif
+#ifdef GL_EXT_sRGB_write_control
+  "GL_EXT_sRGB_write_control",
+#endif
+#ifdef GL_EXT_scene_marker
+  "GL_EXT_scene_marker",
+#endif
+#ifdef GL_EXT_secondary_color
+  "GL_EXT_secondary_color",
+#endif
+#ifdef GL_EXT_semaphore
+  "GL_EXT_semaphore",
+#endif
+#ifdef GL_EXT_semaphore_fd
+  "GL_EXT_semaphore_fd",
+#endif
+#ifdef GL_EXT_semaphore_win32
+  "GL_EXT_semaphore_win32",
+#endif
+#ifdef GL_EXT_separate_shader_objects
+  "GL_EXT_separate_shader_objects",
+#endif
+#ifdef GL_EXT_separate_specular_color
+  "GL_EXT_separate_specular_color",
+#endif
+#ifdef GL_EXT_shader_framebuffer_fetch
+  "GL_EXT_shader_framebuffer_fetch",
+#endif
+#ifdef GL_EXT_shader_group_vote
+  "GL_EXT_shader_group_vote",
+#endif
+#ifdef GL_EXT_shader_image_load_formatted
+  "GL_EXT_shader_image_load_formatted",
+#endif
+#ifdef GL_EXT_shader_image_load_store
+  "GL_EXT_shader_image_load_store",
+#endif
+#ifdef GL_EXT_shader_implicit_conversions
+  "GL_EXT_shader_implicit_conversions",
+#endif
+#ifdef GL_EXT_shader_integer_mix
+  "GL_EXT_shader_integer_mix",
+#endif
+#ifdef GL_EXT_shader_io_blocks
+  "GL_EXT_shader_io_blocks",
+#endif
+#ifdef GL_EXT_shader_non_constant_global_initializers
+  "GL_EXT_shader_non_constant_global_initializers",
+#endif
+#ifdef GL_EXT_shader_pixel_local_storage
+  "GL_EXT_shader_pixel_local_storage",
+#endif
+#ifdef GL_EXT_shader_pixel_local_storage2
+  "GL_EXT_shader_pixel_local_storage2",
+#endif
+#ifdef GL_EXT_shader_texture_lod
+  "GL_EXT_shader_texture_lod",
+#endif
+#ifdef GL_EXT_shadow_funcs
+  "GL_EXT_shadow_funcs",
+#endif
+#ifdef GL_EXT_shadow_samplers
+  "GL_EXT_shadow_samplers",
+#endif
+#ifdef GL_EXT_shared_texture_palette
+  "GL_EXT_shared_texture_palette",
+#endif
+#ifdef GL_EXT_sparse_texture
+  "GL_EXT_sparse_texture",
+#endif
+#ifdef GL_EXT_sparse_texture2
+  "GL_EXT_sparse_texture2",
+#endif
+#ifdef GL_EXT_stencil_clear_tag
+  "GL_EXT_stencil_clear_tag",
+#endif
+#ifdef GL_EXT_stencil_two_side
+  "GL_EXT_stencil_two_side",
+#endif
+#ifdef GL_EXT_stencil_wrap
+  "GL_EXT_stencil_wrap",
+#endif
+#ifdef GL_EXT_subtexture
+  "GL_EXT_subtexture",
+#endif
+#ifdef GL_EXT_texture
+  "GL_EXT_texture",
+#endif
+#ifdef GL_EXT_texture3D
+  "GL_EXT_texture3D",
+#endif
+#ifdef GL_EXT_texture_array
+  "GL_EXT_texture_array",
+#endif
+#ifdef GL_EXT_texture_buffer_object
+  "GL_EXT_texture_buffer_object",
+#endif
+#ifdef GL_EXT_texture_compression_astc_decode_mode
+  "GL_EXT_texture_compression_astc_decode_mode",
+#endif
+#ifdef GL_EXT_texture_compression_astc_decode_mode_rgb9e5
+  "GL_EXT_texture_compression_astc_decode_mode_rgb9e5",
+#endif
+#ifdef GL_EXT_texture_compression_bptc
+  "GL_EXT_texture_compression_bptc",
+#endif
+#ifdef GL_EXT_texture_compression_dxt1
+  "GL_EXT_texture_compression_dxt1",
+#endif
+#ifdef GL_EXT_texture_compression_latc
+  "GL_EXT_texture_compression_latc",
+#endif
+#ifdef GL_EXT_texture_compression_rgtc
+  "GL_EXT_texture_compression_rgtc",
+#endif
+#ifdef GL_EXT_texture_compression_s3tc
+  "GL_EXT_texture_compression_s3tc",
+#endif
+#ifdef GL_EXT_texture_cube_map
+  "GL_EXT_texture_cube_map",
+#endif
+#ifdef GL_EXT_texture_cube_map_array
+  "GL_EXT_texture_cube_map_array",
+#endif
+#ifdef GL_EXT_texture_edge_clamp
+  "GL_EXT_texture_edge_clamp",
+#endif
+#ifdef GL_EXT_texture_env
+  "GL_EXT_texture_env",
+#endif
+#ifdef GL_EXT_texture_env_add
+  "GL_EXT_texture_env_add",
+#endif
+#ifdef GL_EXT_texture_env_combine
+  "GL_EXT_texture_env_combine",
+#endif
+#ifdef GL_EXT_texture_env_dot3
+  "GL_EXT_texture_env_dot3",
+#endif
+#ifdef GL_EXT_texture_filter_anisotropic
+  "GL_EXT_texture_filter_anisotropic",
+#endif
+#ifdef GL_EXT_texture_filter_minmax
+  "GL_EXT_texture_filter_minmax",
+#endif
+#ifdef GL_EXT_texture_format_BGRA8888
+  "GL_EXT_texture_format_BGRA8888",
+#endif
+#ifdef GL_EXT_texture_integer
+  "GL_EXT_texture_integer",
+#endif
+#ifdef GL_EXT_texture_lod_bias
+  "GL_EXT_texture_lod_bias",
+#endif
+#ifdef GL_EXT_texture_mirror_clamp
+  "GL_EXT_texture_mirror_clamp",
+#endif
+#ifdef GL_EXT_texture_norm16
+  "GL_EXT_texture_norm16",
+#endif
+#ifdef GL_EXT_texture_object
+  "GL_EXT_texture_object",
+#endif
+#ifdef GL_EXT_texture_perturb_normal
+  "GL_EXT_texture_perturb_normal",
+#endif
+#ifdef GL_EXT_texture_rectangle
+  "GL_EXT_texture_rectangle",
+#endif
+#ifdef GL_EXT_texture_rg
+  "GL_EXT_texture_rg",
+#endif
+#ifdef GL_EXT_texture_sRGB
+  "GL_EXT_texture_sRGB",
+#endif
+#ifdef GL_EXT_texture_sRGB_R8
+  "GL_EXT_texture_sRGB_R8",
+#endif
+#ifdef GL_EXT_texture_sRGB_RG8
+  "GL_EXT_texture_sRGB_RG8",
+#endif
+#ifdef GL_EXT_texture_sRGB_decode
+  "GL_EXT_texture_sRGB_decode",
+#endif
+#ifdef GL_EXT_texture_shared_exponent
+  "GL_EXT_texture_shared_exponent",
+#endif
+#ifdef GL_EXT_texture_snorm
+  "GL_EXT_texture_snorm",
+#endif
+#ifdef GL_EXT_texture_storage
+  "GL_EXT_texture_storage",
+#endif
+#ifdef GL_EXT_texture_swizzle
+  "GL_EXT_texture_swizzle",
+#endif
+#ifdef GL_EXT_texture_type_2_10_10_10_REV
+  "GL_EXT_texture_type_2_10_10_10_REV",
+#endif
+#ifdef GL_EXT_texture_view
+  "GL_EXT_texture_view",
+#endif
+#ifdef GL_EXT_timer_query
+  "GL_EXT_timer_query",
+#endif
+#ifdef GL_EXT_transform_feedback
+  "GL_EXT_transform_feedback",
+#endif
+#ifdef GL_EXT_unpack_subimage
+  "GL_EXT_unpack_subimage",
+#endif
+#ifdef GL_EXT_vertex_array
+  "GL_EXT_vertex_array",
+#endif
+#ifdef GL_EXT_vertex_array_bgra
+  "GL_EXT_vertex_array_bgra",
+#endif
+#ifdef GL_EXT_vertex_array_setXXX
+  "GL_EXT_vertex_array_setXXX",
+#endif
+#ifdef GL_EXT_vertex_attrib_64bit
+  "GL_EXT_vertex_attrib_64bit",
+#endif
+#ifdef GL_EXT_vertex_shader
+  "GL_EXT_vertex_shader",
+#endif
+#ifdef GL_EXT_vertex_weighting
+  "GL_EXT_vertex_weighting",
+#endif
+#ifdef GL_EXT_win32_keyed_mutex
+  "GL_EXT_win32_keyed_mutex",
+#endif
+#ifdef GL_EXT_window_rectangles
+  "GL_EXT_window_rectangles",
+#endif
+#ifdef GL_EXT_x11_sync_object
+  "GL_EXT_x11_sync_object",
+#endif
+#ifdef GL_GREMEDY_frame_terminator
+  "GL_GREMEDY_frame_terminator",
+#endif
+#ifdef GL_GREMEDY_string_marker
+  "GL_GREMEDY_string_marker",
+#endif
+#ifdef GL_HP_convolution_border_modes
+  "GL_HP_convolution_border_modes",
+#endif
+#ifdef GL_HP_image_transform
+  "GL_HP_image_transform",
+#endif
+#ifdef GL_HP_occlusion_test
+  "GL_HP_occlusion_test",
+#endif
+#ifdef GL_HP_texture_lighting
+  "GL_HP_texture_lighting",
+#endif
+#ifdef GL_IBM_cull_vertex
+  "GL_IBM_cull_vertex",
+#endif
+#ifdef GL_IBM_multimode_draw_arrays
+  "GL_IBM_multimode_draw_arrays",
+#endif
+#ifdef GL_IBM_rasterpos_clip
+  "GL_IBM_rasterpos_clip",
+#endif
+#ifdef GL_IBM_static_data
+  "GL_IBM_static_data",
+#endif
+#ifdef GL_IBM_texture_mirrored_repeat
+  "GL_IBM_texture_mirrored_repeat",
+#endif
+#ifdef GL_IBM_vertex_array_lists
+  "GL_IBM_vertex_array_lists",
+#endif
+#ifdef GL_INGR_color_clamp
+  "GL_INGR_color_clamp",
+#endif
+#ifdef GL_INGR_interlace_read
+  "GL_INGR_interlace_read",
+#endif
+#ifdef GL_INTEL_conservative_rasterization
+  "GL_INTEL_conservative_rasterization",
+#endif
+#ifdef GL_INTEL_fragment_shader_ordering
+  "GL_INTEL_fragment_shader_ordering",
+#endif
+#ifdef GL_INTEL_framebuffer_CMAA
+  "GL_INTEL_framebuffer_CMAA",
+#endif
+#ifdef GL_INTEL_map_texture
+  "GL_INTEL_map_texture",
+#endif
+#ifdef GL_INTEL_parallel_arrays
+  "GL_INTEL_parallel_arrays",
+#endif
+#ifdef GL_INTEL_performance_query
+  "GL_INTEL_performance_query",
+#endif
+#ifdef GL_INTEL_texture_scissor
+  "GL_INTEL_texture_scissor",
+#endif
+#ifdef GL_KHR_blend_equation_advanced
+  "GL_KHR_blend_equation_advanced",
+#endif
+#ifdef GL_KHR_blend_equation_advanced_coherent
+  "GL_KHR_blend_equation_advanced_coherent",
+#endif
+#ifdef GL_KHR_context_flush_control
+  "GL_KHR_context_flush_control",
+#endif
+#ifdef GL_KHR_debug
+  "GL_KHR_debug",
+#endif
+#ifdef GL_KHR_no_error
+  "GL_KHR_no_error",
+#endif
+#ifdef GL_KHR_parallel_shader_compile
+  "GL_KHR_parallel_shader_compile",
+#endif
+#ifdef GL_KHR_robust_buffer_access_behavior
+  "GL_KHR_robust_buffer_access_behavior",
+#endif
+#ifdef GL_KHR_robustness
+  "GL_KHR_robustness",
+#endif
+#ifdef GL_KHR_texture_compression_astc_hdr
+  "GL_KHR_texture_compression_astc_hdr",
+#endif
+#ifdef GL_KHR_texture_compression_astc_ldr
+  "GL_KHR_texture_compression_astc_ldr",
+#endif
+#ifdef GL_KHR_texture_compression_astc_sliced_3d
+  "GL_KHR_texture_compression_astc_sliced_3d",
+#endif
+#ifdef GL_KTX_buffer_region
+  "GL_KTX_buffer_region",
+#endif
+#ifdef GL_MESAX_texture_stack
+  "GL_MESAX_texture_stack",
+#endif
+#ifdef GL_MESA_pack_invert
+  "GL_MESA_pack_invert",
+#endif
+#ifdef GL_MESA_resize_buffers
+  "GL_MESA_resize_buffers",
+#endif
+#ifdef GL_MESA_shader_integer_functions
+  "GL_MESA_shader_integer_functions",
+#endif
+#ifdef GL_MESA_window_pos
+  "GL_MESA_window_pos",
+#endif
+#ifdef GL_MESA_ycbcr_texture
+  "GL_MESA_ycbcr_texture",
+#endif
+#ifdef GL_NVX_blend_equation_advanced_multi_draw_buffers
+  "GL_NVX_blend_equation_advanced_multi_draw_buffers",
+#endif
+#ifdef GL_NVX_conditional_render
+  "GL_NVX_conditional_render",
+#endif
+#ifdef GL_NVX_gpu_memory_info
+  "GL_NVX_gpu_memory_info",
+#endif
+#ifdef GL_NVX_linked_gpu_multicast
+  "GL_NVX_linked_gpu_multicast",
+#endif
+#ifdef GL_NV_3dvision_settings
+  "GL_NV_3dvision_settings",
+#endif
+#ifdef GL_NV_EGL_stream_consumer_external
+  "GL_NV_EGL_stream_consumer_external",
+#endif
+#ifdef GL_NV_alpha_to_coverage_dither_control
+  "GL_NV_alpha_to_coverage_dither_control",
+#endif
+#ifdef GL_NV_bgr
+  "GL_NV_bgr",
+#endif
+#ifdef GL_NV_bindless_multi_draw_indirect
+  "GL_NV_bindless_multi_draw_indirect",
+#endif
+#ifdef GL_NV_bindless_multi_draw_indirect_count
+  "GL_NV_bindless_multi_draw_indirect_count",
+#endif
+#ifdef GL_NV_bindless_texture
+  "GL_NV_bindless_texture",
+#endif
+#ifdef GL_NV_blend_equation_advanced
+  "GL_NV_blend_equation_advanced",
+#endif
+#ifdef GL_NV_blend_equation_advanced_coherent
+  "GL_NV_blend_equation_advanced_coherent",
+#endif
+#ifdef GL_NV_blend_minmax_factor
+  "GL_NV_blend_minmax_factor",
+#endif
+#ifdef GL_NV_blend_square
+  "GL_NV_blend_square",
+#endif
+#ifdef GL_NV_clip_space_w_scaling
+  "GL_NV_clip_space_w_scaling",
+#endif
+#ifdef GL_NV_command_list
+  "GL_NV_command_list",
+#endif
+#ifdef GL_NV_compute_program5
+  "GL_NV_compute_program5",
+#endif
+#ifdef GL_NV_conditional_render
+  "GL_NV_conditional_render",
+#endif
+#ifdef GL_NV_conservative_raster
+  "GL_NV_conservative_raster",
+#endif
+#ifdef GL_NV_conservative_raster_dilate
+  "GL_NV_conservative_raster_dilate",
+#endif
+#ifdef GL_NV_conservative_raster_pre_snap_triangles
+  "GL_NV_conservative_raster_pre_snap_triangles",
+#endif
+#ifdef GL_NV_copy_buffer
+  "GL_NV_copy_buffer",
+#endif
+#ifdef GL_NV_copy_depth_to_color
+  "GL_NV_copy_depth_to_color",
+#endif
+#ifdef GL_NV_copy_image
+  "GL_NV_copy_image",
+#endif
+#ifdef GL_NV_deep_texture3D
+  "GL_NV_deep_texture3D",
+#endif
+#ifdef GL_NV_depth_buffer_float
+  "GL_NV_depth_buffer_float",
+#endif
+#ifdef GL_NV_depth_clamp
+  "GL_NV_depth_clamp",
+#endif
+#ifdef GL_NV_depth_range_unclamped
+  "GL_NV_depth_range_unclamped",
+#endif
+#ifdef GL_NV_draw_buffers
+  "GL_NV_draw_buffers",
+#endif
+#ifdef GL_NV_draw_instanced
+  "GL_NV_draw_instanced",
+#endif
+#ifdef GL_NV_draw_texture
+  "GL_NV_draw_texture",
+#endif
+#ifdef GL_NV_draw_vulkan_image
+  "GL_NV_draw_vulkan_image",
+#endif
+#ifdef GL_NV_evaluators
+  "GL_NV_evaluators",
+#endif
+#ifdef GL_NV_explicit_attrib_location
+  "GL_NV_explicit_attrib_location",
+#endif
+#ifdef GL_NV_explicit_multisample
+  "GL_NV_explicit_multisample",
+#endif
+#ifdef GL_NV_fbo_color_attachments
+  "GL_NV_fbo_color_attachments",
+#endif
+#ifdef GL_NV_fence
+  "GL_NV_fence",
+#endif
+#ifdef GL_NV_fill_rectangle
+  "GL_NV_fill_rectangle",
+#endif
+#ifdef GL_NV_float_buffer
+  "GL_NV_float_buffer",
+#endif
+#ifdef GL_NV_fog_distance
+  "GL_NV_fog_distance",
+#endif
+#ifdef GL_NV_fragment_coverage_to_color
+  "GL_NV_fragment_coverage_to_color",
+#endif
+#ifdef GL_NV_fragment_program
+  "GL_NV_fragment_program",
+#endif
+#ifdef GL_NV_fragment_program2
+  "GL_NV_fragment_program2",
+#endif
+#ifdef GL_NV_fragment_program4
+  "GL_NV_fragment_program4",
+#endif
+#ifdef GL_NV_fragment_program_option
+  "GL_NV_fragment_program_option",
+#endif
+#ifdef GL_NV_fragment_shader_interlock
+  "GL_NV_fragment_shader_interlock",
+#endif
+#ifdef GL_NV_framebuffer_blit
+  "GL_NV_framebuffer_blit",
+#endif
+#ifdef GL_NV_framebuffer_mixed_samples
+  "GL_NV_framebuffer_mixed_samples",
+#endif
+#ifdef GL_NV_framebuffer_multisample
+  "GL_NV_framebuffer_multisample",
+#endif
+#ifdef GL_NV_framebuffer_multisample_coverage
+  "GL_NV_framebuffer_multisample_coverage",
+#endif
+#ifdef GL_NV_generate_mipmap_sRGB
+  "GL_NV_generate_mipmap_sRGB",
+#endif
+#ifdef GL_NV_geometry_program4
+  "GL_NV_geometry_program4",
+#endif
+#ifdef GL_NV_geometry_shader4
+  "GL_NV_geometry_shader4",
+#endif
+#ifdef GL_NV_geometry_shader_passthrough
+  "GL_NV_geometry_shader_passthrough",
+#endif
+#ifdef GL_NV_gpu_multicast
+  "GL_NV_gpu_multicast",
+#endif
+#ifdef GL_NV_gpu_program4
+  "GL_NV_gpu_program4",
+#endif
+#ifdef GL_NV_gpu_program5
+  "GL_NV_gpu_program5",
+#endif
+#ifdef GL_NV_gpu_program5_mem_extended
+  "GL_NV_gpu_program5_mem_extended",
+#endif
+#ifdef GL_NV_gpu_program_fp64
+  "GL_NV_gpu_program_fp64",
+#endif
+#ifdef GL_NV_gpu_shader5
+  "GL_NV_gpu_shader5",
+#endif
+#ifdef GL_NV_half_float
+  "GL_NV_half_float",
+#endif
+#ifdef GL_NV_image_formats
+  "GL_NV_image_formats",
+#endif
+#ifdef GL_NV_instanced_arrays
+  "GL_NV_instanced_arrays",
+#endif
+#ifdef GL_NV_internalformat_sample_query
+  "GL_NV_internalformat_sample_query",
+#endif
+#ifdef GL_NV_light_max_exponent
+  "GL_NV_light_max_exponent",
+#endif
+#ifdef GL_NV_multisample_coverage
+  "GL_NV_multisample_coverage",
+#endif
+#ifdef GL_NV_multisample_filter_hint
+  "GL_NV_multisample_filter_hint",
+#endif
+#ifdef GL_NV_non_square_matrices
+  "GL_NV_non_square_matrices",
+#endif
+#ifdef GL_NV_occlusion_query
+  "GL_NV_occlusion_query",
+#endif
+#ifdef GL_NV_pack_subimage
+  "GL_NV_pack_subimage",
+#endif
+#ifdef GL_NV_packed_depth_stencil
+  "GL_NV_packed_depth_stencil",
+#endif
+#ifdef GL_NV_packed_float
+  "GL_NV_packed_float",
+#endif
+#ifdef GL_NV_packed_float_linear
+  "GL_NV_packed_float_linear",
+#endif
+#ifdef GL_NV_parameter_buffer_object
+  "GL_NV_parameter_buffer_object",
+#endif
+#ifdef GL_NV_parameter_buffer_object2
+  "GL_NV_parameter_buffer_object2",
+#endif
+#ifdef GL_NV_path_rendering
+  "GL_NV_path_rendering",
+#endif
+#ifdef GL_NV_path_rendering_shared_edge
+  "GL_NV_path_rendering_shared_edge",
+#endif
+#ifdef GL_NV_pixel_buffer_object
+  "GL_NV_pixel_buffer_object",
+#endif
+#ifdef GL_NV_pixel_data_range
+  "GL_NV_pixel_data_range",
+#endif
+#ifdef GL_NV_platform_binary
+  "GL_NV_platform_binary",
+#endif
+#ifdef GL_NV_point_sprite
+  "GL_NV_point_sprite",
+#endif
+#ifdef GL_NV_polygon_mode
+  "GL_NV_polygon_mode",
+#endif
+#ifdef GL_NV_present_video
+  "GL_NV_present_video",
+#endif
+#ifdef GL_NV_primitive_restart
+  "GL_NV_primitive_restart",
+#endif
+#ifdef GL_NV_read_depth
+  "GL_NV_read_depth",
+#endif
+#ifdef GL_NV_read_depth_stencil
+  "GL_NV_read_depth_stencil",
+#endif
+#ifdef GL_NV_read_stencil
+  "GL_NV_read_stencil",
+#endif
+#ifdef GL_NV_register_combiners
+  "GL_NV_register_combiners",
+#endif
+#ifdef GL_NV_register_combiners2
+  "GL_NV_register_combiners2",
+#endif
+#ifdef GL_NV_robustness_video_memory_purge
+  "GL_NV_robustness_video_memory_purge",
+#endif
+#ifdef GL_NV_sRGB_formats
+  "GL_NV_sRGB_formats",
+#endif
+#ifdef GL_NV_sample_locations
+  "GL_NV_sample_locations",
+#endif
+#ifdef GL_NV_sample_mask_override_coverage
+  "GL_NV_sample_mask_override_coverage",
+#endif
+#ifdef GL_NV_shader_atomic_counters
+  "GL_NV_shader_atomic_counters",
+#endif
+#ifdef GL_NV_shader_atomic_float
+  "GL_NV_shader_atomic_float",
+#endif
+#ifdef GL_NV_shader_atomic_float64
+  "GL_NV_shader_atomic_float64",
+#endif
+#ifdef GL_NV_shader_atomic_fp16_vector
+  "GL_NV_shader_atomic_fp16_vector",
+#endif
+#ifdef GL_NV_shader_atomic_int64
+  "GL_NV_shader_atomic_int64",
+#endif
+#ifdef GL_NV_shader_buffer_load
+  "GL_NV_shader_buffer_load",
+#endif
+#ifdef GL_NV_shader_noperspective_interpolation
+  "GL_NV_shader_noperspective_interpolation",
+#endif
+#ifdef GL_NV_shader_storage_buffer_object
+  "GL_NV_shader_storage_buffer_object",
+#endif
+#ifdef GL_NV_shader_thread_group
+  "GL_NV_shader_thread_group",
+#endif
+#ifdef GL_NV_shader_thread_shuffle
+  "GL_NV_shader_thread_shuffle",
+#endif
+#ifdef GL_NV_shadow_samplers_array
+  "GL_NV_shadow_samplers_array",
+#endif
+#ifdef GL_NV_shadow_samplers_cube
+  "GL_NV_shadow_samplers_cube",
+#endif
+#ifdef GL_NV_stereo_view_rendering
+  "GL_NV_stereo_view_rendering",
+#endif
+#ifdef GL_NV_tessellation_program5
+  "GL_NV_tessellation_program5",
+#endif
+#ifdef GL_NV_texgen_emboss
+  "GL_NV_texgen_emboss",
+#endif
+#ifdef GL_NV_texgen_reflection
+  "GL_NV_texgen_reflection",
+#endif
+#ifdef GL_NV_texture_array
+  "GL_NV_texture_array",
+#endif
+#ifdef GL_NV_texture_barrier
+  "GL_NV_texture_barrier",
+#endif
+#ifdef GL_NV_texture_border_clamp
+  "GL_NV_texture_border_clamp",
+#endif
+#ifdef GL_NV_texture_compression_latc
+  "GL_NV_texture_compression_latc",
+#endif
+#ifdef GL_NV_texture_compression_s3tc
+  "GL_NV_texture_compression_s3tc",
+#endif
+#ifdef GL_NV_texture_compression_s3tc_update
+  "GL_NV_texture_compression_s3tc_update",
+#endif
+#ifdef GL_NV_texture_compression_vtc
+  "GL_NV_texture_compression_vtc",
+#endif
+#ifdef GL_NV_texture_env_combine4
+  "GL_NV_texture_env_combine4",
+#endif
+#ifdef GL_NV_texture_expand_normal
+  "GL_NV_texture_expand_normal",
+#endif
+#ifdef GL_NV_texture_multisample
+  "GL_NV_texture_multisample",
+#endif
+#ifdef GL_NV_texture_npot_2D_mipmap
+  "GL_NV_texture_npot_2D_mipmap",
+#endif
+#ifdef GL_NV_texture_rectangle
+  "GL_NV_texture_rectangle",
+#endif
+#ifdef GL_NV_texture_rectangle_compressed
+  "GL_NV_texture_rectangle_compressed",
+#endif
+#ifdef GL_NV_texture_shader
+  "GL_NV_texture_shader",
+#endif
+#ifdef GL_NV_texture_shader2
+  "GL_NV_texture_shader2",
+#endif
+#ifdef GL_NV_texture_shader3
+  "GL_NV_texture_shader3",
+#endif
+#ifdef GL_NV_transform_feedback
+  "GL_NV_transform_feedback",
+#endif
+#ifdef GL_NV_transform_feedback2
+  "GL_NV_transform_feedback2",
+#endif
+#ifdef GL_NV_uniform_buffer_unified_memory
+  "GL_NV_uniform_buffer_unified_memory",
+#endif
+#ifdef GL_NV_vdpau_interop
+  "GL_NV_vdpau_interop",
+#endif
+#ifdef GL_NV_vertex_array_range
+  "GL_NV_vertex_array_range",
+#endif
+#ifdef GL_NV_vertex_array_range2
+  "GL_NV_vertex_array_range2",
+#endif
+#ifdef GL_NV_vertex_attrib_integer_64bit
+  "GL_NV_vertex_attrib_integer_64bit",
+#endif
+#ifdef GL_NV_vertex_buffer_unified_memory
+  "GL_NV_vertex_buffer_unified_memory",
+#endif
+#ifdef GL_NV_vertex_program
+  "GL_NV_vertex_program",
+#endif
+#ifdef GL_NV_vertex_program1_1
+  "GL_NV_vertex_program1_1",
+#endif
+#ifdef GL_NV_vertex_program2
+  "GL_NV_vertex_program2",
+#endif
+#ifdef GL_NV_vertex_program2_option
+  "GL_NV_vertex_program2_option",
+#endif
+#ifdef GL_NV_vertex_program3
+  "GL_NV_vertex_program3",
+#endif
+#ifdef GL_NV_vertex_program4
+  "GL_NV_vertex_program4",
+#endif
+#ifdef GL_NV_video_capture
+  "GL_NV_video_capture",
+#endif
+#ifdef GL_NV_viewport_array
+  "GL_NV_viewport_array",
+#endif
+#ifdef GL_NV_viewport_array2
+  "GL_NV_viewport_array2",
+#endif
+#ifdef GL_NV_viewport_swizzle
+  "GL_NV_viewport_swizzle",
+#endif
+#ifdef GL_OES_byte_coordinates
+  "GL_OES_byte_coordinates",
+#endif
+#ifdef GL_OML_interlace
+  "GL_OML_interlace",
+#endif
+#ifdef GL_OML_resample
+  "GL_OML_resample",
+#endif
+#ifdef GL_OML_subsample
+  "GL_OML_subsample",
+#endif
+#ifdef GL_OVR_multiview
+  "GL_OVR_multiview",
+#endif
+#ifdef GL_OVR_multiview2
+  "GL_OVR_multiview2",
+#endif
+#ifdef GL_OVR_multiview_multisampled_render_to_texture
+  "GL_OVR_multiview_multisampled_render_to_texture",
+#endif
+#ifdef GL_PGI_misc_hints
+  "GL_PGI_misc_hints",
+#endif
+#ifdef GL_PGI_vertex_hints
+  "GL_PGI_vertex_hints",
+#endif
+#ifdef GL_QCOM_alpha_test
+  "GL_QCOM_alpha_test",
+#endif
+#ifdef GL_QCOM_binning_control
+  "GL_QCOM_binning_control",
+#endif
+#ifdef GL_QCOM_driver_control
+  "GL_QCOM_driver_control",
+#endif
+#ifdef GL_QCOM_extended_get
+  "GL_QCOM_extended_get",
+#endif
+#ifdef GL_QCOM_extended_get2
+  "GL_QCOM_extended_get2",
+#endif
+#ifdef GL_QCOM_framebuffer_foveated
+  "GL_QCOM_framebuffer_foveated",
+#endif
+#ifdef GL_QCOM_perfmon_global_mode
+  "GL_QCOM_perfmon_global_mode",
+#endif
+#ifdef GL_QCOM_shader_framebuffer_fetch_noncoherent
+  "GL_QCOM_shader_framebuffer_fetch_noncoherent",
+#endif
+#ifdef GL_QCOM_tiled_rendering
+  "GL_QCOM_tiled_rendering",
+#endif
+#ifdef GL_QCOM_writeonly_rendering
+  "GL_QCOM_writeonly_rendering",
+#endif
+#ifdef GL_REGAL_ES1_0_compatibility
+  "GL_REGAL_ES1_0_compatibility",
+#endif
+#ifdef GL_REGAL_ES1_1_compatibility
+  "GL_REGAL_ES1_1_compatibility",
+#endif
+#ifdef GL_REGAL_enable
+  "GL_REGAL_enable",
+#endif
+#ifdef GL_REGAL_error_string
+  "GL_REGAL_error_string",
+#endif
+#ifdef GL_REGAL_extension_query
+  "GL_REGAL_extension_query",
+#endif
+#ifdef GL_REGAL_log
+  "GL_REGAL_log",
+#endif
+#ifdef GL_REGAL_proc_address
+  "GL_REGAL_proc_address",
+#endif
+#ifdef GL_REND_screen_coordinates
+  "GL_REND_screen_coordinates",
+#endif
+#ifdef GL_S3_s3tc
+  "GL_S3_s3tc",
+#endif
+#ifdef GL_SGIS_clip_band_hint
+  "GL_SGIS_clip_band_hint",
+#endif
+#ifdef GL_SGIS_color_range
+  "GL_SGIS_color_range",
+#endif
+#ifdef GL_SGIS_detail_texture
+  "GL_SGIS_detail_texture",
+#endif
+#ifdef GL_SGIS_fog_function
+  "GL_SGIS_fog_function",
+#endif
+#ifdef GL_SGIS_generate_mipmap
+  "GL_SGIS_generate_mipmap",
+#endif
+#ifdef GL_SGIS_line_texgen
+  "GL_SGIS_line_texgen",
+#endif
+#ifdef GL_SGIS_multisample
+  "GL_SGIS_multisample",
+#endif
+#ifdef GL_SGIS_multitexture
+  "GL_SGIS_multitexture",
+#endif
+#ifdef GL_SGIS_pixel_texture
+  "GL_SGIS_pixel_texture",
+#endif
+#ifdef GL_SGIS_point_line_texgen
+  "GL_SGIS_point_line_texgen",
+#endif
+#ifdef GL_SGIS_shared_multisample
+  "GL_SGIS_shared_multisample",
+#endif
+#ifdef GL_SGIS_sharpen_texture
+  "GL_SGIS_sharpen_texture",
+#endif
+#ifdef GL_SGIS_texture4D
+  "GL_SGIS_texture4D",
+#endif
+#ifdef GL_SGIS_texture_border_clamp
+  "GL_SGIS_texture_border_clamp",
+#endif
+#ifdef GL_SGIS_texture_edge_clamp
+  "GL_SGIS_texture_edge_clamp",
+#endif
+#ifdef GL_SGIS_texture_filter4
+  "GL_SGIS_texture_filter4",
+#endif
+#ifdef GL_SGIS_texture_lod
+  "GL_SGIS_texture_lod",
+#endif
+#ifdef GL_SGIS_texture_select
+  "GL_SGIS_texture_select",
+#endif
+#ifdef GL_SGIX_async
+  "GL_SGIX_async",
+#endif
+#ifdef GL_SGIX_async_histogram
+  "GL_SGIX_async_histogram",
+#endif
+#ifdef GL_SGIX_async_pixel
+  "GL_SGIX_async_pixel",
+#endif
+#ifdef GL_SGIX_bali_g_instruments
+  "GL_SGIX_bali_g_instruments",
+#endif
+#ifdef GL_SGIX_bali_r_instruments
+  "GL_SGIX_bali_r_instruments",
+#endif
+#ifdef GL_SGIX_bali_timer_instruments
+  "GL_SGIX_bali_timer_instruments",
+#endif
+#ifdef GL_SGIX_blend_alpha_minmax
+  "GL_SGIX_blend_alpha_minmax",
+#endif
+#ifdef GL_SGIX_blend_cadd
+  "GL_SGIX_blend_cadd",
+#endif
+#ifdef GL_SGIX_blend_cmultiply
+  "GL_SGIX_blend_cmultiply",
+#endif
+#ifdef GL_SGIX_calligraphic_fragment
+  "GL_SGIX_calligraphic_fragment",
+#endif
+#ifdef GL_SGIX_clipmap
+  "GL_SGIX_clipmap",
+#endif
+#ifdef GL_SGIX_color_matrix_accuracy
+  "GL_SGIX_color_matrix_accuracy",
+#endif
+#ifdef GL_SGIX_color_table_index_mode
+  "GL_SGIX_color_table_index_mode",
+#endif
+#ifdef GL_SGIX_complex_polar
+  "GL_SGIX_complex_polar",
+#endif
+#ifdef GL_SGIX_convolution_accuracy
+  "GL_SGIX_convolution_accuracy",
+#endif
+#ifdef GL_SGIX_cube_map
+  "GL_SGIX_cube_map",
+#endif
+#ifdef GL_SGIX_cylinder_texgen
+  "GL_SGIX_cylinder_texgen",
+#endif
+#ifdef GL_SGIX_datapipe
+  "GL_SGIX_datapipe",
+#endif
+#ifdef GL_SGIX_decimation
+  "GL_SGIX_decimation",
+#endif
+#ifdef GL_SGIX_depth_pass_instrument
+  "GL_SGIX_depth_pass_instrument",
+#endif
+#ifdef GL_SGIX_depth_texture
+  "GL_SGIX_depth_texture",
+#endif
+#ifdef GL_SGIX_dvc
+  "GL_SGIX_dvc",
+#endif
+#ifdef GL_SGIX_flush_raster
+  "GL_SGIX_flush_raster",
+#endif
+#ifdef GL_SGIX_fog_blend
+  "GL_SGIX_fog_blend",
+#endif
+#ifdef GL_SGIX_fog_factor_to_alpha
+  "GL_SGIX_fog_factor_to_alpha",
+#endif
+#ifdef GL_SGIX_fog_layers
+  "GL_SGIX_fog_layers",
+#endif
+#ifdef GL_SGIX_fog_offset
+  "GL_SGIX_fog_offset",
+#endif
+#ifdef GL_SGIX_fog_patchy
+  "GL_SGIX_fog_patchy",
+#endif
+#ifdef GL_SGIX_fog_scale
+  "GL_SGIX_fog_scale",
+#endif
+#ifdef GL_SGIX_fog_texture
+  "GL_SGIX_fog_texture",
+#endif
+#ifdef GL_SGIX_fragment_lighting_space
+  "GL_SGIX_fragment_lighting_space",
+#endif
+#ifdef GL_SGIX_fragment_specular_lighting
+  "GL_SGIX_fragment_specular_lighting",
+#endif
+#ifdef GL_SGIX_fragments_instrument
+  "GL_SGIX_fragments_instrument",
+#endif
+#ifdef GL_SGIX_framezoom
+  "GL_SGIX_framezoom",
+#endif
+#ifdef GL_SGIX_icc_texture
+  "GL_SGIX_icc_texture",
+#endif
+#ifdef GL_SGIX_igloo_interface
+  "GL_SGIX_igloo_interface",
+#endif
+#ifdef GL_SGIX_image_compression
+  "GL_SGIX_image_compression",
+#endif
+#ifdef GL_SGIX_impact_pixel_texture
+  "GL_SGIX_impact_pixel_texture",
+#endif
+#ifdef GL_SGIX_instrument_error
+  "GL_SGIX_instrument_error",
+#endif
+#ifdef GL_SGIX_interlace
+  "GL_SGIX_interlace",
+#endif
+#ifdef GL_SGIX_ir_instrument1
+  "GL_SGIX_ir_instrument1",
+#endif
+#ifdef GL_SGIX_line_quality_hint
+  "GL_SGIX_line_quality_hint",
+#endif
+#ifdef GL_SGIX_list_priority
+  "GL_SGIX_list_priority",
+#endif
+#ifdef GL_SGIX_mpeg1
+  "GL_SGIX_mpeg1",
+#endif
+#ifdef GL_SGIX_mpeg2
+  "GL_SGIX_mpeg2",
+#endif
+#ifdef GL_SGIX_nonlinear_lighting_pervertex
+  "GL_SGIX_nonlinear_lighting_pervertex",
+#endif
+#ifdef GL_SGIX_nurbs_eval
+  "GL_SGIX_nurbs_eval",
+#endif
+#ifdef GL_SGIX_occlusion_instrument
+  "GL_SGIX_occlusion_instrument",
+#endif
+#ifdef GL_SGIX_packed_6bytes
+  "GL_SGIX_packed_6bytes",
+#endif
+#ifdef GL_SGIX_pixel_texture
+  "GL_SGIX_pixel_texture",
+#endif
+#ifdef GL_SGIX_pixel_texture_bits
+  "GL_SGIX_pixel_texture_bits",
+#endif
+#ifdef GL_SGIX_pixel_texture_lod
+  "GL_SGIX_pixel_texture_lod",
+#endif
+#ifdef GL_SGIX_pixel_tiles
+  "GL_SGIX_pixel_tiles",
+#endif
+#ifdef GL_SGIX_polynomial_ffd
+  "GL_SGIX_polynomial_ffd",
+#endif
+#ifdef GL_SGIX_quad_mesh
+  "GL_SGIX_quad_mesh",
+#endif
+#ifdef GL_SGIX_reference_plane
+  "GL_SGIX_reference_plane",
+#endif
+#ifdef GL_SGIX_resample
+  "GL_SGIX_resample",
+#endif
+#ifdef GL_SGIX_scalebias_hint
+  "GL_SGIX_scalebias_hint",
+#endif
+#ifdef GL_SGIX_shadow
+  "GL_SGIX_shadow",
+#endif
+#ifdef GL_SGIX_shadow_ambient
+  "GL_SGIX_shadow_ambient",
+#endif
+#ifdef GL_SGIX_slim
+  "GL_SGIX_slim",
+#endif
+#ifdef GL_SGIX_spotlight_cutoff
+  "GL_SGIX_spotlight_cutoff",
+#endif
+#ifdef GL_SGIX_sprite
+  "GL_SGIX_sprite",
+#endif
+#ifdef GL_SGIX_subdiv_patch
+  "GL_SGIX_subdiv_patch",
+#endif
+#ifdef GL_SGIX_subsample
+  "GL_SGIX_subsample",
+#endif
+#ifdef GL_SGIX_tag_sample_buffer
+  "GL_SGIX_tag_sample_buffer",
+#endif
+#ifdef GL_SGIX_texture_add_env
+  "GL_SGIX_texture_add_env",
+#endif
+#ifdef GL_SGIX_texture_coordinate_clamp
+  "GL_SGIX_texture_coordinate_clamp",
+#endif
+#ifdef GL_SGIX_texture_lod_bias
+  "GL_SGIX_texture_lod_bias",
+#endif
+#ifdef GL_SGIX_texture_mipmap_anisotropic
+  "GL_SGIX_texture_mipmap_anisotropic",
+#endif
+#ifdef GL_SGIX_texture_multi_buffer
+  "GL_SGIX_texture_multi_buffer",
+#endif
+#ifdef GL_SGIX_texture_phase
+  "GL_SGIX_texture_phase",
+#endif
+#ifdef GL_SGIX_texture_range
+  "GL_SGIX_texture_range",
+#endif
+#ifdef GL_SGIX_texture_scale_bias
+  "GL_SGIX_texture_scale_bias",
+#endif
+#ifdef GL_SGIX_texture_supersample
+  "GL_SGIX_texture_supersample",
+#endif
+#ifdef GL_SGIX_vector_ops
+  "GL_SGIX_vector_ops",
+#endif
+#ifdef GL_SGIX_vertex_array_object
+  "GL_SGIX_vertex_array_object",
+#endif
+#ifdef GL_SGIX_vertex_preclip
+  "GL_SGIX_vertex_preclip",
+#endif
+#ifdef GL_SGIX_vertex_preclip_hint
+  "GL_SGIX_vertex_preclip_hint",
+#endif
+#ifdef GL_SGIX_ycrcb
+  "GL_SGIX_ycrcb",
+#endif
+#ifdef GL_SGIX_ycrcb_subsample
+  "GL_SGIX_ycrcb_subsample",
+#endif
+#ifdef GL_SGIX_ycrcba
+  "GL_SGIX_ycrcba",
+#endif
+#ifdef GL_SGI_color_matrix
+  "GL_SGI_color_matrix",
+#endif
+#ifdef GL_SGI_color_table
+  "GL_SGI_color_table",
+#endif
+#ifdef GL_SGI_complex
+  "GL_SGI_complex",
+#endif
+#ifdef GL_SGI_complex_type
+  "GL_SGI_complex_type",
+#endif
+#ifdef GL_SGI_fft
+  "GL_SGI_fft",
+#endif
+#ifdef GL_SGI_texture_color_table
+  "GL_SGI_texture_color_table",
+#endif
+#ifdef GL_SUNX_constant_data
+  "GL_SUNX_constant_data",
+#endif
+#ifdef GL_SUN_convolution_border_modes
+  "GL_SUN_convolution_border_modes",
+#endif
+#ifdef GL_SUN_global_alpha
+  "GL_SUN_global_alpha",
+#endif
+#ifdef GL_SUN_mesh_array
+  "GL_SUN_mesh_array",
+#endif
+#ifdef GL_SUN_read_video_pixels
+  "GL_SUN_read_video_pixels",
+#endif
+#ifdef GL_SUN_slice_accum
+  "GL_SUN_slice_accum",
+#endif
+#ifdef GL_SUN_triangle_list
+  "GL_SUN_triangle_list",
+#endif
+#ifdef GL_SUN_vertex
+  "GL_SUN_vertex",
+#endif
+#ifdef GL_WIN_phong_shading
+  "GL_WIN_phong_shading",
+#endif
+#ifdef GL_WIN_scene_markerXXX
+  "GL_WIN_scene_markerXXX",
+#endif
+#ifdef GL_WIN_specular_fog
+  "GL_WIN_specular_fog",
+#endif
+#ifdef GL_WIN_swap_hint
+  "GL_WIN_swap_hint",
+#endif
+  NULL
+};
+
+/* Detected in the extension string or strings */
+static GLboolean  _glewExtensionString[801];
+/* Detected via extension string or experimental mode */
+static GLboolean* _glewExtensionEnabled[] = {
+#ifdef GL_VERSION_1_2
+  &__GLEW_VERSION_1_2,
+#endif
+#ifdef GL_VERSION_1_2_1
+  &__GLEW_VERSION_1_2_1,
+#endif
+#ifdef GL_VERSION_1_3
+  &__GLEW_VERSION_1_3,
+#endif
+#ifdef GL_VERSION_1_4
+  &__GLEW_VERSION_1_4,
+#endif
+#ifdef GL_VERSION_1_5
+  &__GLEW_VERSION_1_5,
+#endif
+#ifdef GL_VERSION_2_0
+  &__GLEW_VERSION_2_0,
+#endif
+#ifdef GL_VERSION_2_1
+  &__GLEW_VERSION_2_1,
+#endif
+#ifdef GL_VERSION_3_0
+  &__GLEW_VERSION_3_0,
+#endif
+#ifdef GL_VERSION_3_1
+  &__GLEW_VERSION_3_1,
+#endif
+#ifdef GL_VERSION_3_2
+  &__GLEW_VERSION_3_2,
+#endif
+#ifdef GL_VERSION_3_3
+  &__GLEW_VERSION_3_3,
+#endif
+#ifdef GL_VERSION_4_0
+  &__GLEW_VERSION_4_0,
+#endif
+#ifdef GL_VERSION_4_1
+  &__GLEW_VERSION_4_1,
+#endif
+#ifdef GL_VERSION_4_2
+  &__GLEW_VERSION_4_2,
+#endif
+#ifdef GL_VERSION_4_3
+  &__GLEW_VERSION_4_3,
+#endif
+#ifdef GL_VERSION_4_4
+  &__GLEW_VERSION_4_4,
+#endif
+#ifdef GL_VERSION_4_5
+  &__GLEW_VERSION_4_5,
+#endif
+#ifdef GL_VERSION_4_6
+  &__GLEW_VERSION_4_6,
+#endif
+#ifdef GL_3DFX_multisample
+  &__GLEW_3DFX_multisample,
+#endif
+#ifdef GL_3DFX_tbuffer
+  &__GLEW_3DFX_tbuffer,
+#endif
+#ifdef GL_3DFX_texture_compression_FXT1
+  &__GLEW_3DFX_texture_compression_FXT1,
+#endif
+#ifdef GL_AMD_blend_minmax_factor
+  &__GLEW_AMD_blend_minmax_factor,
+#endif
+#ifdef GL_AMD_compressed_3DC_texture
+  &__GLEW_AMD_compressed_3DC_texture,
+#endif
+#ifdef GL_AMD_compressed_ATC_texture
+  &__GLEW_AMD_compressed_ATC_texture,
+#endif
+#ifdef GL_AMD_conservative_depth
+  &__GLEW_AMD_conservative_depth,
+#endif
+#ifdef GL_AMD_debug_output
+  &__GLEW_AMD_debug_output,
+#endif
+#ifdef GL_AMD_depth_clamp_separate
+  &__GLEW_AMD_depth_clamp_separate,
+#endif
+#ifdef GL_AMD_draw_buffers_blend
+  &__GLEW_AMD_draw_buffers_blend,
+#endif
+#ifdef GL_AMD_framebuffer_sample_positions
+  &__GLEW_AMD_framebuffer_sample_positions,
+#endif
+#ifdef GL_AMD_gcn_shader
+  &__GLEW_AMD_gcn_shader,
+#endif
+#ifdef GL_AMD_gpu_shader_half_float
+  &__GLEW_AMD_gpu_shader_half_float,
+#endif
+#ifdef GL_AMD_gpu_shader_int16
+  &__GLEW_AMD_gpu_shader_int16,
+#endif
+#ifdef GL_AMD_gpu_shader_int64
+  &__GLEW_AMD_gpu_shader_int64,
+#endif
+#ifdef GL_AMD_interleaved_elements
+  &__GLEW_AMD_interleaved_elements,
+#endif
+#ifdef GL_AMD_multi_draw_indirect
+  &__GLEW_AMD_multi_draw_indirect,
+#endif
+#ifdef GL_AMD_name_gen_delete
+  &__GLEW_AMD_name_gen_delete,
+#endif
+#ifdef GL_AMD_occlusion_query_event
+  &__GLEW_AMD_occlusion_query_event,
+#endif
+#ifdef GL_AMD_performance_monitor
+  &__GLEW_AMD_performance_monitor,
+#endif
+#ifdef GL_AMD_pinned_memory
+  &__GLEW_AMD_pinned_memory,
+#endif
+#ifdef GL_AMD_program_binary_Z400
+  &__GLEW_AMD_program_binary_Z400,
+#endif
+#ifdef GL_AMD_query_buffer_object
+  &__GLEW_AMD_query_buffer_object,
+#endif
+#ifdef GL_AMD_sample_positions
+  &__GLEW_AMD_sample_positions,
+#endif
+#ifdef GL_AMD_seamless_cubemap_per_texture
+  &__GLEW_AMD_seamless_cubemap_per_texture,
+#endif
+#ifdef GL_AMD_shader_atomic_counter_ops
+  &__GLEW_AMD_shader_atomic_counter_ops,
+#endif
+#ifdef GL_AMD_shader_ballot
+  &__GLEW_AMD_shader_ballot,
+#endif
+#ifdef GL_AMD_shader_explicit_vertex_parameter
+  &__GLEW_AMD_shader_explicit_vertex_parameter,
+#endif
+#ifdef GL_AMD_shader_stencil_export
+  &__GLEW_AMD_shader_stencil_export,
+#endif
+#ifdef GL_AMD_shader_stencil_value_export
+  &__GLEW_AMD_shader_stencil_value_export,
+#endif
+#ifdef GL_AMD_shader_trinary_minmax
+  &__GLEW_AMD_shader_trinary_minmax,
+#endif
+#ifdef GL_AMD_sparse_texture
+  &__GLEW_AMD_sparse_texture,
+#endif
+#ifdef GL_AMD_stencil_operation_extended
+  &__GLEW_AMD_stencil_operation_extended,
+#endif
+#ifdef GL_AMD_texture_gather_bias_lod
+  &__GLEW_AMD_texture_gather_bias_lod,
+#endif
+#ifdef GL_AMD_texture_texture4
+  &__GLEW_AMD_texture_texture4,
+#endif
+#ifdef GL_AMD_transform_feedback3_lines_triangles
+  &__GLEW_AMD_transform_feedback3_lines_triangles,
+#endif
+#ifdef GL_AMD_transform_feedback4
+  &__GLEW_AMD_transform_feedback4,
+#endif
+#ifdef GL_AMD_vertex_shader_layer
+  &__GLEW_AMD_vertex_shader_layer,
+#endif
+#ifdef GL_AMD_vertex_shader_tessellator
+  &__GLEW_AMD_vertex_shader_tessellator,
+#endif
+#ifdef GL_AMD_vertex_shader_viewport_index
+  &__GLEW_AMD_vertex_shader_viewport_index,
+#endif
+#ifdef GL_ANDROID_extension_pack_es31a
+  &__GLEW_ANDROID_extension_pack_es31a,
+#endif
+#ifdef GL_ANGLE_depth_texture
+  &__GLEW_ANGLE_depth_texture,
+#endif
+#ifdef GL_ANGLE_framebuffer_blit
+  &__GLEW_ANGLE_framebuffer_blit,
+#endif
+#ifdef GL_ANGLE_framebuffer_multisample
+  &__GLEW_ANGLE_framebuffer_multisample,
+#endif
+#ifdef GL_ANGLE_instanced_arrays
+  &__GLEW_ANGLE_instanced_arrays,
+#endif
+#ifdef GL_ANGLE_pack_reverse_row_order
+  &__GLEW_ANGLE_pack_reverse_row_order,
+#endif
+#ifdef GL_ANGLE_program_binary
+  &__GLEW_ANGLE_program_binary,
+#endif
+#ifdef GL_ANGLE_texture_compression_dxt1
+  &__GLEW_ANGLE_texture_compression_dxt1,
+#endif
+#ifdef GL_ANGLE_texture_compression_dxt3
+  &__GLEW_ANGLE_texture_compression_dxt3,
+#endif
+#ifdef GL_ANGLE_texture_compression_dxt5
+  &__GLEW_ANGLE_texture_compression_dxt5,
+#endif
+#ifdef GL_ANGLE_texture_usage
+  &__GLEW_ANGLE_texture_usage,
+#endif
+#ifdef GL_ANGLE_timer_query
+  &__GLEW_ANGLE_timer_query,
+#endif
+#ifdef GL_ANGLE_translated_shader_source
+  &__GLEW_ANGLE_translated_shader_source,
+#endif
+#ifdef GL_APPLE_aux_depth_stencil
+  &__GLEW_APPLE_aux_depth_stencil,
+#endif
+#ifdef GL_APPLE_client_storage
+  &__GLEW_APPLE_client_storage,
+#endif
+#ifdef GL_APPLE_clip_distance
+  &__GLEW_APPLE_clip_distance,
+#endif
+#ifdef GL_APPLE_color_buffer_packed_float
+  &__GLEW_APPLE_color_buffer_packed_float,
+#endif
+#ifdef GL_APPLE_copy_texture_levels
+  &__GLEW_APPLE_copy_texture_levels,
+#endif
+#ifdef GL_APPLE_element_array
+  &__GLEW_APPLE_element_array,
+#endif
+#ifdef GL_APPLE_fence
+  &__GLEW_APPLE_fence,
+#endif
+#ifdef GL_APPLE_float_pixels
+  &__GLEW_APPLE_float_pixels,
+#endif
+#ifdef GL_APPLE_flush_buffer_range
+  &__GLEW_APPLE_flush_buffer_range,
+#endif
+#ifdef GL_APPLE_framebuffer_multisample
+  &__GLEW_APPLE_framebuffer_multisample,
+#endif
+#ifdef GL_APPLE_object_purgeable
+  &__GLEW_APPLE_object_purgeable,
+#endif
+#ifdef GL_APPLE_pixel_buffer
+  &__GLEW_APPLE_pixel_buffer,
+#endif
+#ifdef GL_APPLE_rgb_422
+  &__GLEW_APPLE_rgb_422,
+#endif
+#ifdef GL_APPLE_row_bytes
+  &__GLEW_APPLE_row_bytes,
+#endif
+#ifdef GL_APPLE_specular_vector
+  &__GLEW_APPLE_specular_vector,
+#endif
+#ifdef GL_APPLE_sync
+  &__GLEW_APPLE_sync,
+#endif
+#ifdef GL_APPLE_texture_2D_limited_npot
+  &__GLEW_APPLE_texture_2D_limited_npot,
+#endif
+#ifdef GL_APPLE_texture_format_BGRA8888
+  &__GLEW_APPLE_texture_format_BGRA8888,
+#endif
+#ifdef GL_APPLE_texture_max_level
+  &__GLEW_APPLE_texture_max_level,
+#endif
+#ifdef GL_APPLE_texture_packed_float
+  &__GLEW_APPLE_texture_packed_float,
+#endif
+#ifdef GL_APPLE_texture_range
+  &__GLEW_APPLE_texture_range,
+#endif
+#ifdef GL_APPLE_transform_hint
+  &__GLEW_APPLE_transform_hint,
+#endif
+#ifdef GL_APPLE_vertex_array_object
+  &__GLEW_APPLE_vertex_array_object,
+#endif
+#ifdef GL_APPLE_vertex_array_range
+  &__GLEW_APPLE_vertex_array_range,
+#endif
+#ifdef GL_APPLE_vertex_program_evaluators
+  &__GLEW_APPLE_vertex_program_evaluators,
+#endif
+#ifdef GL_APPLE_ycbcr_422
+  &__GLEW_APPLE_ycbcr_422,
+#endif
+#ifdef GL_ARB_ES2_compatibility
+  &__GLEW_ARB_ES2_compatibility,
+#endif
+#ifdef GL_ARB_ES3_1_compatibility
+  &__GLEW_ARB_ES3_1_compatibility,
+#endif
+#ifdef GL_ARB_ES3_2_compatibility
+  &__GLEW_ARB_ES3_2_compatibility,
+#endif
+#ifdef GL_ARB_ES3_compatibility
+  &__GLEW_ARB_ES3_compatibility,
+#endif
+#ifdef GL_ARB_arrays_of_arrays
+  &__GLEW_ARB_arrays_of_arrays,
+#endif
+#ifdef GL_ARB_base_instance
+  &__GLEW_ARB_base_instance,
+#endif
+#ifdef GL_ARB_bindless_texture
+  &__GLEW_ARB_bindless_texture,
+#endif
+#ifdef GL_ARB_blend_func_extended
+  &__GLEW_ARB_blend_func_extended,
+#endif
+#ifdef GL_ARB_buffer_storage
+  &__GLEW_ARB_buffer_storage,
+#endif
+#ifdef GL_ARB_cl_event
+  &__GLEW_ARB_cl_event,
+#endif
+#ifdef GL_ARB_clear_buffer_object
+  &__GLEW_ARB_clear_buffer_object,
+#endif
+#ifdef GL_ARB_clear_texture
+  &__GLEW_ARB_clear_texture,
+#endif
+#ifdef GL_ARB_clip_control
+  &__GLEW_ARB_clip_control,
+#endif
+#ifdef GL_ARB_color_buffer_float
+  &__GLEW_ARB_color_buffer_float,
+#endif
+#ifdef GL_ARB_compatibility
+  &__GLEW_ARB_compatibility,
+#endif
+#ifdef GL_ARB_compressed_texture_pixel_storage
+  &__GLEW_ARB_compressed_texture_pixel_storage,
+#endif
+#ifdef GL_ARB_compute_shader
+  &__GLEW_ARB_compute_shader,
+#endif
+#ifdef GL_ARB_compute_variable_group_size
+  &__GLEW_ARB_compute_variable_group_size,
+#endif
+#ifdef GL_ARB_conditional_render_inverted
+  &__GLEW_ARB_conditional_render_inverted,
+#endif
+#ifdef GL_ARB_conservative_depth
+  &__GLEW_ARB_conservative_depth,
+#endif
+#ifdef GL_ARB_copy_buffer
+  &__GLEW_ARB_copy_buffer,
+#endif
+#ifdef GL_ARB_copy_image
+  &__GLEW_ARB_copy_image,
+#endif
+#ifdef GL_ARB_cull_distance
+  &__GLEW_ARB_cull_distance,
+#endif
+#ifdef GL_ARB_debug_output
+  &__GLEW_ARB_debug_output,
+#endif
+#ifdef GL_ARB_depth_buffer_float
+  &__GLEW_ARB_depth_buffer_float,
+#endif
+#ifdef GL_ARB_depth_clamp
+  &__GLEW_ARB_depth_clamp,
+#endif
+#ifdef GL_ARB_depth_texture
+  &__GLEW_ARB_depth_texture,
+#endif
+#ifdef GL_ARB_derivative_control
+  &__GLEW_ARB_derivative_control,
+#endif
+#ifdef GL_ARB_direct_state_access
+  &__GLEW_ARB_direct_state_access,
+#endif
+#ifdef GL_ARB_draw_buffers
+  &__GLEW_ARB_draw_buffers,
+#endif
+#ifdef GL_ARB_draw_buffers_blend
+  &__GLEW_ARB_draw_buffers_blend,
+#endif
+#ifdef GL_ARB_draw_elements_base_vertex
+  &__GLEW_ARB_draw_elements_base_vertex,
+#endif
+#ifdef GL_ARB_draw_indirect
+  &__GLEW_ARB_draw_indirect,
+#endif
+#ifdef GL_ARB_draw_instanced
+  &__GLEW_ARB_draw_instanced,
+#endif
+#ifdef GL_ARB_enhanced_layouts
+  &__GLEW_ARB_enhanced_layouts,
+#endif
+#ifdef GL_ARB_explicit_attrib_location
+  &__GLEW_ARB_explicit_attrib_location,
+#endif
+#ifdef GL_ARB_explicit_uniform_location
+  &__GLEW_ARB_explicit_uniform_location,
+#endif
+#ifdef GL_ARB_fragment_coord_conventions
+  &__GLEW_ARB_fragment_coord_conventions,
+#endif
+#ifdef GL_ARB_fragment_layer_viewport
+  &__GLEW_ARB_fragment_layer_viewport,
+#endif
+#ifdef GL_ARB_fragment_program
+  &__GLEW_ARB_fragment_program,
+#endif
+#ifdef GL_ARB_fragment_program_shadow
+  &__GLEW_ARB_fragment_program_shadow,
+#endif
+#ifdef GL_ARB_fragment_shader
+  &__GLEW_ARB_fragment_shader,
+#endif
+#ifdef GL_ARB_fragment_shader_interlock
+  &__GLEW_ARB_fragment_shader_interlock,
+#endif
+#ifdef GL_ARB_framebuffer_no_attachments
+  &__GLEW_ARB_framebuffer_no_attachments,
+#endif
+#ifdef GL_ARB_framebuffer_object
+  &__GLEW_ARB_framebuffer_object,
+#endif
+#ifdef GL_ARB_framebuffer_sRGB
+  &__GLEW_ARB_framebuffer_sRGB,
+#endif
+#ifdef GL_ARB_geometry_shader4
+  &__GLEW_ARB_geometry_shader4,
+#endif
+#ifdef GL_ARB_get_program_binary
+  &__GLEW_ARB_get_program_binary,
+#endif
+#ifdef GL_ARB_get_texture_sub_image
+  &__GLEW_ARB_get_texture_sub_image,
+#endif
+#ifdef GL_ARB_gl_spirv
+  &__GLEW_ARB_gl_spirv,
+#endif
+#ifdef GL_ARB_gpu_shader5
+  &__GLEW_ARB_gpu_shader5,
+#endif
+#ifdef GL_ARB_gpu_shader_fp64
+  &__GLEW_ARB_gpu_shader_fp64,
+#endif
+#ifdef GL_ARB_gpu_shader_int64
+  &__GLEW_ARB_gpu_shader_int64,
+#endif
+#ifdef GL_ARB_half_float_pixel
+  &__GLEW_ARB_half_float_pixel,
+#endif
+#ifdef GL_ARB_half_float_vertex
+  &__GLEW_ARB_half_float_vertex,
+#endif
+#ifdef GL_ARB_imaging
+  &__GLEW_ARB_imaging,
+#endif
+#ifdef GL_ARB_indirect_parameters
+  &__GLEW_ARB_indirect_parameters,
+#endif
+#ifdef GL_ARB_instanced_arrays
+  &__GLEW_ARB_instanced_arrays,
+#endif
+#ifdef GL_ARB_internalformat_query
+  &__GLEW_ARB_internalformat_query,
+#endif
+#ifdef GL_ARB_internalformat_query2
+  &__GLEW_ARB_internalformat_query2,
+#endif
+#ifdef GL_ARB_invalidate_subdata
+  &__GLEW_ARB_invalidate_subdata,
+#endif
+#ifdef GL_ARB_map_buffer_alignment
+  &__GLEW_ARB_map_buffer_alignment,
+#endif
+#ifdef GL_ARB_map_buffer_range
+  &__GLEW_ARB_map_buffer_range,
+#endif
+#ifdef GL_ARB_matrix_palette
+  &__GLEW_ARB_matrix_palette,
+#endif
+#ifdef GL_ARB_multi_bind
+  &__GLEW_ARB_multi_bind,
+#endif
+#ifdef GL_ARB_multi_draw_indirect
+  &__GLEW_ARB_multi_draw_indirect,
+#endif
+#ifdef GL_ARB_multisample
+  &__GLEW_ARB_multisample,
+#endif
+#ifdef GL_ARB_multitexture
+  &__GLEW_ARB_multitexture,
+#endif
+#ifdef GL_ARB_occlusion_query
+  &__GLEW_ARB_occlusion_query,
+#endif
+#ifdef GL_ARB_occlusion_query2
+  &__GLEW_ARB_occlusion_query2,
+#endif
+#ifdef GL_ARB_parallel_shader_compile
+  &__GLEW_ARB_parallel_shader_compile,
+#endif
+#ifdef GL_ARB_pipeline_statistics_query
+  &__GLEW_ARB_pipeline_statistics_query,
+#endif
+#ifdef GL_ARB_pixel_buffer_object
+  &__GLEW_ARB_pixel_buffer_object,
+#endif
+#ifdef GL_ARB_point_parameters
+  &__GLEW_ARB_point_parameters,
+#endif
+#ifdef GL_ARB_point_sprite
+  &__GLEW_ARB_point_sprite,
+#endif
+#ifdef GL_ARB_polygon_offset_clamp
+  &__GLEW_ARB_polygon_offset_clamp,
+#endif
+#ifdef GL_ARB_post_depth_coverage
+  &__GLEW_ARB_post_depth_coverage,
+#endif
+#ifdef GL_ARB_program_interface_query
+  &__GLEW_ARB_program_interface_query,
+#endif
+#ifdef GL_ARB_provoking_vertex
+  &__GLEW_ARB_provoking_vertex,
+#endif
+#ifdef GL_ARB_query_buffer_object
+  &__GLEW_ARB_query_buffer_object,
+#endif
+#ifdef GL_ARB_robust_buffer_access_behavior
+  &__GLEW_ARB_robust_buffer_access_behavior,
+#endif
+#ifdef GL_ARB_robustness
+  &__GLEW_ARB_robustness,
+#endif
+#ifdef GL_ARB_robustness_application_isolation
+  &__GLEW_ARB_robustness_application_isolation,
+#endif
+#ifdef GL_ARB_robustness_share_group_isolation
+  &__GLEW_ARB_robustness_share_group_isolation,
+#endif
+#ifdef GL_ARB_sample_locations
+  &__GLEW_ARB_sample_locations,
+#endif
+#ifdef GL_ARB_sample_shading
+  &__GLEW_ARB_sample_shading,
+#endif
+#ifdef GL_ARB_sampler_objects
+  &__GLEW_ARB_sampler_objects,
+#endif
+#ifdef GL_ARB_seamless_cube_map
+  &__GLEW_ARB_seamless_cube_map,
+#endif
+#ifdef GL_ARB_seamless_cubemap_per_texture
+  &__GLEW_ARB_seamless_cubemap_per_texture,
+#endif
+#ifdef GL_ARB_separate_shader_objects
+  &__GLEW_ARB_separate_shader_objects,
+#endif
+#ifdef GL_ARB_shader_atomic_counter_ops
+  &__GLEW_ARB_shader_atomic_counter_ops,
+#endif
+#ifdef GL_ARB_shader_atomic_counters
+  &__GLEW_ARB_shader_atomic_counters,
+#endif
+#ifdef GL_ARB_shader_ballot
+  &__GLEW_ARB_shader_ballot,
+#endif
+#ifdef GL_ARB_shader_bit_encoding
+  &__GLEW_ARB_shader_bit_encoding,
+#endif
+#ifdef GL_ARB_shader_clock
+  &__GLEW_ARB_shader_clock,
+#endif
+#ifdef GL_ARB_shader_draw_parameters
+  &__GLEW_ARB_shader_draw_parameters,
+#endif
+#ifdef GL_ARB_shader_group_vote
+  &__GLEW_ARB_shader_group_vote,
+#endif
+#ifdef GL_ARB_shader_image_load_store
+  &__GLEW_ARB_shader_image_load_store,
+#endif
+#ifdef GL_ARB_shader_image_size
+  &__GLEW_ARB_shader_image_size,
+#endif
+#ifdef GL_ARB_shader_objects
+  &__GLEW_ARB_shader_objects,
+#endif
+#ifdef GL_ARB_shader_precision
+  &__GLEW_ARB_shader_precision,
+#endif
+#ifdef GL_ARB_shader_stencil_export
+  &__GLEW_ARB_shader_stencil_export,
+#endif
+#ifdef GL_ARB_shader_storage_buffer_object
+  &__GLEW_ARB_shader_storage_buffer_object,
+#endif
+#ifdef GL_ARB_shader_subroutine
+  &__GLEW_ARB_shader_subroutine,
+#endif
+#ifdef GL_ARB_shader_texture_image_samples
+  &__GLEW_ARB_shader_texture_image_samples,
+#endif
+#ifdef GL_ARB_shader_texture_lod
+  &__GLEW_ARB_shader_texture_lod,
+#endif
+#ifdef GL_ARB_shader_viewport_layer_array
+  &__GLEW_ARB_shader_viewport_layer_array,
+#endif
+#ifdef GL_ARB_shading_language_100
+  &__GLEW_ARB_shading_language_100,
+#endif
+#ifdef GL_ARB_shading_language_420pack
+  &__GLEW_ARB_shading_language_420pack,
+#endif
+#ifdef GL_ARB_shading_language_include
+  &__GLEW_ARB_shading_language_include,
+#endif
+#ifdef GL_ARB_shading_language_packing
+  &__GLEW_ARB_shading_language_packing,
+#endif
+#ifdef GL_ARB_shadow
+  &__GLEW_ARB_shadow,
+#endif
+#ifdef GL_ARB_shadow_ambient
+  &__GLEW_ARB_shadow_ambient,
+#endif
+#ifdef GL_ARB_sparse_buffer
+  &__GLEW_ARB_sparse_buffer,
+#endif
+#ifdef GL_ARB_sparse_texture
+  &__GLEW_ARB_sparse_texture,
+#endif
+#ifdef GL_ARB_sparse_texture2
+  &__GLEW_ARB_sparse_texture2,
+#endif
+#ifdef GL_ARB_sparse_texture_clamp
+  &__GLEW_ARB_sparse_texture_clamp,
+#endif
+#ifdef GL_ARB_spirv_extensions
+  &__GLEW_ARB_spirv_extensions,
+#endif
+#ifdef GL_ARB_stencil_texturing
+  &__GLEW_ARB_stencil_texturing,
+#endif
+#ifdef GL_ARB_sync
+  &__GLEW_ARB_sync,
+#endif
+#ifdef GL_ARB_tessellation_shader
+  &__GLEW_ARB_tessellation_shader,
+#endif
+#ifdef GL_ARB_texture_barrier
+  &__GLEW_ARB_texture_barrier,
+#endif
+#ifdef GL_ARB_texture_border_clamp
+  &__GLEW_ARB_texture_border_clamp,
+#endif
+#ifdef GL_ARB_texture_buffer_object
+  &__GLEW_ARB_texture_buffer_object,
+#endif
+#ifdef GL_ARB_texture_buffer_object_rgb32
+  &__GLEW_ARB_texture_buffer_object_rgb32,
+#endif
+#ifdef GL_ARB_texture_buffer_range
+  &__GLEW_ARB_texture_buffer_range,
+#endif
+#ifdef GL_ARB_texture_compression
+  &__GLEW_ARB_texture_compression,
+#endif
+#ifdef GL_ARB_texture_compression_bptc
+  &__GLEW_ARB_texture_compression_bptc,
+#endif
+#ifdef GL_ARB_texture_compression_rgtc
+  &__GLEW_ARB_texture_compression_rgtc,
+#endif
+#ifdef GL_ARB_texture_cube_map
+  &__GLEW_ARB_texture_cube_map,
+#endif
+#ifdef GL_ARB_texture_cube_map_array
+  &__GLEW_ARB_texture_cube_map_array,
+#endif
+#ifdef GL_ARB_texture_env_add
+  &__GLEW_ARB_texture_env_add,
+#endif
+#ifdef GL_ARB_texture_env_combine
+  &__GLEW_ARB_texture_env_combine,
+#endif
+#ifdef GL_ARB_texture_env_crossbar
+  &__GLEW_ARB_texture_env_crossbar,
+#endif
+#ifdef GL_ARB_texture_env_dot3
+  &__GLEW_ARB_texture_env_dot3,
+#endif
+#ifdef GL_ARB_texture_filter_anisotropic
+  &__GLEW_ARB_texture_filter_anisotropic,
+#endif
+#ifdef GL_ARB_texture_filter_minmax
+  &__GLEW_ARB_texture_filter_minmax,
+#endif
+#ifdef GL_ARB_texture_float
+  &__GLEW_ARB_texture_float,
+#endif
+#ifdef GL_ARB_texture_gather
+  &__GLEW_ARB_texture_gather,
+#endif
+#ifdef GL_ARB_texture_mirror_clamp_to_edge
+  &__GLEW_ARB_texture_mirror_clamp_to_edge,
+#endif
+#ifdef GL_ARB_texture_mirrored_repeat
+  &__GLEW_ARB_texture_mirrored_repeat,
+#endif
+#ifdef GL_ARB_texture_multisample
+  &__GLEW_ARB_texture_multisample,
+#endif
+#ifdef GL_ARB_texture_non_power_of_two
+  &__GLEW_ARB_texture_non_power_of_two,
+#endif
+#ifdef GL_ARB_texture_query_levels
+  &__GLEW_ARB_texture_query_levels,
+#endif
+#ifdef GL_ARB_texture_query_lod
+  &__GLEW_ARB_texture_query_lod,
+#endif
+#ifdef GL_ARB_texture_rectangle
+  &__GLEW_ARB_texture_rectangle,
+#endif
+#ifdef GL_ARB_texture_rg
+  &__GLEW_ARB_texture_rg,
+#endif
+#ifdef GL_ARB_texture_rgb10_a2ui
+  &__GLEW_ARB_texture_rgb10_a2ui,
+#endif
+#ifdef GL_ARB_texture_stencil8
+  &__GLEW_ARB_texture_stencil8,
+#endif
+#ifdef GL_ARB_texture_storage
+  &__GLEW_ARB_texture_storage,
+#endif
+#ifdef GL_ARB_texture_storage_multisample
+  &__GLEW_ARB_texture_storage_multisample,
+#endif
+#ifdef GL_ARB_texture_swizzle
+  &__GLEW_ARB_texture_swizzle,
+#endif
+#ifdef GL_ARB_texture_view
+  &__GLEW_ARB_texture_view,
+#endif
+#ifdef GL_ARB_timer_query
+  &__GLEW_ARB_timer_query,
+#endif
+#ifdef GL_ARB_transform_feedback2
+  &__GLEW_ARB_transform_feedback2,
+#endif
+#ifdef GL_ARB_transform_feedback3
+  &__GLEW_ARB_transform_feedback3,
+#endif
+#ifdef GL_ARB_transform_feedback_instanced
+  &__GLEW_ARB_transform_feedback_instanced,
+#endif
+#ifdef GL_ARB_transform_feedback_overflow_query
+  &__GLEW_ARB_transform_feedback_overflow_query,
+#endif
+#ifdef GL_ARB_transpose_matrix
+  &__GLEW_ARB_transpose_matrix,
+#endif
+#ifdef GL_ARB_uniform_buffer_object
+  &__GLEW_ARB_uniform_buffer_object,
+#endif
+#ifdef GL_ARB_vertex_array_bgra
+  &__GLEW_ARB_vertex_array_bgra,
+#endif
+#ifdef GL_ARB_vertex_array_object
+  &__GLEW_ARB_vertex_array_object,
+#endif
+#ifdef GL_ARB_vertex_attrib_64bit
+  &__GLEW_ARB_vertex_attrib_64bit,
+#endif
+#ifdef GL_ARB_vertex_attrib_binding
+  &__GLEW_ARB_vertex_attrib_binding,
+#endif
+#ifdef GL_ARB_vertex_blend
+  &__GLEW_ARB_vertex_blend,
+#endif
+#ifdef GL_ARB_vertex_buffer_object
+  &__GLEW_ARB_vertex_buffer_object,
+#endif
+#ifdef GL_ARB_vertex_program
+  &__GLEW_ARB_vertex_program,
+#endif
+#ifdef GL_ARB_vertex_shader
+  &__GLEW_ARB_vertex_shader,
+#endif
+#ifdef GL_ARB_vertex_type_10f_11f_11f_rev
+  &__GLEW_ARB_vertex_type_10f_11f_11f_rev,
+#endif
+#ifdef GL_ARB_vertex_type_2_10_10_10_rev
+  &__GLEW_ARB_vertex_type_2_10_10_10_rev,
+#endif
+#ifdef GL_ARB_viewport_array
+  &__GLEW_ARB_viewport_array,
+#endif
+#ifdef GL_ARB_window_pos
+  &__GLEW_ARB_window_pos,
+#endif
+#ifdef GL_ARM_mali_program_binary
+  &__GLEW_ARM_mali_program_binary,
+#endif
+#ifdef GL_ARM_mali_shader_binary
+  &__GLEW_ARM_mali_shader_binary,
+#endif
+#ifdef GL_ARM_rgba8
+  &__GLEW_ARM_rgba8,
+#endif
+#ifdef GL_ARM_shader_framebuffer_fetch
+  &__GLEW_ARM_shader_framebuffer_fetch,
+#endif
+#ifdef GL_ARM_shader_framebuffer_fetch_depth_stencil
+  &__GLEW_ARM_shader_framebuffer_fetch_depth_stencil,
+#endif
+#ifdef GL_ATIX_point_sprites
+  &__GLEW_ATIX_point_sprites,
+#endif
+#ifdef GL_ATIX_texture_env_combine3
+  &__GLEW_ATIX_texture_env_combine3,
+#endif
+#ifdef GL_ATIX_texture_env_route
+  &__GLEW_ATIX_texture_env_route,
+#endif
+#ifdef GL_ATIX_vertex_shader_output_point_size
+  &__GLEW_ATIX_vertex_shader_output_point_size,
+#endif
+#ifdef GL_ATI_draw_buffers
+  &__GLEW_ATI_draw_buffers,
+#endif
+#ifdef GL_ATI_element_array
+  &__GLEW_ATI_element_array,
+#endif
+#ifdef GL_ATI_envmap_bumpmap
+  &__GLEW_ATI_envmap_bumpmap,
+#endif
+#ifdef GL_ATI_fragment_shader
+  &__GLEW_ATI_fragment_shader,
+#endif
+#ifdef GL_ATI_map_object_buffer
+  &__GLEW_ATI_map_object_buffer,
+#endif
+#ifdef GL_ATI_meminfo
+  &__GLEW_ATI_meminfo,
+#endif
+#ifdef GL_ATI_pn_triangles
+  &__GLEW_ATI_pn_triangles,
+#endif
+#ifdef GL_ATI_separate_stencil
+  &__GLEW_ATI_separate_stencil,
+#endif
+#ifdef GL_ATI_shader_texture_lod
+  &__GLEW_ATI_shader_texture_lod,
+#endif
+#ifdef GL_ATI_text_fragment_shader
+  &__GLEW_ATI_text_fragment_shader,
+#endif
+#ifdef GL_ATI_texture_compression_3dc
+  &__GLEW_ATI_texture_compression_3dc,
+#endif
+#ifdef GL_ATI_texture_env_combine3
+  &__GLEW_ATI_texture_env_combine3,
+#endif
+#ifdef GL_ATI_texture_float
+  &__GLEW_ATI_texture_float,
+#endif
+#ifdef GL_ATI_texture_mirror_once
+  &__GLEW_ATI_texture_mirror_once,
+#endif
+#ifdef GL_ATI_vertex_array_object
+  &__GLEW_ATI_vertex_array_object,
+#endif
+#ifdef GL_ATI_vertex_attrib_array_object
+  &__GLEW_ATI_vertex_attrib_array_object,
+#endif
+#ifdef GL_ATI_vertex_streams
+  &__GLEW_ATI_vertex_streams,
+#endif
+#ifdef GL_EGL_KHR_context_flush_control
+  &__GLEW_EGL_KHR_context_flush_control,
+#endif
+#ifdef GL_EGL_NV_robustness_video_memory_purge
+  &__GLEW_EGL_NV_robustness_video_memory_purge,
+#endif
+#ifdef GL_EXT_422_pixels
+  &__GLEW_EXT_422_pixels,
+#endif
+#ifdef GL_EXT_Cg_shader
+  &__GLEW_EXT_Cg_shader,
+#endif
+#ifdef GL_EXT_EGL_image_array
+  &__GLEW_EXT_EGL_image_array,
+#endif
+#ifdef GL_EXT_YUV_target
+  &__GLEW_EXT_YUV_target,
+#endif
+#ifdef GL_EXT_abgr
+  &__GLEW_EXT_abgr,
+#endif
+#ifdef GL_EXT_base_instance
+  &__GLEW_EXT_base_instance,
+#endif
+#ifdef GL_EXT_bgra
+  &__GLEW_EXT_bgra,
+#endif
+#ifdef GL_EXT_bindable_uniform
+  &__GLEW_EXT_bindable_uniform,
+#endif
+#ifdef GL_EXT_blend_color
+  &__GLEW_EXT_blend_color,
+#endif
+#ifdef GL_EXT_blend_equation_separate
+  &__GLEW_EXT_blend_equation_separate,
+#endif
+#ifdef GL_EXT_blend_func_extended
+  &__GLEW_EXT_blend_func_extended,
+#endif
+#ifdef GL_EXT_blend_func_separate
+  &__GLEW_EXT_blend_func_separate,
+#endif
+#ifdef GL_EXT_blend_logic_op
+  &__GLEW_EXT_blend_logic_op,
+#endif
+#ifdef GL_EXT_blend_minmax
+  &__GLEW_EXT_blend_minmax,
+#endif
+#ifdef GL_EXT_blend_subtract
+  &__GLEW_EXT_blend_subtract,
+#endif
+#ifdef GL_EXT_buffer_storage
+  &__GLEW_EXT_buffer_storage,
+#endif
+#ifdef GL_EXT_clear_texture
+  &__GLEW_EXT_clear_texture,
+#endif
+#ifdef GL_EXT_clip_cull_distance
+  &__GLEW_EXT_clip_cull_distance,
+#endif
+#ifdef GL_EXT_clip_volume_hint
+  &__GLEW_EXT_clip_volume_hint,
+#endif
+#ifdef GL_EXT_cmyka
+  &__GLEW_EXT_cmyka,
+#endif
+#ifdef GL_EXT_color_buffer_float
+  &__GLEW_EXT_color_buffer_float,
+#endif
+#ifdef GL_EXT_color_buffer_half_float
+  &__GLEW_EXT_color_buffer_half_float,
+#endif
+#ifdef GL_EXT_color_subtable
+  &__GLEW_EXT_color_subtable,
+#endif
+#ifdef GL_EXT_compiled_vertex_array
+  &__GLEW_EXT_compiled_vertex_array,
+#endif
+#ifdef GL_EXT_compressed_ETC1_RGB8_sub_texture
+  &__GLEW_EXT_compressed_ETC1_RGB8_sub_texture,
+#endif
+#ifdef GL_EXT_conservative_depth
+  &__GLEW_EXT_conservative_depth,
+#endif
+#ifdef GL_EXT_convolution
+  &__GLEW_EXT_convolution,
+#endif
+#ifdef GL_EXT_coordinate_frame
+  &__GLEW_EXT_coordinate_frame,
+#endif
+#ifdef GL_EXT_copy_image
+  &__GLEW_EXT_copy_image,
+#endif
+#ifdef GL_EXT_copy_texture
+  &__GLEW_EXT_copy_texture,
+#endif
+#ifdef GL_EXT_cull_vertex
+  &__GLEW_EXT_cull_vertex,
+#endif
+#ifdef GL_EXT_debug_label
+  &__GLEW_EXT_debug_label,
+#endif
+#ifdef GL_EXT_debug_marker
+  &__GLEW_EXT_debug_marker,
+#endif
+#ifdef GL_EXT_depth_bounds_test
+  &__GLEW_EXT_depth_bounds_test,
+#endif
+#ifdef GL_EXT_direct_state_access
+  &__GLEW_EXT_direct_state_access,
+#endif
+#ifdef GL_EXT_discard_framebuffer
+  &__GLEW_EXT_discard_framebuffer,
+#endif
+#ifdef GL_EXT_draw_buffers
+  &__GLEW_EXT_draw_buffers,
+#endif
+#ifdef GL_EXT_draw_buffers2
+  &__GLEW_EXT_draw_buffers2,
+#endif
+#ifdef GL_EXT_draw_buffers_indexed
+  &__GLEW_EXT_draw_buffers_indexed,
+#endif
+#ifdef GL_EXT_draw_elements_base_vertex
+  &__GLEW_EXT_draw_elements_base_vertex,
+#endif
+#ifdef GL_EXT_draw_instanced
+  &__GLEW_EXT_draw_instanced,
+#endif
+#ifdef GL_EXT_draw_range_elements
+  &__GLEW_EXT_draw_range_elements,
+#endif
+#ifdef GL_EXT_external_buffer
+  &__GLEW_EXT_external_buffer,
+#endif
+#ifdef GL_EXT_float_blend
+  &__GLEW_EXT_float_blend,
+#endif
+#ifdef GL_EXT_fog_coord
+  &__GLEW_EXT_fog_coord,
+#endif
+#ifdef GL_EXT_frag_depth
+  &__GLEW_EXT_frag_depth,
+#endif
+#ifdef GL_EXT_fragment_lighting
+  &__GLEW_EXT_fragment_lighting,
+#endif
+#ifdef GL_EXT_framebuffer_blit
+  &__GLEW_EXT_framebuffer_blit,
+#endif
+#ifdef GL_EXT_framebuffer_multisample
+  &__GLEW_EXT_framebuffer_multisample,
+#endif
+#ifdef GL_EXT_framebuffer_multisample_blit_scaled
+  &__GLEW_EXT_framebuffer_multisample_blit_scaled,
+#endif
+#ifdef GL_EXT_framebuffer_object
+  &__GLEW_EXT_framebuffer_object,
+#endif
+#ifdef GL_EXT_framebuffer_sRGB
+  &__GLEW_EXT_framebuffer_sRGB,
+#endif
+#ifdef GL_EXT_geometry_point_size
+  &__GLEW_EXT_geometry_point_size,
+#endif
+#ifdef GL_EXT_geometry_shader
+  &__GLEW_EXT_geometry_shader,
+#endif
+#ifdef GL_EXT_geometry_shader4
+  &__GLEW_EXT_geometry_shader4,
+#endif
+#ifdef GL_EXT_gpu_program_parameters
+  &__GLEW_EXT_gpu_program_parameters,
+#endif
+#ifdef GL_EXT_gpu_shader4
+  &__GLEW_EXT_gpu_shader4,
+#endif
+#ifdef GL_EXT_gpu_shader5
+  &__GLEW_EXT_gpu_shader5,
+#endif
+#ifdef GL_EXT_histogram
+  &__GLEW_EXT_histogram,
+#endif
+#ifdef GL_EXT_index_array_formats
+  &__GLEW_EXT_index_array_formats,
+#endif
+#ifdef GL_EXT_index_func
+  &__GLEW_EXT_index_func,
+#endif
+#ifdef GL_EXT_index_material
+  &__GLEW_EXT_index_material,
+#endif
+#ifdef GL_EXT_index_texture
+  &__GLEW_EXT_index_texture,
+#endif
+#ifdef GL_EXT_instanced_arrays
+  &__GLEW_EXT_instanced_arrays,
+#endif
+#ifdef GL_EXT_light_texture
+  &__GLEW_EXT_light_texture,
+#endif
+#ifdef GL_EXT_map_buffer_range
+  &__GLEW_EXT_map_buffer_range,
+#endif
+#ifdef GL_EXT_memory_object
+  &__GLEW_EXT_memory_object,
+#endif
+#ifdef GL_EXT_memory_object_fd
+  &__GLEW_EXT_memory_object_fd,
+#endif
+#ifdef GL_EXT_memory_object_win32
+  &__GLEW_EXT_memory_object_win32,
+#endif
+#ifdef GL_EXT_misc_attribute
+  &__GLEW_EXT_misc_attribute,
+#endif
+#ifdef GL_EXT_multi_draw_arrays
+  &__GLEW_EXT_multi_draw_arrays,
+#endif
+#ifdef GL_EXT_multi_draw_indirect
+  &__GLEW_EXT_multi_draw_indirect,
+#endif
+#ifdef GL_EXT_multiple_textures
+  &__GLEW_EXT_multiple_textures,
+#endif
+#ifdef GL_EXT_multisample
+  &__GLEW_EXT_multisample,
+#endif
+#ifdef GL_EXT_multisample_compatibility
+  &__GLEW_EXT_multisample_compatibility,
+#endif
+#ifdef GL_EXT_multisampled_render_to_texture
+  &__GLEW_EXT_multisampled_render_to_texture,
+#endif
+#ifdef GL_EXT_multisampled_render_to_texture2
+  &__GLEW_EXT_multisampled_render_to_texture2,
+#endif
+#ifdef GL_EXT_multiview_draw_buffers
+  &__GLEW_EXT_multiview_draw_buffers,
+#endif
+#ifdef GL_EXT_packed_depth_stencil
+  &__GLEW_EXT_packed_depth_stencil,
+#endif
+#ifdef GL_EXT_packed_float
+  &__GLEW_EXT_packed_float,
+#endif
+#ifdef GL_EXT_packed_pixels
+  &__GLEW_EXT_packed_pixels,
+#endif
+#ifdef GL_EXT_paletted_texture
+  &__GLEW_EXT_paletted_texture,
+#endif
+#ifdef GL_EXT_pixel_buffer_object
+  &__GLEW_EXT_pixel_buffer_object,
+#endif
+#ifdef GL_EXT_pixel_transform
+  &__GLEW_EXT_pixel_transform,
+#endif
+#ifdef GL_EXT_pixel_transform_color_table
+  &__GLEW_EXT_pixel_transform_color_table,
+#endif
+#ifdef GL_EXT_point_parameters
+  &__GLEW_EXT_point_parameters,
+#endif
+#ifdef GL_EXT_polygon_offset
+  &__GLEW_EXT_polygon_offset,
+#endif
+#ifdef GL_EXT_polygon_offset_clamp
+  &__GLEW_EXT_polygon_offset_clamp,
+#endif
+#ifdef GL_EXT_post_depth_coverage
+  &__GLEW_EXT_post_depth_coverage,
+#endif
+#ifdef GL_EXT_provoking_vertex
+  &__GLEW_EXT_provoking_vertex,
+#endif
+#ifdef GL_EXT_pvrtc_sRGB
+  &__GLEW_EXT_pvrtc_sRGB,
+#endif
+#ifdef GL_EXT_raster_multisample
+  &__GLEW_EXT_raster_multisample,
+#endif
+#ifdef GL_EXT_read_format_bgra
+  &__GLEW_EXT_read_format_bgra,
+#endif
+#ifdef GL_EXT_render_snorm
+  &__GLEW_EXT_render_snorm,
+#endif
+#ifdef GL_EXT_rescale_normal
+  &__GLEW_EXT_rescale_normal,
+#endif
+#ifdef GL_EXT_sRGB
+  &__GLEW_EXT_sRGB,
+#endif
+#ifdef GL_EXT_sRGB_write_control
+  &__GLEW_EXT_sRGB_write_control,
+#endif
+#ifdef GL_EXT_scene_marker
+  &__GLEW_EXT_scene_marker,
+#endif
+#ifdef GL_EXT_secondary_color
+  &__GLEW_EXT_secondary_color,
+#endif
+#ifdef GL_EXT_semaphore
+  &__GLEW_EXT_semaphore,
+#endif
+#ifdef GL_EXT_semaphore_fd
+  &__GLEW_EXT_semaphore_fd,
+#endif
+#ifdef GL_EXT_semaphore_win32
+  &__GLEW_EXT_semaphore_win32,
+#endif
+#ifdef GL_EXT_separate_shader_objects
+  &__GLEW_EXT_separate_shader_objects,
+#endif
+#ifdef GL_EXT_separate_specular_color
+  &__GLEW_EXT_separate_specular_color,
+#endif
+#ifdef GL_EXT_shader_framebuffer_fetch
+  &__GLEW_EXT_shader_framebuffer_fetch,
+#endif
+#ifdef GL_EXT_shader_group_vote
+  &__GLEW_EXT_shader_group_vote,
+#endif
+#ifdef GL_EXT_shader_image_load_formatted
+  &__GLEW_EXT_shader_image_load_formatted,
+#endif
+#ifdef GL_EXT_shader_image_load_store
+  &__GLEW_EXT_shader_image_load_store,
+#endif
+#ifdef GL_EXT_shader_implicit_conversions
+  &__GLEW_EXT_shader_implicit_conversions,
+#endif
+#ifdef GL_EXT_shader_integer_mix
+  &__GLEW_EXT_shader_integer_mix,
+#endif
+#ifdef GL_EXT_shader_io_blocks
+  &__GLEW_EXT_shader_io_blocks,
+#endif
+#ifdef GL_EXT_shader_non_constant_global_initializers
+  &__GLEW_EXT_shader_non_constant_global_initializers,
+#endif
+#ifdef GL_EXT_shader_pixel_local_storage
+  &__GLEW_EXT_shader_pixel_local_storage,
+#endif
+#ifdef GL_EXT_shader_pixel_local_storage2
+  &__GLEW_EXT_shader_pixel_local_storage2,
+#endif
+#ifdef GL_EXT_shader_texture_lod
+  &__GLEW_EXT_shader_texture_lod,
+#endif
+#ifdef GL_EXT_shadow_funcs
+  &__GLEW_EXT_shadow_funcs,
+#endif
+#ifdef GL_EXT_shadow_samplers
+  &__GLEW_EXT_shadow_samplers,
+#endif
+#ifdef GL_EXT_shared_texture_palette
+  &__GLEW_EXT_shared_texture_palette,
+#endif
+#ifdef GL_EXT_sparse_texture
+  &__GLEW_EXT_sparse_texture,
+#endif
+#ifdef GL_EXT_sparse_texture2
+  &__GLEW_EXT_sparse_texture2,
+#endif
+#ifdef GL_EXT_stencil_clear_tag
+  &__GLEW_EXT_stencil_clear_tag,
+#endif
+#ifdef GL_EXT_stencil_two_side
+  &__GLEW_EXT_stencil_two_side,
+#endif
+#ifdef GL_EXT_stencil_wrap
+  &__GLEW_EXT_stencil_wrap,
+#endif
+#ifdef GL_EXT_subtexture
+  &__GLEW_EXT_subtexture,
+#endif
+#ifdef GL_EXT_texture
+  &__GLEW_EXT_texture,
+#endif
+#ifdef GL_EXT_texture3D
+  &__GLEW_EXT_texture3D,
+#endif
+#ifdef GL_EXT_texture_array
+  &__GLEW_EXT_texture_array,
+#endif
+#ifdef GL_EXT_texture_buffer_object
+  &__GLEW_EXT_texture_buffer_object,
+#endif
+#ifdef GL_EXT_texture_compression_astc_decode_mode
+  &__GLEW_EXT_texture_compression_astc_decode_mode,
+#endif
+#ifdef GL_EXT_texture_compression_astc_decode_mode_rgb9e5
+  &__GLEW_EXT_texture_compression_astc_decode_mode_rgb9e5,
+#endif
+#ifdef GL_EXT_texture_compression_bptc
+  &__GLEW_EXT_texture_compression_bptc,
+#endif
+#ifdef GL_EXT_texture_compression_dxt1
+  &__GLEW_EXT_texture_compression_dxt1,
+#endif
+#ifdef GL_EXT_texture_compression_latc
+  &__GLEW_EXT_texture_compression_latc,
+#endif
+#ifdef GL_EXT_texture_compression_rgtc
+  &__GLEW_EXT_texture_compression_rgtc,
+#endif
+#ifdef GL_EXT_texture_compression_s3tc
+  &__GLEW_EXT_texture_compression_s3tc,
+#endif
+#ifdef GL_EXT_texture_cube_map
+  &__GLEW_EXT_texture_cube_map,
+#endif
+#ifdef GL_EXT_texture_cube_map_array
+  &__GLEW_EXT_texture_cube_map_array,
+#endif
+#ifdef GL_EXT_texture_edge_clamp
+  &__GLEW_EXT_texture_edge_clamp,
+#endif
+#ifdef GL_EXT_texture_env
+  &__GLEW_EXT_texture_env,
+#endif
+#ifdef GL_EXT_texture_env_add
+  &__GLEW_EXT_texture_env_add,
+#endif
+#ifdef GL_EXT_texture_env_combine
+  &__GLEW_EXT_texture_env_combine,
+#endif
+#ifdef GL_EXT_texture_env_dot3
+  &__GLEW_EXT_texture_env_dot3,
+#endif
+#ifdef GL_EXT_texture_filter_anisotropic
+  &__GLEW_EXT_texture_filter_anisotropic,
+#endif
+#ifdef GL_EXT_texture_filter_minmax
+  &__GLEW_EXT_texture_filter_minmax,
+#endif
+#ifdef GL_EXT_texture_format_BGRA8888
+  &__GLEW_EXT_texture_format_BGRA8888,
+#endif
+#ifdef GL_EXT_texture_integer
+  &__GLEW_EXT_texture_integer,
+#endif
+#ifdef GL_EXT_texture_lod_bias
+  &__GLEW_EXT_texture_lod_bias,
+#endif
+#ifdef GL_EXT_texture_mirror_clamp
+  &__GLEW_EXT_texture_mirror_clamp,
+#endif
+#ifdef GL_EXT_texture_norm16
+  &__GLEW_EXT_texture_norm16,
+#endif
+#ifdef GL_EXT_texture_object
+  &__GLEW_EXT_texture_object,
+#endif
+#ifdef GL_EXT_texture_perturb_normal
+  &__GLEW_EXT_texture_perturb_normal,
+#endif
+#ifdef GL_EXT_texture_rectangle
+  &__GLEW_EXT_texture_rectangle,
+#endif
+#ifdef GL_EXT_texture_rg
+  &__GLEW_EXT_texture_rg,
+#endif
+#ifdef GL_EXT_texture_sRGB
+  &__GLEW_EXT_texture_sRGB,
+#endif
+#ifdef GL_EXT_texture_sRGB_R8
+  &__GLEW_EXT_texture_sRGB_R8,
+#endif
+#ifdef GL_EXT_texture_sRGB_RG8
+  &__GLEW_EXT_texture_sRGB_RG8,
+#endif
+#ifdef GL_EXT_texture_sRGB_decode
+  &__GLEW_EXT_texture_sRGB_decode,
+#endif
+#ifdef GL_EXT_texture_shared_exponent
+  &__GLEW_EXT_texture_shared_exponent,
+#endif
+#ifdef GL_EXT_texture_snorm
+  &__GLEW_EXT_texture_snorm,
+#endif
+#ifdef GL_EXT_texture_storage
+  &__GLEW_EXT_texture_storage,
+#endif
+#ifdef GL_EXT_texture_swizzle
+  &__GLEW_EXT_texture_swizzle,
+#endif
+#ifdef GL_EXT_texture_type_2_10_10_10_REV
+  &__GLEW_EXT_texture_type_2_10_10_10_REV,
+#endif
+#ifdef GL_EXT_texture_view
+  &__GLEW_EXT_texture_view,
+#endif
+#ifdef GL_EXT_timer_query
+  &__GLEW_EXT_timer_query,
+#endif
+#ifdef GL_EXT_transform_feedback
+  &__GLEW_EXT_transform_feedback,
+#endif
+#ifdef GL_EXT_unpack_subimage
+  &__GLEW_EXT_unpack_subimage,
+#endif
+#ifdef GL_EXT_vertex_array
+  &__GLEW_EXT_vertex_array,
+#endif
+#ifdef GL_EXT_vertex_array_bgra
+  &__GLEW_EXT_vertex_array_bgra,
+#endif
+#ifdef GL_EXT_vertex_array_setXXX
+  &__GLEW_EXT_vertex_array_setXXX,
+#endif
+#ifdef GL_EXT_vertex_attrib_64bit
+  &__GLEW_EXT_vertex_attrib_64bit,
+#endif
+#ifdef GL_EXT_vertex_shader
+  &__GLEW_EXT_vertex_shader,
+#endif
+#ifdef GL_EXT_vertex_weighting
+  &__GLEW_EXT_vertex_weighting,
+#endif
+#ifdef GL_EXT_win32_keyed_mutex
+  &__GLEW_EXT_win32_keyed_mutex,
+#endif
+#ifdef GL_EXT_window_rectangles
+  &__GLEW_EXT_window_rectangles,
+#endif
+#ifdef GL_EXT_x11_sync_object
+  &__GLEW_EXT_x11_sync_object,
+#endif
+#ifdef GL_GREMEDY_frame_terminator
+  &__GLEW_GREMEDY_frame_terminator,
+#endif
+#ifdef GL_GREMEDY_string_marker
+  &__GLEW_GREMEDY_string_marker,
+#endif
+#ifdef GL_HP_convolution_border_modes
+  &__GLEW_HP_convolution_border_modes,
+#endif
+#ifdef GL_HP_image_transform
+  &__GLEW_HP_image_transform,
+#endif
+#ifdef GL_HP_occlusion_test
+  &__GLEW_HP_occlusion_test,
+#endif
+#ifdef GL_HP_texture_lighting
+  &__GLEW_HP_texture_lighting,
+#endif
+#ifdef GL_IBM_cull_vertex
+  &__GLEW_IBM_cull_vertex,
+#endif
+#ifdef GL_IBM_multimode_draw_arrays
+  &__GLEW_IBM_multimode_draw_arrays,
+#endif
+#ifdef GL_IBM_rasterpos_clip
+  &__GLEW_IBM_rasterpos_clip,
+#endif
+#ifdef GL_IBM_static_data
+  &__GLEW_IBM_static_data,
+#endif
+#ifdef GL_IBM_texture_mirrored_repeat
+  &__GLEW_IBM_texture_mirrored_repeat,
+#endif
+#ifdef GL_IBM_vertex_array_lists
+  &__GLEW_IBM_vertex_array_lists,
+#endif
+#ifdef GL_INGR_color_clamp
+  &__GLEW_INGR_color_clamp,
+#endif
+#ifdef GL_INGR_interlace_read
+  &__GLEW_INGR_interlace_read,
+#endif
+#ifdef GL_INTEL_conservative_rasterization
+  &__GLEW_INTEL_conservative_rasterization,
+#endif
+#ifdef GL_INTEL_fragment_shader_ordering
+  &__GLEW_INTEL_fragment_shader_ordering,
+#endif
+#ifdef GL_INTEL_framebuffer_CMAA
+  &__GLEW_INTEL_framebuffer_CMAA,
+#endif
+#ifdef GL_INTEL_map_texture
+  &__GLEW_INTEL_map_texture,
+#endif
+#ifdef GL_INTEL_parallel_arrays
+  &__GLEW_INTEL_parallel_arrays,
+#endif
+#ifdef GL_INTEL_performance_query
+  &__GLEW_INTEL_performance_query,
+#endif
+#ifdef GL_INTEL_texture_scissor
+  &__GLEW_INTEL_texture_scissor,
+#endif
+#ifdef GL_KHR_blend_equation_advanced
+  &__GLEW_KHR_blend_equation_advanced,
+#endif
+#ifdef GL_KHR_blend_equation_advanced_coherent
+  &__GLEW_KHR_blend_equation_advanced_coherent,
+#endif
+#ifdef GL_KHR_context_flush_control
+  &__GLEW_KHR_context_flush_control,
+#endif
+#ifdef GL_KHR_debug
+  &__GLEW_KHR_debug,
+#endif
+#ifdef GL_KHR_no_error
+  &__GLEW_KHR_no_error,
+#endif
+#ifdef GL_KHR_parallel_shader_compile
+  &__GLEW_KHR_parallel_shader_compile,
+#endif
+#ifdef GL_KHR_robust_buffer_access_behavior
+  &__GLEW_KHR_robust_buffer_access_behavior,
+#endif
+#ifdef GL_KHR_robustness
+  &__GLEW_KHR_robustness,
+#endif
+#ifdef GL_KHR_texture_compression_astc_hdr
+  &__GLEW_KHR_texture_compression_astc_hdr,
+#endif
+#ifdef GL_KHR_texture_compression_astc_ldr
+  &__GLEW_KHR_texture_compression_astc_ldr,
+#endif
+#ifdef GL_KHR_texture_compression_astc_sliced_3d
+  &__GLEW_KHR_texture_compression_astc_sliced_3d,
+#endif
+#ifdef GL_KTX_buffer_region
+  &__GLEW_KTX_buffer_region,
+#endif
+#ifdef GL_MESAX_texture_stack
+  &__GLEW_MESAX_texture_stack,
+#endif
+#ifdef GL_MESA_pack_invert
+  &__GLEW_MESA_pack_invert,
+#endif
+#ifdef GL_MESA_resize_buffers
+  &__GLEW_MESA_resize_buffers,
+#endif
+#ifdef GL_MESA_shader_integer_functions
+  &__GLEW_MESA_shader_integer_functions,
+#endif
+#ifdef GL_MESA_window_pos
+  &__GLEW_MESA_window_pos,
+#endif
+#ifdef GL_MESA_ycbcr_texture
+  &__GLEW_MESA_ycbcr_texture,
+#endif
+#ifdef GL_NVX_blend_equation_advanced_multi_draw_buffers
+  &__GLEW_NVX_blend_equation_advanced_multi_draw_buffers,
+#endif
+#ifdef GL_NVX_conditional_render
+  &__GLEW_NVX_conditional_render,
+#endif
+#ifdef GL_NVX_gpu_memory_info
+  &__GLEW_NVX_gpu_memory_info,
+#endif
+#ifdef GL_NVX_linked_gpu_multicast
+  &__GLEW_NVX_linked_gpu_multicast,
+#endif
+#ifdef GL_NV_3dvision_settings
+  &__GLEW_NV_3dvision_settings,
+#endif
+#ifdef GL_NV_EGL_stream_consumer_external
+  &__GLEW_NV_EGL_stream_consumer_external,
+#endif
+#ifdef GL_NV_alpha_to_coverage_dither_control
+  &__GLEW_NV_alpha_to_coverage_dither_control,
+#endif
+#ifdef GL_NV_bgr
+  &__GLEW_NV_bgr,
+#endif
+#ifdef GL_NV_bindless_multi_draw_indirect
+  &__GLEW_NV_bindless_multi_draw_indirect,
+#endif
+#ifdef GL_NV_bindless_multi_draw_indirect_count
+  &__GLEW_NV_bindless_multi_draw_indirect_count,
+#endif
+#ifdef GL_NV_bindless_texture
+  &__GLEW_NV_bindless_texture,
+#endif
+#ifdef GL_NV_blend_equation_advanced
+  &__GLEW_NV_blend_equation_advanced,
+#endif
+#ifdef GL_NV_blend_equation_advanced_coherent
+  &__GLEW_NV_blend_equation_advanced_coherent,
+#endif
+#ifdef GL_NV_blend_minmax_factor
+  &__GLEW_NV_blend_minmax_factor,
+#endif
+#ifdef GL_NV_blend_square
+  &__GLEW_NV_blend_square,
+#endif
+#ifdef GL_NV_clip_space_w_scaling
+  &__GLEW_NV_clip_space_w_scaling,
+#endif
+#ifdef GL_NV_command_list
+  &__GLEW_NV_command_list,
+#endif
+#ifdef GL_NV_compute_program5
+  &__GLEW_NV_compute_program5,
+#endif
+#ifdef GL_NV_conditional_render
+  &__GLEW_NV_conditional_render,
+#endif
+#ifdef GL_NV_conservative_raster
+  &__GLEW_NV_conservative_raster,
+#endif
+#ifdef GL_NV_conservative_raster_dilate
+  &__GLEW_NV_conservative_raster_dilate,
+#endif
+#ifdef GL_NV_conservative_raster_pre_snap_triangles
+  &__GLEW_NV_conservative_raster_pre_snap_triangles,
+#endif
+#ifdef GL_NV_copy_buffer
+  &__GLEW_NV_copy_buffer,
+#endif
+#ifdef GL_NV_copy_depth_to_color
+  &__GLEW_NV_copy_depth_to_color,
+#endif
+#ifdef GL_NV_copy_image
+  &__GLEW_NV_copy_image,
+#endif
+#ifdef GL_NV_deep_texture3D
+  &__GLEW_NV_deep_texture3D,
+#endif
+#ifdef GL_NV_depth_buffer_float
+  &__GLEW_NV_depth_buffer_float,
+#endif
+#ifdef GL_NV_depth_clamp
+  &__GLEW_NV_depth_clamp,
+#endif
+#ifdef GL_NV_depth_range_unclamped
+  &__GLEW_NV_depth_range_unclamped,
+#endif
+#ifdef GL_NV_draw_buffers
+  &__GLEW_NV_draw_buffers,
+#endif
+#ifdef GL_NV_draw_instanced
+  &__GLEW_NV_draw_instanced,
+#endif
+#ifdef GL_NV_draw_texture
+  &__GLEW_NV_draw_texture,
+#endif
+#ifdef GL_NV_draw_vulkan_image
+  &__GLEW_NV_draw_vulkan_image,
+#endif
+#ifdef GL_NV_evaluators
+  &__GLEW_NV_evaluators,
+#endif
+#ifdef GL_NV_explicit_attrib_location
+  &__GLEW_NV_explicit_attrib_location,
+#endif
+#ifdef GL_NV_explicit_multisample
+  &__GLEW_NV_explicit_multisample,
+#endif
+#ifdef GL_NV_fbo_color_attachments
+  &__GLEW_NV_fbo_color_attachments,
+#endif
+#ifdef GL_NV_fence
+  &__GLEW_NV_fence,
+#endif
+#ifdef GL_NV_fill_rectangle
+  &__GLEW_NV_fill_rectangle,
+#endif
+#ifdef GL_NV_float_buffer
+  &__GLEW_NV_float_buffer,
+#endif
+#ifdef GL_NV_fog_distance
+  &__GLEW_NV_fog_distance,
+#endif
+#ifdef GL_NV_fragment_coverage_to_color
+  &__GLEW_NV_fragment_coverage_to_color,
+#endif
+#ifdef GL_NV_fragment_program
+  &__GLEW_NV_fragment_program,
+#endif
+#ifdef GL_NV_fragment_program2
+  &__GLEW_NV_fragment_program2,
+#endif
+#ifdef GL_NV_fragment_program4
+  &__GLEW_NV_fragment_program4,
+#endif
+#ifdef GL_NV_fragment_program_option
+  &__GLEW_NV_fragment_program_option,
+#endif
+#ifdef GL_NV_fragment_shader_interlock
+  &__GLEW_NV_fragment_shader_interlock,
+#endif
+#ifdef GL_NV_framebuffer_blit
+  &__GLEW_NV_framebuffer_blit,
+#endif
+#ifdef GL_NV_framebuffer_mixed_samples
+  &__GLEW_NV_framebuffer_mixed_samples,
+#endif
+#ifdef GL_NV_framebuffer_multisample
+  &__GLEW_NV_framebuffer_multisample,
+#endif
+#ifdef GL_NV_framebuffer_multisample_coverage
+  &__GLEW_NV_framebuffer_multisample_coverage,
+#endif
+#ifdef GL_NV_generate_mipmap_sRGB
+  &__GLEW_NV_generate_mipmap_sRGB,
+#endif
+#ifdef GL_NV_geometry_program4
+  &__GLEW_NV_geometry_program4,
+#endif
+#ifdef GL_NV_geometry_shader4
+  &__GLEW_NV_geometry_shader4,
+#endif
+#ifdef GL_NV_geometry_shader_passthrough
+  &__GLEW_NV_geometry_shader_passthrough,
+#endif
+#ifdef GL_NV_gpu_multicast
+  &__GLEW_NV_gpu_multicast,
+#endif
+#ifdef GL_NV_gpu_program4
+  &__GLEW_NV_gpu_program4,
+#endif
+#ifdef GL_NV_gpu_program5
+  &__GLEW_NV_gpu_program5,
+#endif
+#ifdef GL_NV_gpu_program5_mem_extended
+  &__GLEW_NV_gpu_program5_mem_extended,
+#endif
+#ifdef GL_NV_gpu_program_fp64
+  &__GLEW_NV_gpu_program_fp64,
+#endif
+#ifdef GL_NV_gpu_shader5
+  &__GLEW_NV_gpu_shader5,
+#endif
+#ifdef GL_NV_half_float
+  &__GLEW_NV_half_float,
+#endif
+#ifdef GL_NV_image_formats
+  &__GLEW_NV_image_formats,
+#endif
+#ifdef GL_NV_instanced_arrays
+  &__GLEW_NV_instanced_arrays,
+#endif
+#ifdef GL_NV_internalformat_sample_query
+  &__GLEW_NV_internalformat_sample_query,
+#endif
+#ifdef GL_NV_light_max_exponent
+  &__GLEW_NV_light_max_exponent,
+#endif
+#ifdef GL_NV_multisample_coverage
+  &__GLEW_NV_multisample_coverage,
+#endif
+#ifdef GL_NV_multisample_filter_hint
+  &__GLEW_NV_multisample_filter_hint,
+#endif
+#ifdef GL_NV_non_square_matrices
+  &__GLEW_NV_non_square_matrices,
+#endif
+#ifdef GL_NV_occlusion_query
+  &__GLEW_NV_occlusion_query,
+#endif
+#ifdef GL_NV_pack_subimage
+  &__GLEW_NV_pack_subimage,
+#endif
+#ifdef GL_NV_packed_depth_stencil
+  &__GLEW_NV_packed_depth_stencil,
+#endif
+#ifdef GL_NV_packed_float
+  &__GLEW_NV_packed_float,
+#endif
+#ifdef GL_NV_packed_float_linear
+  &__GLEW_NV_packed_float_linear,
+#endif
+#ifdef GL_NV_parameter_buffer_object
+  &__GLEW_NV_parameter_buffer_object,
+#endif
+#ifdef GL_NV_parameter_buffer_object2
+  &__GLEW_NV_parameter_buffer_object2,
+#endif
+#ifdef GL_NV_path_rendering
+  &__GLEW_NV_path_rendering,
+#endif
+#ifdef GL_NV_path_rendering_shared_edge
+  &__GLEW_NV_path_rendering_shared_edge,
+#endif
+#ifdef GL_NV_pixel_buffer_object
+  &__GLEW_NV_pixel_buffer_object,
+#endif
+#ifdef GL_NV_pixel_data_range
+  &__GLEW_NV_pixel_data_range,
+#endif
+#ifdef GL_NV_platform_binary
+  &__GLEW_NV_platform_binary,
+#endif
+#ifdef GL_NV_point_sprite
+  &__GLEW_NV_point_sprite,
+#endif
+#ifdef GL_NV_polygon_mode
+  &__GLEW_NV_polygon_mode,
+#endif
+#ifdef GL_NV_present_video
+  &__GLEW_NV_present_video,
+#endif
+#ifdef GL_NV_primitive_restart
+  &__GLEW_NV_primitive_restart,
+#endif
+#ifdef GL_NV_read_depth
+  &__GLEW_NV_read_depth,
+#endif
+#ifdef GL_NV_read_depth_stencil
+  &__GLEW_NV_read_depth_stencil,
+#endif
+#ifdef GL_NV_read_stencil
+  &__GLEW_NV_read_stencil,
+#endif
+#ifdef GL_NV_register_combiners
+  &__GLEW_NV_register_combiners,
+#endif
+#ifdef GL_NV_register_combiners2
+  &__GLEW_NV_register_combiners2,
+#endif
+#ifdef GL_NV_robustness_video_memory_purge
+  &__GLEW_NV_robustness_video_memory_purge,
+#endif
+#ifdef GL_NV_sRGB_formats
+  &__GLEW_NV_sRGB_formats,
+#endif
+#ifdef GL_NV_sample_locations
+  &__GLEW_NV_sample_locations,
+#endif
+#ifdef GL_NV_sample_mask_override_coverage
+  &__GLEW_NV_sample_mask_override_coverage,
+#endif
+#ifdef GL_NV_shader_atomic_counters
+  &__GLEW_NV_shader_atomic_counters,
+#endif
+#ifdef GL_NV_shader_atomic_float
+  &__GLEW_NV_shader_atomic_float,
+#endif
+#ifdef GL_NV_shader_atomic_float64
+  &__GLEW_NV_shader_atomic_float64,
+#endif
+#ifdef GL_NV_shader_atomic_fp16_vector
+  &__GLEW_NV_shader_atomic_fp16_vector,
+#endif
+#ifdef GL_NV_shader_atomic_int64
+  &__GLEW_NV_shader_atomic_int64,
+#endif
+#ifdef GL_NV_shader_buffer_load
+  &__GLEW_NV_shader_buffer_load,
+#endif
+#ifdef GL_NV_shader_noperspective_interpolation
+  &__GLEW_NV_shader_noperspective_interpolation,
+#endif
+#ifdef GL_NV_shader_storage_buffer_object
+  &__GLEW_NV_shader_storage_buffer_object,
+#endif
+#ifdef GL_NV_shader_thread_group
+  &__GLEW_NV_shader_thread_group,
+#endif
+#ifdef GL_NV_shader_thread_shuffle
+  &__GLEW_NV_shader_thread_shuffle,
+#endif
+#ifdef GL_NV_shadow_samplers_array
+  &__GLEW_NV_shadow_samplers_array,
+#endif
+#ifdef GL_NV_shadow_samplers_cube
+  &__GLEW_NV_shadow_samplers_cube,
+#endif
+#ifdef GL_NV_stereo_view_rendering
+  &__GLEW_NV_stereo_view_rendering,
+#endif
+#ifdef GL_NV_tessellation_program5
+  &__GLEW_NV_tessellation_program5,
+#endif
+#ifdef GL_NV_texgen_emboss
+  &__GLEW_NV_texgen_emboss,
+#endif
+#ifdef GL_NV_texgen_reflection
+  &__GLEW_NV_texgen_reflection,
+#endif
+#ifdef GL_NV_texture_array
+  &__GLEW_NV_texture_array,
+#endif
+#ifdef GL_NV_texture_barrier
+  &__GLEW_NV_texture_barrier,
+#endif
+#ifdef GL_NV_texture_border_clamp
+  &__GLEW_NV_texture_border_clamp,
+#endif
+#ifdef GL_NV_texture_compression_latc
+  &__GLEW_NV_texture_compression_latc,
+#endif
+#ifdef GL_NV_texture_compression_s3tc
+  &__GLEW_NV_texture_compression_s3tc,
+#endif
+#ifdef GL_NV_texture_compression_s3tc_update
+  &__GLEW_NV_texture_compression_s3tc_update,
+#endif
+#ifdef GL_NV_texture_compression_vtc
+  &__GLEW_NV_texture_compression_vtc,
+#endif
+#ifdef GL_NV_texture_env_combine4
+  &__GLEW_NV_texture_env_combine4,
+#endif
+#ifdef GL_NV_texture_expand_normal
+  &__GLEW_NV_texture_expand_normal,
+#endif
+#ifdef GL_NV_texture_multisample
+  &__GLEW_NV_texture_multisample,
+#endif
+#ifdef GL_NV_texture_npot_2D_mipmap
+  &__GLEW_NV_texture_npot_2D_mipmap,
+#endif
+#ifdef GL_NV_texture_rectangle
+  &__GLEW_NV_texture_rectangle,
+#endif
+#ifdef GL_NV_texture_rectangle_compressed
+  &__GLEW_NV_texture_rectangle_compressed,
+#endif
+#ifdef GL_NV_texture_shader
+  &__GLEW_NV_texture_shader,
+#endif
+#ifdef GL_NV_texture_shader2
+  &__GLEW_NV_texture_shader2,
+#endif
+#ifdef GL_NV_texture_shader3
+  &__GLEW_NV_texture_shader3,
+#endif
+#ifdef GL_NV_transform_feedback
+  &__GLEW_NV_transform_feedback,
+#endif
+#ifdef GL_NV_transform_feedback2
+  &__GLEW_NV_transform_feedback2,
+#endif
+#ifdef GL_NV_uniform_buffer_unified_memory
+  &__GLEW_NV_uniform_buffer_unified_memory,
+#endif
+#ifdef GL_NV_vdpau_interop
+  &__GLEW_NV_vdpau_interop,
+#endif
+#ifdef GL_NV_vertex_array_range
+  &__GLEW_NV_vertex_array_range,
+#endif
+#ifdef GL_NV_vertex_array_range2
+  &__GLEW_NV_vertex_array_range2,
+#endif
+#ifdef GL_NV_vertex_attrib_integer_64bit
+  &__GLEW_NV_vertex_attrib_integer_64bit,
+#endif
+#ifdef GL_NV_vertex_buffer_unified_memory
+  &__GLEW_NV_vertex_buffer_unified_memory,
+#endif
+#ifdef GL_NV_vertex_program
+  &__GLEW_NV_vertex_program,
+#endif
+#ifdef GL_NV_vertex_program1_1
+  &__GLEW_NV_vertex_program1_1,
+#endif
+#ifdef GL_NV_vertex_program2
+  &__GLEW_NV_vertex_program2,
+#endif
+#ifdef GL_NV_vertex_program2_option
+  &__GLEW_NV_vertex_program2_option,
+#endif
+#ifdef GL_NV_vertex_program3
+  &__GLEW_NV_vertex_program3,
+#endif
+#ifdef GL_NV_vertex_program4
+  &__GLEW_NV_vertex_program4,
+#endif
+#ifdef GL_NV_video_capture
+  &__GLEW_NV_video_capture,
+#endif
+#ifdef GL_NV_viewport_array
+  &__GLEW_NV_viewport_array,
+#endif
+#ifdef GL_NV_viewport_array2
+  &__GLEW_NV_viewport_array2,
+#endif
+#ifdef GL_NV_viewport_swizzle
+  &__GLEW_NV_viewport_swizzle,
+#endif
+#ifdef GL_OES_byte_coordinates
+  &__GLEW_OES_byte_coordinates,
+#endif
+#ifdef GL_OML_interlace
+  &__GLEW_OML_interlace,
+#endif
+#ifdef GL_OML_resample
+  &__GLEW_OML_resample,
+#endif
+#ifdef GL_OML_subsample
+  &__GLEW_OML_subsample,
+#endif
+#ifdef GL_OVR_multiview
+  &__GLEW_OVR_multiview,
+#endif
+#ifdef GL_OVR_multiview2
+  &__GLEW_OVR_multiview2,
+#endif
+#ifdef GL_OVR_multiview_multisampled_render_to_texture
+  &__GLEW_OVR_multiview_multisampled_render_to_texture,
+#endif
+#ifdef GL_PGI_misc_hints
+  &__GLEW_PGI_misc_hints,
+#endif
+#ifdef GL_PGI_vertex_hints
+  &__GLEW_PGI_vertex_hints,
+#endif
+#ifdef GL_QCOM_alpha_test
+  &__GLEW_QCOM_alpha_test,
+#endif
+#ifdef GL_QCOM_binning_control
+  &__GLEW_QCOM_binning_control,
+#endif
+#ifdef GL_QCOM_driver_control
+  &__GLEW_QCOM_driver_control,
+#endif
+#ifdef GL_QCOM_extended_get
+  &__GLEW_QCOM_extended_get,
+#endif
+#ifdef GL_QCOM_extended_get2
+  &__GLEW_QCOM_extended_get2,
+#endif
+#ifdef GL_QCOM_framebuffer_foveated
+  &__GLEW_QCOM_framebuffer_foveated,
+#endif
+#ifdef GL_QCOM_perfmon_global_mode
+  &__GLEW_QCOM_perfmon_global_mode,
+#endif
+#ifdef GL_QCOM_shader_framebuffer_fetch_noncoherent
+  &__GLEW_QCOM_shader_framebuffer_fetch_noncoherent,
+#endif
+#ifdef GL_QCOM_tiled_rendering
+  &__GLEW_QCOM_tiled_rendering,
+#endif
+#ifdef GL_QCOM_writeonly_rendering
+  &__GLEW_QCOM_writeonly_rendering,
+#endif
+#ifdef GL_REGAL_ES1_0_compatibility
+  &__GLEW_REGAL_ES1_0_compatibility,
+#endif
+#ifdef GL_REGAL_ES1_1_compatibility
+  &__GLEW_REGAL_ES1_1_compatibility,
+#endif
+#ifdef GL_REGAL_enable
+  &__GLEW_REGAL_enable,
+#endif
+#ifdef GL_REGAL_error_string
+  &__GLEW_REGAL_error_string,
+#endif
+#ifdef GL_REGAL_extension_query
+  &__GLEW_REGAL_extension_query,
+#endif
+#ifdef GL_REGAL_log
+  &__GLEW_REGAL_log,
+#endif
+#ifdef GL_REGAL_proc_address
+  &__GLEW_REGAL_proc_address,
+#endif
+#ifdef GL_REND_screen_coordinates
+  &__GLEW_REND_screen_coordinates,
+#endif
+#ifdef GL_S3_s3tc
+  &__GLEW_S3_s3tc,
+#endif
+#ifdef GL_SGIS_clip_band_hint
+  &__GLEW_SGIS_clip_band_hint,
+#endif
+#ifdef GL_SGIS_color_range
+  &__GLEW_SGIS_color_range,
+#endif
+#ifdef GL_SGIS_detail_texture
+  &__GLEW_SGIS_detail_texture,
+#endif
+#ifdef GL_SGIS_fog_function
+  &__GLEW_SGIS_fog_function,
+#endif
+#ifdef GL_SGIS_generate_mipmap
+  &__GLEW_SGIS_generate_mipmap,
+#endif
+#ifdef GL_SGIS_line_texgen
+  &__GLEW_SGIS_line_texgen,
+#endif
+#ifdef GL_SGIS_multisample
+  &__GLEW_SGIS_multisample,
+#endif
+#ifdef GL_SGIS_multitexture
+  &__GLEW_SGIS_multitexture,
+#endif
+#ifdef GL_SGIS_pixel_texture
+  &__GLEW_SGIS_pixel_texture,
+#endif
+#ifdef GL_SGIS_point_line_texgen
+  &__GLEW_SGIS_point_line_texgen,
+#endif
+#ifdef GL_SGIS_shared_multisample
+  &__GLEW_SGIS_shared_multisample,
+#endif
+#ifdef GL_SGIS_sharpen_texture
+  &__GLEW_SGIS_sharpen_texture,
+#endif
+#ifdef GL_SGIS_texture4D
+  &__GLEW_SGIS_texture4D,
+#endif
+#ifdef GL_SGIS_texture_border_clamp
+  &__GLEW_SGIS_texture_border_clamp,
+#endif
+#ifdef GL_SGIS_texture_edge_clamp
+  &__GLEW_SGIS_texture_edge_clamp,
+#endif
+#ifdef GL_SGIS_texture_filter4
+  &__GLEW_SGIS_texture_filter4,
+#endif
+#ifdef GL_SGIS_texture_lod
+  &__GLEW_SGIS_texture_lod,
+#endif
+#ifdef GL_SGIS_texture_select
+  &__GLEW_SGIS_texture_select,
+#endif
+#ifdef GL_SGIX_async
+  &__GLEW_SGIX_async,
+#endif
+#ifdef GL_SGIX_async_histogram
+  &__GLEW_SGIX_async_histogram,
+#endif
+#ifdef GL_SGIX_async_pixel
+  &__GLEW_SGIX_async_pixel,
+#endif
+#ifdef GL_SGIX_bali_g_instruments
+  &__GLEW_SGIX_bali_g_instruments,
+#endif
+#ifdef GL_SGIX_bali_r_instruments
+  &__GLEW_SGIX_bali_r_instruments,
+#endif
+#ifdef GL_SGIX_bali_timer_instruments
+  &__GLEW_SGIX_bali_timer_instruments,
+#endif
+#ifdef GL_SGIX_blend_alpha_minmax
+  &__GLEW_SGIX_blend_alpha_minmax,
+#endif
+#ifdef GL_SGIX_blend_cadd
+  &__GLEW_SGIX_blend_cadd,
+#endif
+#ifdef GL_SGIX_blend_cmultiply
+  &__GLEW_SGIX_blend_cmultiply,
+#endif
+#ifdef GL_SGIX_calligraphic_fragment
+  &__GLEW_SGIX_calligraphic_fragment,
+#endif
+#ifdef GL_SGIX_clipmap
+  &__GLEW_SGIX_clipmap,
+#endif
+#ifdef GL_SGIX_color_matrix_accuracy
+  &__GLEW_SGIX_color_matrix_accuracy,
+#endif
+#ifdef GL_SGIX_color_table_index_mode
+  &__GLEW_SGIX_color_table_index_mode,
+#endif
+#ifdef GL_SGIX_complex_polar
+  &__GLEW_SGIX_complex_polar,
+#endif
+#ifdef GL_SGIX_convolution_accuracy
+  &__GLEW_SGIX_convolution_accuracy,
+#endif
+#ifdef GL_SGIX_cube_map
+  &__GLEW_SGIX_cube_map,
+#endif
+#ifdef GL_SGIX_cylinder_texgen
+  &__GLEW_SGIX_cylinder_texgen,
+#endif
+#ifdef GL_SGIX_datapipe
+  &__GLEW_SGIX_datapipe,
+#endif
+#ifdef GL_SGIX_decimation
+  &__GLEW_SGIX_decimation,
+#endif
+#ifdef GL_SGIX_depth_pass_instrument
+  &__GLEW_SGIX_depth_pass_instrument,
+#endif
+#ifdef GL_SGIX_depth_texture
+  &__GLEW_SGIX_depth_texture,
+#endif
+#ifdef GL_SGIX_dvc
+  &__GLEW_SGIX_dvc,
+#endif
+#ifdef GL_SGIX_flush_raster
+  &__GLEW_SGIX_flush_raster,
+#endif
+#ifdef GL_SGIX_fog_blend
+  &__GLEW_SGIX_fog_blend,
+#endif
+#ifdef GL_SGIX_fog_factor_to_alpha
+  &__GLEW_SGIX_fog_factor_to_alpha,
+#endif
+#ifdef GL_SGIX_fog_layers
+  &__GLEW_SGIX_fog_layers,
+#endif
+#ifdef GL_SGIX_fog_offset
+  &__GLEW_SGIX_fog_offset,
+#endif
+#ifdef GL_SGIX_fog_patchy
+  &__GLEW_SGIX_fog_patchy,
+#endif
+#ifdef GL_SGIX_fog_scale
+  &__GLEW_SGIX_fog_scale,
+#endif
+#ifdef GL_SGIX_fog_texture
+  &__GLEW_SGIX_fog_texture,
+#endif
+#ifdef GL_SGIX_fragment_lighting_space
+  &__GLEW_SGIX_fragment_lighting_space,
+#endif
+#ifdef GL_SGIX_fragment_specular_lighting
+  &__GLEW_SGIX_fragment_specular_lighting,
+#endif
+#ifdef GL_SGIX_fragments_instrument
+  &__GLEW_SGIX_fragments_instrument,
+#endif
+#ifdef GL_SGIX_framezoom
+  &__GLEW_SGIX_framezoom,
+#endif
+#ifdef GL_SGIX_icc_texture
+  &__GLEW_SGIX_icc_texture,
+#endif
+#ifdef GL_SGIX_igloo_interface
+  &__GLEW_SGIX_igloo_interface,
+#endif
+#ifdef GL_SGIX_image_compression
+  &__GLEW_SGIX_image_compression,
+#endif
+#ifdef GL_SGIX_impact_pixel_texture
+  &__GLEW_SGIX_impact_pixel_texture,
+#endif
+#ifdef GL_SGIX_instrument_error
+  &__GLEW_SGIX_instrument_error,
+#endif
+#ifdef GL_SGIX_interlace
+  &__GLEW_SGIX_interlace,
+#endif
+#ifdef GL_SGIX_ir_instrument1
+  &__GLEW_SGIX_ir_instrument1,
+#endif
+#ifdef GL_SGIX_line_quality_hint
+  &__GLEW_SGIX_line_quality_hint,
+#endif
+#ifdef GL_SGIX_list_priority
+  &__GLEW_SGIX_list_priority,
+#endif
+#ifdef GL_SGIX_mpeg1
+  &__GLEW_SGIX_mpeg1,
+#endif
+#ifdef GL_SGIX_mpeg2
+  &__GLEW_SGIX_mpeg2,
+#endif
+#ifdef GL_SGIX_nonlinear_lighting_pervertex
+  &__GLEW_SGIX_nonlinear_lighting_pervertex,
+#endif
+#ifdef GL_SGIX_nurbs_eval
+  &__GLEW_SGIX_nurbs_eval,
+#endif
+#ifdef GL_SGIX_occlusion_instrument
+  &__GLEW_SGIX_occlusion_instrument,
+#endif
+#ifdef GL_SGIX_packed_6bytes
+  &__GLEW_SGIX_packed_6bytes,
+#endif
+#ifdef GL_SGIX_pixel_texture
+  &__GLEW_SGIX_pixel_texture,
+#endif
+#ifdef GL_SGIX_pixel_texture_bits
+  &__GLEW_SGIX_pixel_texture_bits,
+#endif
+#ifdef GL_SGIX_pixel_texture_lod
+  &__GLEW_SGIX_pixel_texture_lod,
+#endif
+#ifdef GL_SGIX_pixel_tiles
+  &__GLEW_SGIX_pixel_tiles,
+#endif
+#ifdef GL_SGIX_polynomial_ffd
+  &__GLEW_SGIX_polynomial_ffd,
+#endif
+#ifdef GL_SGIX_quad_mesh
+  &__GLEW_SGIX_quad_mesh,
+#endif
+#ifdef GL_SGIX_reference_plane
+  &__GLEW_SGIX_reference_plane,
+#endif
+#ifdef GL_SGIX_resample
+  &__GLEW_SGIX_resample,
+#endif
+#ifdef GL_SGIX_scalebias_hint
+  &__GLEW_SGIX_scalebias_hint,
+#endif
+#ifdef GL_SGIX_shadow
+  &__GLEW_SGIX_shadow,
+#endif
+#ifdef GL_SGIX_shadow_ambient
+  &__GLEW_SGIX_shadow_ambient,
+#endif
+#ifdef GL_SGIX_slim
+  &__GLEW_SGIX_slim,
+#endif
+#ifdef GL_SGIX_spotlight_cutoff
+  &__GLEW_SGIX_spotlight_cutoff,
+#endif
+#ifdef GL_SGIX_sprite
+  &__GLEW_SGIX_sprite,
+#endif
+#ifdef GL_SGIX_subdiv_patch
+  &__GLEW_SGIX_subdiv_patch,
+#endif
+#ifdef GL_SGIX_subsample
+  &__GLEW_SGIX_subsample,
+#endif
+#ifdef GL_SGIX_tag_sample_buffer
+  &__GLEW_SGIX_tag_sample_buffer,
+#endif
+#ifdef GL_SGIX_texture_add_env
+  &__GLEW_SGIX_texture_add_env,
+#endif
+#ifdef GL_SGIX_texture_coordinate_clamp
+  &__GLEW_SGIX_texture_coordinate_clamp,
+#endif
+#ifdef GL_SGIX_texture_lod_bias
+  &__GLEW_SGIX_texture_lod_bias,
+#endif
+#ifdef GL_SGIX_texture_mipmap_anisotropic
+  &__GLEW_SGIX_texture_mipmap_anisotropic,
+#endif
+#ifdef GL_SGIX_texture_multi_buffer
+  &__GLEW_SGIX_texture_multi_buffer,
+#endif
+#ifdef GL_SGIX_texture_phase
+  &__GLEW_SGIX_texture_phase,
+#endif
+#ifdef GL_SGIX_texture_range
+  &__GLEW_SGIX_texture_range,
+#endif
+#ifdef GL_SGIX_texture_scale_bias
+  &__GLEW_SGIX_texture_scale_bias,
+#endif
+#ifdef GL_SGIX_texture_supersample
+  &__GLEW_SGIX_texture_supersample,
+#endif
+#ifdef GL_SGIX_vector_ops
+  &__GLEW_SGIX_vector_ops,
+#endif
+#ifdef GL_SGIX_vertex_array_object
+  &__GLEW_SGIX_vertex_array_object,
+#endif
+#ifdef GL_SGIX_vertex_preclip
+  &__GLEW_SGIX_vertex_preclip,
+#endif
+#ifdef GL_SGIX_vertex_preclip_hint
+  &__GLEW_SGIX_vertex_preclip_hint,
+#endif
+#ifdef GL_SGIX_ycrcb
+  &__GLEW_SGIX_ycrcb,
+#endif
+#ifdef GL_SGIX_ycrcb_subsample
+  &__GLEW_SGIX_ycrcb_subsample,
+#endif
+#ifdef GL_SGIX_ycrcba
+  &__GLEW_SGIX_ycrcba,
+#endif
+#ifdef GL_SGI_color_matrix
+  &__GLEW_SGI_color_matrix,
+#endif
+#ifdef GL_SGI_color_table
+  &__GLEW_SGI_color_table,
+#endif
+#ifdef GL_SGI_complex
+  &__GLEW_SGI_complex,
+#endif
+#ifdef GL_SGI_complex_type
+  &__GLEW_SGI_complex_type,
+#endif
+#ifdef GL_SGI_fft
+  &__GLEW_SGI_fft,
+#endif
+#ifdef GL_SGI_texture_color_table
+  &__GLEW_SGI_texture_color_table,
+#endif
+#ifdef GL_SUNX_constant_data
+  &__GLEW_SUNX_constant_data,
+#endif
+#ifdef GL_SUN_convolution_border_modes
+  &__GLEW_SUN_convolution_border_modes,
+#endif
+#ifdef GL_SUN_global_alpha
+  &__GLEW_SUN_global_alpha,
+#endif
+#ifdef GL_SUN_mesh_array
+  &__GLEW_SUN_mesh_array,
+#endif
+#ifdef GL_SUN_read_video_pixels
+  &__GLEW_SUN_read_video_pixels,
+#endif
+#ifdef GL_SUN_slice_accum
+  &__GLEW_SUN_slice_accum,
+#endif
+#ifdef GL_SUN_triangle_list
+  &__GLEW_SUN_triangle_list,
+#endif
+#ifdef GL_SUN_vertex
+  &__GLEW_SUN_vertex,
+#endif
+#ifdef GL_WIN_phong_shading
+  &__GLEW_WIN_phong_shading,
+#endif
+#ifdef GL_WIN_scene_markerXXX
+  &__GLEW_WIN_scene_markerXXX,
+#endif
+#ifdef GL_WIN_specular_fog
+  &__GLEW_WIN_specular_fog,
+#endif
+#ifdef GL_WIN_swap_hint
+  &__GLEW_WIN_swap_hint,
+#endif
+  NULL
+};
+static GLboolean _glewInit_GL_VERSION_1_2 ();
+static GLboolean _glewInit_GL_VERSION_1_3 ();
+static GLboolean _glewInit_GL_VERSION_1_4 ();
+static GLboolean _glewInit_GL_VERSION_1_5 ();
+static GLboolean _glewInit_GL_VERSION_2_0 ();
+static GLboolean _glewInit_GL_VERSION_2_1 ();
+static GLboolean _glewInit_GL_VERSION_3_0 ();
+static GLboolean _glewInit_GL_VERSION_3_1 ();
+static GLboolean _glewInit_GL_VERSION_3_2 ();
+static GLboolean _glewInit_GL_VERSION_3_3 ();
+static GLboolean _glewInit_GL_VERSION_4_0 ();
+static GLboolean _glewInit_GL_VERSION_4_5 ();
+static GLboolean _glewInit_GL_VERSION_4_6 ();
+static GLboolean _glewInit_GL_3DFX_tbuffer ();
+static GLboolean _glewInit_GL_AMD_debug_output ();
+static GLboolean _glewInit_GL_AMD_draw_buffers_blend ();
+static GLboolean _glewInit_GL_AMD_framebuffer_sample_positions ();
+static GLboolean _glewInit_GL_AMD_interleaved_elements ();
+static GLboolean _glewInit_GL_AMD_multi_draw_indirect ();
+static GLboolean _glewInit_GL_AMD_name_gen_delete ();
+static GLboolean _glewInit_GL_AMD_occlusion_query_event ();
+static GLboolean _glewInit_GL_AMD_performance_monitor ();
+static GLboolean _glewInit_GL_AMD_sample_positions ();
+static GLboolean _glewInit_GL_AMD_sparse_texture ();
+static GLboolean _glewInit_GL_AMD_stencil_operation_extended ();
+static GLboolean _glewInit_GL_AMD_vertex_shader_tessellator ();
+static GLboolean _glewInit_GL_ANGLE_framebuffer_blit ();
+static GLboolean _glewInit_GL_ANGLE_framebuffer_multisample ();
+static GLboolean _glewInit_GL_ANGLE_instanced_arrays ();
+static GLboolean _glewInit_GL_ANGLE_timer_query ();
+static GLboolean _glewInit_GL_ANGLE_translated_shader_source ();
+static GLboolean _glewInit_GL_APPLE_copy_texture_levels ();
+static GLboolean _glewInit_GL_APPLE_element_array ();
+static GLboolean _glewInit_GL_APPLE_fence ();
+static GLboolean _glewInit_GL_APPLE_flush_buffer_range ();
+static GLboolean _glewInit_GL_APPLE_framebuffer_multisample ();
+static GLboolean _glewInit_GL_APPLE_object_purgeable ();
+static GLboolean _glewInit_GL_APPLE_sync ();
+static GLboolean _glewInit_GL_APPLE_texture_range ();
+static GLboolean _glewInit_GL_APPLE_vertex_array_object ();
+static GLboolean _glewInit_GL_APPLE_vertex_array_range ();
+static GLboolean _glewInit_GL_APPLE_vertex_program_evaluators ();
+static GLboolean _glewInit_GL_ARB_ES2_compatibility ();
+static GLboolean _glewInit_GL_ARB_ES3_1_compatibility ();
+static GLboolean _glewInit_GL_ARB_ES3_2_compatibility ();
+static GLboolean _glewInit_GL_ARB_base_instance ();
+static GLboolean _glewInit_GL_ARB_bindless_texture ();
+static GLboolean _glewInit_GL_ARB_blend_func_extended ();
+static GLboolean _glewInit_GL_ARB_buffer_storage ();
+static GLboolean _glewInit_GL_ARB_cl_event ();
+static GLboolean _glewInit_GL_ARB_clear_buffer_object ();
+static GLboolean _glewInit_GL_ARB_clear_texture ();
+static GLboolean _glewInit_GL_ARB_clip_control ();
+static GLboolean _glewInit_GL_ARB_color_buffer_float ();
+static GLboolean _glewInit_GL_ARB_compute_shader ();
+static GLboolean _glewInit_GL_ARB_compute_variable_group_size ();
+static GLboolean _glewInit_GL_ARB_copy_buffer ();
+static GLboolean _glewInit_GL_ARB_copy_image ();
+static GLboolean _glewInit_GL_ARB_debug_output ();
+static GLboolean _glewInit_GL_ARB_direct_state_access ();
+static GLboolean _glewInit_GL_ARB_draw_buffers ();
+static GLboolean _glewInit_GL_ARB_draw_buffers_blend ();
+static GLboolean _glewInit_GL_ARB_draw_elements_base_vertex ();
+static GLboolean _glewInit_GL_ARB_draw_indirect ();
+static GLboolean _glewInit_GL_ARB_framebuffer_no_attachments ();
+static GLboolean _glewInit_GL_ARB_framebuffer_object ();
+static GLboolean _glewInit_GL_ARB_geometry_shader4 ();
+static GLboolean _glewInit_GL_ARB_get_program_binary ();
+static GLboolean _glewInit_GL_ARB_get_texture_sub_image ();
+static GLboolean _glewInit_GL_ARB_gl_spirv ();
+static GLboolean _glewInit_GL_ARB_gpu_shader_fp64 ();
+static GLboolean _glewInit_GL_ARB_gpu_shader_int64 ();
+static GLboolean _glewInit_GL_ARB_imaging ();
+static GLboolean _glewInit_GL_ARB_indirect_parameters ();
+static GLboolean _glewInit_GL_ARB_instanced_arrays ();
+static GLboolean _glewInit_GL_ARB_internalformat_query ();
+static GLboolean _glewInit_GL_ARB_internalformat_query2 ();
+static GLboolean _glewInit_GL_ARB_invalidate_subdata ();
+static GLboolean _glewInit_GL_ARB_map_buffer_range ();
+static GLboolean _glewInit_GL_ARB_matrix_palette ();
+static GLboolean _glewInit_GL_ARB_multi_bind ();
+static GLboolean _glewInit_GL_ARB_multi_draw_indirect ();
+static GLboolean _glewInit_GL_ARB_multisample ();
+static GLboolean _glewInit_GL_ARB_multitexture ();
+static GLboolean _glewInit_GL_ARB_occlusion_query ();
+static GLboolean _glewInit_GL_ARB_parallel_shader_compile ();
+static GLboolean _glewInit_GL_ARB_point_parameters ();
+static GLboolean _glewInit_GL_ARB_polygon_offset_clamp ();
+static GLboolean _glewInit_GL_ARB_program_interface_query ();
+static GLboolean _glewInit_GL_ARB_provoking_vertex ();
+static GLboolean _glewInit_GL_ARB_robustness ();
+static GLboolean _glewInit_GL_ARB_sample_locations ();
+static GLboolean _glewInit_GL_ARB_sample_shading ();
+static GLboolean _glewInit_GL_ARB_sampler_objects ();
+static GLboolean _glewInit_GL_ARB_separate_shader_objects ();
+static GLboolean _glewInit_GL_ARB_shader_atomic_counters ();
+static GLboolean _glewInit_GL_ARB_shader_image_load_store ();
+static GLboolean _glewInit_GL_ARB_shader_objects ();
+static GLboolean _glewInit_GL_ARB_shader_storage_buffer_object ();
+static GLboolean _glewInit_GL_ARB_shader_subroutine ();
+static GLboolean _glewInit_GL_ARB_shading_language_include ();
+static GLboolean _glewInit_GL_ARB_sparse_buffer ();
+static GLboolean _glewInit_GL_ARB_sparse_texture ();
+static GLboolean _glewInit_GL_ARB_sync ();
+static GLboolean _glewInit_GL_ARB_tessellation_shader ();
+static GLboolean _glewInit_GL_ARB_texture_barrier ();
+static GLboolean _glewInit_GL_ARB_texture_buffer_object ();
+static GLboolean _glewInit_GL_ARB_texture_buffer_range ();
+static GLboolean _glewInit_GL_ARB_texture_compression ();
+static GLboolean _glewInit_GL_ARB_texture_multisample ();
+static GLboolean _glewInit_GL_ARB_texture_storage ();
+static GLboolean _glewInit_GL_ARB_texture_storage_multisample ();
+static GLboolean _glewInit_GL_ARB_texture_view ();
+static GLboolean _glewInit_GL_ARB_timer_query ();
+static GLboolean _glewInit_GL_ARB_transform_feedback2 ();
+static GLboolean _glewInit_GL_ARB_transform_feedback3 ();
+static GLboolean _glewInit_GL_ARB_transform_feedback_instanced ();
+static GLboolean _glewInit_GL_ARB_transpose_matrix ();
+static GLboolean _glewInit_GL_ARB_uniform_buffer_object ();
+static GLboolean _glewInit_GL_ARB_vertex_array_object ();
+static GLboolean _glewInit_GL_ARB_vertex_attrib_64bit ();
+static GLboolean _glewInit_GL_ARB_vertex_attrib_binding ();
+static GLboolean _glewInit_GL_ARB_vertex_blend ();
+static GLboolean _glewInit_GL_ARB_vertex_buffer_object ();
+static GLboolean _glewInit_GL_ARB_vertex_program ();
+static GLboolean _glewInit_GL_ARB_vertex_shader ();
+static GLboolean _glewInit_GL_ARB_vertex_type_2_10_10_10_rev ();
+static GLboolean _glewInit_GL_ARB_viewport_array ();
+static GLboolean _glewInit_GL_ARB_window_pos ();
+static GLboolean _glewInit_GL_ATI_draw_buffers ();
+static GLboolean _glewInit_GL_ATI_element_array ();
+static GLboolean _glewInit_GL_ATI_envmap_bumpmap ();
+static GLboolean _glewInit_GL_ATI_fragment_shader ();
+static GLboolean _glewInit_GL_ATI_map_object_buffer ();
+static GLboolean _glewInit_GL_ATI_pn_triangles ();
+static GLboolean _glewInit_GL_ATI_separate_stencil ();
+static GLboolean _glewInit_GL_ATI_vertex_array_object ();
+static GLboolean _glewInit_GL_ATI_vertex_attrib_array_object ();
+static GLboolean _glewInit_GL_ATI_vertex_streams ();
+static GLboolean _glewInit_GL_EXT_base_instance ();
+static GLboolean _glewInit_GL_EXT_bindable_uniform ();
+static GLboolean _glewInit_GL_EXT_blend_color ();
+static GLboolean _glewInit_GL_EXT_blend_equation_separate ();
+static GLboolean _glewInit_GL_EXT_blend_func_extended ();
+static GLboolean _glewInit_GL_EXT_blend_func_separate ();
+static GLboolean _glewInit_GL_EXT_blend_minmax ();
+static GLboolean _glewInit_GL_EXT_buffer_storage ();
+static GLboolean _glewInit_GL_EXT_clear_texture ();
+static GLboolean _glewInit_GL_EXT_color_subtable ();
+static GLboolean _glewInit_GL_EXT_compiled_vertex_array ();
+static GLboolean _glewInit_GL_EXT_convolution ();
+static GLboolean _glewInit_GL_EXT_coordinate_frame ();
+static GLboolean _glewInit_GL_EXT_copy_image ();
+static GLboolean _glewInit_GL_EXT_copy_texture ();
+static GLboolean _glewInit_GL_EXT_cull_vertex ();
+static GLboolean _glewInit_GL_EXT_debug_label ();
+static GLboolean _glewInit_GL_EXT_debug_marker ();
+static GLboolean _glewInit_GL_EXT_depth_bounds_test ();
+static GLboolean _glewInit_GL_EXT_direct_state_access ();
+static GLboolean _glewInit_GL_EXT_discard_framebuffer ();
+static GLboolean _glewInit_GL_EXT_draw_buffers ();
+static GLboolean _glewInit_GL_EXT_draw_buffers2 ();
+static GLboolean _glewInit_GL_EXT_draw_buffers_indexed ();
+static GLboolean _glewInit_GL_EXT_draw_elements_base_vertex ();
+static GLboolean _glewInit_GL_EXT_draw_instanced ();
+static GLboolean _glewInit_GL_EXT_draw_range_elements ();
+static GLboolean _glewInit_GL_EXT_external_buffer ();
+static GLboolean _glewInit_GL_EXT_fog_coord ();
+static GLboolean _glewInit_GL_EXT_fragment_lighting ();
+static GLboolean _glewInit_GL_EXT_framebuffer_blit ();
+static GLboolean _glewInit_GL_EXT_framebuffer_multisample ();
+static GLboolean _glewInit_GL_EXT_framebuffer_object ();
+static GLboolean _glewInit_GL_EXT_geometry_shader4 ();
+static GLboolean _glewInit_GL_EXT_gpu_program_parameters ();
+static GLboolean _glewInit_GL_EXT_gpu_shader4 ();
+static GLboolean _glewInit_GL_EXT_histogram ();
+static GLboolean _glewInit_GL_EXT_index_func ();
+static GLboolean _glewInit_GL_EXT_index_material ();
+static GLboolean _glewInit_GL_EXT_instanced_arrays ();
+static GLboolean _glewInit_GL_EXT_light_texture ();
+static GLboolean _glewInit_GL_EXT_map_buffer_range ();
+static GLboolean _glewInit_GL_EXT_memory_object ();
+static GLboolean _glewInit_GL_EXT_memory_object_fd ();
+static GLboolean _glewInit_GL_EXT_memory_object_win32 ();
+static GLboolean _glewInit_GL_EXT_multi_draw_arrays ();
+static GLboolean _glewInit_GL_EXT_multi_draw_indirect ();
+static GLboolean _glewInit_GL_EXT_multisample ();
+static GLboolean _glewInit_GL_EXT_multisampled_render_to_texture ();
+static GLboolean _glewInit_GL_EXT_multiview_draw_buffers ();
+static GLboolean _glewInit_GL_EXT_paletted_texture ();
+static GLboolean _glewInit_GL_EXT_pixel_transform ();
+static GLboolean _glewInit_GL_EXT_point_parameters ();
+static GLboolean _glewInit_GL_EXT_polygon_offset ();
+static GLboolean _glewInit_GL_EXT_polygon_offset_clamp ();
+static GLboolean _glewInit_GL_EXT_provoking_vertex ();
+static GLboolean _glewInit_GL_EXT_raster_multisample ();
+static GLboolean _glewInit_GL_EXT_scene_marker ();
+static GLboolean _glewInit_GL_EXT_secondary_color ();
+static GLboolean _glewInit_GL_EXT_semaphore ();
+static GLboolean _glewInit_GL_EXT_semaphore_fd ();
+static GLboolean _glewInit_GL_EXT_semaphore_win32 ();
+static GLboolean _glewInit_GL_EXT_separate_shader_objects ();
+static GLboolean _glewInit_GL_EXT_shader_image_load_store ();
+static GLboolean _glewInit_GL_EXT_shader_pixel_local_storage2 ();
+static GLboolean _glewInit_GL_EXT_sparse_texture ();
+static GLboolean _glewInit_GL_EXT_stencil_two_side ();
+static GLboolean _glewInit_GL_EXT_subtexture ();
+static GLboolean _glewInit_GL_EXT_texture3D ();
+static GLboolean _glewInit_GL_EXT_texture_array ();
+static GLboolean _glewInit_GL_EXT_texture_buffer_object ();
+static GLboolean _glewInit_GL_EXT_texture_integer ();
+static GLboolean _glewInit_GL_EXT_texture_object ();
+static GLboolean _glewInit_GL_EXT_texture_perturb_normal ();
+static GLboolean _glewInit_GL_EXT_texture_storage ();
+static GLboolean _glewInit_GL_EXT_texture_view ();
+static GLboolean _glewInit_GL_EXT_timer_query ();
+static GLboolean _glewInit_GL_EXT_transform_feedback ();
+static GLboolean _glewInit_GL_EXT_vertex_array ();
+static GLboolean _glewInit_GL_EXT_vertex_array_setXXX ();
+static GLboolean _glewInit_GL_EXT_vertex_attrib_64bit ();
+static GLboolean _glewInit_GL_EXT_vertex_shader ();
+static GLboolean _glewInit_GL_EXT_vertex_weighting ();
+static GLboolean _glewInit_GL_EXT_win32_keyed_mutex ();
+static GLboolean _glewInit_GL_EXT_window_rectangles ();
+static GLboolean _glewInit_GL_EXT_x11_sync_object ();
+static GLboolean _glewInit_GL_GREMEDY_frame_terminator ();
+static GLboolean _glewInit_GL_GREMEDY_string_marker ();
+static GLboolean _glewInit_GL_HP_image_transform ();
+static GLboolean _glewInit_GL_IBM_multimode_draw_arrays ();
+static GLboolean _glewInit_GL_IBM_vertex_array_lists ();
+static GLboolean _glewInit_GL_INTEL_map_texture ();
+static GLboolean _glewInit_GL_INTEL_parallel_arrays ();
+static GLboolean _glewInit_GL_INTEL_performance_query ();
+static GLboolean _glewInit_GL_INTEL_texture_scissor ();
+static GLboolean _glewInit_GL_KHR_blend_equation_advanced ();
+static GLboolean _glewInit_GL_KHR_debug ();
+static GLboolean _glewInit_GL_KHR_parallel_shader_compile ();
+static GLboolean _glewInit_GL_KHR_robustness ();
+static GLboolean _glewInit_GL_KTX_buffer_region ();
+static GLboolean _glewInit_GL_MESA_resize_buffers ();
+static GLboolean _glewInit_GL_MESA_window_pos ();
+static GLboolean _glewInit_GL_NVX_conditional_render ();
+static GLboolean _glewInit_GL_NVX_linked_gpu_multicast ();
+static GLboolean _glewInit_GL_NV_3dvision_settings ();
+static GLboolean _glewInit_GL_NV_bindless_multi_draw_indirect ();
+static GLboolean _glewInit_GL_NV_bindless_multi_draw_indirect_count ();
+static GLboolean _glewInit_GL_NV_bindless_texture ();
+static GLboolean _glewInit_GL_NV_blend_equation_advanced ();
+static GLboolean _glewInit_GL_NV_clip_space_w_scaling ();
+static GLboolean _glewInit_GL_NV_command_list ();
+static GLboolean _glewInit_GL_NV_conditional_render ();
+static GLboolean _glewInit_GL_NV_conservative_raster ();
+static GLboolean _glewInit_GL_NV_conservative_raster_dilate ();
+static GLboolean _glewInit_GL_NV_conservative_raster_pre_snap_triangles ();
+static GLboolean _glewInit_GL_NV_copy_buffer ();
+static GLboolean _glewInit_GL_NV_copy_image ();
+static GLboolean _glewInit_GL_NV_depth_buffer_float ();
+static GLboolean _glewInit_GL_NV_draw_buffers ();
+static GLboolean _glewInit_GL_NV_draw_instanced ();
+static GLboolean _glewInit_GL_NV_draw_texture ();
+static GLboolean _glewInit_GL_NV_draw_vulkan_image ();
+static GLboolean _glewInit_GL_NV_evaluators ();
+static GLboolean _glewInit_GL_NV_explicit_multisample ();
+static GLboolean _glewInit_GL_NV_fence ();
+static GLboolean _glewInit_GL_NV_fragment_coverage_to_color ();
+static GLboolean _glewInit_GL_NV_fragment_program ();
+static GLboolean _glewInit_GL_NV_framebuffer_blit ();
+static GLboolean _glewInit_GL_NV_framebuffer_multisample ();
+static GLboolean _glewInit_GL_NV_framebuffer_multisample_coverage ();
+static GLboolean _glewInit_GL_NV_geometry_program4 ();
+static GLboolean _glewInit_GL_NV_gpu_multicast ();
+static GLboolean _glewInit_GL_NV_gpu_program4 ();
+static GLboolean _glewInit_GL_NV_gpu_shader5 ();
+static GLboolean _glewInit_GL_NV_half_float ();
+static GLboolean _glewInit_GL_NV_instanced_arrays ();
+static GLboolean _glewInit_GL_NV_internalformat_sample_query ();
+static GLboolean _glewInit_GL_NV_non_square_matrices ();
+static GLboolean _glewInit_GL_NV_occlusion_query ();
+static GLboolean _glewInit_GL_NV_parameter_buffer_object ();
+static GLboolean _glewInit_GL_NV_path_rendering ();
+static GLboolean _glewInit_GL_NV_pixel_data_range ();
+static GLboolean _glewInit_GL_NV_point_sprite ();
+static GLboolean _glewInit_GL_NV_polygon_mode ();
+static GLboolean _glewInit_GL_NV_present_video ();
+static GLboolean _glewInit_GL_NV_primitive_restart ();
+static GLboolean _glewInit_GL_NV_register_combiners ();
+static GLboolean _glewInit_GL_NV_register_combiners2 ();
+static GLboolean _glewInit_GL_NV_sample_locations ();
+static GLboolean _glewInit_GL_NV_shader_buffer_load ();
+static GLboolean _glewInit_GL_NV_texture_array ();
+static GLboolean _glewInit_GL_NV_texture_barrier ();
+static GLboolean _glewInit_GL_NV_texture_multisample ();
+static GLboolean _glewInit_GL_NV_transform_feedback ();
+static GLboolean _glewInit_GL_NV_transform_feedback2 ();
+static GLboolean _glewInit_GL_NV_vdpau_interop ();
+static GLboolean _glewInit_GL_NV_vertex_array_range ();
+static GLboolean _glewInit_GL_NV_vertex_attrib_integer_64bit ();
+static GLboolean _glewInit_GL_NV_vertex_buffer_unified_memory ();
+static GLboolean _glewInit_GL_NV_vertex_program ();
+static GLboolean _glewInit_GL_NV_video_capture ();
+static GLboolean _glewInit_GL_NV_viewport_array ();
+static GLboolean _glewInit_GL_NV_viewport_swizzle ();
+static GLboolean _glewInit_GL_OVR_multiview ();
+static GLboolean _glewInit_GL_OVR_multiview_multisampled_render_to_texture ();
+static GLboolean _glewInit_GL_QCOM_alpha_test ();
+static GLboolean _glewInit_GL_QCOM_driver_control ();
+static GLboolean _glewInit_GL_QCOM_extended_get ();
+static GLboolean _glewInit_GL_QCOM_extended_get2 ();
+static GLboolean _glewInit_GL_QCOM_framebuffer_foveated ();
+static GLboolean _glewInit_GL_QCOM_shader_framebuffer_fetch_noncoherent ();
+static GLboolean _glewInit_GL_QCOM_tiled_rendering ();
+static GLboolean _glewInit_GL_REGAL_ES1_0_compatibility ();
+static GLboolean _glewInit_GL_REGAL_ES1_1_compatibility ();
+static GLboolean _glewInit_GL_REGAL_error_string ();
+static GLboolean _glewInit_GL_REGAL_extension_query ();
+static GLboolean _glewInit_GL_REGAL_log ();
+static GLboolean _glewInit_GL_REGAL_proc_address ();
+static GLboolean _glewInit_GL_SGIS_detail_texture ();
+static GLboolean _glewInit_GL_SGIS_fog_function ();
+static GLboolean _glewInit_GL_SGIS_multisample ();
+static GLboolean _glewInit_GL_SGIS_multitexture ();
+static GLboolean _glewInit_GL_SGIS_shared_multisample ();
+static GLboolean _glewInit_GL_SGIS_sharpen_texture ();
+static GLboolean _glewInit_GL_SGIS_texture4D ();
+static GLboolean _glewInit_GL_SGIS_texture_filter4 ();
+static GLboolean _glewInit_GL_SGIX_async ();
+static GLboolean _glewInit_GL_SGIX_datapipe ();
+static GLboolean _glewInit_GL_SGIX_flush_raster ();
+static GLboolean _glewInit_GL_SGIX_fog_layers ();
+static GLboolean _glewInit_GL_SGIX_fog_texture ();
+static GLboolean _glewInit_GL_SGIX_fragment_specular_lighting ();
+static GLboolean _glewInit_GL_SGIX_framezoom ();
+static GLboolean _glewInit_GL_SGIX_igloo_interface ();
+static GLboolean _glewInit_GL_SGIX_mpeg1 ();
+static GLboolean _glewInit_GL_SGIX_nonlinear_lighting_pervertex ();
+static GLboolean _glewInit_GL_SGIX_pixel_texture ();
+static GLboolean _glewInit_GL_SGIX_polynomial_ffd ();
+static GLboolean _glewInit_GL_SGIX_quad_mesh ();
+static GLboolean _glewInit_GL_SGIX_reference_plane ();
+static GLboolean _glewInit_GL_SGIX_sprite ();
+static GLboolean _glewInit_GL_SGIX_tag_sample_buffer ();
+static GLboolean _glewInit_GL_SGIX_vector_ops ();
+static GLboolean _glewInit_GL_SGIX_vertex_array_object ();
+static GLboolean _glewInit_GL_SGI_color_table ();
+static GLboolean _glewInit_GL_SGI_fft ();
+static GLboolean _glewInit_GL_SUNX_constant_data ();
+static GLboolean _glewInit_GL_SUN_global_alpha ();
+static GLboolean _glewInit_GL_SUN_read_video_pixels ();
+static GLboolean _glewInit_GL_SUN_triangle_list ();
+static GLboolean _glewInit_GL_SUN_vertex ();
+static GLboolean _glewInit_GL_WIN_swap_hint ();
 
 #ifdef GL_VERSION_1_2
 
-static GLboolean _glewInit_GL_VERSION_1_2 (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_VERSION_1_2 ()
 {
   GLboolean r = GL_FALSE;
 
@@ -3499,13 +9265,9 @@ static GLboolean _glewInit_GL_VERSION_1_2 (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_VERSION_1_2 */
 
-#ifdef GL_VERSION_1_2_1
-
-#endif /* GL_VERSION_1_2_1 */
-
 #ifdef GL_VERSION_1_3
 
-static GLboolean _glewInit_GL_VERSION_1_3 (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_VERSION_1_3 ()
 {
   GLboolean r = GL_FALSE;
 
@@ -3563,7 +9325,7 @@ static GLboolean _glewInit_GL_VERSION_1_3 (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_VERSION_1_4
 
-static GLboolean _glewInit_GL_VERSION_1_4 (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_VERSION_1_4 ()
 {
   GLboolean r = GL_FALSE;
 
@@ -3622,7 +9384,7 @@ static GLboolean _glewInit_GL_VERSION_1_4 (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_VERSION_1_5
 
-static GLboolean _glewInit_GL_VERSION_1_5 (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_VERSION_1_5 ()
 {
   GLboolean r = GL_FALSE;
 
@@ -3653,7 +9415,7 @@ static GLboolean _glewInit_GL_VERSION_1_5 (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_VERSION_2_0
 
-static GLboolean _glewInit_GL_VERSION_2_0 (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_VERSION_2_0 ()
 {
   GLboolean r = GL_FALSE;
 
@@ -3758,7 +9520,7 @@ static GLboolean _glewInit_GL_VERSION_2_0 (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_VERSION_2_1
 
-static GLboolean _glewInit_GL_VERSION_2_1 (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_VERSION_2_1 ()
 {
   GLboolean r = GL_FALSE;
 
@@ -3776,9 +9538,14 @@ static GLboolean _glewInit_GL_VERSION_2_1 (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_VERSION_3_0
 
-static GLboolean _glewInit_GL_VERSION_3_0 (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_VERSION_3_0 ()
 {
   GLboolean r = GL_FALSE;
+
+  r = _glewInit_GL_ARB_framebuffer_object() || r;
+  r = _glewInit_GL_ARB_map_buffer_range() || r;
+  r = _glewInit_GL_ARB_uniform_buffer_object() || r;
+  r = _glewInit_GL_ARB_vertex_array_object() || r;
 
   r = ((glBeginConditionalRender = (PFNGLBEGINCONDITIONALRENDERPROC)glewGetProcAddress((const GLubyte*)"glBeginConditionalRender")) == NULL) || r;
   r = ((glBeginTransformFeedback = (PFNGLBEGINTRANSFORMFEEDBACKPROC)glewGetProcAddress((const GLubyte*)"glBeginTransformFeedback")) == NULL) || r;
@@ -3843,9 +9610,11 @@ static GLboolean _glewInit_GL_VERSION_3_0 (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_VERSION_3_1
 
-static GLboolean _glewInit_GL_VERSION_3_1 (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_VERSION_3_1 ()
 {
   GLboolean r = GL_FALSE;
+
+  r = _glewInit_GL_ARB_copy_buffer() || r;
 
   r = ((glDrawArraysInstanced = (PFNGLDRAWARRAYSINSTANCEDPROC)glewGetProcAddress((const GLubyte*)"glDrawArraysInstanced")) == NULL) || r;
   r = ((glDrawElementsInstanced = (PFNGLDRAWELEMENTSINSTANCEDPROC)glewGetProcAddress((const GLubyte*)"glDrawElementsInstanced")) == NULL) || r;
@@ -3859,9 +9628,14 @@ static GLboolean _glewInit_GL_VERSION_3_1 (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_VERSION_3_2
 
-static GLboolean _glewInit_GL_VERSION_3_2 (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_VERSION_3_2 ()
 {
   GLboolean r = GL_FALSE;
+
+  r = _glewInit_GL_ARB_draw_elements_base_vertex() || r;
+  r = _glewInit_GL_ARB_provoking_vertex() || r;
+  r = _glewInit_GL_ARB_sync() || r;
+  r = _glewInit_GL_ARB_texture_multisample() || r;
 
   r = ((glFramebufferTexture = (PFNGLFRAMEBUFFERTEXTUREPROC)glewGetProcAddress((const GLubyte*)"glFramebufferTexture")) == NULL) || r;
   r = ((glGetBufferParameteri64v = (PFNGLGETBUFFERPARAMETERI64VPROC)glewGetProcAddress((const GLubyte*)"glGetBufferParameteri64v")) == NULL) || r;
@@ -3874,7 +9648,7 @@ static GLboolean _glewInit_GL_VERSION_3_2 (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_VERSION_3_3
 
-static GLboolean _glewInit_GL_VERSION_3_3 (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_VERSION_3_3 ()
 {
   GLboolean r = GL_FALSE;
 
@@ -3887,7 +9661,7 @@ static GLboolean _glewInit_GL_VERSION_3_3 (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_VERSION_4_0
 
-static GLboolean _glewInit_GL_VERSION_4_0 (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_VERSION_4_0 ()
 {
   GLboolean r = GL_FALSE;
 
@@ -3902,33 +9676,40 @@ static GLboolean _glewInit_GL_VERSION_4_0 (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_VERSION_4_0 */
 
-#ifdef GL_VERSION_4_1
-
-#endif /* GL_VERSION_4_1 */
-
-#ifdef GL_VERSION_4_2
-
-#endif /* GL_VERSION_4_2 */
-
-#ifdef GL_VERSION_4_3
-
-#endif /* GL_VERSION_4_3 */
-
-#ifdef GL_VERSION_4_4
-
-#endif /* GL_VERSION_4_4 */
-
 #ifdef GL_VERSION_4_5
+
+static GLboolean _glewInit_GL_VERSION_4_5 ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glGetGraphicsResetStatus = (PFNGLGETGRAPHICSRESETSTATUSPROC)glewGetProcAddress((const GLubyte*)"glGetGraphicsResetStatus")) == NULL) || r;
+  r = ((glGetnCompressedTexImage = (PFNGLGETNCOMPRESSEDTEXIMAGEPROC)glewGetProcAddress((const GLubyte*)"glGetnCompressedTexImage")) == NULL) || r;
+  r = ((glGetnTexImage = (PFNGLGETNTEXIMAGEPROC)glewGetProcAddress((const GLubyte*)"glGetnTexImage")) == NULL) || r;
+  r = ((glGetnUniformdv = (PFNGLGETNUNIFORMDVPROC)glewGetProcAddress((const GLubyte*)"glGetnUniformdv")) == NULL) || r;
+
+  return r;
+}
 
 #endif /* GL_VERSION_4_5 */
 
-#ifdef GL_3DFX_multisample
+#ifdef GL_VERSION_4_6
 
-#endif /* GL_3DFX_multisample */
+static GLboolean _glewInit_GL_VERSION_4_6 ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glMultiDrawArraysIndirectCount = (PFNGLMULTIDRAWARRAYSINDIRECTCOUNTPROC)glewGetProcAddress((const GLubyte*)"glMultiDrawArraysIndirectCount")) == NULL) || r;
+  r = ((glMultiDrawElementsIndirectCount = (PFNGLMULTIDRAWELEMENTSINDIRECTCOUNTPROC)glewGetProcAddress((const GLubyte*)"glMultiDrawElementsIndirectCount")) == NULL) || r;
+  r = ((glSpecializeShader = (PFNGLSPECIALIZESHADERPROC)glewGetProcAddress((const GLubyte*)"glSpecializeShader")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_VERSION_4_6 */
 
 #ifdef GL_3DFX_tbuffer
 
-static GLboolean _glewInit_GL_3DFX_tbuffer (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_3DFX_tbuffer ()
 {
   GLboolean r = GL_FALSE;
 
@@ -3939,21 +9720,9 @@ static GLboolean _glewInit_GL_3DFX_tbuffer (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_3DFX_tbuffer */
 
-#ifdef GL_3DFX_texture_compression_FXT1
-
-#endif /* GL_3DFX_texture_compression_FXT1 */
-
-#ifdef GL_AMD_blend_minmax_factor
-
-#endif /* GL_AMD_blend_minmax_factor */
-
-#ifdef GL_AMD_conservative_depth
-
-#endif /* GL_AMD_conservative_depth */
-
 #ifdef GL_AMD_debug_output
 
-static GLboolean _glewInit_GL_AMD_debug_output (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_AMD_debug_output ()
 {
   GLboolean r = GL_FALSE;
 
@@ -3967,13 +9736,9 @@ static GLboolean _glewInit_GL_AMD_debug_output (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_AMD_debug_output */
 
-#ifdef GL_AMD_depth_clamp_separate
-
-#endif /* GL_AMD_depth_clamp_separate */
-
 #ifdef GL_AMD_draw_buffers_blend
 
-static GLboolean _glewInit_GL_AMD_draw_buffers_blend (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_AMD_draw_buffers_blend ()
 {
   GLboolean r = GL_FALSE;
 
@@ -3987,17 +9752,25 @@ static GLboolean _glewInit_GL_AMD_draw_buffers_blend (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_AMD_draw_buffers_blend */
 
-#ifdef GL_AMD_gcn_shader
+#ifdef GL_AMD_framebuffer_sample_positions
 
-#endif /* GL_AMD_gcn_shader */
+static GLboolean _glewInit_GL_AMD_framebuffer_sample_positions ()
+{
+  GLboolean r = GL_FALSE;
 
-#ifdef GL_AMD_gpu_shader_int64
+  r = ((glFramebufferSamplePositionsfvAMD = (PFNGLFRAMEBUFFERSAMPLEPOSITIONSFVAMDPROC)glewGetProcAddress((const GLubyte*)"glFramebufferSamplePositionsfvAMD")) == NULL) || r;
+  r = ((glGetFramebufferParameterfvAMD = (PFNGLGETFRAMEBUFFERPARAMETERFVAMDPROC)glewGetProcAddress((const GLubyte*)"glGetFramebufferParameterfvAMD")) == NULL) || r;
+  r = ((glGetNamedFramebufferParameterfvAMD = (PFNGLGETNAMEDFRAMEBUFFERPARAMETERFVAMDPROC)glewGetProcAddress((const GLubyte*)"glGetNamedFramebufferParameterfvAMD")) == NULL) || r;
+  r = ((glNamedFramebufferSamplePositionsfvAMD = (PFNGLNAMEDFRAMEBUFFERSAMPLEPOSITIONSFVAMDPROC)glewGetProcAddress((const GLubyte*)"glNamedFramebufferSamplePositionsfvAMD")) == NULL) || r;
 
-#endif /* GL_AMD_gpu_shader_int64 */
+  return r;
+}
+
+#endif /* GL_AMD_framebuffer_sample_positions */
 
 #ifdef GL_AMD_interleaved_elements
 
-static GLboolean _glewInit_GL_AMD_interleaved_elements (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_AMD_interleaved_elements ()
 {
   GLboolean r = GL_FALSE;
 
@@ -4010,7 +9783,7 @@ static GLboolean _glewInit_GL_AMD_interleaved_elements (GLEW_CONTEXT_ARG_DEF_INI
 
 #ifdef GL_AMD_multi_draw_indirect
 
-static GLboolean _glewInit_GL_AMD_multi_draw_indirect (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_AMD_multi_draw_indirect ()
 {
   GLboolean r = GL_FALSE;
 
@@ -4024,7 +9797,7 @@ static GLboolean _glewInit_GL_AMD_multi_draw_indirect (GLEW_CONTEXT_ARG_DEF_INIT
 
 #ifdef GL_AMD_name_gen_delete
 
-static GLboolean _glewInit_GL_AMD_name_gen_delete (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_AMD_name_gen_delete ()
 {
   GLboolean r = GL_FALSE;
 
@@ -4039,7 +9812,7 @@ static GLboolean _glewInit_GL_AMD_name_gen_delete (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_AMD_occlusion_query_event
 
-static GLboolean _glewInit_GL_AMD_occlusion_query_event (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_AMD_occlusion_query_event ()
 {
   GLboolean r = GL_FALSE;
 
@@ -4052,7 +9825,7 @@ static GLboolean _glewInit_GL_AMD_occlusion_query_event (GLEW_CONTEXT_ARG_DEF_IN
 
 #ifdef GL_AMD_performance_monitor
 
-static GLboolean _glewInit_GL_AMD_performance_monitor (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_AMD_performance_monitor ()
 {
   GLboolean r = GL_FALSE;
 
@@ -4073,17 +9846,9 @@ static GLboolean _glewInit_GL_AMD_performance_monitor (GLEW_CONTEXT_ARG_DEF_INIT
 
 #endif /* GL_AMD_performance_monitor */
 
-#ifdef GL_AMD_pinned_memory
-
-#endif /* GL_AMD_pinned_memory */
-
-#ifdef GL_AMD_query_buffer_object
-
-#endif /* GL_AMD_query_buffer_object */
-
 #ifdef GL_AMD_sample_positions
 
-static GLboolean _glewInit_GL_AMD_sample_positions (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_AMD_sample_positions ()
 {
   GLboolean r = GL_FALSE;
 
@@ -4094,29 +9859,9 @@ static GLboolean _glewInit_GL_AMD_sample_positions (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_AMD_sample_positions */
 
-#ifdef GL_AMD_seamless_cubemap_per_texture
-
-#endif /* GL_AMD_seamless_cubemap_per_texture */
-
-#ifdef GL_AMD_shader_atomic_counter_ops
-
-#endif /* GL_AMD_shader_atomic_counter_ops */
-
-#ifdef GL_AMD_shader_stencil_export
-
-#endif /* GL_AMD_shader_stencil_export */
-
-#ifdef GL_AMD_shader_stencil_value_export
-
-#endif /* GL_AMD_shader_stencil_value_export */
-
-#ifdef GL_AMD_shader_trinary_minmax
-
-#endif /* GL_AMD_shader_trinary_minmax */
-
 #ifdef GL_AMD_sparse_texture
 
-static GLboolean _glewInit_GL_AMD_sparse_texture (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_AMD_sparse_texture ()
 {
   GLboolean r = GL_FALSE;
 
@@ -4130,7 +9875,7 @@ static GLboolean _glewInit_GL_AMD_sparse_texture (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_AMD_stencil_operation_extended
 
-static GLboolean _glewInit_GL_AMD_stencil_operation_extended (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_AMD_stencil_operation_extended ()
 {
   GLboolean r = GL_FALSE;
 
@@ -4141,25 +9886,9 @@ static GLboolean _glewInit_GL_AMD_stencil_operation_extended (GLEW_CONTEXT_ARG_D
 
 #endif /* GL_AMD_stencil_operation_extended */
 
-#ifdef GL_AMD_texture_texture4
-
-#endif /* GL_AMD_texture_texture4 */
-
-#ifdef GL_AMD_transform_feedback3_lines_triangles
-
-#endif /* GL_AMD_transform_feedback3_lines_triangles */
-
-#ifdef GL_AMD_transform_feedback4
-
-#endif /* GL_AMD_transform_feedback4 */
-
-#ifdef GL_AMD_vertex_shader_layer
-
-#endif /* GL_AMD_vertex_shader_layer */
-
 #ifdef GL_AMD_vertex_shader_tessellator
 
-static GLboolean _glewInit_GL_AMD_vertex_shader_tessellator (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_AMD_vertex_shader_tessellator ()
 {
   GLboolean r = GL_FALSE;
 
@@ -4171,17 +9900,9 @@ static GLboolean _glewInit_GL_AMD_vertex_shader_tessellator (GLEW_CONTEXT_ARG_DE
 
 #endif /* GL_AMD_vertex_shader_tessellator */
 
-#ifdef GL_AMD_vertex_shader_viewport_index
-
-#endif /* GL_AMD_vertex_shader_viewport_index */
-
-#ifdef GL_ANGLE_depth_texture
-
-#endif /* GL_ANGLE_depth_texture */
-
 #ifdef GL_ANGLE_framebuffer_blit
 
-static GLboolean _glewInit_GL_ANGLE_framebuffer_blit (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ANGLE_framebuffer_blit ()
 {
   GLboolean r = GL_FALSE;
 
@@ -4194,7 +9915,7 @@ static GLboolean _glewInit_GL_ANGLE_framebuffer_blit (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_ANGLE_framebuffer_multisample
 
-static GLboolean _glewInit_GL_ANGLE_framebuffer_multisample (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ANGLE_framebuffer_multisample ()
 {
   GLboolean r = GL_FALSE;
 
@@ -4207,7 +9928,7 @@ static GLboolean _glewInit_GL_ANGLE_framebuffer_multisample (GLEW_CONTEXT_ARG_DE
 
 #ifdef GL_ANGLE_instanced_arrays
 
-static GLboolean _glewInit_GL_ANGLE_instanced_arrays (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ANGLE_instanced_arrays ()
 {
   GLboolean r = GL_FALSE;
 
@@ -4220,33 +9941,9 @@ static GLboolean _glewInit_GL_ANGLE_instanced_arrays (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_ANGLE_instanced_arrays */
 
-#ifdef GL_ANGLE_pack_reverse_row_order
-
-#endif /* GL_ANGLE_pack_reverse_row_order */
-
-#ifdef GL_ANGLE_program_binary
-
-#endif /* GL_ANGLE_program_binary */
-
-#ifdef GL_ANGLE_texture_compression_dxt1
-
-#endif /* GL_ANGLE_texture_compression_dxt1 */
-
-#ifdef GL_ANGLE_texture_compression_dxt3
-
-#endif /* GL_ANGLE_texture_compression_dxt3 */
-
-#ifdef GL_ANGLE_texture_compression_dxt5
-
-#endif /* GL_ANGLE_texture_compression_dxt5 */
-
-#ifdef GL_ANGLE_texture_usage
-
-#endif /* GL_ANGLE_texture_usage */
-
 #ifdef GL_ANGLE_timer_query
 
-static GLboolean _glewInit_GL_ANGLE_timer_query (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ANGLE_timer_query ()
 {
   GLboolean r = GL_FALSE;
 
@@ -4269,7 +9966,7 @@ static GLboolean _glewInit_GL_ANGLE_timer_query (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_ANGLE_translated_shader_source
 
-static GLboolean _glewInit_GL_ANGLE_translated_shader_source (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ANGLE_translated_shader_source ()
 {
   GLboolean r = GL_FALSE;
 
@@ -4280,17 +9977,22 @@ static GLboolean _glewInit_GL_ANGLE_translated_shader_source (GLEW_CONTEXT_ARG_D
 
 #endif /* GL_ANGLE_translated_shader_source */
 
-#ifdef GL_APPLE_aux_depth_stencil
+#ifdef GL_APPLE_copy_texture_levels
 
-#endif /* GL_APPLE_aux_depth_stencil */
+static GLboolean _glewInit_GL_APPLE_copy_texture_levels ()
+{
+  GLboolean r = GL_FALSE;
 
-#ifdef GL_APPLE_client_storage
+  r = ((glCopyTextureLevelsAPPLE = (PFNGLCOPYTEXTURELEVELSAPPLEPROC)glewGetProcAddress((const GLubyte*)"glCopyTextureLevelsAPPLE")) == NULL) || r;
 
-#endif /* GL_APPLE_client_storage */
+  return r;
+}
+
+#endif /* GL_APPLE_copy_texture_levels */
 
 #ifdef GL_APPLE_element_array
 
-static GLboolean _glewInit_GL_APPLE_element_array (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_APPLE_element_array ()
 {
   GLboolean r = GL_FALSE;
 
@@ -4307,7 +10009,7 @@ static GLboolean _glewInit_GL_APPLE_element_array (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_APPLE_fence
 
-static GLboolean _glewInit_GL_APPLE_fence (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_APPLE_fence ()
 {
   GLboolean r = GL_FALSE;
 
@@ -4325,13 +10027,9 @@ static GLboolean _glewInit_GL_APPLE_fence (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_APPLE_fence */
 
-#ifdef GL_APPLE_float_pixels
-
-#endif /* GL_APPLE_float_pixels */
-
 #ifdef GL_APPLE_flush_buffer_range
 
-static GLboolean _glewInit_GL_APPLE_flush_buffer_range (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_APPLE_flush_buffer_range ()
 {
   GLboolean r = GL_FALSE;
 
@@ -4343,9 +10041,23 @@ static GLboolean _glewInit_GL_APPLE_flush_buffer_range (GLEW_CONTEXT_ARG_DEF_INI
 
 #endif /* GL_APPLE_flush_buffer_range */
 
+#ifdef GL_APPLE_framebuffer_multisample
+
+static GLboolean _glewInit_GL_APPLE_framebuffer_multisample ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glRenderbufferStorageMultisampleAPPLE = (PFNGLRENDERBUFFERSTORAGEMULTISAMPLEAPPLEPROC)glewGetProcAddress((const GLubyte*)"glRenderbufferStorageMultisampleAPPLE")) == NULL) || r;
+  r = ((glResolveMultisampleFramebufferAPPLE = (PFNGLRESOLVEMULTISAMPLEFRAMEBUFFERAPPLEPROC)glewGetProcAddress((const GLubyte*)"glResolveMultisampleFramebufferAPPLE")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_APPLE_framebuffer_multisample */
+
 #ifdef GL_APPLE_object_purgeable
 
-static GLboolean _glewInit_GL_APPLE_object_purgeable (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_APPLE_object_purgeable ()
 {
   GLboolean r = GL_FALSE;
 
@@ -4358,25 +10070,28 @@ static GLboolean _glewInit_GL_APPLE_object_purgeable (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_APPLE_object_purgeable */
 
-#ifdef GL_APPLE_pixel_buffer
+#ifdef GL_APPLE_sync
 
-#endif /* GL_APPLE_pixel_buffer */
+static GLboolean _glewInit_GL_APPLE_sync ()
+{
+  GLboolean r = GL_FALSE;
 
-#ifdef GL_APPLE_rgb_422
+  r = ((glClientWaitSyncAPPLE = (PFNGLCLIENTWAITSYNCAPPLEPROC)glewGetProcAddress((const GLubyte*)"glClientWaitSyncAPPLE")) == NULL) || r;
+  r = ((glDeleteSyncAPPLE = (PFNGLDELETESYNCAPPLEPROC)glewGetProcAddress((const GLubyte*)"glDeleteSyncAPPLE")) == NULL) || r;
+  r = ((glFenceSyncAPPLE = (PFNGLFENCESYNCAPPLEPROC)glewGetProcAddress((const GLubyte*)"glFenceSyncAPPLE")) == NULL) || r;
+  r = ((glGetInteger64vAPPLE = (PFNGLGETINTEGER64VAPPLEPROC)glewGetProcAddress((const GLubyte*)"glGetInteger64vAPPLE")) == NULL) || r;
+  r = ((glGetSyncivAPPLE = (PFNGLGETSYNCIVAPPLEPROC)glewGetProcAddress((const GLubyte*)"glGetSyncivAPPLE")) == NULL) || r;
+  r = ((glIsSyncAPPLE = (PFNGLISSYNCAPPLEPROC)glewGetProcAddress((const GLubyte*)"glIsSyncAPPLE")) == NULL) || r;
+  r = ((glWaitSyncAPPLE = (PFNGLWAITSYNCAPPLEPROC)glewGetProcAddress((const GLubyte*)"glWaitSyncAPPLE")) == NULL) || r;
 
-#endif /* GL_APPLE_rgb_422 */
+  return r;
+}
 
-#ifdef GL_APPLE_row_bytes
-
-#endif /* GL_APPLE_row_bytes */
-
-#ifdef GL_APPLE_specular_vector
-
-#endif /* GL_APPLE_specular_vector */
+#endif /* GL_APPLE_sync */
 
 #ifdef GL_APPLE_texture_range
 
-static GLboolean _glewInit_GL_APPLE_texture_range (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_APPLE_texture_range ()
 {
   GLboolean r = GL_FALSE;
 
@@ -4388,13 +10103,9 @@ static GLboolean _glewInit_GL_APPLE_texture_range (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_APPLE_texture_range */
 
-#ifdef GL_APPLE_transform_hint
-
-#endif /* GL_APPLE_transform_hint */
-
 #ifdef GL_APPLE_vertex_array_object
 
-static GLboolean _glewInit_GL_APPLE_vertex_array_object (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_APPLE_vertex_array_object ()
 {
   GLboolean r = GL_FALSE;
 
@@ -4410,7 +10121,7 @@ static GLboolean _glewInit_GL_APPLE_vertex_array_object (GLEW_CONTEXT_ARG_DEF_IN
 
 #ifdef GL_APPLE_vertex_array_range
 
-static GLboolean _glewInit_GL_APPLE_vertex_array_range (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_APPLE_vertex_array_range ()
 {
   GLboolean r = GL_FALSE;
 
@@ -4425,7 +10136,7 @@ static GLboolean _glewInit_GL_APPLE_vertex_array_range (GLEW_CONTEXT_ARG_DEF_INI
 
 #ifdef GL_APPLE_vertex_program_evaluators
 
-static GLboolean _glewInit_GL_APPLE_vertex_program_evaluators (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_APPLE_vertex_program_evaluators ()
 {
   GLboolean r = GL_FALSE;
 
@@ -4442,13 +10153,9 @@ static GLboolean _glewInit_GL_APPLE_vertex_program_evaluators (GLEW_CONTEXT_ARG_
 
 #endif /* GL_APPLE_vertex_program_evaluators */
 
-#ifdef GL_APPLE_ycbcr_422
-
-#endif /* GL_APPLE_ycbcr_422 */
-
 #ifdef GL_ARB_ES2_compatibility
 
-static GLboolean _glewInit_GL_ARB_ES2_compatibility (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_ES2_compatibility ()
 {
   GLboolean r = GL_FALSE;
 
@@ -4465,7 +10172,7 @@ static GLboolean _glewInit_GL_ARB_ES2_compatibility (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_ARB_ES3_1_compatibility
 
-static GLboolean _glewInit_GL_ARB_ES3_1_compatibility (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_ES3_1_compatibility ()
 {
   GLboolean r = GL_FALSE;
 
@@ -4476,17 +10183,22 @@ static GLboolean _glewInit_GL_ARB_ES3_1_compatibility (GLEW_CONTEXT_ARG_DEF_INIT
 
 #endif /* GL_ARB_ES3_1_compatibility */
 
-#ifdef GL_ARB_ES3_compatibility
+#ifdef GL_ARB_ES3_2_compatibility
 
-#endif /* GL_ARB_ES3_compatibility */
+static GLboolean _glewInit_GL_ARB_ES3_2_compatibility ()
+{
+  GLboolean r = GL_FALSE;
 
-#ifdef GL_ARB_arrays_of_arrays
+  r = ((glPrimitiveBoundingBoxARB = (PFNGLPRIMITIVEBOUNDINGBOXARBPROC)glewGetProcAddress((const GLubyte*)"glPrimitiveBoundingBoxARB")) == NULL) || r;
 
-#endif /* GL_ARB_arrays_of_arrays */
+  return r;
+}
+
+#endif /* GL_ARB_ES3_2_compatibility */
 
 #ifdef GL_ARB_base_instance
 
-static GLboolean _glewInit_GL_ARB_base_instance (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_base_instance ()
 {
   GLboolean r = GL_FALSE;
 
@@ -4501,7 +10213,7 @@ static GLboolean _glewInit_GL_ARB_base_instance (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_ARB_bindless_texture
 
-static GLboolean _glewInit_GL_ARB_bindless_texture (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_bindless_texture ()
 {
   GLboolean r = GL_FALSE;
 
@@ -4529,7 +10241,7 @@ static GLboolean _glewInit_GL_ARB_bindless_texture (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_ARB_blend_func_extended
 
-static GLboolean _glewInit_GL_ARB_blend_func_extended (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_blend_func_extended ()
 {
   GLboolean r = GL_FALSE;
 
@@ -4543,12 +10255,11 @@ static GLboolean _glewInit_GL_ARB_blend_func_extended (GLEW_CONTEXT_ARG_DEF_INIT
 
 #ifdef GL_ARB_buffer_storage
 
-static GLboolean _glewInit_GL_ARB_buffer_storage (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_buffer_storage ()
 {
   GLboolean r = GL_FALSE;
 
   r = ((glBufferStorage = (PFNGLBUFFERSTORAGEPROC)glewGetProcAddress((const GLubyte*)"glBufferStorage")) == NULL) || r;
-  r = ((glNamedBufferStorageEXT = (PFNGLNAMEDBUFFERSTORAGEEXTPROC)glewGetProcAddress((const GLubyte*)"glNamedBufferStorageEXT")) == NULL) || r;
 
   return r;
 }
@@ -4557,7 +10268,7 @@ static GLboolean _glewInit_GL_ARB_buffer_storage (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_ARB_cl_event
 
-static GLboolean _glewInit_GL_ARB_cl_event (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_cl_event ()
 {
   GLboolean r = GL_FALSE;
 
@@ -4570,7 +10281,7 @@ static GLboolean _glewInit_GL_ARB_cl_event (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_ARB_clear_buffer_object
 
-static GLboolean _glewInit_GL_ARB_clear_buffer_object (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_clear_buffer_object ()
 {
   GLboolean r = GL_FALSE;
 
@@ -4586,7 +10297,7 @@ static GLboolean _glewInit_GL_ARB_clear_buffer_object (GLEW_CONTEXT_ARG_DEF_INIT
 
 #ifdef GL_ARB_clear_texture
 
-static GLboolean _glewInit_GL_ARB_clear_texture (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_clear_texture ()
 {
   GLboolean r = GL_FALSE;
 
@@ -4600,7 +10311,7 @@ static GLboolean _glewInit_GL_ARB_clear_texture (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_ARB_clip_control
 
-static GLboolean _glewInit_GL_ARB_clip_control (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_clip_control ()
 {
   GLboolean r = GL_FALSE;
 
@@ -4613,7 +10324,7 @@ static GLboolean _glewInit_GL_ARB_clip_control (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_ARB_color_buffer_float
 
-static GLboolean _glewInit_GL_ARB_color_buffer_float (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_color_buffer_float ()
 {
   GLboolean r = GL_FALSE;
 
@@ -4624,17 +10335,9 @@ static GLboolean _glewInit_GL_ARB_color_buffer_float (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_ARB_color_buffer_float */
 
-#ifdef GL_ARB_compatibility
-
-#endif /* GL_ARB_compatibility */
-
-#ifdef GL_ARB_compressed_texture_pixel_storage
-
-#endif /* GL_ARB_compressed_texture_pixel_storage */
-
 #ifdef GL_ARB_compute_shader
 
-static GLboolean _glewInit_GL_ARB_compute_shader (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_compute_shader ()
 {
   GLboolean r = GL_FALSE;
 
@@ -4648,7 +10351,7 @@ static GLboolean _glewInit_GL_ARB_compute_shader (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_ARB_compute_variable_group_size
 
-static GLboolean _glewInit_GL_ARB_compute_variable_group_size (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_compute_variable_group_size ()
 {
   GLboolean r = GL_FALSE;
 
@@ -4659,17 +10362,9 @@ static GLboolean _glewInit_GL_ARB_compute_variable_group_size (GLEW_CONTEXT_ARG_
 
 #endif /* GL_ARB_compute_variable_group_size */
 
-#ifdef GL_ARB_conditional_render_inverted
-
-#endif /* GL_ARB_conditional_render_inverted */
-
-#ifdef GL_ARB_conservative_depth
-
-#endif /* GL_ARB_conservative_depth */
-
 #ifdef GL_ARB_copy_buffer
 
-static GLboolean _glewInit_GL_ARB_copy_buffer (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_copy_buffer ()
 {
   GLboolean r = GL_FALSE;
 
@@ -4682,7 +10377,7 @@ static GLboolean _glewInit_GL_ARB_copy_buffer (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_ARB_copy_image
 
-static GLboolean _glewInit_GL_ARB_copy_image (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_copy_image ()
 {
   GLboolean r = GL_FALSE;
 
@@ -4693,13 +10388,9 @@ static GLboolean _glewInit_GL_ARB_copy_image (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_ARB_copy_image */
 
-#ifdef GL_ARB_cull_distance
-
-#endif /* GL_ARB_cull_distance */
-
 #ifdef GL_ARB_debug_output
 
-static GLboolean _glewInit_GL_ARB_debug_output (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_debug_output ()
 {
   GLboolean r = GL_FALSE;
 
@@ -4713,25 +10404,9 @@ static GLboolean _glewInit_GL_ARB_debug_output (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_ARB_debug_output */
 
-#ifdef GL_ARB_depth_buffer_float
-
-#endif /* GL_ARB_depth_buffer_float */
-
-#ifdef GL_ARB_depth_clamp
-
-#endif /* GL_ARB_depth_clamp */
-
-#ifdef GL_ARB_depth_texture
-
-#endif /* GL_ARB_depth_texture */
-
-#ifdef GL_ARB_derivative_control
-
-#endif /* GL_ARB_derivative_control */
-
 #ifdef GL_ARB_direct_state_access
 
-static GLboolean _glewInit_GL_ARB_direct_state_access (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_direct_state_access ()
 {
   GLboolean r = GL_FALSE;
 
@@ -4772,6 +10447,10 @@ static GLboolean _glewInit_GL_ARB_direct_state_access (GLEW_CONTEXT_ARG_DEF_INIT
   r = ((glGetNamedFramebufferAttachmentParameteriv = (PFNGLGETNAMEDFRAMEBUFFERATTACHMENTPARAMETERIVPROC)glewGetProcAddress((const GLubyte*)"glGetNamedFramebufferAttachmentParameteriv")) == NULL) || r;
   r = ((glGetNamedFramebufferParameteriv = (PFNGLGETNAMEDFRAMEBUFFERPARAMETERIVPROC)glewGetProcAddress((const GLubyte*)"glGetNamedFramebufferParameteriv")) == NULL) || r;
   r = ((glGetNamedRenderbufferParameteriv = (PFNGLGETNAMEDRENDERBUFFERPARAMETERIVPROC)glewGetProcAddress((const GLubyte*)"glGetNamedRenderbufferParameteriv")) == NULL) || r;
+  r = ((glGetQueryBufferObjecti64v = (PFNGLGETQUERYBUFFEROBJECTI64VPROC)glewGetProcAddress((const GLubyte*)"glGetQueryBufferObjecti64v")) == NULL) || r;
+  r = ((glGetQueryBufferObjectiv = (PFNGLGETQUERYBUFFEROBJECTIVPROC)glewGetProcAddress((const GLubyte*)"glGetQueryBufferObjectiv")) == NULL) || r;
+  r = ((glGetQueryBufferObjectui64v = (PFNGLGETQUERYBUFFEROBJECTUI64VPROC)glewGetProcAddress((const GLubyte*)"glGetQueryBufferObjectui64v")) == NULL) || r;
+  r = ((glGetQueryBufferObjectuiv = (PFNGLGETQUERYBUFFEROBJECTUIVPROC)glewGetProcAddress((const GLubyte*)"glGetQueryBufferObjectuiv")) == NULL) || r;
   r = ((glGetTextureImage = (PFNGLGETTEXTUREIMAGEPROC)glewGetProcAddress((const GLubyte*)"glGetTextureImage")) == NULL) || r;
   r = ((glGetTextureLevelParameterfv = (PFNGLGETTEXTURELEVELPARAMETERFVPROC)glewGetProcAddress((const GLubyte*)"glGetTextureLevelParameterfv")) == NULL) || r;
   r = ((glGetTextureLevelParameteriv = (PFNGLGETTEXTURELEVELPARAMETERIVPROC)glewGetProcAddress((const GLubyte*)"glGetTextureLevelParameteriv")) == NULL) || r;
@@ -4836,7 +10515,7 @@ static GLboolean _glewInit_GL_ARB_direct_state_access (GLEW_CONTEXT_ARG_DEF_INIT
 
 #ifdef GL_ARB_draw_buffers
 
-static GLboolean _glewInit_GL_ARB_draw_buffers (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_draw_buffers ()
 {
   GLboolean r = GL_FALSE;
 
@@ -4849,7 +10528,7 @@ static GLboolean _glewInit_GL_ARB_draw_buffers (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_ARB_draw_buffers_blend
 
-static GLboolean _glewInit_GL_ARB_draw_buffers_blend (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_draw_buffers_blend ()
 {
   GLboolean r = GL_FALSE;
 
@@ -4865,7 +10544,7 @@ static GLboolean _glewInit_GL_ARB_draw_buffers_blend (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_ARB_draw_elements_base_vertex
 
-static GLboolean _glewInit_GL_ARB_draw_elements_base_vertex (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_draw_elements_base_vertex ()
 {
   GLboolean r = GL_FALSE;
 
@@ -4881,7 +10560,7 @@ static GLboolean _glewInit_GL_ARB_draw_elements_base_vertex (GLEW_CONTEXT_ARG_DE
 
 #ifdef GL_ARB_draw_indirect
 
-static GLboolean _glewInit_GL_ARB_draw_indirect (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_draw_indirect ()
 {
   GLboolean r = GL_FALSE;
 
@@ -4893,45 +10572,9 @@ static GLboolean _glewInit_GL_ARB_draw_indirect (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_ARB_draw_indirect */
 
-#ifdef GL_ARB_draw_instanced
-
-#endif /* GL_ARB_draw_instanced */
-
-#ifdef GL_ARB_enhanced_layouts
-
-#endif /* GL_ARB_enhanced_layouts */
-
-#ifdef GL_ARB_explicit_attrib_location
-
-#endif /* GL_ARB_explicit_attrib_location */
-
-#ifdef GL_ARB_explicit_uniform_location
-
-#endif /* GL_ARB_explicit_uniform_location */
-
-#ifdef GL_ARB_fragment_coord_conventions
-
-#endif /* GL_ARB_fragment_coord_conventions */
-
-#ifdef GL_ARB_fragment_layer_viewport
-
-#endif /* GL_ARB_fragment_layer_viewport */
-
-#ifdef GL_ARB_fragment_program
-
-#endif /* GL_ARB_fragment_program */
-
-#ifdef GL_ARB_fragment_program_shadow
-
-#endif /* GL_ARB_fragment_program_shadow */
-
-#ifdef GL_ARB_fragment_shader
-
-#endif /* GL_ARB_fragment_shader */
-
 #ifdef GL_ARB_framebuffer_no_attachments
 
-static GLboolean _glewInit_GL_ARB_framebuffer_no_attachments (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_framebuffer_no_attachments ()
 {
   GLboolean r = GL_FALSE;
 
@@ -4947,7 +10590,7 @@ static GLboolean _glewInit_GL_ARB_framebuffer_no_attachments (GLEW_CONTEXT_ARG_D
 
 #ifdef GL_ARB_framebuffer_object
 
-static GLboolean _glewInit_GL_ARB_framebuffer_object (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_framebuffer_object ()
 {
   GLboolean r = GL_FALSE;
 
@@ -4977,13 +10620,9 @@ static GLboolean _glewInit_GL_ARB_framebuffer_object (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_ARB_framebuffer_object */
 
-#ifdef GL_ARB_framebuffer_sRGB
-
-#endif /* GL_ARB_framebuffer_sRGB */
-
 #ifdef GL_ARB_geometry_shader4
 
-static GLboolean _glewInit_GL_ARB_geometry_shader4 (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_geometry_shader4 ()
 {
   GLboolean r = GL_FALSE;
 
@@ -4999,7 +10638,7 @@ static GLboolean _glewInit_GL_ARB_geometry_shader4 (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_ARB_get_program_binary
 
-static GLboolean _glewInit_GL_ARB_get_program_binary (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_get_program_binary ()
 {
   GLboolean r = GL_FALSE;
 
@@ -5014,7 +10653,7 @@ static GLboolean _glewInit_GL_ARB_get_program_binary (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_ARB_get_texture_sub_image
 
-static GLboolean _glewInit_GL_ARB_get_texture_sub_image (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_get_texture_sub_image ()
 {
   GLboolean r = GL_FALSE;
 
@@ -5026,13 +10665,22 @@ static GLboolean _glewInit_GL_ARB_get_texture_sub_image (GLEW_CONTEXT_ARG_DEF_IN
 
 #endif /* GL_ARB_get_texture_sub_image */
 
-#ifdef GL_ARB_gpu_shader5
+#ifdef GL_ARB_gl_spirv
 
-#endif /* GL_ARB_gpu_shader5 */
+static GLboolean _glewInit_GL_ARB_gl_spirv ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glSpecializeShaderARB = (PFNGLSPECIALIZESHADERARBPROC)glewGetProcAddress((const GLubyte*)"glSpecializeShaderARB")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_ARB_gl_spirv */
 
 #ifdef GL_ARB_gpu_shader_fp64
 
-static GLboolean _glewInit_GL_ARB_gpu_shader_fp64 (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_gpu_shader_fp64 ()
 {
   GLboolean r = GL_FALSE;
 
@@ -5060,17 +10708,57 @@ static GLboolean _glewInit_GL_ARB_gpu_shader_fp64 (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_ARB_gpu_shader_fp64 */
 
-#ifdef GL_ARB_half_float_pixel
+#ifdef GL_ARB_gpu_shader_int64
 
-#endif /* GL_ARB_half_float_pixel */
+static GLboolean _glewInit_GL_ARB_gpu_shader_int64 ()
+{
+  GLboolean r = GL_FALSE;
 
-#ifdef GL_ARB_half_float_vertex
+  r = ((glGetUniformi64vARB = (PFNGLGETUNIFORMI64VARBPROC)glewGetProcAddress((const GLubyte*)"glGetUniformi64vARB")) == NULL) || r;
+  r = ((glGetUniformui64vARB = (PFNGLGETUNIFORMUI64VARBPROC)glewGetProcAddress((const GLubyte*)"glGetUniformui64vARB")) == NULL) || r;
+  r = ((glGetnUniformi64vARB = (PFNGLGETNUNIFORMI64VARBPROC)glewGetProcAddress((const GLubyte*)"glGetnUniformi64vARB")) == NULL) || r;
+  r = ((glGetnUniformui64vARB = (PFNGLGETNUNIFORMUI64VARBPROC)glewGetProcAddress((const GLubyte*)"glGetnUniformui64vARB")) == NULL) || r;
+  r = ((glProgramUniform1i64ARB = (PFNGLPROGRAMUNIFORM1I64ARBPROC)glewGetProcAddress((const GLubyte*)"glProgramUniform1i64ARB")) == NULL) || r;
+  r = ((glProgramUniform1i64vARB = (PFNGLPROGRAMUNIFORM1I64VARBPROC)glewGetProcAddress((const GLubyte*)"glProgramUniform1i64vARB")) == NULL) || r;
+  r = ((glProgramUniform1ui64ARB = (PFNGLPROGRAMUNIFORM1UI64ARBPROC)glewGetProcAddress((const GLubyte*)"glProgramUniform1ui64ARB")) == NULL) || r;
+  r = ((glProgramUniform1ui64vARB = (PFNGLPROGRAMUNIFORM1UI64VARBPROC)glewGetProcAddress((const GLubyte*)"glProgramUniform1ui64vARB")) == NULL) || r;
+  r = ((glProgramUniform2i64ARB = (PFNGLPROGRAMUNIFORM2I64ARBPROC)glewGetProcAddress((const GLubyte*)"glProgramUniform2i64ARB")) == NULL) || r;
+  r = ((glProgramUniform2i64vARB = (PFNGLPROGRAMUNIFORM2I64VARBPROC)glewGetProcAddress((const GLubyte*)"glProgramUniform2i64vARB")) == NULL) || r;
+  r = ((glProgramUniform2ui64ARB = (PFNGLPROGRAMUNIFORM2UI64ARBPROC)glewGetProcAddress((const GLubyte*)"glProgramUniform2ui64ARB")) == NULL) || r;
+  r = ((glProgramUniform2ui64vARB = (PFNGLPROGRAMUNIFORM2UI64VARBPROC)glewGetProcAddress((const GLubyte*)"glProgramUniform2ui64vARB")) == NULL) || r;
+  r = ((glProgramUniform3i64ARB = (PFNGLPROGRAMUNIFORM3I64ARBPROC)glewGetProcAddress((const GLubyte*)"glProgramUniform3i64ARB")) == NULL) || r;
+  r = ((glProgramUniform3i64vARB = (PFNGLPROGRAMUNIFORM3I64VARBPROC)glewGetProcAddress((const GLubyte*)"glProgramUniform3i64vARB")) == NULL) || r;
+  r = ((glProgramUniform3ui64ARB = (PFNGLPROGRAMUNIFORM3UI64ARBPROC)glewGetProcAddress((const GLubyte*)"glProgramUniform3ui64ARB")) == NULL) || r;
+  r = ((glProgramUniform3ui64vARB = (PFNGLPROGRAMUNIFORM3UI64VARBPROC)glewGetProcAddress((const GLubyte*)"glProgramUniform3ui64vARB")) == NULL) || r;
+  r = ((glProgramUniform4i64ARB = (PFNGLPROGRAMUNIFORM4I64ARBPROC)glewGetProcAddress((const GLubyte*)"glProgramUniform4i64ARB")) == NULL) || r;
+  r = ((glProgramUniform4i64vARB = (PFNGLPROGRAMUNIFORM4I64VARBPROC)glewGetProcAddress((const GLubyte*)"glProgramUniform4i64vARB")) == NULL) || r;
+  r = ((glProgramUniform4ui64ARB = (PFNGLPROGRAMUNIFORM4UI64ARBPROC)glewGetProcAddress((const GLubyte*)"glProgramUniform4ui64ARB")) == NULL) || r;
+  r = ((glProgramUniform4ui64vARB = (PFNGLPROGRAMUNIFORM4UI64VARBPROC)glewGetProcAddress((const GLubyte*)"glProgramUniform4ui64vARB")) == NULL) || r;
+  r = ((glUniform1i64ARB = (PFNGLUNIFORM1I64ARBPROC)glewGetProcAddress((const GLubyte*)"glUniform1i64ARB")) == NULL) || r;
+  r = ((glUniform1i64vARB = (PFNGLUNIFORM1I64VARBPROC)glewGetProcAddress((const GLubyte*)"glUniform1i64vARB")) == NULL) || r;
+  r = ((glUniform1ui64ARB = (PFNGLUNIFORM1UI64ARBPROC)glewGetProcAddress((const GLubyte*)"glUniform1ui64ARB")) == NULL) || r;
+  r = ((glUniform1ui64vARB = (PFNGLUNIFORM1UI64VARBPROC)glewGetProcAddress((const GLubyte*)"glUniform1ui64vARB")) == NULL) || r;
+  r = ((glUniform2i64ARB = (PFNGLUNIFORM2I64ARBPROC)glewGetProcAddress((const GLubyte*)"glUniform2i64ARB")) == NULL) || r;
+  r = ((glUniform2i64vARB = (PFNGLUNIFORM2I64VARBPROC)glewGetProcAddress((const GLubyte*)"glUniform2i64vARB")) == NULL) || r;
+  r = ((glUniform2ui64ARB = (PFNGLUNIFORM2UI64ARBPROC)glewGetProcAddress((const GLubyte*)"glUniform2ui64ARB")) == NULL) || r;
+  r = ((glUniform2ui64vARB = (PFNGLUNIFORM2UI64VARBPROC)glewGetProcAddress((const GLubyte*)"glUniform2ui64vARB")) == NULL) || r;
+  r = ((glUniform3i64ARB = (PFNGLUNIFORM3I64ARBPROC)glewGetProcAddress((const GLubyte*)"glUniform3i64ARB")) == NULL) || r;
+  r = ((glUniform3i64vARB = (PFNGLUNIFORM3I64VARBPROC)glewGetProcAddress((const GLubyte*)"glUniform3i64vARB")) == NULL) || r;
+  r = ((glUniform3ui64ARB = (PFNGLUNIFORM3UI64ARBPROC)glewGetProcAddress((const GLubyte*)"glUniform3ui64ARB")) == NULL) || r;
+  r = ((glUniform3ui64vARB = (PFNGLUNIFORM3UI64VARBPROC)glewGetProcAddress((const GLubyte*)"glUniform3ui64vARB")) == NULL) || r;
+  r = ((glUniform4i64ARB = (PFNGLUNIFORM4I64ARBPROC)glewGetProcAddress((const GLubyte*)"glUniform4i64ARB")) == NULL) || r;
+  r = ((glUniform4i64vARB = (PFNGLUNIFORM4I64VARBPROC)glewGetProcAddress((const GLubyte*)"glUniform4i64vARB")) == NULL) || r;
+  r = ((glUniform4ui64ARB = (PFNGLUNIFORM4UI64ARBPROC)glewGetProcAddress((const GLubyte*)"glUniform4ui64ARB")) == NULL) || r;
+  r = ((glUniform4ui64vARB = (PFNGLUNIFORM4UI64VARBPROC)glewGetProcAddress((const GLubyte*)"glUniform4ui64vARB")) == NULL) || r;
 
-#endif /* GL_ARB_half_float_vertex */
+  return r;
+}
+
+#endif /* GL_ARB_gpu_shader_int64 */
 
 #ifdef GL_ARB_imaging
 
-static GLboolean _glewInit_GL_ARB_imaging (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_imaging ()
 {
   GLboolean r = GL_FALSE;
 
@@ -5115,7 +10803,7 @@ static GLboolean _glewInit_GL_ARB_imaging (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_ARB_indirect_parameters
 
-static GLboolean _glewInit_GL_ARB_indirect_parameters (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_indirect_parameters ()
 {
   GLboolean r = GL_FALSE;
 
@@ -5129,7 +10817,7 @@ static GLboolean _glewInit_GL_ARB_indirect_parameters (GLEW_CONTEXT_ARG_DEF_INIT
 
 #ifdef GL_ARB_instanced_arrays
 
-static GLboolean _glewInit_GL_ARB_instanced_arrays (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_instanced_arrays ()
 {
   GLboolean r = GL_FALSE;
 
@@ -5144,7 +10832,7 @@ static GLboolean _glewInit_GL_ARB_instanced_arrays (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_ARB_internalformat_query
 
-static GLboolean _glewInit_GL_ARB_internalformat_query (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_internalformat_query ()
 {
   GLboolean r = GL_FALSE;
 
@@ -5157,7 +10845,7 @@ static GLboolean _glewInit_GL_ARB_internalformat_query (GLEW_CONTEXT_ARG_DEF_INI
 
 #ifdef GL_ARB_internalformat_query2
 
-static GLboolean _glewInit_GL_ARB_internalformat_query2 (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_internalformat_query2 ()
 {
   GLboolean r = GL_FALSE;
 
@@ -5170,7 +10858,7 @@ static GLboolean _glewInit_GL_ARB_internalformat_query2 (GLEW_CONTEXT_ARG_DEF_IN
 
 #ifdef GL_ARB_invalidate_subdata
 
-static GLboolean _glewInit_GL_ARB_invalidate_subdata (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_invalidate_subdata ()
 {
   GLboolean r = GL_FALSE;
 
@@ -5186,13 +10874,9 @@ static GLboolean _glewInit_GL_ARB_invalidate_subdata (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_ARB_invalidate_subdata */
 
-#ifdef GL_ARB_map_buffer_alignment
-
-#endif /* GL_ARB_map_buffer_alignment */
-
 #ifdef GL_ARB_map_buffer_range
 
-static GLboolean _glewInit_GL_ARB_map_buffer_range (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_map_buffer_range ()
 {
   GLboolean r = GL_FALSE;
 
@@ -5206,7 +10890,7 @@ static GLboolean _glewInit_GL_ARB_map_buffer_range (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_ARB_matrix_palette
 
-static GLboolean _glewInit_GL_ARB_matrix_palette (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_matrix_palette ()
 {
   GLboolean r = GL_FALSE;
 
@@ -5223,7 +10907,7 @@ static GLboolean _glewInit_GL_ARB_matrix_palette (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_ARB_multi_bind
 
-static GLboolean _glewInit_GL_ARB_multi_bind (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_multi_bind ()
 {
   GLboolean r = GL_FALSE;
 
@@ -5241,7 +10925,7 @@ static GLboolean _glewInit_GL_ARB_multi_bind (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_ARB_multi_draw_indirect
 
-static GLboolean _glewInit_GL_ARB_multi_draw_indirect (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_multi_draw_indirect ()
 {
   GLboolean r = GL_FALSE;
 
@@ -5255,7 +10939,7 @@ static GLboolean _glewInit_GL_ARB_multi_draw_indirect (GLEW_CONTEXT_ARG_DEF_INIT
 
 #ifdef GL_ARB_multisample
 
-static GLboolean _glewInit_GL_ARB_multisample (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_multisample ()
 {
   GLboolean r = GL_FALSE;
 
@@ -5268,7 +10952,7 @@ static GLboolean _glewInit_GL_ARB_multisample (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_ARB_multitexture
 
-static GLboolean _glewInit_GL_ARB_multitexture (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_multitexture ()
 {
   GLboolean r = GL_FALSE;
 
@@ -5314,7 +10998,7 @@ static GLboolean _glewInit_GL_ARB_multitexture (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_ARB_occlusion_query
 
-static GLboolean _glewInit_GL_ARB_occlusion_query (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_occlusion_query ()
 {
   GLboolean r = GL_FALSE;
 
@@ -5332,21 +11016,22 @@ static GLboolean _glewInit_GL_ARB_occlusion_query (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_ARB_occlusion_query */
 
-#ifdef GL_ARB_occlusion_query2
+#ifdef GL_ARB_parallel_shader_compile
 
-#endif /* GL_ARB_occlusion_query2 */
+static GLboolean _glewInit_GL_ARB_parallel_shader_compile ()
+{
+  GLboolean r = GL_FALSE;
 
-#ifdef GL_ARB_pipeline_statistics_query
+  r = ((glMaxShaderCompilerThreadsARB = (PFNGLMAXSHADERCOMPILERTHREADSARBPROC)glewGetProcAddress((const GLubyte*)"glMaxShaderCompilerThreadsARB")) == NULL) || r;
 
-#endif /* GL_ARB_pipeline_statistics_query */
+  return r;
+}
 
-#ifdef GL_ARB_pixel_buffer_object
-
-#endif /* GL_ARB_pixel_buffer_object */
+#endif /* GL_ARB_parallel_shader_compile */
 
 #ifdef GL_ARB_point_parameters
 
-static GLboolean _glewInit_GL_ARB_point_parameters (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_point_parameters ()
 {
   GLboolean r = GL_FALSE;
 
@@ -5358,13 +11043,22 @@ static GLboolean _glewInit_GL_ARB_point_parameters (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_ARB_point_parameters */
 
-#ifdef GL_ARB_point_sprite
+#ifdef GL_ARB_polygon_offset_clamp
 
-#endif /* GL_ARB_point_sprite */
+static GLboolean _glewInit_GL_ARB_polygon_offset_clamp ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glPolygonOffsetClamp = (PFNGLPOLYGONOFFSETCLAMPPROC)glewGetProcAddress((const GLubyte*)"glPolygonOffsetClamp")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_ARB_polygon_offset_clamp */
 
 #ifdef GL_ARB_program_interface_query
 
-static GLboolean _glewInit_GL_ARB_program_interface_query (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_program_interface_query ()
 {
   GLboolean r = GL_FALSE;
 
@@ -5382,7 +11076,7 @@ static GLboolean _glewInit_GL_ARB_program_interface_query (GLEW_CONTEXT_ARG_DEF_
 
 #ifdef GL_ARB_provoking_vertex
 
-static GLboolean _glewInit_GL_ARB_provoking_vertex (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_provoking_vertex ()
 {
   GLboolean r = GL_FALSE;
 
@@ -5393,17 +11087,9 @@ static GLboolean _glewInit_GL_ARB_provoking_vertex (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_ARB_provoking_vertex */
 
-#ifdef GL_ARB_query_buffer_object
-
-#endif /* GL_ARB_query_buffer_object */
-
-#ifdef GL_ARB_robust_buffer_access_behavior
-
-#endif /* GL_ARB_robust_buffer_access_behavior */
-
 #ifdef GL_ARB_robustness
 
-static GLboolean _glewInit_GL_ARB_robustness (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_robustness ()
 {
   GLboolean r = GL_FALSE;
 
@@ -5433,17 +11119,23 @@ static GLboolean _glewInit_GL_ARB_robustness (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_ARB_robustness */
 
-#ifdef GL_ARB_robustness_application_isolation
+#ifdef GL_ARB_sample_locations
 
-#endif /* GL_ARB_robustness_application_isolation */
+static GLboolean _glewInit_GL_ARB_sample_locations ()
+{
+  GLboolean r = GL_FALSE;
 
-#ifdef GL_ARB_robustness_share_group_isolation
+  r = ((glFramebufferSampleLocationsfvARB = (PFNGLFRAMEBUFFERSAMPLELOCATIONSFVARBPROC)glewGetProcAddress((const GLubyte*)"glFramebufferSampleLocationsfvARB")) == NULL) || r;
+  r = ((glNamedFramebufferSampleLocationsfvARB = (PFNGLNAMEDFRAMEBUFFERSAMPLELOCATIONSFVARBPROC)glewGetProcAddress((const GLubyte*)"glNamedFramebufferSampleLocationsfvARB")) == NULL) || r;
 
-#endif /* GL_ARB_robustness_share_group_isolation */
+  return r;
+}
+
+#endif /* GL_ARB_sample_locations */
 
 #ifdef GL_ARB_sample_shading
 
-static GLboolean _glewInit_GL_ARB_sample_shading (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_sample_shading ()
 {
   GLboolean r = GL_FALSE;
 
@@ -5456,7 +11148,7 @@ static GLboolean _glewInit_GL_ARB_sample_shading (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_ARB_sampler_objects
 
-static GLboolean _glewInit_GL_ARB_sampler_objects (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_sampler_objects ()
 {
   GLboolean r = GL_FALSE;
 
@@ -5480,17 +11172,9 @@ static GLboolean _glewInit_GL_ARB_sampler_objects (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_ARB_sampler_objects */
 
-#ifdef GL_ARB_seamless_cube_map
-
-#endif /* GL_ARB_seamless_cube_map */
-
-#ifdef GL_ARB_seamless_cubemap_per_texture
-
-#endif /* GL_ARB_seamless_cubemap_per_texture */
-
 #ifdef GL_ARB_separate_shader_objects
 
-static GLboolean _glewInit_GL_ARB_separate_shader_objects (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_separate_shader_objects ()
 {
   GLboolean r = GL_FALSE;
 
@@ -5562,7 +11246,7 @@ static GLboolean _glewInit_GL_ARB_separate_shader_objects (GLEW_CONTEXT_ARG_DEF_
 
 #ifdef GL_ARB_shader_atomic_counters
 
-static GLboolean _glewInit_GL_ARB_shader_atomic_counters (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_shader_atomic_counters ()
 {
   GLboolean r = GL_FALSE;
 
@@ -5573,21 +11257,9 @@ static GLboolean _glewInit_GL_ARB_shader_atomic_counters (GLEW_CONTEXT_ARG_DEF_I
 
 #endif /* GL_ARB_shader_atomic_counters */
 
-#ifdef GL_ARB_shader_bit_encoding
-
-#endif /* GL_ARB_shader_bit_encoding */
-
-#ifdef GL_ARB_shader_draw_parameters
-
-#endif /* GL_ARB_shader_draw_parameters */
-
-#ifdef GL_ARB_shader_group_vote
-
-#endif /* GL_ARB_shader_group_vote */
-
 #ifdef GL_ARB_shader_image_load_store
 
-static GLboolean _glewInit_GL_ARB_shader_image_load_store (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_shader_image_load_store ()
 {
   GLboolean r = GL_FALSE;
 
@@ -5599,13 +11271,9 @@ static GLboolean _glewInit_GL_ARB_shader_image_load_store (GLEW_CONTEXT_ARG_DEF_
 
 #endif /* GL_ARB_shader_image_load_store */
 
-#ifdef GL_ARB_shader_image_size
-
-#endif /* GL_ARB_shader_image_size */
-
 #ifdef GL_ARB_shader_objects
 
-static GLboolean _glewInit_GL_ARB_shader_objects (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_shader_objects ()
 {
   GLboolean r = GL_FALSE;
 
@@ -5654,17 +11322,9 @@ static GLboolean _glewInit_GL_ARB_shader_objects (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_ARB_shader_objects */
 
-#ifdef GL_ARB_shader_precision
-
-#endif /* GL_ARB_shader_precision */
-
-#ifdef GL_ARB_shader_stencil_export
-
-#endif /* GL_ARB_shader_stencil_export */
-
 #ifdef GL_ARB_shader_storage_buffer_object
 
-static GLboolean _glewInit_GL_ARB_shader_storage_buffer_object (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_shader_storage_buffer_object ()
 {
   GLboolean r = GL_FALSE;
 
@@ -5677,7 +11337,7 @@ static GLboolean _glewInit_GL_ARB_shader_storage_buffer_object (GLEW_CONTEXT_ARG
 
 #ifdef GL_ARB_shader_subroutine
 
-static GLboolean _glewInit_GL_ARB_shader_subroutine (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_shader_subroutine ()
 {
   GLboolean r = GL_FALSE;
 
@@ -5695,25 +11355,9 @@ static GLboolean _glewInit_GL_ARB_shader_subroutine (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_ARB_shader_subroutine */
 
-#ifdef GL_ARB_shader_texture_image_samples
-
-#endif /* GL_ARB_shader_texture_image_samples */
-
-#ifdef GL_ARB_shader_texture_lod
-
-#endif /* GL_ARB_shader_texture_lod */
-
-#ifdef GL_ARB_shading_language_100
-
-#endif /* GL_ARB_shading_language_100 */
-
-#ifdef GL_ARB_shading_language_420pack
-
-#endif /* GL_ARB_shading_language_420pack */
-
 #ifdef GL_ARB_shading_language_include
 
-static GLboolean _glewInit_GL_ARB_shading_language_include (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_shading_language_include ()
 {
   GLboolean r = GL_FALSE;
 
@@ -5729,21 +11373,9 @@ static GLboolean _glewInit_GL_ARB_shading_language_include (GLEW_CONTEXT_ARG_DEF
 
 #endif /* GL_ARB_shading_language_include */
 
-#ifdef GL_ARB_shading_language_packing
-
-#endif /* GL_ARB_shading_language_packing */
-
-#ifdef GL_ARB_shadow
-
-#endif /* GL_ARB_shadow */
-
-#ifdef GL_ARB_shadow_ambient
-
-#endif /* GL_ARB_shadow_ambient */
-
 #ifdef GL_ARB_sparse_buffer
 
-static GLboolean _glewInit_GL_ARB_sparse_buffer (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_sparse_buffer ()
 {
   GLboolean r = GL_FALSE;
 
@@ -5756,25 +11388,20 @@ static GLboolean _glewInit_GL_ARB_sparse_buffer (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_ARB_sparse_texture
 
-static GLboolean _glewInit_GL_ARB_sparse_texture (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_sparse_texture ()
 {
   GLboolean r = GL_FALSE;
 
   r = ((glTexPageCommitmentARB = (PFNGLTEXPAGECOMMITMENTARBPROC)glewGetProcAddress((const GLubyte*)"glTexPageCommitmentARB")) == NULL) || r;
-  r = ((glTexturePageCommitmentEXT = (PFNGLTEXTUREPAGECOMMITMENTEXTPROC)glewGetProcAddress((const GLubyte*)"glTexturePageCommitmentEXT")) == NULL) || r;
 
   return r;
 }
 
 #endif /* GL_ARB_sparse_texture */
 
-#ifdef GL_ARB_stencil_texturing
-
-#endif /* GL_ARB_stencil_texturing */
-
 #ifdef GL_ARB_sync
 
-static GLboolean _glewInit_GL_ARB_sync (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_sync ()
 {
   GLboolean r = GL_FALSE;
 
@@ -5793,7 +11420,7 @@ static GLboolean _glewInit_GL_ARB_sync (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_ARB_tessellation_shader
 
-static GLboolean _glewInit_GL_ARB_tessellation_shader (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_tessellation_shader ()
 {
   GLboolean r = GL_FALSE;
 
@@ -5807,7 +11434,7 @@ static GLboolean _glewInit_GL_ARB_tessellation_shader (GLEW_CONTEXT_ARG_DEF_INIT
 
 #ifdef GL_ARB_texture_barrier
 
-static GLboolean _glewInit_GL_ARB_texture_barrier (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_texture_barrier ()
 {
   GLboolean r = GL_FALSE;
 
@@ -5818,13 +11445,9 @@ static GLboolean _glewInit_GL_ARB_texture_barrier (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_ARB_texture_barrier */
 
-#ifdef GL_ARB_texture_border_clamp
-
-#endif /* GL_ARB_texture_border_clamp */
-
 #ifdef GL_ARB_texture_buffer_object
 
-static GLboolean _glewInit_GL_ARB_texture_buffer_object (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_texture_buffer_object ()
 {
   GLboolean r = GL_FALSE;
 
@@ -5835,13 +11458,9 @@ static GLboolean _glewInit_GL_ARB_texture_buffer_object (GLEW_CONTEXT_ARG_DEF_IN
 
 #endif /* GL_ARB_texture_buffer_object */
 
-#ifdef GL_ARB_texture_buffer_object_rgb32
-
-#endif /* GL_ARB_texture_buffer_object_rgb32 */
-
 #ifdef GL_ARB_texture_buffer_range
 
-static GLboolean _glewInit_GL_ARB_texture_buffer_range (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_texture_buffer_range ()
 {
   GLboolean r = GL_FALSE;
 
@@ -5855,7 +11474,7 @@ static GLboolean _glewInit_GL_ARB_texture_buffer_range (GLEW_CONTEXT_ARG_DEF_INI
 
 #ifdef GL_ARB_texture_compression
 
-static GLboolean _glewInit_GL_ARB_texture_compression (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_texture_compression ()
 {
   GLboolean r = GL_FALSE;
 
@@ -5872,57 +11491,9 @@ static GLboolean _glewInit_GL_ARB_texture_compression (GLEW_CONTEXT_ARG_DEF_INIT
 
 #endif /* GL_ARB_texture_compression */
 
-#ifdef GL_ARB_texture_compression_bptc
-
-#endif /* GL_ARB_texture_compression_bptc */
-
-#ifdef GL_ARB_texture_compression_rgtc
-
-#endif /* GL_ARB_texture_compression_rgtc */
-
-#ifdef GL_ARB_texture_cube_map
-
-#endif /* GL_ARB_texture_cube_map */
-
-#ifdef GL_ARB_texture_cube_map_array
-
-#endif /* GL_ARB_texture_cube_map_array */
-
-#ifdef GL_ARB_texture_env_add
-
-#endif /* GL_ARB_texture_env_add */
-
-#ifdef GL_ARB_texture_env_combine
-
-#endif /* GL_ARB_texture_env_combine */
-
-#ifdef GL_ARB_texture_env_crossbar
-
-#endif /* GL_ARB_texture_env_crossbar */
-
-#ifdef GL_ARB_texture_env_dot3
-
-#endif /* GL_ARB_texture_env_dot3 */
-
-#ifdef GL_ARB_texture_float
-
-#endif /* GL_ARB_texture_float */
-
-#ifdef GL_ARB_texture_gather
-
-#endif /* GL_ARB_texture_gather */
-
-#ifdef GL_ARB_texture_mirror_clamp_to_edge
-
-#endif /* GL_ARB_texture_mirror_clamp_to_edge */
-
-#ifdef GL_ARB_texture_mirrored_repeat
-
-#endif /* GL_ARB_texture_mirrored_repeat */
-
 #ifdef GL_ARB_texture_multisample
 
-static GLboolean _glewInit_GL_ARB_texture_multisample (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_texture_multisample ()
 {
   GLboolean r = GL_FALSE;
 
@@ -5936,46 +11507,15 @@ static GLboolean _glewInit_GL_ARB_texture_multisample (GLEW_CONTEXT_ARG_DEF_INIT
 
 #endif /* GL_ARB_texture_multisample */
 
-#ifdef GL_ARB_texture_non_power_of_two
-
-#endif /* GL_ARB_texture_non_power_of_two */
-
-#ifdef GL_ARB_texture_query_levels
-
-#endif /* GL_ARB_texture_query_levels */
-
-#ifdef GL_ARB_texture_query_lod
-
-#endif /* GL_ARB_texture_query_lod */
-
-#ifdef GL_ARB_texture_rectangle
-
-#endif /* GL_ARB_texture_rectangle */
-
-#ifdef GL_ARB_texture_rg
-
-#endif /* GL_ARB_texture_rg */
-
-#ifdef GL_ARB_texture_rgb10_a2ui
-
-#endif /* GL_ARB_texture_rgb10_a2ui */
-
-#ifdef GL_ARB_texture_stencil8
-
-#endif /* GL_ARB_texture_stencil8 */
-
 #ifdef GL_ARB_texture_storage
 
-static GLboolean _glewInit_GL_ARB_texture_storage (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_texture_storage ()
 {
   GLboolean r = GL_FALSE;
 
   r = ((glTexStorage1D = (PFNGLTEXSTORAGE1DPROC)glewGetProcAddress((const GLubyte*)"glTexStorage1D")) == NULL) || r;
   r = ((glTexStorage2D = (PFNGLTEXSTORAGE2DPROC)glewGetProcAddress((const GLubyte*)"glTexStorage2D")) == NULL) || r;
   r = ((glTexStorage3D = (PFNGLTEXSTORAGE3DPROC)glewGetProcAddress((const GLubyte*)"glTexStorage3D")) == NULL) || r;
-  r = ((glTextureStorage1DEXT = (PFNGLTEXTURESTORAGE1DEXTPROC)glewGetProcAddress((const GLubyte*)"glTextureStorage1DEXT")) == NULL) || r;
-  r = ((glTextureStorage2DEXT = (PFNGLTEXTURESTORAGE2DEXTPROC)glewGetProcAddress((const GLubyte*)"glTextureStorage2DEXT")) == NULL) || r;
-  r = ((glTextureStorage3DEXT = (PFNGLTEXTURESTORAGE3DEXTPROC)glewGetProcAddress((const GLubyte*)"glTextureStorage3DEXT")) == NULL) || r;
 
   return r;
 }
@@ -5984,7 +11524,7 @@ static GLboolean _glewInit_GL_ARB_texture_storage (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_ARB_texture_storage_multisample
 
-static GLboolean _glewInit_GL_ARB_texture_storage_multisample (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_texture_storage_multisample ()
 {
   GLboolean r = GL_FALSE;
 
@@ -5998,13 +11538,9 @@ static GLboolean _glewInit_GL_ARB_texture_storage_multisample (GLEW_CONTEXT_ARG_
 
 #endif /* GL_ARB_texture_storage_multisample */
 
-#ifdef GL_ARB_texture_swizzle
-
-#endif /* GL_ARB_texture_swizzle */
-
 #ifdef GL_ARB_texture_view
 
-static GLboolean _glewInit_GL_ARB_texture_view (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_texture_view ()
 {
   GLboolean r = GL_FALSE;
 
@@ -6017,7 +11553,7 @@ static GLboolean _glewInit_GL_ARB_texture_view (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_ARB_timer_query
 
-static GLboolean _glewInit_GL_ARB_timer_query (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_timer_query ()
 {
   GLboolean r = GL_FALSE;
 
@@ -6032,7 +11568,7 @@ static GLboolean _glewInit_GL_ARB_timer_query (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_ARB_transform_feedback2
 
-static GLboolean _glewInit_GL_ARB_transform_feedback2 (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_transform_feedback2 ()
 {
   GLboolean r = GL_FALSE;
 
@@ -6051,7 +11587,7 @@ static GLboolean _glewInit_GL_ARB_transform_feedback2 (GLEW_CONTEXT_ARG_DEF_INIT
 
 #ifdef GL_ARB_transform_feedback3
 
-static GLboolean _glewInit_GL_ARB_transform_feedback3 (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_transform_feedback3 ()
 {
   GLboolean r = GL_FALSE;
 
@@ -6067,7 +11603,7 @@ static GLboolean _glewInit_GL_ARB_transform_feedback3 (GLEW_CONTEXT_ARG_DEF_INIT
 
 #ifdef GL_ARB_transform_feedback_instanced
 
-static GLboolean _glewInit_GL_ARB_transform_feedback_instanced (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_transform_feedback_instanced ()
 {
   GLboolean r = GL_FALSE;
 
@@ -6079,13 +11615,9 @@ static GLboolean _glewInit_GL_ARB_transform_feedback_instanced (GLEW_CONTEXT_ARG
 
 #endif /* GL_ARB_transform_feedback_instanced */
 
-#ifdef GL_ARB_transform_feedback_overflow_query
-
-#endif /* GL_ARB_transform_feedback_overflow_query */
-
 #ifdef GL_ARB_transpose_matrix
 
-static GLboolean _glewInit_GL_ARB_transpose_matrix (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_transpose_matrix ()
 {
   GLboolean r = GL_FALSE;
 
@@ -6101,7 +11633,7 @@ static GLboolean _glewInit_GL_ARB_transpose_matrix (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_ARB_uniform_buffer_object
 
-static GLboolean _glewInit_GL_ARB_uniform_buffer_object (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_uniform_buffer_object ()
 {
   GLboolean r = GL_FALSE;
 
@@ -6121,13 +11653,9 @@ static GLboolean _glewInit_GL_ARB_uniform_buffer_object (GLEW_CONTEXT_ARG_DEF_IN
 
 #endif /* GL_ARB_uniform_buffer_object */
 
-#ifdef GL_ARB_vertex_array_bgra
-
-#endif /* GL_ARB_vertex_array_bgra */
-
 #ifdef GL_ARB_vertex_array_object
 
-static GLboolean _glewInit_GL_ARB_vertex_array_object (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_vertex_array_object ()
 {
   GLboolean r = GL_FALSE;
 
@@ -6143,7 +11671,7 @@ static GLboolean _glewInit_GL_ARB_vertex_array_object (GLEW_CONTEXT_ARG_DEF_INIT
 
 #ifdef GL_ARB_vertex_attrib_64bit
 
-static GLboolean _glewInit_GL_ARB_vertex_attrib_64bit (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_vertex_attrib_64bit ()
 {
   GLboolean r = GL_FALSE;
 
@@ -6165,7 +11693,7 @@ static GLboolean _glewInit_GL_ARB_vertex_attrib_64bit (GLEW_CONTEXT_ARG_DEF_INIT
 
 #ifdef GL_ARB_vertex_attrib_binding
 
-static GLboolean _glewInit_GL_ARB_vertex_attrib_binding (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_vertex_attrib_binding ()
 {
   GLboolean r = GL_FALSE;
 
@@ -6189,7 +11717,7 @@ static GLboolean _glewInit_GL_ARB_vertex_attrib_binding (GLEW_CONTEXT_ARG_DEF_IN
 
 #ifdef GL_ARB_vertex_blend
 
-static GLboolean _glewInit_GL_ARB_vertex_blend (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_vertex_blend ()
 {
   GLboolean r = GL_FALSE;
 
@@ -6211,7 +11739,7 @@ static GLboolean _glewInit_GL_ARB_vertex_blend (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_ARB_vertex_buffer_object
 
-static GLboolean _glewInit_GL_ARB_vertex_buffer_object (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_vertex_buffer_object ()
 {
   GLboolean r = GL_FALSE;
 
@@ -6234,7 +11762,7 @@ static GLboolean _glewInit_GL_ARB_vertex_buffer_object (GLEW_CONTEXT_ARG_DEF_INI
 
 #ifdef GL_ARB_vertex_program
 
-static GLboolean _glewInit_GL_ARB_vertex_program (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_vertex_program ()
 {
   GLboolean r = GL_FALSE;
 
@@ -6308,7 +11836,7 @@ static GLboolean _glewInit_GL_ARB_vertex_program (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_ARB_vertex_shader
 
-static GLboolean _glewInit_GL_ARB_vertex_shader (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_vertex_shader ()
 {
   GLboolean r = GL_FALSE;
 
@@ -6321,13 +11849,9 @@ static GLboolean _glewInit_GL_ARB_vertex_shader (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_ARB_vertex_shader */
 
-#ifdef GL_ARB_vertex_type_10f_11f_11f_rev
-
-#endif /* GL_ARB_vertex_type_10f_11f_11f_rev */
-
 #ifdef GL_ARB_vertex_type_2_10_10_10_rev
 
-static GLboolean _glewInit_GL_ARB_vertex_type_2_10_10_10_rev (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_vertex_type_2_10_10_10_rev ()
 {
   GLboolean r = GL_FALSE;
 
@@ -6377,7 +11901,7 @@ static GLboolean _glewInit_GL_ARB_vertex_type_2_10_10_10_rev (GLEW_CONTEXT_ARG_D
 
 #ifdef GL_ARB_viewport_array
 
-static GLboolean _glewInit_GL_ARB_viewport_array (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_viewport_array ()
 {
   GLboolean r = GL_FALSE;
 
@@ -6399,7 +11923,7 @@ static GLboolean _glewInit_GL_ARB_viewport_array (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_ARB_window_pos
 
-static GLboolean _glewInit_GL_ARB_window_pos (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ARB_window_pos ()
 {
   GLboolean r = GL_FALSE;
 
@@ -6425,25 +11949,9 @@ static GLboolean _glewInit_GL_ARB_window_pos (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_ARB_window_pos */
 
-#ifdef GL_ATIX_point_sprites
-
-#endif /* GL_ATIX_point_sprites */
-
-#ifdef GL_ATIX_texture_env_combine3
-
-#endif /* GL_ATIX_texture_env_combine3 */
-
-#ifdef GL_ATIX_texture_env_route
-
-#endif /* GL_ATIX_texture_env_route */
-
-#ifdef GL_ATIX_vertex_shader_output_point_size
-
-#endif /* GL_ATIX_vertex_shader_output_point_size */
-
 #ifdef GL_ATI_draw_buffers
 
-static GLboolean _glewInit_GL_ATI_draw_buffers (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ATI_draw_buffers ()
 {
   GLboolean r = GL_FALSE;
 
@@ -6456,7 +11964,7 @@ static GLboolean _glewInit_GL_ATI_draw_buffers (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_ATI_element_array
 
-static GLboolean _glewInit_GL_ATI_element_array (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ATI_element_array ()
 {
   GLboolean r = GL_FALSE;
 
@@ -6471,7 +11979,7 @@ static GLboolean _glewInit_GL_ATI_element_array (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_ATI_envmap_bumpmap
 
-static GLboolean _glewInit_GL_ATI_envmap_bumpmap (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ATI_envmap_bumpmap ()
 {
   GLboolean r = GL_FALSE;
 
@@ -6487,7 +11995,7 @@ static GLboolean _glewInit_GL_ATI_envmap_bumpmap (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_ATI_fragment_shader
 
-static GLboolean _glewInit_GL_ATI_fragment_shader (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ATI_fragment_shader ()
 {
   GLboolean r = GL_FALSE;
 
@@ -6513,7 +12021,7 @@ static GLboolean _glewInit_GL_ATI_fragment_shader (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_ATI_map_object_buffer
 
-static GLboolean _glewInit_GL_ATI_map_object_buffer (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ATI_map_object_buffer ()
 {
   GLboolean r = GL_FALSE;
 
@@ -6525,13 +12033,9 @@ static GLboolean _glewInit_GL_ATI_map_object_buffer (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_ATI_map_object_buffer */
 
-#ifdef GL_ATI_meminfo
-
-#endif /* GL_ATI_meminfo */
-
 #ifdef GL_ATI_pn_triangles
 
-static GLboolean _glewInit_GL_ATI_pn_triangles (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ATI_pn_triangles ()
 {
   GLboolean r = GL_FALSE;
 
@@ -6545,7 +12049,7 @@ static GLboolean _glewInit_GL_ATI_pn_triangles (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_ATI_separate_stencil
 
-static GLboolean _glewInit_GL_ATI_separate_stencil (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ATI_separate_stencil ()
 {
   GLboolean r = GL_FALSE;
 
@@ -6557,33 +12061,9 @@ static GLboolean _glewInit_GL_ATI_separate_stencil (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_ATI_separate_stencil */
 
-#ifdef GL_ATI_shader_texture_lod
-
-#endif /* GL_ATI_shader_texture_lod */
-
-#ifdef GL_ATI_text_fragment_shader
-
-#endif /* GL_ATI_text_fragment_shader */
-
-#ifdef GL_ATI_texture_compression_3dc
-
-#endif /* GL_ATI_texture_compression_3dc */
-
-#ifdef GL_ATI_texture_env_combine3
-
-#endif /* GL_ATI_texture_env_combine3 */
-
-#ifdef GL_ATI_texture_float
-
-#endif /* GL_ATI_texture_float */
-
-#ifdef GL_ATI_texture_mirror_once
-
-#endif /* GL_ATI_texture_mirror_once */
-
 #ifdef GL_ATI_vertex_array_object
 
-static GLboolean _glewInit_GL_ATI_vertex_array_object (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ATI_vertex_array_object ()
 {
   GLboolean r = GL_FALSE;
 
@@ -6607,7 +12087,7 @@ static GLboolean _glewInit_GL_ATI_vertex_array_object (GLEW_CONTEXT_ARG_DEF_INIT
 
 #ifdef GL_ATI_vertex_attrib_array_object
 
-static GLboolean _glewInit_GL_ATI_vertex_attrib_array_object (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ATI_vertex_attrib_array_object ()
 {
   GLboolean r = GL_FALSE;
 
@@ -6622,7 +12102,7 @@ static GLboolean _glewInit_GL_ATI_vertex_attrib_array_object (GLEW_CONTEXT_ARG_D
 
 #ifdef GL_ATI_vertex_streams
 
-static GLboolean _glewInit_GL_ATI_vertex_streams (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_ATI_vertex_streams ()
 {
   GLboolean r = GL_FALSE;
 
@@ -6677,25 +12157,24 @@ static GLboolean _glewInit_GL_ATI_vertex_streams (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_ATI_vertex_streams */
 
-#ifdef GL_EXT_422_pixels
+#ifdef GL_EXT_base_instance
 
-#endif /* GL_EXT_422_pixels */
+static GLboolean _glewInit_GL_EXT_base_instance ()
+{
+  GLboolean r = GL_FALSE;
 
-#ifdef GL_EXT_Cg_shader
+  r = ((glDrawArraysInstancedBaseInstanceEXT = (PFNGLDRAWARRAYSINSTANCEDBASEINSTANCEEXTPROC)glewGetProcAddress((const GLubyte*)"glDrawArraysInstancedBaseInstanceEXT")) == NULL) || r;
+  r = ((glDrawElementsInstancedBaseInstanceEXT = (PFNGLDRAWELEMENTSINSTANCEDBASEINSTANCEEXTPROC)glewGetProcAddress((const GLubyte*)"glDrawElementsInstancedBaseInstanceEXT")) == NULL) || r;
+  r = ((glDrawElementsInstancedBaseVertexBaseInstanceEXT = (PFNGLDRAWELEMENTSINSTANCEDBASEVERTEXBASEINSTANCEEXTPROC)glewGetProcAddress((const GLubyte*)"glDrawElementsInstancedBaseVertexBaseInstanceEXT")) == NULL) || r;
 
-#endif /* GL_EXT_Cg_shader */
+  return r;
+}
 
-#ifdef GL_EXT_abgr
-
-#endif /* GL_EXT_abgr */
-
-#ifdef GL_EXT_bgra
-
-#endif /* GL_EXT_bgra */
+#endif /* GL_EXT_base_instance */
 
 #ifdef GL_EXT_bindable_uniform
 
-static GLboolean _glewInit_GL_EXT_bindable_uniform (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_bindable_uniform ()
 {
   GLboolean r = GL_FALSE;
 
@@ -6710,7 +12189,7 @@ static GLboolean _glewInit_GL_EXT_bindable_uniform (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_EXT_blend_color
 
-static GLboolean _glewInit_GL_EXT_blend_color (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_blend_color ()
 {
   GLboolean r = GL_FALSE;
 
@@ -6723,7 +12202,7 @@ static GLboolean _glewInit_GL_EXT_blend_color (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_EXT_blend_equation_separate
 
-static GLboolean _glewInit_GL_EXT_blend_equation_separate (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_blend_equation_separate ()
 {
   GLboolean r = GL_FALSE;
 
@@ -6734,9 +12213,24 @@ static GLboolean _glewInit_GL_EXT_blend_equation_separate (GLEW_CONTEXT_ARG_DEF_
 
 #endif /* GL_EXT_blend_equation_separate */
 
+#ifdef GL_EXT_blend_func_extended
+
+static GLboolean _glewInit_GL_EXT_blend_func_extended ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glBindFragDataLocationIndexedEXT = (PFNGLBINDFRAGDATALOCATIONINDEXEDEXTPROC)glewGetProcAddress((const GLubyte*)"glBindFragDataLocationIndexedEXT")) == NULL) || r;
+  r = ((glGetFragDataIndexEXT = (PFNGLGETFRAGDATAINDEXEXTPROC)glewGetProcAddress((const GLubyte*)"glGetFragDataIndexEXT")) == NULL) || r;
+  r = ((glGetProgramResourceLocationIndexEXT = (PFNGLGETPROGRAMRESOURCELOCATIONINDEXEXTPROC)glewGetProcAddress((const GLubyte*)"glGetProgramResourceLocationIndexEXT")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_EXT_blend_func_extended */
+
 #ifdef GL_EXT_blend_func_separate
 
-static GLboolean _glewInit_GL_EXT_blend_func_separate (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_blend_func_separate ()
 {
   GLboolean r = GL_FALSE;
 
@@ -6747,13 +12241,9 @@ static GLboolean _glewInit_GL_EXT_blend_func_separate (GLEW_CONTEXT_ARG_DEF_INIT
 
 #endif /* GL_EXT_blend_func_separate */
 
-#ifdef GL_EXT_blend_logic_op
-
-#endif /* GL_EXT_blend_logic_op */
-
 #ifdef GL_EXT_blend_minmax
 
-static GLboolean _glewInit_GL_EXT_blend_minmax (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_blend_minmax ()
 {
   GLboolean r = GL_FALSE;
 
@@ -6764,21 +12254,37 @@ static GLboolean _glewInit_GL_EXT_blend_minmax (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_EXT_blend_minmax */
 
-#ifdef GL_EXT_blend_subtract
+#ifdef GL_EXT_buffer_storage
 
-#endif /* GL_EXT_blend_subtract */
+static GLboolean _glewInit_GL_EXT_buffer_storage ()
+{
+  GLboolean r = GL_FALSE;
 
-#ifdef GL_EXT_clip_volume_hint
+  r = ((glBufferStorageEXT = (PFNGLBUFFERSTORAGEEXTPROC)glewGetProcAddress((const GLubyte*)"glBufferStorageEXT")) == NULL) || r;
+  r = ((glNamedBufferStorageEXT = (PFNGLNAMEDBUFFERSTORAGEEXTPROC)glewGetProcAddress((const GLubyte*)"glNamedBufferStorageEXT")) == NULL) || r;
 
-#endif /* GL_EXT_clip_volume_hint */
+  return r;
+}
 
-#ifdef GL_EXT_cmyka
+#endif /* GL_EXT_buffer_storage */
 
-#endif /* GL_EXT_cmyka */
+#ifdef GL_EXT_clear_texture
+
+static GLboolean _glewInit_GL_EXT_clear_texture ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glClearTexImageEXT = (PFNGLCLEARTEXIMAGEEXTPROC)glewGetProcAddress((const GLubyte*)"glClearTexImageEXT")) == NULL) || r;
+  r = ((glClearTexSubImageEXT = (PFNGLCLEARTEXSUBIMAGEEXTPROC)glewGetProcAddress((const GLubyte*)"glClearTexSubImageEXT")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_EXT_clear_texture */
 
 #ifdef GL_EXT_color_subtable
 
-static GLboolean _glewInit_GL_EXT_color_subtable (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_color_subtable ()
 {
   GLboolean r = GL_FALSE;
 
@@ -6792,7 +12298,7 @@ static GLboolean _glewInit_GL_EXT_color_subtable (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_EXT_compiled_vertex_array
 
-static GLboolean _glewInit_GL_EXT_compiled_vertex_array (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_compiled_vertex_array ()
 {
   GLboolean r = GL_FALSE;
 
@@ -6806,7 +12312,7 @@ static GLboolean _glewInit_GL_EXT_compiled_vertex_array (GLEW_CONTEXT_ARG_DEF_IN
 
 #ifdef GL_EXT_convolution
 
-static GLboolean _glewInit_GL_EXT_convolution (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_convolution ()
 {
   GLboolean r = GL_FALSE;
 
@@ -6831,7 +12337,7 @@ static GLboolean _glewInit_GL_EXT_convolution (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_EXT_coordinate_frame
 
-static GLboolean _glewInit_GL_EXT_coordinate_frame (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_coordinate_frame ()
 {
   GLboolean r = GL_FALSE;
 
@@ -6843,9 +12349,22 @@ static GLboolean _glewInit_GL_EXT_coordinate_frame (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_EXT_coordinate_frame */
 
+#ifdef GL_EXT_copy_image
+
+static GLboolean _glewInit_GL_EXT_copy_image ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glCopyImageSubDataEXT = (PFNGLCOPYIMAGESUBDATAEXTPROC)glewGetProcAddress((const GLubyte*)"glCopyImageSubDataEXT")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_EXT_copy_image */
+
 #ifdef GL_EXT_copy_texture
 
-static GLboolean _glewInit_GL_EXT_copy_texture (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_copy_texture ()
 {
   GLboolean r = GL_FALSE;
 
@@ -6862,7 +12381,7 @@ static GLboolean _glewInit_GL_EXT_copy_texture (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_EXT_cull_vertex
 
-static GLboolean _glewInit_GL_EXT_cull_vertex (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_cull_vertex ()
 {
   GLboolean r = GL_FALSE;
 
@@ -6876,7 +12395,7 @@ static GLboolean _glewInit_GL_EXT_cull_vertex (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_EXT_debug_label
 
-static GLboolean _glewInit_GL_EXT_debug_label (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_debug_label ()
 {
   GLboolean r = GL_FALSE;
 
@@ -6890,7 +12409,7 @@ static GLboolean _glewInit_GL_EXT_debug_label (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_EXT_debug_marker
 
-static GLboolean _glewInit_GL_EXT_debug_marker (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_debug_marker ()
 {
   GLboolean r = GL_FALSE;
 
@@ -6905,7 +12424,7 @@ static GLboolean _glewInit_GL_EXT_debug_marker (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_EXT_depth_bounds_test
 
-static GLboolean _glewInit_GL_EXT_depth_bounds_test (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_depth_bounds_test ()
 {
   GLboolean r = GL_FALSE;
 
@@ -6918,7 +12437,7 @@ static GLboolean _glewInit_GL_EXT_depth_bounds_test (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_EXT_direct_state_access
 
-static GLboolean _glewInit_GL_EXT_direct_state_access (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_direct_state_access ()
 {
   GLboolean r = GL_FALSE;
 
@@ -7142,9 +12661,35 @@ static GLboolean _glewInit_GL_EXT_direct_state_access (GLEW_CONTEXT_ARG_DEF_INIT
 
 #endif /* GL_EXT_direct_state_access */
 
+#ifdef GL_EXT_discard_framebuffer
+
+static GLboolean _glewInit_GL_EXT_discard_framebuffer ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glDiscardFramebufferEXT = (PFNGLDISCARDFRAMEBUFFEREXTPROC)glewGetProcAddress((const GLubyte*)"glDiscardFramebufferEXT")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_EXT_discard_framebuffer */
+
+#ifdef GL_EXT_draw_buffers
+
+static GLboolean _glewInit_GL_EXT_draw_buffers ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glDrawBuffersEXT = (PFNGLDRAWBUFFERSEXTPROC)glewGetProcAddress((const GLubyte*)"glDrawBuffersEXT")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_EXT_draw_buffers */
+
 #ifdef GL_EXT_draw_buffers2
 
-static GLboolean _glewInit_GL_EXT_draw_buffers2 (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_draw_buffers2 ()
 {
   GLboolean r = GL_FALSE;
 
@@ -7160,9 +12705,45 @@ static GLboolean _glewInit_GL_EXT_draw_buffers2 (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_EXT_draw_buffers2 */
 
+#ifdef GL_EXT_draw_buffers_indexed
+
+static GLboolean _glewInit_GL_EXT_draw_buffers_indexed ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glBlendEquationSeparateiEXT = (PFNGLBLENDEQUATIONSEPARATEIEXTPROC)glewGetProcAddress((const GLubyte*)"glBlendEquationSeparateiEXT")) == NULL) || r;
+  r = ((glBlendEquationiEXT = (PFNGLBLENDEQUATIONIEXTPROC)glewGetProcAddress((const GLubyte*)"glBlendEquationiEXT")) == NULL) || r;
+  r = ((glBlendFuncSeparateiEXT = (PFNGLBLENDFUNCSEPARATEIEXTPROC)glewGetProcAddress((const GLubyte*)"glBlendFuncSeparateiEXT")) == NULL) || r;
+  r = ((glBlendFunciEXT = (PFNGLBLENDFUNCIEXTPROC)glewGetProcAddress((const GLubyte*)"glBlendFunciEXT")) == NULL) || r;
+  r = ((glColorMaskiEXT = (PFNGLCOLORMASKIEXTPROC)glewGetProcAddress((const GLubyte*)"glColorMaskiEXT")) == NULL) || r;
+  r = ((glDisableiEXT = (PFNGLDISABLEIEXTPROC)glewGetProcAddress((const GLubyte*)"glDisableiEXT")) == NULL) || r;
+  r = ((glEnableiEXT = (PFNGLENABLEIEXTPROC)glewGetProcAddress((const GLubyte*)"glEnableiEXT")) == NULL) || r;
+  r = ((glIsEnablediEXT = (PFNGLISENABLEDIEXTPROC)glewGetProcAddress((const GLubyte*)"glIsEnablediEXT")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_EXT_draw_buffers_indexed */
+
+#ifdef GL_EXT_draw_elements_base_vertex
+
+static GLboolean _glewInit_GL_EXT_draw_elements_base_vertex ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glDrawElementsBaseVertexEXT = (PFNGLDRAWELEMENTSBASEVERTEXEXTPROC)glewGetProcAddress((const GLubyte*)"glDrawElementsBaseVertexEXT")) == NULL) || r;
+  r = ((glDrawElementsInstancedBaseVertexEXT = (PFNGLDRAWELEMENTSINSTANCEDBASEVERTEXEXTPROC)glewGetProcAddress((const GLubyte*)"glDrawElementsInstancedBaseVertexEXT")) == NULL) || r;
+  r = ((glDrawRangeElementsBaseVertexEXT = (PFNGLDRAWRANGEELEMENTSBASEVERTEXEXTPROC)glewGetProcAddress((const GLubyte*)"glDrawRangeElementsBaseVertexEXT")) == NULL) || r;
+  r = ((glMultiDrawElementsBaseVertexEXT = (PFNGLMULTIDRAWELEMENTSBASEVERTEXEXTPROC)glewGetProcAddress((const GLubyte*)"glMultiDrawElementsBaseVertexEXT")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_EXT_draw_elements_base_vertex */
+
 #ifdef GL_EXT_draw_instanced
 
-static GLboolean _glewInit_GL_EXT_draw_instanced (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_draw_instanced ()
 {
   GLboolean r = GL_FALSE;
 
@@ -7176,7 +12757,7 @@ static GLboolean _glewInit_GL_EXT_draw_instanced (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_EXT_draw_range_elements
 
-static GLboolean _glewInit_GL_EXT_draw_range_elements (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_draw_range_elements ()
 {
   GLboolean r = GL_FALSE;
 
@@ -7187,9 +12768,23 @@ static GLboolean _glewInit_GL_EXT_draw_range_elements (GLEW_CONTEXT_ARG_DEF_INIT
 
 #endif /* GL_EXT_draw_range_elements */
 
+#ifdef GL_EXT_external_buffer
+
+static GLboolean _glewInit_GL_EXT_external_buffer ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glBufferStorageExternalEXT = (PFNGLBUFFERSTORAGEEXTERNALEXTPROC)glewGetProcAddress((const GLubyte*)"glBufferStorageExternalEXT")) == NULL) || r;
+  r = ((glNamedBufferStorageExternalEXT = (PFNGLNAMEDBUFFERSTORAGEEXTERNALEXTPROC)glewGetProcAddress((const GLubyte*)"glNamedBufferStorageExternalEXT")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_EXT_external_buffer */
+
 #ifdef GL_EXT_fog_coord
 
-static GLboolean _glewInit_GL_EXT_fog_coord (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_fog_coord ()
 {
   GLboolean r = GL_FALSE;
 
@@ -7206,7 +12801,7 @@ static GLboolean _glewInit_GL_EXT_fog_coord (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_EXT_fragment_lighting
 
-static GLboolean _glewInit_GL_EXT_fragment_lighting (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_fragment_lighting ()
 {
   GLboolean r = GL_FALSE;
 
@@ -7236,7 +12831,7 @@ static GLboolean _glewInit_GL_EXT_fragment_lighting (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_EXT_framebuffer_blit
 
-static GLboolean _glewInit_GL_EXT_framebuffer_blit (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_framebuffer_blit ()
 {
   GLboolean r = GL_FALSE;
 
@@ -7249,7 +12844,7 @@ static GLboolean _glewInit_GL_EXT_framebuffer_blit (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_EXT_framebuffer_multisample
 
-static GLboolean _glewInit_GL_EXT_framebuffer_multisample (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_framebuffer_multisample ()
 {
   GLboolean r = GL_FALSE;
 
@@ -7260,13 +12855,9 @@ static GLboolean _glewInit_GL_EXT_framebuffer_multisample (GLEW_CONTEXT_ARG_DEF_
 
 #endif /* GL_EXT_framebuffer_multisample */
 
-#ifdef GL_EXT_framebuffer_multisample_blit_scaled
-
-#endif /* GL_EXT_framebuffer_multisample_blit_scaled */
-
 #ifdef GL_EXT_framebuffer_object
 
-static GLboolean _glewInit_GL_EXT_framebuffer_object (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_framebuffer_object ()
 {
   GLboolean r = GL_FALSE;
 
@@ -7293,13 +12884,9 @@ static GLboolean _glewInit_GL_EXT_framebuffer_object (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_EXT_framebuffer_object */
 
-#ifdef GL_EXT_framebuffer_sRGB
-
-#endif /* GL_EXT_framebuffer_sRGB */
-
 #ifdef GL_EXT_geometry_shader4
 
-static GLboolean _glewInit_GL_EXT_geometry_shader4 (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_geometry_shader4 ()
 {
   GLboolean r = GL_FALSE;
 
@@ -7314,7 +12901,7 @@ static GLboolean _glewInit_GL_EXT_geometry_shader4 (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_EXT_gpu_program_parameters
 
-static GLboolean _glewInit_GL_EXT_gpu_program_parameters (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_gpu_program_parameters ()
 {
   GLboolean r = GL_FALSE;
 
@@ -7328,7 +12915,7 @@ static GLboolean _glewInit_GL_EXT_gpu_program_parameters (GLEW_CONTEXT_ARG_DEF_I
 
 #ifdef GL_EXT_gpu_shader4
 
-static GLboolean _glewInit_GL_EXT_gpu_shader4 (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_gpu_shader4 ()
 {
   GLboolean r = GL_FALSE;
 
@@ -7374,7 +12961,7 @@ static GLboolean _glewInit_GL_EXT_gpu_shader4 (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_EXT_histogram
 
-static GLboolean _glewInit_GL_EXT_histogram (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_histogram ()
 {
   GLboolean r = GL_FALSE;
 
@@ -7394,13 +12981,9 @@ static GLboolean _glewInit_GL_EXT_histogram (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_EXT_histogram */
 
-#ifdef GL_EXT_index_array_formats
-
-#endif /* GL_EXT_index_array_formats */
-
 #ifdef GL_EXT_index_func
 
-static GLboolean _glewInit_GL_EXT_index_func (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_index_func ()
 {
   GLboolean r = GL_FALSE;
 
@@ -7413,7 +12996,7 @@ static GLboolean _glewInit_GL_EXT_index_func (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_EXT_index_material
 
-static GLboolean _glewInit_GL_EXT_index_material (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_index_material ()
 {
   GLboolean r = GL_FALSE;
 
@@ -7424,13 +13007,22 @@ static GLboolean _glewInit_GL_EXT_index_material (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_EXT_index_material */
 
-#ifdef GL_EXT_index_texture
+#ifdef GL_EXT_instanced_arrays
 
-#endif /* GL_EXT_index_texture */
+static GLboolean _glewInit_GL_EXT_instanced_arrays ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glVertexAttribDivisorEXT = (PFNGLVERTEXATTRIBDIVISOREXTPROC)glewGetProcAddress((const GLubyte*)"glVertexAttribDivisorEXT")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_EXT_instanced_arrays */
 
 #ifdef GL_EXT_light_texture
 
-static GLboolean _glewInit_GL_EXT_light_texture (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_light_texture ()
 {
   GLboolean r = GL_FALSE;
 
@@ -7443,13 +13035,81 @@ static GLboolean _glewInit_GL_EXT_light_texture (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_EXT_light_texture */
 
-#ifdef GL_EXT_misc_attribute
+#ifdef GL_EXT_map_buffer_range
 
-#endif /* GL_EXT_misc_attribute */
+static GLboolean _glewInit_GL_EXT_map_buffer_range ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glFlushMappedBufferRangeEXT = (PFNGLFLUSHMAPPEDBUFFERRANGEEXTPROC)glewGetProcAddress((const GLubyte*)"glFlushMappedBufferRangeEXT")) == NULL) || r;
+  r = ((glMapBufferRangeEXT = (PFNGLMAPBUFFERRANGEEXTPROC)glewGetProcAddress((const GLubyte*)"glMapBufferRangeEXT")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_EXT_map_buffer_range */
+
+#ifdef GL_EXT_memory_object
+
+static GLboolean _glewInit_GL_EXT_memory_object ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glBufferStorageMemEXT = (PFNGLBUFFERSTORAGEMEMEXTPROC)glewGetProcAddress((const GLubyte*)"glBufferStorageMemEXT")) == NULL) || r;
+  r = ((glCreateMemoryObjectsEXT = (PFNGLCREATEMEMORYOBJECTSEXTPROC)glewGetProcAddress((const GLubyte*)"glCreateMemoryObjectsEXT")) == NULL) || r;
+  r = ((glDeleteMemoryObjectsEXT = (PFNGLDELETEMEMORYOBJECTSEXTPROC)glewGetProcAddress((const GLubyte*)"glDeleteMemoryObjectsEXT")) == NULL) || r;
+  r = ((glGetMemoryObjectParameterivEXT = (PFNGLGETMEMORYOBJECTPARAMETERIVEXTPROC)glewGetProcAddress((const GLubyte*)"glGetMemoryObjectParameterivEXT")) == NULL) || r;
+  r = ((glGetUnsignedBytei_vEXT = (PFNGLGETUNSIGNEDBYTEI_VEXTPROC)glewGetProcAddress((const GLubyte*)"glGetUnsignedBytei_vEXT")) == NULL) || r;
+  r = ((glGetUnsignedBytevEXT = (PFNGLGETUNSIGNEDBYTEVEXTPROC)glewGetProcAddress((const GLubyte*)"glGetUnsignedBytevEXT")) == NULL) || r;
+  r = ((glIsMemoryObjectEXT = (PFNGLISMEMORYOBJECTEXTPROC)glewGetProcAddress((const GLubyte*)"glIsMemoryObjectEXT")) == NULL) || r;
+  r = ((glMemoryObjectParameterivEXT = (PFNGLMEMORYOBJECTPARAMETERIVEXTPROC)glewGetProcAddress((const GLubyte*)"glMemoryObjectParameterivEXT")) == NULL) || r;
+  r = ((glNamedBufferStorageMemEXT = (PFNGLNAMEDBUFFERSTORAGEMEMEXTPROC)glewGetProcAddress((const GLubyte*)"glNamedBufferStorageMemEXT")) == NULL) || r;
+  r = ((glTexStorageMem1DEXT = (PFNGLTEXSTORAGEMEM1DEXTPROC)glewGetProcAddress((const GLubyte*)"glTexStorageMem1DEXT")) == NULL) || r;
+  r = ((glTexStorageMem2DEXT = (PFNGLTEXSTORAGEMEM2DEXTPROC)glewGetProcAddress((const GLubyte*)"glTexStorageMem2DEXT")) == NULL) || r;
+  r = ((glTexStorageMem2DMultisampleEXT = (PFNGLTEXSTORAGEMEM2DMULTISAMPLEEXTPROC)glewGetProcAddress((const GLubyte*)"glTexStorageMem2DMultisampleEXT")) == NULL) || r;
+  r = ((glTexStorageMem3DEXT = (PFNGLTEXSTORAGEMEM3DEXTPROC)glewGetProcAddress((const GLubyte*)"glTexStorageMem3DEXT")) == NULL) || r;
+  r = ((glTexStorageMem3DMultisampleEXT = (PFNGLTEXSTORAGEMEM3DMULTISAMPLEEXTPROC)glewGetProcAddress((const GLubyte*)"glTexStorageMem3DMultisampleEXT")) == NULL) || r;
+  r = ((glTextureStorageMem1DEXT = (PFNGLTEXTURESTORAGEMEM1DEXTPROC)glewGetProcAddress((const GLubyte*)"glTextureStorageMem1DEXT")) == NULL) || r;
+  r = ((glTextureStorageMem2DEXT = (PFNGLTEXTURESTORAGEMEM2DEXTPROC)glewGetProcAddress((const GLubyte*)"glTextureStorageMem2DEXT")) == NULL) || r;
+  r = ((glTextureStorageMem2DMultisampleEXT = (PFNGLTEXTURESTORAGEMEM2DMULTISAMPLEEXTPROC)glewGetProcAddress((const GLubyte*)"glTextureStorageMem2DMultisampleEXT")) == NULL) || r;
+  r = ((glTextureStorageMem3DEXT = (PFNGLTEXTURESTORAGEMEM3DEXTPROC)glewGetProcAddress((const GLubyte*)"glTextureStorageMem3DEXT")) == NULL) || r;
+  r = ((glTextureStorageMem3DMultisampleEXT = (PFNGLTEXTURESTORAGEMEM3DMULTISAMPLEEXTPROC)glewGetProcAddress((const GLubyte*)"glTextureStorageMem3DMultisampleEXT")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_EXT_memory_object */
+
+#ifdef GL_EXT_memory_object_fd
+
+static GLboolean _glewInit_GL_EXT_memory_object_fd ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glImportMemoryFdEXT = (PFNGLIMPORTMEMORYFDEXTPROC)glewGetProcAddress((const GLubyte*)"glImportMemoryFdEXT")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_EXT_memory_object_fd */
+
+#ifdef GL_EXT_memory_object_win32
+
+static GLboolean _glewInit_GL_EXT_memory_object_win32 ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glImportMemoryWin32HandleEXT = (PFNGLIMPORTMEMORYWIN32HANDLEEXTPROC)glewGetProcAddress((const GLubyte*)"glImportMemoryWin32HandleEXT")) == NULL) || r;
+  r = ((glImportMemoryWin32NameEXT = (PFNGLIMPORTMEMORYWIN32NAMEEXTPROC)glewGetProcAddress((const GLubyte*)"glImportMemoryWin32NameEXT")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_EXT_memory_object_win32 */
 
 #ifdef GL_EXT_multi_draw_arrays
 
-static GLboolean _glewInit_GL_EXT_multi_draw_arrays (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_multi_draw_arrays ()
 {
   GLboolean r = GL_FALSE;
 
@@ -7461,9 +13121,23 @@ static GLboolean _glewInit_GL_EXT_multi_draw_arrays (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_EXT_multi_draw_arrays */
 
+#ifdef GL_EXT_multi_draw_indirect
+
+static GLboolean _glewInit_GL_EXT_multi_draw_indirect ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glMultiDrawArraysIndirectEXT = (PFNGLMULTIDRAWARRAYSINDIRECTEXTPROC)glewGetProcAddress((const GLubyte*)"glMultiDrawArraysIndirectEXT")) == NULL) || r;
+  r = ((glMultiDrawElementsIndirectEXT = (PFNGLMULTIDRAWELEMENTSINDIRECTEXTPROC)glewGetProcAddress((const GLubyte*)"glMultiDrawElementsIndirectEXT")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_EXT_multi_draw_indirect */
+
 #ifdef GL_EXT_multisample
 
-static GLboolean _glewInit_GL_EXT_multisample (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_multisample ()
 {
   GLboolean r = GL_FALSE;
 
@@ -7475,21 +13149,37 @@ static GLboolean _glewInit_GL_EXT_multisample (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_EXT_multisample */
 
-#ifdef GL_EXT_packed_depth_stencil
+#ifdef GL_EXT_multisampled_render_to_texture
 
-#endif /* GL_EXT_packed_depth_stencil */
+static GLboolean _glewInit_GL_EXT_multisampled_render_to_texture ()
+{
+  GLboolean r = GL_FALSE;
 
-#ifdef GL_EXT_packed_float
+  r = ((glFramebufferTexture2DMultisampleEXT = (PFNGLFRAMEBUFFERTEXTURE2DMULTISAMPLEEXTPROC)glewGetProcAddress((const GLubyte*)"glFramebufferTexture2DMultisampleEXT")) == NULL) || r;
 
-#endif /* GL_EXT_packed_float */
+  return r;
+}
 
-#ifdef GL_EXT_packed_pixels
+#endif /* GL_EXT_multisampled_render_to_texture */
 
-#endif /* GL_EXT_packed_pixels */
+#ifdef GL_EXT_multiview_draw_buffers
+
+static GLboolean _glewInit_GL_EXT_multiview_draw_buffers ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glDrawBuffersIndexedEXT = (PFNGLDRAWBUFFERSINDEXEDEXTPROC)glewGetProcAddress((const GLubyte*)"glDrawBuffersIndexedEXT")) == NULL) || r;
+  r = ((glGetIntegeri_vEXT = (PFNGLGETINTEGERI_VEXTPROC)glewGetProcAddress((const GLubyte*)"glGetIntegeri_vEXT")) == NULL) || r;
+  r = ((glReadBufferIndexedEXT = (PFNGLREADBUFFERINDEXEDEXTPROC)glewGetProcAddress((const GLubyte*)"glReadBufferIndexedEXT")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_EXT_multiview_draw_buffers */
 
 #ifdef GL_EXT_paletted_texture
 
-static GLboolean _glewInit_GL_EXT_paletted_texture (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_paletted_texture ()
 {
   GLboolean r = GL_FALSE;
 
@@ -7503,13 +13193,9 @@ static GLboolean _glewInit_GL_EXT_paletted_texture (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_EXT_paletted_texture */
 
-#ifdef GL_EXT_pixel_buffer_object
-
-#endif /* GL_EXT_pixel_buffer_object */
-
 #ifdef GL_EXT_pixel_transform
 
-static GLboolean _glewInit_GL_EXT_pixel_transform (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_pixel_transform ()
 {
   GLboolean r = GL_FALSE;
 
@@ -7525,13 +13211,9 @@ static GLboolean _glewInit_GL_EXT_pixel_transform (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_EXT_pixel_transform */
 
-#ifdef GL_EXT_pixel_transform_color_table
-
-#endif /* GL_EXT_pixel_transform_color_table */
-
 #ifdef GL_EXT_point_parameters
 
-static GLboolean _glewInit_GL_EXT_point_parameters (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_point_parameters ()
 {
   GLboolean r = GL_FALSE;
 
@@ -7545,7 +13227,7 @@ static GLboolean _glewInit_GL_EXT_point_parameters (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_EXT_polygon_offset
 
-static GLboolean _glewInit_GL_EXT_polygon_offset (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_polygon_offset ()
 {
   GLboolean r = GL_FALSE;
 
@@ -7556,9 +13238,22 @@ static GLboolean _glewInit_GL_EXT_polygon_offset (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_EXT_polygon_offset */
 
+#ifdef GL_EXT_polygon_offset_clamp
+
+static GLboolean _glewInit_GL_EXT_polygon_offset_clamp ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glPolygonOffsetClampEXT = (PFNGLPOLYGONOFFSETCLAMPEXTPROC)glewGetProcAddress((const GLubyte*)"glPolygonOffsetClampEXT")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_EXT_polygon_offset_clamp */
+
 #ifdef GL_EXT_provoking_vertex
 
-static GLboolean _glewInit_GL_EXT_provoking_vertex (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_provoking_vertex ()
 {
   GLboolean r = GL_FALSE;
 
@@ -7569,13 +13264,25 @@ static GLboolean _glewInit_GL_EXT_provoking_vertex (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_EXT_provoking_vertex */
 
-#ifdef GL_EXT_rescale_normal
+#ifdef GL_EXT_raster_multisample
 
-#endif /* GL_EXT_rescale_normal */
+static GLboolean _glewInit_GL_EXT_raster_multisample ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glCoverageModulationNV = (PFNGLCOVERAGEMODULATIONNVPROC)glewGetProcAddress((const GLubyte*)"glCoverageModulationNV")) == NULL) || r;
+  r = ((glCoverageModulationTableNV = (PFNGLCOVERAGEMODULATIONTABLENVPROC)glewGetProcAddress((const GLubyte*)"glCoverageModulationTableNV")) == NULL) || r;
+  r = ((glGetCoverageModulationTableNV = (PFNGLGETCOVERAGEMODULATIONTABLENVPROC)glewGetProcAddress((const GLubyte*)"glGetCoverageModulationTableNV")) == NULL) || r;
+  r = ((glRasterSamplesEXT = (PFNGLRASTERSAMPLESEXTPROC)glewGetProcAddress((const GLubyte*)"glRasterSamplesEXT")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_EXT_raster_multisample */
 
 #ifdef GL_EXT_scene_marker
 
-static GLboolean _glewInit_GL_EXT_scene_marker (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_scene_marker ()
 {
   GLboolean r = GL_FALSE;
 
@@ -7589,7 +13296,7 @@ static GLboolean _glewInit_GL_EXT_scene_marker (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_EXT_secondary_color
 
-static GLboolean _glewInit_GL_EXT_secondary_color (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_secondary_color ()
 {
   GLboolean r = GL_FALSE;
 
@@ -7616,9 +13323,55 @@ static GLboolean _glewInit_GL_EXT_secondary_color (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_EXT_secondary_color */
 
+#ifdef GL_EXT_semaphore
+
+static GLboolean _glewInit_GL_EXT_semaphore ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glDeleteSemaphoresEXT = (PFNGLDELETESEMAPHORESEXTPROC)glewGetProcAddress((const GLubyte*)"glDeleteSemaphoresEXT")) == NULL) || r;
+  r = ((glGenSemaphoresEXT = (PFNGLGENSEMAPHORESEXTPROC)glewGetProcAddress((const GLubyte*)"glGenSemaphoresEXT")) == NULL) || r;
+  r = ((glGetSemaphoreParameterui64vEXT = (PFNGLGETSEMAPHOREPARAMETERUI64VEXTPROC)glewGetProcAddress((const GLubyte*)"glGetSemaphoreParameterui64vEXT")) == NULL) || r;
+  r = ((glIsSemaphoreEXT = (PFNGLISSEMAPHOREEXTPROC)glewGetProcAddress((const GLubyte*)"glIsSemaphoreEXT")) == NULL) || r;
+  r = ((glSemaphoreParameterui64vEXT = (PFNGLSEMAPHOREPARAMETERUI64VEXTPROC)glewGetProcAddress((const GLubyte*)"glSemaphoreParameterui64vEXT")) == NULL) || r;
+  r = ((glSignalSemaphoreEXT = (PFNGLSIGNALSEMAPHOREEXTPROC)glewGetProcAddress((const GLubyte*)"glSignalSemaphoreEXT")) == NULL) || r;
+  r = ((glWaitSemaphoreEXT = (PFNGLWAITSEMAPHOREEXTPROC)glewGetProcAddress((const GLubyte*)"glWaitSemaphoreEXT")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_EXT_semaphore */
+
+#ifdef GL_EXT_semaphore_fd
+
+static GLboolean _glewInit_GL_EXT_semaphore_fd ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glImportSemaphoreFdEXT = (PFNGLIMPORTSEMAPHOREFDEXTPROC)glewGetProcAddress((const GLubyte*)"glImportSemaphoreFdEXT")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_EXT_semaphore_fd */
+
+#ifdef GL_EXT_semaphore_win32
+
+static GLboolean _glewInit_GL_EXT_semaphore_win32 ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glImportSemaphoreWin32HandleEXT = (PFNGLIMPORTSEMAPHOREWIN32HANDLEEXTPROC)glewGetProcAddress((const GLubyte*)"glImportSemaphoreWin32HandleEXT")) == NULL) || r;
+  r = ((glImportSemaphoreWin32NameEXT = (PFNGLIMPORTSEMAPHOREWIN32NAMEEXTPROC)glewGetProcAddress((const GLubyte*)"glImportSemaphoreWin32NameEXT")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_EXT_semaphore_win32 */
+
 #ifdef GL_EXT_separate_shader_objects
 
-static GLboolean _glewInit_GL_EXT_separate_shader_objects (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_separate_shader_objects ()
 {
   GLboolean r = GL_FALSE;
 
@@ -7631,17 +13384,9 @@ static GLboolean _glewInit_GL_EXT_separate_shader_objects (GLEW_CONTEXT_ARG_DEF_
 
 #endif /* GL_EXT_separate_shader_objects */
 
-#ifdef GL_EXT_separate_specular_color
-
-#endif /* GL_EXT_separate_specular_color */
-
-#ifdef GL_EXT_shader_image_load_formatted
-
-#endif /* GL_EXT_shader_image_load_formatted */
-
 #ifdef GL_EXT_shader_image_load_store
 
-static GLboolean _glewInit_GL_EXT_shader_image_load_store (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_shader_image_load_store ()
 {
   GLboolean r = GL_FALSE;
 
@@ -7653,25 +13398,38 @@ static GLboolean _glewInit_GL_EXT_shader_image_load_store (GLEW_CONTEXT_ARG_DEF_
 
 #endif /* GL_EXT_shader_image_load_store */
 
-#ifdef GL_EXT_shader_integer_mix
+#ifdef GL_EXT_shader_pixel_local_storage2
 
-#endif /* GL_EXT_shader_integer_mix */
+static GLboolean _glewInit_GL_EXT_shader_pixel_local_storage2 ()
+{
+  GLboolean r = GL_FALSE;
 
-#ifdef GL_EXT_shadow_funcs
+  r = ((glClearPixelLocalStorageuiEXT = (PFNGLCLEARPIXELLOCALSTORAGEUIEXTPROC)glewGetProcAddress((const GLubyte*)"glClearPixelLocalStorageuiEXT")) == NULL) || r;
+  r = ((glFramebufferPixelLocalStorageSizeEXT = (PFNGLFRAMEBUFFERPIXELLOCALSTORAGESIZEEXTPROC)glewGetProcAddress((const GLubyte*)"glFramebufferPixelLocalStorageSizeEXT")) == NULL) || r;
+  r = ((glGetFramebufferPixelLocalStorageSizeEXT = (PFNGLGETFRAMEBUFFERPIXELLOCALSTORAGESIZEEXTPROC)glewGetProcAddress((const GLubyte*)"glGetFramebufferPixelLocalStorageSizeEXT")) == NULL) || r;
 
-#endif /* GL_EXT_shadow_funcs */
+  return r;
+}
 
-#ifdef GL_EXT_shared_texture_palette
+#endif /* GL_EXT_shader_pixel_local_storage2 */
 
-#endif /* GL_EXT_shared_texture_palette */
+#ifdef GL_EXT_sparse_texture
 
-#ifdef GL_EXT_stencil_clear_tag
+static GLboolean _glewInit_GL_EXT_sparse_texture ()
+{
+  GLboolean r = GL_FALSE;
 
-#endif /* GL_EXT_stencil_clear_tag */
+  r = ((glTexPageCommitmentEXT = (PFNGLTEXPAGECOMMITMENTEXTPROC)glewGetProcAddress((const GLubyte*)"glTexPageCommitmentEXT")) == NULL) || r;
+  r = ((glTexturePageCommitmentEXT = (PFNGLTEXTUREPAGECOMMITMENTEXTPROC)glewGetProcAddress((const GLubyte*)"glTexturePageCommitmentEXT")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_EXT_sparse_texture */
 
 #ifdef GL_EXT_stencil_two_side
 
-static GLboolean _glewInit_GL_EXT_stencil_two_side (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_stencil_two_side ()
 {
   GLboolean r = GL_FALSE;
 
@@ -7682,13 +13440,9 @@ static GLboolean _glewInit_GL_EXT_stencil_two_side (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_EXT_stencil_two_side */
 
-#ifdef GL_EXT_stencil_wrap
-
-#endif /* GL_EXT_stencil_wrap */
-
 #ifdef GL_EXT_subtexture
 
-static GLboolean _glewInit_GL_EXT_subtexture (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_subtexture ()
 {
   GLboolean r = GL_FALSE;
 
@@ -7701,13 +13455,9 @@ static GLboolean _glewInit_GL_EXT_subtexture (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_EXT_subtexture */
 
-#ifdef GL_EXT_texture
-
-#endif /* GL_EXT_texture */
-
 #ifdef GL_EXT_texture3D
 
-static GLboolean _glewInit_GL_EXT_texture3D (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_texture3D ()
 {
   GLboolean r = GL_FALSE;
 
@@ -7720,7 +13470,7 @@ static GLboolean _glewInit_GL_EXT_texture3D (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_EXT_texture_array
 
-static GLboolean _glewInit_GL_EXT_texture_array (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_texture_array ()
 {
   GLboolean r = GL_FALSE;
 
@@ -7733,7 +13483,7 @@ static GLboolean _glewInit_GL_EXT_texture_array (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_EXT_texture_buffer_object
 
-static GLboolean _glewInit_GL_EXT_texture_buffer_object (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_texture_buffer_object ()
 {
   GLboolean r = GL_FALSE;
 
@@ -7744,53 +13494,9 @@ static GLboolean _glewInit_GL_EXT_texture_buffer_object (GLEW_CONTEXT_ARG_DEF_IN
 
 #endif /* GL_EXT_texture_buffer_object */
 
-#ifdef GL_EXT_texture_compression_dxt1
-
-#endif /* GL_EXT_texture_compression_dxt1 */
-
-#ifdef GL_EXT_texture_compression_latc
-
-#endif /* GL_EXT_texture_compression_latc */
-
-#ifdef GL_EXT_texture_compression_rgtc
-
-#endif /* GL_EXT_texture_compression_rgtc */
-
-#ifdef GL_EXT_texture_compression_s3tc
-
-#endif /* GL_EXT_texture_compression_s3tc */
-
-#ifdef GL_EXT_texture_cube_map
-
-#endif /* GL_EXT_texture_cube_map */
-
-#ifdef GL_EXT_texture_edge_clamp
-
-#endif /* GL_EXT_texture_edge_clamp */
-
-#ifdef GL_EXT_texture_env
-
-#endif /* GL_EXT_texture_env */
-
-#ifdef GL_EXT_texture_env_add
-
-#endif /* GL_EXT_texture_env_add */
-
-#ifdef GL_EXT_texture_env_combine
-
-#endif /* GL_EXT_texture_env_combine */
-
-#ifdef GL_EXT_texture_env_dot3
-
-#endif /* GL_EXT_texture_env_dot3 */
-
-#ifdef GL_EXT_texture_filter_anisotropic
-
-#endif /* GL_EXT_texture_filter_anisotropic */
-
 #ifdef GL_EXT_texture_integer
 
-static GLboolean _glewInit_GL_EXT_texture_integer (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_texture_integer ()
 {
   GLboolean r = GL_FALSE;
 
@@ -7806,17 +13512,9 @@ static GLboolean _glewInit_GL_EXT_texture_integer (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_EXT_texture_integer */
 
-#ifdef GL_EXT_texture_lod_bias
-
-#endif /* GL_EXT_texture_lod_bias */
-
-#ifdef GL_EXT_texture_mirror_clamp
-
-#endif /* GL_EXT_texture_mirror_clamp */
-
 #ifdef GL_EXT_texture_object
 
-static GLboolean _glewInit_GL_EXT_texture_object (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_texture_object ()
 {
   GLboolean r = GL_FALSE;
 
@@ -7834,7 +13532,7 @@ static GLboolean _glewInit_GL_EXT_texture_object (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_EXT_texture_perturb_normal
 
-static GLboolean _glewInit_GL_EXT_texture_perturb_normal (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_texture_perturb_normal ()
 {
   GLboolean r = GL_FALSE;
 
@@ -7845,33 +13543,40 @@ static GLboolean _glewInit_GL_EXT_texture_perturb_normal (GLEW_CONTEXT_ARG_DEF_I
 
 #endif /* GL_EXT_texture_perturb_normal */
 
-#ifdef GL_EXT_texture_rectangle
+#ifdef GL_EXT_texture_storage
 
-#endif /* GL_EXT_texture_rectangle */
+static GLboolean _glewInit_GL_EXT_texture_storage ()
+{
+  GLboolean r = GL_FALSE;
 
-#ifdef GL_EXT_texture_sRGB
+  r = ((glTexStorage1DEXT = (PFNGLTEXSTORAGE1DEXTPROC)glewGetProcAddress((const GLubyte*)"glTexStorage1DEXT")) == NULL) || r;
+  r = ((glTexStorage2DEXT = (PFNGLTEXSTORAGE2DEXTPROC)glewGetProcAddress((const GLubyte*)"glTexStorage2DEXT")) == NULL) || r;
+  r = ((glTexStorage3DEXT = (PFNGLTEXSTORAGE3DEXTPROC)glewGetProcAddress((const GLubyte*)"glTexStorage3DEXT")) == NULL) || r;
+  r = ((glTextureStorage1DEXT = (PFNGLTEXTURESTORAGE1DEXTPROC)glewGetProcAddress((const GLubyte*)"glTextureStorage1DEXT")) == NULL) || r;
+  r = ((glTextureStorage2DEXT = (PFNGLTEXTURESTORAGE2DEXTPROC)glewGetProcAddress((const GLubyte*)"glTextureStorage2DEXT")) == NULL) || r;
+  r = ((glTextureStorage3DEXT = (PFNGLTEXTURESTORAGE3DEXTPROC)glewGetProcAddress((const GLubyte*)"glTextureStorage3DEXT")) == NULL) || r;
 
-#endif /* GL_EXT_texture_sRGB */
+  return r;
+}
 
-#ifdef GL_EXT_texture_sRGB_decode
+#endif /* GL_EXT_texture_storage */
 
-#endif /* GL_EXT_texture_sRGB_decode */
+#ifdef GL_EXT_texture_view
 
-#ifdef GL_EXT_texture_shared_exponent
+static GLboolean _glewInit_GL_EXT_texture_view ()
+{
+  GLboolean r = GL_FALSE;
 
-#endif /* GL_EXT_texture_shared_exponent */
+  r = ((glTextureViewEXT = (PFNGLTEXTUREVIEWEXTPROC)glewGetProcAddress((const GLubyte*)"glTextureViewEXT")) == NULL) || r;
 
-#ifdef GL_EXT_texture_snorm
+  return r;
+}
 
-#endif /* GL_EXT_texture_snorm */
-
-#ifdef GL_EXT_texture_swizzle
-
-#endif /* GL_EXT_texture_swizzle */
+#endif /* GL_EXT_texture_view */
 
 #ifdef GL_EXT_timer_query
 
-static GLboolean _glewInit_GL_EXT_timer_query (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_timer_query ()
 {
   GLboolean r = GL_FALSE;
 
@@ -7885,7 +13590,7 @@ static GLboolean _glewInit_GL_EXT_timer_query (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_EXT_transform_feedback
 
-static GLboolean _glewInit_GL_EXT_transform_feedback (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_transform_feedback ()
 {
   GLboolean r = GL_FALSE;
 
@@ -7904,7 +13609,7 @@ static GLboolean _glewInit_GL_EXT_transform_feedback (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_EXT_vertex_array
 
-static GLboolean _glewInit_GL_EXT_vertex_array (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_vertex_array ()
 {
   GLboolean r = GL_FALSE;
 
@@ -7922,13 +13627,24 @@ static GLboolean _glewInit_GL_EXT_vertex_array (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_EXT_vertex_array */
 
-#ifdef GL_EXT_vertex_array_bgra
+#ifdef GL_EXT_vertex_array_setXXX
 
-#endif /* GL_EXT_vertex_array_bgra */
+static GLboolean _glewInit_GL_EXT_vertex_array_setXXX ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glBindArraySetEXT = (PFNGLBINDARRAYSETEXTPROC)glewGetProcAddress((const GLubyte*)"glBindArraySetEXT")) == NULL) || r;
+  r = ((glCreateArraySetExt = (PFNGLCREATEARRAYSETEXTPROC)glewGetProcAddress((const GLubyte*)"glCreateArraySetExt")) == NULL) || r;
+  r = ((glDeleteArraySetsEXT = (PFNGLDELETEARRAYSETSEXTPROC)glewGetProcAddress((const GLubyte*)"glDeleteArraySetsEXT")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_EXT_vertex_array_setXXX */
 
 #ifdef GL_EXT_vertex_attrib_64bit
 
-static GLboolean _glewInit_GL_EXT_vertex_attrib_64bit (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_vertex_attrib_64bit ()
 {
   GLboolean r = GL_FALSE;
 
@@ -7951,7 +13667,7 @@ static GLboolean _glewInit_GL_EXT_vertex_attrib_64bit (GLEW_CONTEXT_ARG_DEF_INIT
 
 #ifdef GL_EXT_vertex_shader
 
-static GLboolean _glewInit_GL_EXT_vertex_shader (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_vertex_shader ()
 {
   GLboolean r = GL_FALSE;
 
@@ -8005,7 +13721,7 @@ static GLboolean _glewInit_GL_EXT_vertex_shader (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_EXT_vertex_weighting
 
-static GLboolean _glewInit_GL_EXT_vertex_weighting (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_vertex_weighting ()
 {
   GLboolean r = GL_FALSE;
 
@@ -8018,9 +13734,36 @@ static GLboolean _glewInit_GL_EXT_vertex_weighting (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_EXT_vertex_weighting */
 
+#ifdef GL_EXT_win32_keyed_mutex
+
+static GLboolean _glewInit_GL_EXT_win32_keyed_mutex ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glAcquireKeyedMutexWin32EXT = (PFNGLACQUIREKEYEDMUTEXWIN32EXTPROC)glewGetProcAddress((const GLubyte*)"glAcquireKeyedMutexWin32EXT")) == NULL) || r;
+  r = ((glReleaseKeyedMutexWin32EXT = (PFNGLRELEASEKEYEDMUTEXWIN32EXTPROC)glewGetProcAddress((const GLubyte*)"glReleaseKeyedMutexWin32EXT")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_EXT_win32_keyed_mutex */
+
+#ifdef GL_EXT_window_rectangles
+
+static GLboolean _glewInit_GL_EXT_window_rectangles ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glWindowRectanglesEXT = (PFNGLWINDOWRECTANGLESEXTPROC)glewGetProcAddress((const GLubyte*)"glWindowRectanglesEXT")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_EXT_window_rectangles */
+
 #ifdef GL_EXT_x11_sync_object
 
-static GLboolean _glewInit_GL_EXT_x11_sync_object (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_EXT_x11_sync_object ()
 {
   GLboolean r = GL_FALSE;
 
@@ -8033,7 +13776,7 @@ static GLboolean _glewInit_GL_EXT_x11_sync_object (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_GREMEDY_frame_terminator
 
-static GLboolean _glewInit_GL_GREMEDY_frame_terminator (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_GREMEDY_frame_terminator ()
 {
   GLboolean r = GL_FALSE;
 
@@ -8046,7 +13789,7 @@ static GLboolean _glewInit_GL_GREMEDY_frame_terminator (GLEW_CONTEXT_ARG_DEF_INI
 
 #ifdef GL_GREMEDY_string_marker
 
-static GLboolean _glewInit_GL_GREMEDY_string_marker (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_GREMEDY_string_marker ()
 {
   GLboolean r = GL_FALSE;
 
@@ -8057,13 +13800,9 @@ static GLboolean _glewInit_GL_GREMEDY_string_marker (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_GREMEDY_string_marker */
 
-#ifdef GL_HP_convolution_border_modes
-
-#endif /* GL_HP_convolution_border_modes */
-
 #ifdef GL_HP_image_transform
 
-static GLboolean _glewInit_GL_HP_image_transform (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_HP_image_transform ()
 {
   GLboolean r = GL_FALSE;
 
@@ -8079,21 +13818,9 @@ static GLboolean _glewInit_GL_HP_image_transform (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_HP_image_transform */
 
-#ifdef GL_HP_occlusion_test
-
-#endif /* GL_HP_occlusion_test */
-
-#ifdef GL_HP_texture_lighting
-
-#endif /* GL_HP_texture_lighting */
-
-#ifdef GL_IBM_cull_vertex
-
-#endif /* GL_IBM_cull_vertex */
-
 #ifdef GL_IBM_multimode_draw_arrays
 
-static GLboolean _glewInit_GL_IBM_multimode_draw_arrays (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_IBM_multimode_draw_arrays ()
 {
   GLboolean r = GL_FALSE;
 
@@ -8105,21 +13832,9 @@ static GLboolean _glewInit_GL_IBM_multimode_draw_arrays (GLEW_CONTEXT_ARG_DEF_IN
 
 #endif /* GL_IBM_multimode_draw_arrays */
 
-#ifdef GL_IBM_rasterpos_clip
-
-#endif /* GL_IBM_rasterpos_clip */
-
-#ifdef GL_IBM_static_data
-
-#endif /* GL_IBM_static_data */
-
-#ifdef GL_IBM_texture_mirrored_repeat
-
-#endif /* GL_IBM_texture_mirrored_repeat */
-
 #ifdef GL_IBM_vertex_array_lists
 
-static GLboolean _glewInit_GL_IBM_vertex_array_lists (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_IBM_vertex_array_lists ()
 {
   GLboolean r = GL_FALSE;
 
@@ -8137,21 +13852,9 @@ static GLboolean _glewInit_GL_IBM_vertex_array_lists (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_IBM_vertex_array_lists */
 
-#ifdef GL_INGR_color_clamp
-
-#endif /* GL_INGR_color_clamp */
-
-#ifdef GL_INGR_interlace_read
-
-#endif /* GL_INGR_interlace_read */
-
-#ifdef GL_INTEL_fragment_shader_ordering
-
-#endif /* GL_INTEL_fragment_shader_ordering */
-
 #ifdef GL_INTEL_map_texture
 
-static GLboolean _glewInit_GL_INTEL_map_texture (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_INTEL_map_texture ()
 {
   GLboolean r = GL_FALSE;
 
@@ -8166,7 +13869,7 @@ static GLboolean _glewInit_GL_INTEL_map_texture (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_INTEL_parallel_arrays
 
-static GLboolean _glewInit_GL_INTEL_parallel_arrays (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_INTEL_parallel_arrays ()
 {
   GLboolean r = GL_FALSE;
 
@@ -8182,7 +13885,7 @@ static GLboolean _glewInit_GL_INTEL_parallel_arrays (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_INTEL_performance_query
 
-static GLboolean _glewInit_GL_INTEL_performance_query (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_INTEL_performance_query ()
 {
   GLboolean r = GL_FALSE;
 
@@ -8204,7 +13907,7 @@ static GLboolean _glewInit_GL_INTEL_performance_query (GLEW_CONTEXT_ARG_DEF_INIT
 
 #ifdef GL_INTEL_texture_scissor
 
-static GLboolean _glewInit_GL_INTEL_texture_scissor (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_INTEL_texture_scissor ()
 {
   GLboolean r = GL_FALSE;
 
@@ -8218,7 +13921,7 @@ static GLboolean _glewInit_GL_INTEL_texture_scissor (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_KHR_blend_equation_advanced
 
-static GLboolean _glewInit_GL_KHR_blend_equation_advanced (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_KHR_blend_equation_advanced ()
 {
   GLboolean r = GL_FALSE;
 
@@ -8229,17 +13932,9 @@ static GLboolean _glewInit_GL_KHR_blend_equation_advanced (GLEW_CONTEXT_ARG_DEF_
 
 #endif /* GL_KHR_blend_equation_advanced */
 
-#ifdef GL_KHR_blend_equation_advanced_coherent
-
-#endif /* GL_KHR_blend_equation_advanced_coherent */
-
-#ifdef GL_KHR_context_flush_control
-
-#endif /* GL_KHR_context_flush_control */
-
 #ifdef GL_KHR_debug
 
-static GLboolean _glewInit_GL_KHR_debug (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_KHR_debug ()
 {
   GLboolean r = GL_FALSE;
 
@@ -8259,13 +13954,22 @@ static GLboolean _glewInit_GL_KHR_debug (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_KHR_debug */
 
-#ifdef GL_KHR_robust_buffer_access_behavior
+#ifdef GL_KHR_parallel_shader_compile
 
-#endif /* GL_KHR_robust_buffer_access_behavior */
+static GLboolean _glewInit_GL_KHR_parallel_shader_compile ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glMaxShaderCompilerThreadsKHR = (PFNGLMAXSHADERCOMPILERTHREADSKHRPROC)glewGetProcAddress((const GLubyte*)"glMaxShaderCompilerThreadsKHR")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_KHR_parallel_shader_compile */
 
 #ifdef GL_KHR_robustness
 
-static GLboolean _glewInit_GL_KHR_robustness (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_KHR_robustness ()
 {
   GLboolean r = GL_FALSE;
 
@@ -8279,17 +13983,9 @@ static GLboolean _glewInit_GL_KHR_robustness (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_KHR_robustness */
 
-#ifdef GL_KHR_texture_compression_astc_hdr
-
-#endif /* GL_KHR_texture_compression_astc_hdr */
-
-#ifdef GL_KHR_texture_compression_astc_ldr
-
-#endif /* GL_KHR_texture_compression_astc_ldr */
-
 #ifdef GL_KTX_buffer_region
 
-static GLboolean _glewInit_GL_KTX_buffer_region (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_KTX_buffer_region ()
 {
   GLboolean r = GL_FALSE;
 
@@ -8304,17 +14000,9 @@ static GLboolean _glewInit_GL_KTX_buffer_region (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_KTX_buffer_region */
 
-#ifdef GL_MESAX_texture_stack
-
-#endif /* GL_MESAX_texture_stack */
-
-#ifdef GL_MESA_pack_invert
-
-#endif /* GL_MESA_pack_invert */
-
 #ifdef GL_MESA_resize_buffers
 
-static GLboolean _glewInit_GL_MESA_resize_buffers (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_MESA_resize_buffers ()
 {
   GLboolean r = GL_FALSE;
 
@@ -8327,7 +14015,7 @@ static GLboolean _glewInit_GL_MESA_resize_buffers (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_MESA_window_pos
 
-static GLboolean _glewInit_GL_MESA_window_pos (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_MESA_window_pos ()
 {
   GLboolean r = GL_FALSE;
 
@@ -8361,13 +14049,9 @@ static GLboolean _glewInit_GL_MESA_window_pos (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_MESA_window_pos */
 
-#ifdef GL_MESA_ycbcr_texture
-
-#endif /* GL_MESA_ycbcr_texture */
-
 #ifdef GL_NVX_conditional_render
 
-static GLboolean _glewInit_GL_NVX_conditional_render (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_NVX_conditional_render ()
 {
   GLboolean r = GL_FALSE;
 
@@ -8379,13 +14063,38 @@ static GLboolean _glewInit_GL_NVX_conditional_render (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_NVX_conditional_render */
 
-#ifdef GL_NVX_gpu_memory_info
+#ifdef GL_NVX_linked_gpu_multicast
 
-#endif /* GL_NVX_gpu_memory_info */
+static GLboolean _glewInit_GL_NVX_linked_gpu_multicast ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glLGPUCopyImageSubDataNVX = (PFNGLLGPUCOPYIMAGESUBDATANVXPROC)glewGetProcAddress((const GLubyte*)"glLGPUCopyImageSubDataNVX")) == NULL) || r;
+  r = ((glLGPUInterlockNVX = (PFNGLLGPUINTERLOCKNVXPROC)glewGetProcAddress((const GLubyte*)"glLGPUInterlockNVX")) == NULL) || r;
+  r = ((glLGPUNamedBufferSubDataNVX = (PFNGLLGPUNAMEDBUFFERSUBDATANVXPROC)glewGetProcAddress((const GLubyte*)"glLGPUNamedBufferSubDataNVX")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_NVX_linked_gpu_multicast */
+
+#ifdef GL_NV_3dvision_settings
+
+static GLboolean _glewInit_GL_NV_3dvision_settings ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glStereoParameterfNV = (PFNGLSTEREOPARAMETERFNVPROC)glewGetProcAddress((const GLubyte*)"glStereoParameterfNV")) == NULL) || r;
+  r = ((glStereoParameteriNV = (PFNGLSTEREOPARAMETERINVPROC)glewGetProcAddress((const GLubyte*)"glStereoParameteriNV")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_NV_3dvision_settings */
 
 #ifdef GL_NV_bindless_multi_draw_indirect
 
-static GLboolean _glewInit_GL_NV_bindless_multi_draw_indirect (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_NV_bindless_multi_draw_indirect ()
 {
   GLboolean r = GL_FALSE;
 
@@ -8399,7 +14108,7 @@ static GLboolean _glewInit_GL_NV_bindless_multi_draw_indirect (GLEW_CONTEXT_ARG_
 
 #ifdef GL_NV_bindless_multi_draw_indirect_count
 
-static GLboolean _glewInit_GL_NV_bindless_multi_draw_indirect_count (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_NV_bindless_multi_draw_indirect_count ()
 {
   GLboolean r = GL_FALSE;
 
@@ -8413,7 +14122,7 @@ static GLboolean _glewInit_GL_NV_bindless_multi_draw_indirect_count (GLEW_CONTEX
 
 #ifdef GL_NV_bindless_texture
 
-static GLboolean _glewInit_GL_NV_bindless_texture (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_NV_bindless_texture ()
 {
   GLboolean r = GL_FALSE;
 
@@ -8438,7 +14147,7 @@ static GLboolean _glewInit_GL_NV_bindless_texture (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_NV_blend_equation_advanced
 
-static GLboolean _glewInit_GL_NV_blend_equation_advanced (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_NV_blend_equation_advanced ()
 {
   GLboolean r = GL_FALSE;
 
@@ -8450,21 +14159,51 @@ static GLboolean _glewInit_GL_NV_blend_equation_advanced (GLEW_CONTEXT_ARG_DEF_I
 
 #endif /* GL_NV_blend_equation_advanced */
 
-#ifdef GL_NV_blend_equation_advanced_coherent
+#ifdef GL_NV_clip_space_w_scaling
 
-#endif /* GL_NV_blend_equation_advanced_coherent */
+static GLboolean _glewInit_GL_NV_clip_space_w_scaling ()
+{
+  GLboolean r = GL_FALSE;
 
-#ifdef GL_NV_blend_square
+  r = ((glViewportPositionWScaleNV = (PFNGLVIEWPORTPOSITIONWSCALENVPROC)glewGetProcAddress((const GLubyte*)"glViewportPositionWScaleNV")) == NULL) || r;
 
-#endif /* GL_NV_blend_square */
+  return r;
+}
 
-#ifdef GL_NV_compute_program5
+#endif /* GL_NV_clip_space_w_scaling */
 
-#endif /* GL_NV_compute_program5 */
+#ifdef GL_NV_command_list
+
+static GLboolean _glewInit_GL_NV_command_list ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glCallCommandListNV = (PFNGLCALLCOMMANDLISTNVPROC)glewGetProcAddress((const GLubyte*)"glCallCommandListNV")) == NULL) || r;
+  r = ((glCommandListSegmentsNV = (PFNGLCOMMANDLISTSEGMENTSNVPROC)glewGetProcAddress((const GLubyte*)"glCommandListSegmentsNV")) == NULL) || r;
+  r = ((glCompileCommandListNV = (PFNGLCOMPILECOMMANDLISTNVPROC)glewGetProcAddress((const GLubyte*)"glCompileCommandListNV")) == NULL) || r;
+  r = ((glCreateCommandListsNV = (PFNGLCREATECOMMANDLISTSNVPROC)glewGetProcAddress((const GLubyte*)"glCreateCommandListsNV")) == NULL) || r;
+  r = ((glCreateStatesNV = (PFNGLCREATESTATESNVPROC)glewGetProcAddress((const GLubyte*)"glCreateStatesNV")) == NULL) || r;
+  r = ((glDeleteCommandListsNV = (PFNGLDELETECOMMANDLISTSNVPROC)glewGetProcAddress((const GLubyte*)"glDeleteCommandListsNV")) == NULL) || r;
+  r = ((glDeleteStatesNV = (PFNGLDELETESTATESNVPROC)glewGetProcAddress((const GLubyte*)"glDeleteStatesNV")) == NULL) || r;
+  r = ((glDrawCommandsAddressNV = (PFNGLDRAWCOMMANDSADDRESSNVPROC)glewGetProcAddress((const GLubyte*)"glDrawCommandsAddressNV")) == NULL) || r;
+  r = ((glDrawCommandsNV = (PFNGLDRAWCOMMANDSNVPROC)glewGetProcAddress((const GLubyte*)"glDrawCommandsNV")) == NULL) || r;
+  r = ((glDrawCommandsStatesAddressNV = (PFNGLDRAWCOMMANDSSTATESADDRESSNVPROC)glewGetProcAddress((const GLubyte*)"glDrawCommandsStatesAddressNV")) == NULL) || r;
+  r = ((glDrawCommandsStatesNV = (PFNGLDRAWCOMMANDSSTATESNVPROC)glewGetProcAddress((const GLubyte*)"glDrawCommandsStatesNV")) == NULL) || r;
+  r = ((glGetCommandHeaderNV = (PFNGLGETCOMMANDHEADERNVPROC)glewGetProcAddress((const GLubyte*)"glGetCommandHeaderNV")) == NULL) || r;
+  r = ((glGetStageIndexNV = (PFNGLGETSTAGEINDEXNVPROC)glewGetProcAddress((const GLubyte*)"glGetStageIndexNV")) == NULL) || r;
+  r = ((glIsCommandListNV = (PFNGLISCOMMANDLISTNVPROC)glewGetProcAddress((const GLubyte*)"glIsCommandListNV")) == NULL) || r;
+  r = ((glIsStateNV = (PFNGLISSTATENVPROC)glewGetProcAddress((const GLubyte*)"glIsStateNV")) == NULL) || r;
+  r = ((glListDrawCommandsStatesClientNV = (PFNGLLISTDRAWCOMMANDSSTATESCLIENTNVPROC)glewGetProcAddress((const GLubyte*)"glListDrawCommandsStatesClientNV")) == NULL) || r;
+  r = ((glStateCaptureNV = (PFNGLSTATECAPTURENVPROC)glewGetProcAddress((const GLubyte*)"glStateCaptureNV")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_NV_command_list */
 
 #ifdef GL_NV_conditional_render
 
-static GLboolean _glewInit_GL_NV_conditional_render (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_NV_conditional_render ()
 {
   GLboolean r = GL_FALSE;
 
@@ -8476,13 +14215,61 @@ static GLboolean _glewInit_GL_NV_conditional_render (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_NV_conditional_render */
 
-#ifdef GL_NV_copy_depth_to_color
+#ifdef GL_NV_conservative_raster
 
-#endif /* GL_NV_copy_depth_to_color */
+static GLboolean _glewInit_GL_NV_conservative_raster ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glSubpixelPrecisionBiasNV = (PFNGLSUBPIXELPRECISIONBIASNVPROC)glewGetProcAddress((const GLubyte*)"glSubpixelPrecisionBiasNV")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_NV_conservative_raster */
+
+#ifdef GL_NV_conservative_raster_dilate
+
+static GLboolean _glewInit_GL_NV_conservative_raster_dilate ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glConservativeRasterParameterfNV = (PFNGLCONSERVATIVERASTERPARAMETERFNVPROC)glewGetProcAddress((const GLubyte*)"glConservativeRasterParameterfNV")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_NV_conservative_raster_dilate */
+
+#ifdef GL_NV_conservative_raster_pre_snap_triangles
+
+static GLboolean _glewInit_GL_NV_conservative_raster_pre_snap_triangles ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glConservativeRasterParameteriNV = (PFNGLCONSERVATIVERASTERPARAMETERINVPROC)glewGetProcAddress((const GLubyte*)"glConservativeRasterParameteriNV")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_NV_conservative_raster_pre_snap_triangles */
+
+#ifdef GL_NV_copy_buffer
+
+static GLboolean _glewInit_GL_NV_copy_buffer ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glCopyBufferSubDataNV = (PFNGLCOPYBUFFERSUBDATANVPROC)glewGetProcAddress((const GLubyte*)"glCopyBufferSubDataNV")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_NV_copy_buffer */
 
 #ifdef GL_NV_copy_image
 
-static GLboolean _glewInit_GL_NV_copy_image (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_NV_copy_image ()
 {
   GLboolean r = GL_FALSE;
 
@@ -8493,13 +14280,9 @@ static GLboolean _glewInit_GL_NV_copy_image (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_NV_copy_image */
 
-#ifdef GL_NV_deep_texture3D
-
-#endif /* GL_NV_deep_texture3D */
-
 #ifdef GL_NV_depth_buffer_float
 
-static GLboolean _glewInit_GL_NV_depth_buffer_float (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_NV_depth_buffer_float ()
 {
   GLboolean r = GL_FALSE;
 
@@ -8512,17 +14295,36 @@ static GLboolean _glewInit_GL_NV_depth_buffer_float (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_NV_depth_buffer_float */
 
-#ifdef GL_NV_depth_clamp
+#ifdef GL_NV_draw_buffers
 
-#endif /* GL_NV_depth_clamp */
+static GLboolean _glewInit_GL_NV_draw_buffers ()
+{
+  GLboolean r = GL_FALSE;
 
-#ifdef GL_NV_depth_range_unclamped
+  r = ((glDrawBuffersNV = (PFNGLDRAWBUFFERSNVPROC)glewGetProcAddress((const GLubyte*)"glDrawBuffersNV")) == NULL) || r;
 
-#endif /* GL_NV_depth_range_unclamped */
+  return r;
+}
+
+#endif /* GL_NV_draw_buffers */
+
+#ifdef GL_NV_draw_instanced
+
+static GLboolean _glewInit_GL_NV_draw_instanced ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glDrawArraysInstancedNV = (PFNGLDRAWARRAYSINSTANCEDNVPROC)glewGetProcAddress((const GLubyte*)"glDrawArraysInstancedNV")) == NULL) || r;
+  r = ((glDrawElementsInstancedNV = (PFNGLDRAWELEMENTSINSTANCEDNVPROC)glewGetProcAddress((const GLubyte*)"glDrawElementsInstancedNV")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_NV_draw_instanced */
 
 #ifdef GL_NV_draw_texture
 
-static GLboolean _glewInit_GL_NV_draw_texture (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_NV_draw_texture ()
 {
   GLboolean r = GL_FALSE;
 
@@ -8533,9 +14335,26 @@ static GLboolean _glewInit_GL_NV_draw_texture (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_NV_draw_texture */
 
+#ifdef GL_NV_draw_vulkan_image
+
+static GLboolean _glewInit_GL_NV_draw_vulkan_image ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glDrawVkImageNV = (PFNGLDRAWVKIMAGENVPROC)glewGetProcAddress((const GLubyte*)"glDrawVkImageNV")) == NULL) || r;
+  r = ((glGetVkProcAddrNV = (PFNGLGETVKPROCADDRNVPROC)glewGetProcAddress((const GLubyte*)"glGetVkProcAddrNV")) == NULL) || r;
+  r = ((glSignalVkFenceNV = (PFNGLSIGNALVKFENCENVPROC)glewGetProcAddress((const GLubyte*)"glSignalVkFenceNV")) == NULL) || r;
+  r = ((glSignalVkSemaphoreNV = (PFNGLSIGNALVKSEMAPHORENVPROC)glewGetProcAddress((const GLubyte*)"glSignalVkSemaphoreNV")) == NULL) || r;
+  r = ((glWaitVkSemaphoreNV = (PFNGLWAITVKSEMAPHORENVPROC)glewGetProcAddress((const GLubyte*)"glWaitVkSemaphoreNV")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_NV_draw_vulkan_image */
+
 #ifdef GL_NV_evaluators
 
-static GLboolean _glewInit_GL_NV_evaluators (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_NV_evaluators ()
 {
   GLboolean r = GL_FALSE;
 
@@ -8556,7 +14375,7 @@ static GLboolean _glewInit_GL_NV_evaluators (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_NV_explicit_multisample
 
-static GLboolean _glewInit_GL_NV_explicit_multisample (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_NV_explicit_multisample ()
 {
   GLboolean r = GL_FALSE;
 
@@ -8571,7 +14390,7 @@ static GLboolean _glewInit_GL_NV_explicit_multisample (GLEW_CONTEXT_ARG_DEF_INIT
 
 #ifdef GL_NV_fence
 
-static GLboolean _glewInit_GL_NV_fence (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_NV_fence ()
 {
   GLboolean r = GL_FALSE;
 
@@ -8588,17 +14407,22 @@ static GLboolean _glewInit_GL_NV_fence (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_NV_fence */
 
-#ifdef GL_NV_float_buffer
+#ifdef GL_NV_fragment_coverage_to_color
 
-#endif /* GL_NV_float_buffer */
+static GLboolean _glewInit_GL_NV_fragment_coverage_to_color ()
+{
+  GLboolean r = GL_FALSE;
 
-#ifdef GL_NV_fog_distance
+  r = ((glFragmentCoverageColorNV = (PFNGLFRAGMENTCOVERAGECOLORNVPROC)glewGetProcAddress((const GLubyte*)"glFragmentCoverageColorNV")) == NULL) || r;
 
-#endif /* GL_NV_fog_distance */
+  return r;
+}
+
+#endif /* GL_NV_fragment_coverage_to_color */
 
 #ifdef GL_NV_fragment_program
 
-static GLboolean _glewInit_GL_NV_fragment_program (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_NV_fragment_program ()
 {
   GLboolean r = GL_FALSE;
 
@@ -8614,21 +14438,35 @@ static GLboolean _glewInit_GL_NV_fragment_program (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_NV_fragment_program */
 
-#ifdef GL_NV_fragment_program2
+#ifdef GL_NV_framebuffer_blit
 
-#endif /* GL_NV_fragment_program2 */
+static GLboolean _glewInit_GL_NV_framebuffer_blit ()
+{
+  GLboolean r = GL_FALSE;
 
-#ifdef GL_NV_fragment_program4
+  r = ((glBlitFramebufferNV = (PFNGLBLITFRAMEBUFFERNVPROC)glewGetProcAddress((const GLubyte*)"glBlitFramebufferNV")) == NULL) || r;
 
-#endif /* GL_NV_fragment_program4 */
+  return r;
+}
 
-#ifdef GL_NV_fragment_program_option
+#endif /* GL_NV_framebuffer_blit */
 
-#endif /* GL_NV_fragment_program_option */
+#ifdef GL_NV_framebuffer_multisample
+
+static GLboolean _glewInit_GL_NV_framebuffer_multisample ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glRenderbufferStorageMultisampleNV = (PFNGLRENDERBUFFERSTORAGEMULTISAMPLENVPROC)glewGetProcAddress((const GLubyte*)"glRenderbufferStorageMultisampleNV")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_NV_framebuffer_multisample */
 
 #ifdef GL_NV_framebuffer_multisample_coverage
 
-static GLboolean _glewInit_GL_NV_framebuffer_multisample_coverage (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_NV_framebuffer_multisample_coverage ()
 {
   GLboolean r = GL_FALSE;
 
@@ -8641,7 +14479,7 @@ static GLboolean _glewInit_GL_NV_framebuffer_multisample_coverage (GLEW_CONTEXT_
 
 #ifdef GL_NV_geometry_program4
 
-static GLboolean _glewInit_GL_NV_geometry_program4 (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_NV_geometry_program4 ()
 {
   GLboolean r = GL_FALSE;
 
@@ -8652,13 +14490,33 @@ static GLboolean _glewInit_GL_NV_geometry_program4 (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_NV_geometry_program4 */
 
-#ifdef GL_NV_geometry_shader4
+#ifdef GL_NV_gpu_multicast
 
-#endif /* GL_NV_geometry_shader4 */
+static GLboolean _glewInit_GL_NV_gpu_multicast ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glMulticastBarrierNV = (PFNGLMULTICASTBARRIERNVPROC)glewGetProcAddress((const GLubyte*)"glMulticastBarrierNV")) == NULL) || r;
+  r = ((glMulticastBlitFramebufferNV = (PFNGLMULTICASTBLITFRAMEBUFFERNVPROC)glewGetProcAddress((const GLubyte*)"glMulticastBlitFramebufferNV")) == NULL) || r;
+  r = ((glMulticastBufferSubDataNV = (PFNGLMULTICASTBUFFERSUBDATANVPROC)glewGetProcAddress((const GLubyte*)"glMulticastBufferSubDataNV")) == NULL) || r;
+  r = ((glMulticastCopyBufferSubDataNV = (PFNGLMULTICASTCOPYBUFFERSUBDATANVPROC)glewGetProcAddress((const GLubyte*)"glMulticastCopyBufferSubDataNV")) == NULL) || r;
+  r = ((glMulticastCopyImageSubDataNV = (PFNGLMULTICASTCOPYIMAGESUBDATANVPROC)glewGetProcAddress((const GLubyte*)"glMulticastCopyImageSubDataNV")) == NULL) || r;
+  r = ((glMulticastFramebufferSampleLocationsfvNV = (PFNGLMULTICASTFRAMEBUFFERSAMPLELOCATIONSFVNVPROC)glewGetProcAddress((const GLubyte*)"glMulticastFramebufferSampleLocationsfvNV")) == NULL) || r;
+  r = ((glMulticastGetQueryObjecti64vNV = (PFNGLMULTICASTGETQUERYOBJECTI64VNVPROC)glewGetProcAddress((const GLubyte*)"glMulticastGetQueryObjecti64vNV")) == NULL) || r;
+  r = ((glMulticastGetQueryObjectivNV = (PFNGLMULTICASTGETQUERYOBJECTIVNVPROC)glewGetProcAddress((const GLubyte*)"glMulticastGetQueryObjectivNV")) == NULL) || r;
+  r = ((glMulticastGetQueryObjectui64vNV = (PFNGLMULTICASTGETQUERYOBJECTUI64VNVPROC)glewGetProcAddress((const GLubyte*)"glMulticastGetQueryObjectui64vNV")) == NULL) || r;
+  r = ((glMulticastGetQueryObjectuivNV = (PFNGLMULTICASTGETQUERYOBJECTUIVNVPROC)glewGetProcAddress((const GLubyte*)"glMulticastGetQueryObjectuivNV")) == NULL) || r;
+  r = ((glMulticastWaitSyncNV = (PFNGLMULTICASTWAITSYNCNVPROC)glewGetProcAddress((const GLubyte*)"glMulticastWaitSyncNV")) == NULL) || r;
+  r = ((glRenderGpuMaskNV = (PFNGLRENDERGPUMASKNVPROC)glewGetProcAddress((const GLubyte*)"glRenderGpuMaskNV")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_NV_gpu_multicast */
 
 #ifdef GL_NV_gpu_program4
 
-static GLboolean _glewInit_GL_NV_gpu_program4 (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_NV_gpu_program4 ()
 {
   GLboolean r = GL_FALSE;
 
@@ -8680,21 +14538,9 @@ static GLboolean _glewInit_GL_NV_gpu_program4 (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_NV_gpu_program4 */
 
-#ifdef GL_NV_gpu_program5
-
-#endif /* GL_NV_gpu_program5 */
-
-#ifdef GL_NV_gpu_program5_mem_extended
-
-#endif /* GL_NV_gpu_program5_mem_extended */
-
-#ifdef GL_NV_gpu_program_fp64
-
-#endif /* GL_NV_gpu_program_fp64 */
-
 #ifdef GL_NV_gpu_shader5
 
-static GLboolean _glewInit_GL_NV_gpu_shader5 (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_NV_gpu_shader5 ()
 {
   GLboolean r = GL_FALSE;
 
@@ -8740,7 +14586,7 @@ static GLboolean _glewInit_GL_NV_gpu_shader5 (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_NV_half_float
 
-static GLboolean _glewInit_GL_NV_half_float (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_NV_half_float ()
 {
   GLboolean r = GL_FALSE;
 
@@ -8796,21 +14642,53 @@ static GLboolean _glewInit_GL_NV_half_float (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_NV_half_float */
 
-#ifdef GL_NV_light_max_exponent
+#ifdef GL_NV_instanced_arrays
 
-#endif /* GL_NV_light_max_exponent */
+static GLboolean _glewInit_GL_NV_instanced_arrays ()
+{
+  GLboolean r = GL_FALSE;
 
-#ifdef GL_NV_multisample_coverage
+  r = ((glVertexAttribDivisorNV = (PFNGLVERTEXATTRIBDIVISORNVPROC)glewGetProcAddress((const GLubyte*)"glVertexAttribDivisorNV")) == NULL) || r;
 
-#endif /* GL_NV_multisample_coverage */
+  return r;
+}
 
-#ifdef GL_NV_multisample_filter_hint
+#endif /* GL_NV_instanced_arrays */
 
-#endif /* GL_NV_multisample_filter_hint */
+#ifdef GL_NV_internalformat_sample_query
+
+static GLboolean _glewInit_GL_NV_internalformat_sample_query ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glGetInternalformatSampleivNV = (PFNGLGETINTERNALFORMATSAMPLEIVNVPROC)glewGetProcAddress((const GLubyte*)"glGetInternalformatSampleivNV")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_NV_internalformat_sample_query */
+
+#ifdef GL_NV_non_square_matrices
+
+static GLboolean _glewInit_GL_NV_non_square_matrices ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glUniformMatrix2x3fvNV = (PFNGLUNIFORMMATRIX2X3FVNVPROC)glewGetProcAddress((const GLubyte*)"glUniformMatrix2x3fvNV")) == NULL) || r;
+  r = ((glUniformMatrix2x4fvNV = (PFNGLUNIFORMMATRIX2X4FVNVPROC)glewGetProcAddress((const GLubyte*)"glUniformMatrix2x4fvNV")) == NULL) || r;
+  r = ((glUniformMatrix3x2fvNV = (PFNGLUNIFORMMATRIX3X2FVNVPROC)glewGetProcAddress((const GLubyte*)"glUniformMatrix3x2fvNV")) == NULL) || r;
+  r = ((glUniformMatrix3x4fvNV = (PFNGLUNIFORMMATRIX3X4FVNVPROC)glewGetProcAddress((const GLubyte*)"glUniformMatrix3x4fvNV")) == NULL) || r;
+  r = ((glUniformMatrix4x2fvNV = (PFNGLUNIFORMMATRIX4X2FVNVPROC)glewGetProcAddress((const GLubyte*)"glUniformMatrix4x2fvNV")) == NULL) || r;
+  r = ((glUniformMatrix4x3fvNV = (PFNGLUNIFORMMATRIX4X3FVNVPROC)glewGetProcAddress((const GLubyte*)"glUniformMatrix4x3fvNV")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_NV_non_square_matrices */
 
 #ifdef GL_NV_occlusion_query
 
-static GLboolean _glewInit_GL_NV_occlusion_query (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_NV_occlusion_query ()
 {
   GLboolean r = GL_FALSE;
 
@@ -8827,13 +14705,9 @@ static GLboolean _glewInit_GL_NV_occlusion_query (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_NV_occlusion_query */
 
-#ifdef GL_NV_packed_depth_stencil
-
-#endif /* GL_NV_packed_depth_stencil */
-
 #ifdef GL_NV_parameter_buffer_object
 
-static GLboolean _glewInit_GL_NV_parameter_buffer_object (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_NV_parameter_buffer_object ()
 {
   GLboolean r = GL_FALSE;
 
@@ -8846,13 +14720,9 @@ static GLboolean _glewInit_GL_NV_parameter_buffer_object (GLEW_CONTEXT_ARG_DEF_I
 
 #endif /* GL_NV_parameter_buffer_object */
 
-#ifdef GL_NV_parameter_buffer_object2
-
-#endif /* GL_NV_parameter_buffer_object2 */
-
 #ifdef GL_NV_path_rendering
 
-static GLboolean _glewInit_GL_NV_path_rendering (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_NV_path_rendering ()
 {
   GLboolean r = GL_FALSE;
 
@@ -8876,18 +14746,28 @@ static GLboolean _glewInit_GL_NV_path_rendering (GLEW_CONTEXT_ARG_DEF_INIT)
   r = ((glGetPathSpacingNV = (PFNGLGETPATHSPACINGNVPROC)glewGetProcAddress((const GLubyte*)"glGetPathSpacingNV")) == NULL) || r;
   r = ((glGetPathTexGenfvNV = (PFNGLGETPATHTEXGENFVNVPROC)glewGetProcAddress((const GLubyte*)"glGetPathTexGenfvNV")) == NULL) || r;
   r = ((glGetPathTexGenivNV = (PFNGLGETPATHTEXGENIVNVPROC)glewGetProcAddress((const GLubyte*)"glGetPathTexGenivNV")) == NULL) || r;
+  r = ((glGetProgramResourcefvNV = (PFNGLGETPROGRAMRESOURCEFVNVPROC)glewGetProcAddress((const GLubyte*)"glGetProgramResourcefvNV")) == NULL) || r;
   r = ((glInterpolatePathsNV = (PFNGLINTERPOLATEPATHSNVPROC)glewGetProcAddress((const GLubyte*)"glInterpolatePathsNV")) == NULL) || r;
   r = ((glIsPathNV = (PFNGLISPATHNVPROC)glewGetProcAddress((const GLubyte*)"glIsPathNV")) == NULL) || r;
   r = ((glIsPointInFillPathNV = (PFNGLISPOINTINFILLPATHNVPROC)glewGetProcAddress((const GLubyte*)"glIsPointInFillPathNV")) == NULL) || r;
   r = ((glIsPointInStrokePathNV = (PFNGLISPOINTINSTROKEPATHNVPROC)glewGetProcAddress((const GLubyte*)"glIsPointInStrokePathNV")) == NULL) || r;
+  r = ((glMatrixLoad3x2fNV = (PFNGLMATRIXLOAD3X2FNVPROC)glewGetProcAddress((const GLubyte*)"glMatrixLoad3x2fNV")) == NULL) || r;
+  r = ((glMatrixLoad3x3fNV = (PFNGLMATRIXLOAD3X3FNVPROC)glewGetProcAddress((const GLubyte*)"glMatrixLoad3x3fNV")) == NULL) || r;
+  r = ((glMatrixLoadTranspose3x3fNV = (PFNGLMATRIXLOADTRANSPOSE3X3FNVPROC)glewGetProcAddress((const GLubyte*)"glMatrixLoadTranspose3x3fNV")) == NULL) || r;
+  r = ((glMatrixMult3x2fNV = (PFNGLMATRIXMULT3X2FNVPROC)glewGetProcAddress((const GLubyte*)"glMatrixMult3x2fNV")) == NULL) || r;
+  r = ((glMatrixMult3x3fNV = (PFNGLMATRIXMULT3X3FNVPROC)glewGetProcAddress((const GLubyte*)"glMatrixMult3x3fNV")) == NULL) || r;
+  r = ((glMatrixMultTranspose3x3fNV = (PFNGLMATRIXMULTTRANSPOSE3X3FNVPROC)glewGetProcAddress((const GLubyte*)"glMatrixMultTranspose3x3fNV")) == NULL) || r;
   r = ((glPathColorGenNV = (PFNGLPATHCOLORGENNVPROC)glewGetProcAddress((const GLubyte*)"glPathColorGenNV")) == NULL) || r;
   r = ((glPathCommandsNV = (PFNGLPATHCOMMANDSNVPROC)glewGetProcAddress((const GLubyte*)"glPathCommandsNV")) == NULL) || r;
   r = ((glPathCoordsNV = (PFNGLPATHCOORDSNVPROC)glewGetProcAddress((const GLubyte*)"glPathCoordsNV")) == NULL) || r;
   r = ((glPathCoverDepthFuncNV = (PFNGLPATHCOVERDEPTHFUNCNVPROC)glewGetProcAddress((const GLubyte*)"glPathCoverDepthFuncNV")) == NULL) || r;
   r = ((glPathDashArrayNV = (PFNGLPATHDASHARRAYNVPROC)glewGetProcAddress((const GLubyte*)"glPathDashArrayNV")) == NULL) || r;
   r = ((glPathFogGenNV = (PFNGLPATHFOGGENNVPROC)glewGetProcAddress((const GLubyte*)"glPathFogGenNV")) == NULL) || r;
+  r = ((glPathGlyphIndexArrayNV = (PFNGLPATHGLYPHINDEXARRAYNVPROC)glewGetProcAddress((const GLubyte*)"glPathGlyphIndexArrayNV")) == NULL) || r;
+  r = ((glPathGlyphIndexRangeNV = (PFNGLPATHGLYPHINDEXRANGENVPROC)glewGetProcAddress((const GLubyte*)"glPathGlyphIndexRangeNV")) == NULL) || r;
   r = ((glPathGlyphRangeNV = (PFNGLPATHGLYPHRANGENVPROC)glewGetProcAddress((const GLubyte*)"glPathGlyphRangeNV")) == NULL) || r;
   r = ((glPathGlyphsNV = (PFNGLPATHGLYPHSNVPROC)glewGetProcAddress((const GLubyte*)"glPathGlyphsNV")) == NULL) || r;
+  r = ((glPathMemoryGlyphIndexArrayNV = (PFNGLPATHMEMORYGLYPHINDEXARRAYNVPROC)glewGetProcAddress((const GLubyte*)"glPathMemoryGlyphIndexArrayNV")) == NULL) || r;
   r = ((glPathParameterfNV = (PFNGLPATHPARAMETERFNVPROC)glewGetProcAddress((const GLubyte*)"glPathParameterfNV")) == NULL) || r;
   r = ((glPathParameterfvNV = (PFNGLPATHPARAMETERFVNVPROC)glewGetProcAddress((const GLubyte*)"glPathParameterfvNV")) == NULL) || r;
   r = ((glPathParameteriNV = (PFNGLPATHPARAMETERINVPROC)glewGetProcAddress((const GLubyte*)"glPathParameteriNV")) == NULL) || r;
@@ -8899,10 +14779,15 @@ static GLboolean _glewInit_GL_NV_path_rendering (GLEW_CONTEXT_ARG_DEF_INIT)
   r = ((glPathSubCoordsNV = (PFNGLPATHSUBCOORDSNVPROC)glewGetProcAddress((const GLubyte*)"glPathSubCoordsNV")) == NULL) || r;
   r = ((glPathTexGenNV = (PFNGLPATHTEXGENNVPROC)glewGetProcAddress((const GLubyte*)"glPathTexGenNV")) == NULL) || r;
   r = ((glPointAlongPathNV = (PFNGLPOINTALONGPATHNVPROC)glewGetProcAddress((const GLubyte*)"glPointAlongPathNV")) == NULL) || r;
+  r = ((glProgramPathFragmentInputGenNV = (PFNGLPROGRAMPATHFRAGMENTINPUTGENNVPROC)glewGetProcAddress((const GLubyte*)"glProgramPathFragmentInputGenNV")) == NULL) || r;
   r = ((glStencilFillPathInstancedNV = (PFNGLSTENCILFILLPATHINSTANCEDNVPROC)glewGetProcAddress((const GLubyte*)"glStencilFillPathInstancedNV")) == NULL) || r;
   r = ((glStencilFillPathNV = (PFNGLSTENCILFILLPATHNVPROC)glewGetProcAddress((const GLubyte*)"glStencilFillPathNV")) == NULL) || r;
   r = ((glStencilStrokePathInstancedNV = (PFNGLSTENCILSTROKEPATHINSTANCEDNVPROC)glewGetProcAddress((const GLubyte*)"glStencilStrokePathInstancedNV")) == NULL) || r;
   r = ((glStencilStrokePathNV = (PFNGLSTENCILSTROKEPATHNVPROC)glewGetProcAddress((const GLubyte*)"glStencilStrokePathNV")) == NULL) || r;
+  r = ((glStencilThenCoverFillPathInstancedNV = (PFNGLSTENCILTHENCOVERFILLPATHINSTANCEDNVPROC)glewGetProcAddress((const GLubyte*)"glStencilThenCoverFillPathInstancedNV")) == NULL) || r;
+  r = ((glStencilThenCoverFillPathNV = (PFNGLSTENCILTHENCOVERFILLPATHNVPROC)glewGetProcAddress((const GLubyte*)"glStencilThenCoverFillPathNV")) == NULL) || r;
+  r = ((glStencilThenCoverStrokePathInstancedNV = (PFNGLSTENCILTHENCOVERSTROKEPATHINSTANCEDNVPROC)glewGetProcAddress((const GLubyte*)"glStencilThenCoverStrokePathInstancedNV")) == NULL) || r;
+  r = ((glStencilThenCoverStrokePathNV = (PFNGLSTENCILTHENCOVERSTROKEPATHNVPROC)glewGetProcAddress((const GLubyte*)"glStencilThenCoverStrokePathNV")) == NULL) || r;
   r = ((glTransformPathNV = (PFNGLTRANSFORMPATHNVPROC)glewGetProcAddress((const GLubyte*)"glTransformPathNV")) == NULL) || r;
   r = ((glWeightPathsNV = (PFNGLWEIGHTPATHSNVPROC)glewGetProcAddress((const GLubyte*)"glWeightPathsNV")) == NULL) || r;
 
@@ -8913,7 +14798,7 @@ static GLboolean _glewInit_GL_NV_path_rendering (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_NV_pixel_data_range
 
-static GLboolean _glewInit_GL_NV_pixel_data_range (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_NV_pixel_data_range ()
 {
   GLboolean r = GL_FALSE;
 
@@ -8927,7 +14812,7 @@ static GLboolean _glewInit_GL_NV_pixel_data_range (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_NV_point_sprite
 
-static GLboolean _glewInit_GL_NV_point_sprite (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_NV_point_sprite ()
 {
   GLboolean r = GL_FALSE;
 
@@ -8939,9 +14824,22 @@ static GLboolean _glewInit_GL_NV_point_sprite (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_NV_point_sprite */
 
+#ifdef GL_NV_polygon_mode
+
+static GLboolean _glewInit_GL_NV_polygon_mode ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glPolygonModeNV = (PFNGLPOLYGONMODENVPROC)glewGetProcAddress((const GLubyte*)"glPolygonModeNV")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_NV_polygon_mode */
+
 #ifdef GL_NV_present_video
 
-static GLboolean _glewInit_GL_NV_present_video (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_NV_present_video ()
 {
   GLboolean r = GL_FALSE;
 
@@ -8959,7 +14857,7 @@ static GLboolean _glewInit_GL_NV_present_video (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_NV_primitive_restart
 
-static GLboolean _glewInit_GL_NV_primitive_restart (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_NV_primitive_restart ()
 {
   GLboolean r = GL_FALSE;
 
@@ -8973,7 +14871,7 @@ static GLboolean _glewInit_GL_NV_primitive_restart (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_NV_register_combiners
 
-static GLboolean _glewInit_GL_NV_register_combiners (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_NV_register_combiners ()
 {
   GLboolean r = GL_FALSE;
 
@@ -8998,7 +14896,7 @@ static GLboolean _glewInit_GL_NV_register_combiners (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_NV_register_combiners2
 
-static GLboolean _glewInit_GL_NV_register_combiners2 (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_NV_register_combiners2 ()
 {
   GLboolean r = GL_FALSE;
 
@@ -9010,21 +14908,23 @@ static GLboolean _glewInit_GL_NV_register_combiners2 (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_NV_register_combiners2 */
 
-#ifdef GL_NV_shader_atomic_counters
+#ifdef GL_NV_sample_locations
 
-#endif /* GL_NV_shader_atomic_counters */
+static GLboolean _glewInit_GL_NV_sample_locations ()
+{
+  GLboolean r = GL_FALSE;
 
-#ifdef GL_NV_shader_atomic_float
+  r = ((glFramebufferSampleLocationsfvNV = (PFNGLFRAMEBUFFERSAMPLELOCATIONSFVNVPROC)glewGetProcAddress((const GLubyte*)"glFramebufferSampleLocationsfvNV")) == NULL) || r;
+  r = ((glNamedFramebufferSampleLocationsfvNV = (PFNGLNAMEDFRAMEBUFFERSAMPLELOCATIONSFVNVPROC)glewGetProcAddress((const GLubyte*)"glNamedFramebufferSampleLocationsfvNV")) == NULL) || r;
 
-#endif /* GL_NV_shader_atomic_float */
+  return r;
+}
 
-#ifdef GL_NV_shader_atomic_int64
-
-#endif /* GL_NV_shader_atomic_int64 */
+#endif /* GL_NV_sample_locations */
 
 #ifdef GL_NV_shader_buffer_load
 
-static GLboolean _glewInit_GL_NV_shader_buffer_load (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_NV_shader_buffer_load ()
 {
   GLboolean r = GL_FALSE;
 
@@ -9047,33 +14947,27 @@ static GLboolean _glewInit_GL_NV_shader_buffer_load (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_NV_shader_buffer_load */
 
-#ifdef GL_NV_shader_storage_buffer_object
+#ifdef GL_NV_texture_array
 
-#endif /* GL_NV_shader_storage_buffer_object */
+static GLboolean _glewInit_GL_NV_texture_array ()
+{
+  GLboolean r = GL_FALSE;
 
-#ifdef GL_NV_shader_thread_group
+  r = ((glCompressedTexImage3DNV = (PFNGLCOMPRESSEDTEXIMAGE3DNVPROC)glewGetProcAddress((const GLubyte*)"glCompressedTexImage3DNV")) == NULL) || r;
+  r = ((glCompressedTexSubImage3DNV = (PFNGLCOMPRESSEDTEXSUBIMAGE3DNVPROC)glewGetProcAddress((const GLubyte*)"glCompressedTexSubImage3DNV")) == NULL) || r;
+  r = ((glCopyTexSubImage3DNV = (PFNGLCOPYTEXSUBIMAGE3DNVPROC)glewGetProcAddress((const GLubyte*)"glCopyTexSubImage3DNV")) == NULL) || r;
+  r = ((glFramebufferTextureLayerNV = (PFNGLFRAMEBUFFERTEXTURELAYERNVPROC)glewGetProcAddress((const GLubyte*)"glFramebufferTextureLayerNV")) == NULL) || r;
+  r = ((glTexImage3DNV = (PFNGLTEXIMAGE3DNVPROC)glewGetProcAddress((const GLubyte*)"glTexImage3DNV")) == NULL) || r;
+  r = ((glTexSubImage3DNV = (PFNGLTEXSUBIMAGE3DNVPROC)glewGetProcAddress((const GLubyte*)"glTexSubImage3DNV")) == NULL) || r;
 
-#endif /* GL_NV_shader_thread_group */
+  return r;
+}
 
-#ifdef GL_NV_shader_thread_shuffle
-
-#endif /* GL_NV_shader_thread_shuffle */
-
-#ifdef GL_NV_tessellation_program5
-
-#endif /* GL_NV_tessellation_program5 */
-
-#ifdef GL_NV_texgen_emboss
-
-#endif /* GL_NV_texgen_emboss */
-
-#ifdef GL_NV_texgen_reflection
-
-#endif /* GL_NV_texgen_reflection */
+#endif /* GL_NV_texture_array */
 
 #ifdef GL_NV_texture_barrier
 
-static GLboolean _glewInit_GL_NV_texture_barrier (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_NV_texture_barrier ()
 {
   GLboolean r = GL_FALSE;
 
@@ -9084,21 +14978,9 @@ static GLboolean _glewInit_GL_NV_texture_barrier (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_NV_texture_barrier */
 
-#ifdef GL_NV_texture_compression_vtc
-
-#endif /* GL_NV_texture_compression_vtc */
-
-#ifdef GL_NV_texture_env_combine4
-
-#endif /* GL_NV_texture_env_combine4 */
-
-#ifdef GL_NV_texture_expand_normal
-
-#endif /* GL_NV_texture_expand_normal */
-
 #ifdef GL_NV_texture_multisample
 
-static GLboolean _glewInit_GL_NV_texture_multisample (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_NV_texture_multisample ()
 {
   GLboolean r = GL_FALSE;
 
@@ -9114,25 +14996,9 @@ static GLboolean _glewInit_GL_NV_texture_multisample (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_NV_texture_multisample */
 
-#ifdef GL_NV_texture_rectangle
-
-#endif /* GL_NV_texture_rectangle */
-
-#ifdef GL_NV_texture_shader
-
-#endif /* GL_NV_texture_shader */
-
-#ifdef GL_NV_texture_shader2
-
-#endif /* GL_NV_texture_shader2 */
-
-#ifdef GL_NV_texture_shader3
-
-#endif /* GL_NV_texture_shader3 */
-
 #ifdef GL_NV_transform_feedback
 
-static GLboolean _glewInit_GL_NV_transform_feedback (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_NV_transform_feedback ()
 {
   GLboolean r = GL_FALSE;
 
@@ -9155,7 +15021,7 @@ static GLboolean _glewInit_GL_NV_transform_feedback (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_NV_transform_feedback2
 
-static GLboolean _glewInit_GL_NV_transform_feedback2 (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_NV_transform_feedback2 ()
 {
   GLboolean r = GL_FALSE;
 
@@ -9174,7 +15040,7 @@ static GLboolean _glewInit_GL_NV_transform_feedback2 (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_NV_vdpau_interop
 
-static GLboolean _glewInit_GL_NV_vdpau_interop (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_NV_vdpau_interop ()
 {
   GLboolean r = GL_FALSE;
 
@@ -9196,7 +15062,7 @@ static GLboolean _glewInit_GL_NV_vdpau_interop (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_NV_vertex_array_range
 
-static GLboolean _glewInit_GL_NV_vertex_array_range (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_NV_vertex_array_range ()
 {
   GLboolean r = GL_FALSE;
 
@@ -9208,13 +15074,9 @@ static GLboolean _glewInit_GL_NV_vertex_array_range (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_NV_vertex_array_range */
 
-#ifdef GL_NV_vertex_array_range2
-
-#endif /* GL_NV_vertex_array_range2 */
-
 #ifdef GL_NV_vertex_attrib_integer_64bit
 
-static GLboolean _glewInit_GL_NV_vertex_attrib_integer_64bit (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_NV_vertex_attrib_integer_64bit ()
 {
   GLboolean r = GL_FALSE;
 
@@ -9245,7 +15107,7 @@ static GLboolean _glewInit_GL_NV_vertex_attrib_integer_64bit (GLEW_CONTEXT_ARG_D
 
 #ifdef GL_NV_vertex_buffer_unified_memory
 
-static GLboolean _glewInit_GL_NV_vertex_buffer_unified_memory (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_NV_vertex_buffer_unified_memory ()
 {
   GLboolean r = GL_FALSE;
 
@@ -9269,7 +15131,7 @@ static GLboolean _glewInit_GL_NV_vertex_buffer_unified_memory (GLEW_CONTEXT_ARG_
 
 #ifdef GL_NV_vertex_program
 
-static GLboolean _glewInit_GL_NV_vertex_program (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_NV_vertex_program ()
 {
   GLboolean r = GL_FALSE;
 
@@ -9343,29 +15205,9 @@ static GLboolean _glewInit_GL_NV_vertex_program (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_NV_vertex_program */
 
-#ifdef GL_NV_vertex_program1_1
-
-#endif /* GL_NV_vertex_program1_1 */
-
-#ifdef GL_NV_vertex_program2
-
-#endif /* GL_NV_vertex_program2 */
-
-#ifdef GL_NV_vertex_program2_option
-
-#endif /* GL_NV_vertex_program2_option */
-
-#ifdef GL_NV_vertex_program3
-
-#endif /* GL_NV_vertex_program3 */
-
-#ifdef GL_NV_vertex_program4
-
-#endif /* GL_NV_vertex_program4 */
-
 #ifdef GL_NV_video_capture
 
-static GLboolean _glewInit_GL_NV_video_capture (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_NV_video_capture ()
 {
   GLboolean r = GL_FALSE;
 
@@ -9387,59 +15229,178 @@ static GLboolean _glewInit_GL_NV_video_capture (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_NV_video_capture */
 
-#ifdef GL_OES_byte_coordinates
+#ifdef GL_NV_viewport_array
 
-#endif /* GL_OES_byte_coordinates */
-
-#ifdef GL_OES_compressed_paletted_texture
-
-#endif /* GL_OES_compressed_paletted_texture */
-
-#ifdef GL_OES_read_format
-
-#endif /* GL_OES_read_format */
-
-#ifdef GL_OES_single_precision
-
-static GLboolean _glewInit_GL_OES_single_precision (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_NV_viewport_array ()
 {
   GLboolean r = GL_FALSE;
 
-  r = ((glClearDepthfOES = (PFNGLCLEARDEPTHFOESPROC)glewGetProcAddress((const GLubyte*)"glClearDepthfOES")) == NULL) || r;
-  r = ((glClipPlanefOES = (PFNGLCLIPPLANEFOESPROC)glewGetProcAddress((const GLubyte*)"glClipPlanefOES")) == NULL) || r;
-  r = ((glDepthRangefOES = (PFNGLDEPTHRANGEFOESPROC)glewGetProcAddress((const GLubyte*)"glDepthRangefOES")) == NULL) || r;
-  r = ((glFrustumfOES = (PFNGLFRUSTUMFOESPROC)glewGetProcAddress((const GLubyte*)"glFrustumfOES")) == NULL) || r;
-  r = ((glGetClipPlanefOES = (PFNGLGETCLIPPLANEFOESPROC)glewGetProcAddress((const GLubyte*)"glGetClipPlanefOES")) == NULL) || r;
-  r = ((glOrthofOES = (PFNGLORTHOFOESPROC)glewGetProcAddress((const GLubyte*)"glOrthofOES")) == NULL) || r;
+  r = ((glDepthRangeArrayfvNV = (PFNGLDEPTHRANGEARRAYFVNVPROC)glewGetProcAddress((const GLubyte*)"glDepthRangeArrayfvNV")) == NULL) || r;
+  r = ((glDepthRangeIndexedfNV = (PFNGLDEPTHRANGEINDEXEDFNVPROC)glewGetProcAddress((const GLubyte*)"glDepthRangeIndexedfNV")) == NULL) || r;
+  r = ((glDisableiNV = (PFNGLDISABLEINVPROC)glewGetProcAddress((const GLubyte*)"glDisableiNV")) == NULL) || r;
+  r = ((glEnableiNV = (PFNGLENABLEINVPROC)glewGetProcAddress((const GLubyte*)"glEnableiNV")) == NULL) || r;
+  r = ((glGetFloati_vNV = (PFNGLGETFLOATI_VNVPROC)glewGetProcAddress((const GLubyte*)"glGetFloati_vNV")) == NULL) || r;
+  r = ((glIsEnablediNV = (PFNGLISENABLEDINVPROC)glewGetProcAddress((const GLubyte*)"glIsEnablediNV")) == NULL) || r;
+  r = ((glScissorArrayvNV = (PFNGLSCISSORARRAYVNVPROC)glewGetProcAddress((const GLubyte*)"glScissorArrayvNV")) == NULL) || r;
+  r = ((glScissorIndexedNV = (PFNGLSCISSORINDEXEDNVPROC)glewGetProcAddress((const GLubyte*)"glScissorIndexedNV")) == NULL) || r;
+  r = ((glScissorIndexedvNV = (PFNGLSCISSORINDEXEDVNVPROC)glewGetProcAddress((const GLubyte*)"glScissorIndexedvNV")) == NULL) || r;
+  r = ((glViewportArrayvNV = (PFNGLVIEWPORTARRAYVNVPROC)glewGetProcAddress((const GLubyte*)"glViewportArrayvNV")) == NULL) || r;
+  r = ((glViewportIndexedfNV = (PFNGLVIEWPORTINDEXEDFNVPROC)glewGetProcAddress((const GLubyte*)"glViewportIndexedfNV")) == NULL) || r;
+  r = ((glViewportIndexedfvNV = (PFNGLVIEWPORTINDEXEDFVNVPROC)glewGetProcAddress((const GLubyte*)"glViewportIndexedfvNV")) == NULL) || r;
 
   return r;
 }
 
-#endif /* GL_OES_single_precision */
+#endif /* GL_NV_viewport_array */
 
-#ifdef GL_OML_interlace
+#ifdef GL_NV_viewport_swizzle
 
-#endif /* GL_OML_interlace */
+static GLboolean _glewInit_GL_NV_viewport_swizzle ()
+{
+  GLboolean r = GL_FALSE;
 
-#ifdef GL_OML_resample
+  r = ((glViewportSwizzleNV = (PFNGLVIEWPORTSWIZZLENVPROC)glewGetProcAddress((const GLubyte*)"glViewportSwizzleNV")) == NULL) || r;
 
-#endif /* GL_OML_resample */
+  return r;
+}
 
-#ifdef GL_OML_subsample
+#endif /* GL_NV_viewport_swizzle */
 
-#endif /* GL_OML_subsample */
+#ifdef GL_OVR_multiview
 
-#ifdef GL_PGI_misc_hints
+static GLboolean _glewInit_GL_OVR_multiview ()
+{
+  GLboolean r = GL_FALSE;
 
-#endif /* GL_PGI_misc_hints */
+  r = ((glFramebufferTextureMultiviewOVR = (PFNGLFRAMEBUFFERTEXTUREMULTIVIEWOVRPROC)glewGetProcAddress((const GLubyte*)"glFramebufferTextureMultiviewOVR")) == NULL) || r;
 
-#ifdef GL_PGI_vertex_hints
+  return r;
+}
 
-#endif /* GL_PGI_vertex_hints */
+#endif /* GL_OVR_multiview */
+
+#ifdef GL_OVR_multiview_multisampled_render_to_texture
+
+static GLboolean _glewInit_GL_OVR_multiview_multisampled_render_to_texture ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glFramebufferTextureMultisampleMultiviewOVR = (PFNGLFRAMEBUFFERTEXTUREMULTISAMPLEMULTIVIEWOVRPROC)glewGetProcAddress((const GLubyte*)"glFramebufferTextureMultisampleMultiviewOVR")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_OVR_multiview_multisampled_render_to_texture */
+
+#ifdef GL_QCOM_alpha_test
+
+static GLboolean _glewInit_GL_QCOM_alpha_test ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glAlphaFuncQCOM = (PFNGLALPHAFUNCQCOMPROC)glewGetProcAddress((const GLubyte*)"glAlphaFuncQCOM")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_QCOM_alpha_test */
+
+#ifdef GL_QCOM_driver_control
+
+static GLboolean _glewInit_GL_QCOM_driver_control ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glDisableDriverControlQCOM = (PFNGLDISABLEDRIVERCONTROLQCOMPROC)glewGetProcAddress((const GLubyte*)"glDisableDriverControlQCOM")) == NULL) || r;
+  r = ((glEnableDriverControlQCOM = (PFNGLENABLEDRIVERCONTROLQCOMPROC)glewGetProcAddress((const GLubyte*)"glEnableDriverControlQCOM")) == NULL) || r;
+  r = ((glGetDriverControlStringQCOM = (PFNGLGETDRIVERCONTROLSTRINGQCOMPROC)glewGetProcAddress((const GLubyte*)"glGetDriverControlStringQCOM")) == NULL) || r;
+  r = ((glGetDriverControlsQCOM = (PFNGLGETDRIVERCONTROLSQCOMPROC)glewGetProcAddress((const GLubyte*)"glGetDriverControlsQCOM")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_QCOM_driver_control */
+
+#ifdef GL_QCOM_extended_get
+
+static GLboolean _glewInit_GL_QCOM_extended_get ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glExtGetBufferPointervQCOM = (PFNGLEXTGETBUFFERPOINTERVQCOMPROC)glewGetProcAddress((const GLubyte*)"glExtGetBufferPointervQCOM")) == NULL) || r;
+  r = ((glExtGetBuffersQCOM = (PFNGLEXTGETBUFFERSQCOMPROC)glewGetProcAddress((const GLubyte*)"glExtGetBuffersQCOM")) == NULL) || r;
+  r = ((glExtGetFramebuffersQCOM = (PFNGLEXTGETFRAMEBUFFERSQCOMPROC)glewGetProcAddress((const GLubyte*)"glExtGetFramebuffersQCOM")) == NULL) || r;
+  r = ((glExtGetRenderbuffersQCOM = (PFNGLEXTGETRENDERBUFFERSQCOMPROC)glewGetProcAddress((const GLubyte*)"glExtGetRenderbuffersQCOM")) == NULL) || r;
+  r = ((glExtGetTexLevelParameterivQCOM = (PFNGLEXTGETTEXLEVELPARAMETERIVQCOMPROC)glewGetProcAddress((const GLubyte*)"glExtGetTexLevelParameterivQCOM")) == NULL) || r;
+  r = ((glExtGetTexSubImageQCOM = (PFNGLEXTGETTEXSUBIMAGEQCOMPROC)glewGetProcAddress((const GLubyte*)"glExtGetTexSubImageQCOM")) == NULL) || r;
+  r = ((glExtGetTexturesQCOM = (PFNGLEXTGETTEXTURESQCOMPROC)glewGetProcAddress((const GLubyte*)"glExtGetTexturesQCOM")) == NULL) || r;
+  r = ((glExtTexObjectStateOverrideiQCOM = (PFNGLEXTTEXOBJECTSTATEOVERRIDEIQCOMPROC)glewGetProcAddress((const GLubyte*)"glExtTexObjectStateOverrideiQCOM")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_QCOM_extended_get */
+
+#ifdef GL_QCOM_extended_get2
+
+static GLboolean _glewInit_GL_QCOM_extended_get2 ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glExtGetProgramBinarySourceQCOM = (PFNGLEXTGETPROGRAMBINARYSOURCEQCOMPROC)glewGetProcAddress((const GLubyte*)"glExtGetProgramBinarySourceQCOM")) == NULL) || r;
+  r = ((glExtGetProgramsQCOM = (PFNGLEXTGETPROGRAMSQCOMPROC)glewGetProcAddress((const GLubyte*)"glExtGetProgramsQCOM")) == NULL) || r;
+  r = ((glExtGetShadersQCOM = (PFNGLEXTGETSHADERSQCOMPROC)glewGetProcAddress((const GLubyte*)"glExtGetShadersQCOM")) == NULL) || r;
+  r = ((glExtIsProgramBinaryQCOM = (PFNGLEXTISPROGRAMBINARYQCOMPROC)glewGetProcAddress((const GLubyte*)"glExtIsProgramBinaryQCOM")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_QCOM_extended_get2 */
+
+#ifdef GL_QCOM_framebuffer_foveated
+
+static GLboolean _glewInit_GL_QCOM_framebuffer_foveated ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glFramebufferFoveationConfigQCOM = (PFNGLFRAMEBUFFERFOVEATIONCONFIGQCOMPROC)glewGetProcAddress((const GLubyte*)"glFramebufferFoveationConfigQCOM")) == NULL) || r;
+  r = ((glFramebufferFoveationParametersQCOM = (PFNGLFRAMEBUFFERFOVEATIONPARAMETERSQCOMPROC)glewGetProcAddress((const GLubyte*)"glFramebufferFoveationParametersQCOM")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_QCOM_framebuffer_foveated */
+
+#ifdef GL_QCOM_shader_framebuffer_fetch_noncoherent
+
+static GLboolean _glewInit_GL_QCOM_shader_framebuffer_fetch_noncoherent ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glFramebufferFetchBarrierQCOM = (PFNGLFRAMEBUFFERFETCHBARRIERQCOMPROC)glewGetProcAddress((const GLubyte*)"glFramebufferFetchBarrierQCOM")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_QCOM_shader_framebuffer_fetch_noncoherent */
+
+#ifdef GL_QCOM_tiled_rendering
+
+static GLboolean _glewInit_GL_QCOM_tiled_rendering ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glEndTilingQCOM = (PFNGLENDTILINGQCOMPROC)glewGetProcAddress((const GLubyte*)"glEndTilingQCOM")) == NULL) || r;
+  r = ((glStartTilingQCOM = (PFNGLSTARTTILINGQCOMPROC)glewGetProcAddress((const GLubyte*)"glStartTilingQCOM")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_QCOM_tiled_rendering */
 
 #ifdef GL_REGAL_ES1_0_compatibility
 
-static GLboolean _glewInit_GL_REGAL_ES1_0_compatibility (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_REGAL_ES1_0_compatibility ()
 {
   GLboolean r = GL_FALSE;
 
@@ -9482,7 +15443,7 @@ static GLboolean _glewInit_GL_REGAL_ES1_0_compatibility (GLEW_CONTEXT_ARG_DEF_IN
 
 #ifdef GL_REGAL_ES1_1_compatibility
 
-static GLboolean _glewInit_GL_REGAL_ES1_1_compatibility (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_REGAL_ES1_1_compatibility ()
 {
   GLboolean r = GL_FALSE;
 
@@ -9505,13 +15466,9 @@ static GLboolean _glewInit_GL_REGAL_ES1_1_compatibility (GLEW_CONTEXT_ARG_DEF_IN
 
 #endif /* GL_REGAL_ES1_1_compatibility */
 
-#ifdef GL_REGAL_enable
-
-#endif /* GL_REGAL_enable */
-
 #ifdef GL_REGAL_error_string
 
-static GLboolean _glewInit_GL_REGAL_error_string (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_REGAL_error_string ()
 {
   GLboolean r = GL_FALSE;
 
@@ -9524,7 +15481,7 @@ static GLboolean _glewInit_GL_REGAL_error_string (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_REGAL_extension_query
 
-static GLboolean _glewInit_GL_REGAL_extension_query (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_REGAL_extension_query ()
 {
   GLboolean r = GL_FALSE;
 
@@ -9538,7 +15495,7 @@ static GLboolean _glewInit_GL_REGAL_extension_query (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_REGAL_log
 
-static GLboolean _glewInit_GL_REGAL_log (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_REGAL_log ()
 {
   GLboolean r = GL_FALSE;
 
@@ -9551,7 +15508,7 @@ static GLboolean _glewInit_GL_REGAL_log (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_REGAL_proc_address
 
-static GLboolean _glewInit_GL_REGAL_proc_address (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_REGAL_proc_address ()
 {
   GLboolean r = GL_FALSE;
 
@@ -9562,21 +15519,9 @@ static GLboolean _glewInit_GL_REGAL_proc_address (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_REGAL_proc_address */
 
-#ifdef GL_REND_screen_coordinates
-
-#endif /* GL_REND_screen_coordinates */
-
-#ifdef GL_S3_s3tc
-
-#endif /* GL_S3_s3tc */
-
-#ifdef GL_SGIS_color_range
-
-#endif /* GL_SGIS_color_range */
-
 #ifdef GL_SGIS_detail_texture
 
-static GLboolean _glewInit_GL_SGIS_detail_texture (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_SGIS_detail_texture ()
 {
   GLboolean r = GL_FALSE;
 
@@ -9590,7 +15535,7 @@ static GLboolean _glewInit_GL_SGIS_detail_texture (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_SGIS_fog_function
 
-static GLboolean _glewInit_GL_SGIS_fog_function (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_SGIS_fog_function ()
 {
   GLboolean r = GL_FALSE;
 
@@ -9602,13 +15547,9 @@ static GLboolean _glewInit_GL_SGIS_fog_function (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_SGIS_fog_function */
 
-#ifdef GL_SGIS_generate_mipmap
-
-#endif /* GL_SGIS_generate_mipmap */
-
 #ifdef GL_SGIS_multisample
 
-static GLboolean _glewInit_GL_SGIS_multisample (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_SGIS_multisample ()
 {
   GLboolean r = GL_FALSE;
 
@@ -9620,17 +15561,38 @@ static GLboolean _glewInit_GL_SGIS_multisample (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_SGIS_multisample */
 
-#ifdef GL_SGIS_pixel_texture
+#ifdef GL_SGIS_multitexture
 
-#endif /* GL_SGIS_pixel_texture */
+static GLboolean _glewInit_GL_SGIS_multitexture ()
+{
+  GLboolean r = GL_FALSE;
 
-#ifdef GL_SGIS_point_line_texgen
+  r = ((glInterleavedTextureCoordSetsSGIS = (PFNGLINTERLEAVEDTEXTURECOORDSETSSGISPROC)glewGetProcAddress((const GLubyte*)"glInterleavedTextureCoordSetsSGIS")) == NULL) || r;
+  r = ((glSelectTextureCoordSetSGIS = (PFNGLSELECTTEXTURECOORDSETSGISPROC)glewGetProcAddress((const GLubyte*)"glSelectTextureCoordSetSGIS")) == NULL) || r;
+  r = ((glSelectTextureSGIS = (PFNGLSELECTTEXTURESGISPROC)glewGetProcAddress((const GLubyte*)"glSelectTextureSGIS")) == NULL) || r;
+  r = ((glSelectTextureTransformSGIS = (PFNGLSELECTTEXTURETRANSFORMSGISPROC)glewGetProcAddress((const GLubyte*)"glSelectTextureTransformSGIS")) == NULL) || r;
 
-#endif /* GL_SGIS_point_line_texgen */
+  return r;
+}
+
+#endif /* GL_SGIS_multitexture */
+
+#ifdef GL_SGIS_shared_multisample
+
+static GLboolean _glewInit_GL_SGIS_shared_multisample ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glMultisampleSubRectPosSGIS = (PFNGLMULTISAMPLESUBRECTPOSSGISPROC)glewGetProcAddress((const GLubyte*)"glMultisampleSubRectPosSGIS")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_SGIS_shared_multisample */
 
 #ifdef GL_SGIS_sharpen_texture
 
-static GLboolean _glewInit_GL_SGIS_sharpen_texture (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_SGIS_sharpen_texture ()
 {
   GLboolean r = GL_FALSE;
 
@@ -9644,7 +15606,7 @@ static GLboolean _glewInit_GL_SGIS_sharpen_texture (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_SGIS_texture4D
 
-static GLboolean _glewInit_GL_SGIS_texture4D (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_SGIS_texture4D ()
 {
   GLboolean r = GL_FALSE;
 
@@ -9656,17 +15618,9 @@ static GLboolean _glewInit_GL_SGIS_texture4D (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_SGIS_texture4D */
 
-#ifdef GL_SGIS_texture_border_clamp
-
-#endif /* GL_SGIS_texture_border_clamp */
-
-#ifdef GL_SGIS_texture_edge_clamp
-
-#endif /* GL_SGIS_texture_edge_clamp */
-
 #ifdef GL_SGIS_texture_filter4
 
-static GLboolean _glewInit_GL_SGIS_texture_filter4 (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_SGIS_texture_filter4 ()
 {
   GLboolean r = GL_FALSE;
 
@@ -9678,17 +15632,9 @@ static GLboolean _glewInit_GL_SGIS_texture_filter4 (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_SGIS_texture_filter4 */
 
-#ifdef GL_SGIS_texture_lod
-
-#endif /* GL_SGIS_texture_lod */
-
-#ifdef GL_SGIS_texture_select
-
-#endif /* GL_SGIS_texture_select */
-
 #ifdef GL_SGIX_async
 
-static GLboolean _glewInit_GL_SGIX_async (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_SGIX_async ()
 {
   GLboolean r = GL_FALSE;
 
@@ -9704,33 +15650,23 @@ static GLboolean _glewInit_GL_SGIX_async (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_SGIX_async */
 
-#ifdef GL_SGIX_async_histogram
+#ifdef GL_SGIX_datapipe
 
-#endif /* GL_SGIX_async_histogram */
+static GLboolean _glewInit_GL_SGIX_datapipe ()
+{
+  GLboolean r = GL_FALSE;
 
-#ifdef GL_SGIX_async_pixel
+  r = ((glAddressSpace = (PFNGLADDRESSSPACEPROC)glewGetProcAddress((const GLubyte*)"glAddressSpace")) == NULL) || r;
+  r = ((glDataPipe = (PFNGLDATAPIPEPROC)glewGetProcAddress((const GLubyte*)"glDataPipe")) == NULL) || r;
 
-#endif /* GL_SGIX_async_pixel */
+  return r;
+}
 
-#ifdef GL_SGIX_blend_alpha_minmax
-
-#endif /* GL_SGIX_blend_alpha_minmax */
-
-#ifdef GL_SGIX_clipmap
-
-#endif /* GL_SGIX_clipmap */
-
-#ifdef GL_SGIX_convolution_accuracy
-
-#endif /* GL_SGIX_convolution_accuracy */
-
-#ifdef GL_SGIX_depth_texture
-
-#endif /* GL_SGIX_depth_texture */
+#endif /* GL_SGIX_datapipe */
 
 #ifdef GL_SGIX_flush_raster
 
-static GLboolean _glewInit_GL_SGIX_flush_raster (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_SGIX_flush_raster ()
 {
   GLboolean r = GL_FALSE;
 
@@ -9741,13 +15677,23 @@ static GLboolean _glewInit_GL_SGIX_flush_raster (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_SGIX_flush_raster */
 
-#ifdef GL_SGIX_fog_offset
+#ifdef GL_SGIX_fog_layers
 
-#endif /* GL_SGIX_fog_offset */
+static GLboolean _glewInit_GL_SGIX_fog_layers ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glFogLayersSGIX = (PFNGLFOGLAYERSSGIXPROC)glewGetProcAddress((const GLubyte*)"glFogLayersSGIX")) == NULL) || r;
+  r = ((glGetFogLayersSGIX = (PFNGLGETFOGLAYERSSGIXPROC)glewGetProcAddress((const GLubyte*)"glGetFogLayersSGIX")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_SGIX_fog_layers */
 
 #ifdef GL_SGIX_fog_texture
 
-static GLboolean _glewInit_GL_SGIX_fog_texture (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_SGIX_fog_texture ()
 {
   GLboolean r = GL_FALSE;
 
@@ -9760,7 +15706,7 @@ static GLboolean _glewInit_GL_SGIX_fog_texture (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_SGIX_fragment_specular_lighting
 
-static GLboolean _glewInit_GL_SGIX_fragment_specular_lighting (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_SGIX_fragment_specular_lighting ()
 {
   GLboolean r = GL_FALSE;
 
@@ -9789,7 +15735,7 @@ static GLboolean _glewInit_GL_SGIX_fragment_specular_lighting (GLEW_CONTEXT_ARG_
 
 #ifdef GL_SGIX_framezoom
 
-static GLboolean _glewInit_GL_SGIX_framezoom (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_SGIX_framezoom ()
 {
   GLboolean r = GL_FALSE;
 
@@ -9800,21 +15746,61 @@ static GLboolean _glewInit_GL_SGIX_framezoom (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_SGIX_framezoom */
 
-#ifdef GL_SGIX_interlace
+#ifdef GL_SGIX_igloo_interface
 
-#endif /* GL_SGIX_interlace */
+static GLboolean _glewInit_GL_SGIX_igloo_interface ()
+{
+  GLboolean r = GL_FALSE;
 
-#ifdef GL_SGIX_ir_instrument1
+  r = ((glIglooInterfaceSGIX = (PFNGLIGLOOINTERFACESGIXPROC)glewGetProcAddress((const GLubyte*)"glIglooInterfaceSGIX")) == NULL) || r;
 
-#endif /* GL_SGIX_ir_instrument1 */
+  return r;
+}
 
-#ifdef GL_SGIX_list_priority
+#endif /* GL_SGIX_igloo_interface */
 
-#endif /* GL_SGIX_list_priority */
+#ifdef GL_SGIX_mpeg1
+
+static GLboolean _glewInit_GL_SGIX_mpeg1 ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glAllocMPEGPredictorsSGIX = (PFNGLALLOCMPEGPREDICTORSSGIXPROC)glewGetProcAddress((const GLubyte*)"glAllocMPEGPredictorsSGIX")) == NULL) || r;
+  r = ((glDeleteMPEGPredictorsSGIX = (PFNGLDELETEMPEGPREDICTORSSGIXPROC)glewGetProcAddress((const GLubyte*)"glDeleteMPEGPredictorsSGIX")) == NULL) || r;
+  r = ((glGenMPEGPredictorsSGIX = (PFNGLGENMPEGPREDICTORSSGIXPROC)glewGetProcAddress((const GLubyte*)"glGenMPEGPredictorsSGIX")) == NULL) || r;
+  r = ((glGetMPEGParameterfvSGIX = (PFNGLGETMPEGPARAMETERFVSGIXPROC)glewGetProcAddress((const GLubyte*)"glGetMPEGParameterfvSGIX")) == NULL) || r;
+  r = ((glGetMPEGParameterivSGIX = (PFNGLGETMPEGPARAMETERIVSGIXPROC)glewGetProcAddress((const GLubyte*)"glGetMPEGParameterivSGIX")) == NULL) || r;
+  r = ((glGetMPEGPredictorSGIX = (PFNGLGETMPEGPREDICTORSGIXPROC)glewGetProcAddress((const GLubyte*)"glGetMPEGPredictorSGIX")) == NULL) || r;
+  r = ((glGetMPEGQuantTableubv = (PFNGLGETMPEGQUANTTABLEUBVPROC)glewGetProcAddress((const GLubyte*)"glGetMPEGQuantTableubv")) == NULL) || r;
+  r = ((glIsMPEGPredictorSGIX = (PFNGLISMPEGPREDICTORSGIXPROC)glewGetProcAddress((const GLubyte*)"glIsMPEGPredictorSGIX")) == NULL) || r;
+  r = ((glMPEGPredictorSGIX = (PFNGLMPEGPREDICTORSGIXPROC)glewGetProcAddress((const GLubyte*)"glMPEGPredictorSGIX")) == NULL) || r;
+  r = ((glMPEGQuantTableubv = (PFNGLMPEGQUANTTABLEUBVPROC)glewGetProcAddress((const GLubyte*)"glMPEGQuantTableubv")) == NULL) || r;
+  r = ((glSwapMPEGPredictorsSGIX = (PFNGLSWAPMPEGPREDICTORSSGIXPROC)glewGetProcAddress((const GLubyte*)"glSwapMPEGPredictorsSGIX")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_SGIX_mpeg1 */
+
+#ifdef GL_SGIX_nonlinear_lighting_pervertex
+
+static GLboolean _glewInit_GL_SGIX_nonlinear_lighting_pervertex ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glGetNonlinLightfvSGIX = (PFNGLGETNONLINLIGHTFVSGIXPROC)glewGetProcAddress((const GLubyte*)"glGetNonlinLightfvSGIX")) == NULL) || r;
+  r = ((glGetNonlinMaterialfvSGIX = (PFNGLGETNONLINMATERIALFVSGIXPROC)glewGetProcAddress((const GLubyte*)"glGetNonlinMaterialfvSGIX")) == NULL) || r;
+  r = ((glNonlinLightfvSGIX = (PFNGLNONLINLIGHTFVSGIXPROC)glewGetProcAddress((const GLubyte*)"glNonlinLightfvSGIX")) == NULL) || r;
+  r = ((glNonlinMaterialfvSGIX = (PFNGLNONLINMATERIALFVSGIXPROC)glewGetProcAddress((const GLubyte*)"glNonlinMaterialfvSGIX")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_SGIX_nonlinear_lighting_pervertex */
 
 #ifdef GL_SGIX_pixel_texture
 
-static GLboolean _glewInit_GL_SGIX_pixel_texture (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_SGIX_pixel_texture ()
 {
   GLboolean r = GL_FALSE;
 
@@ -9825,13 +15811,37 @@ static GLboolean _glewInit_GL_SGIX_pixel_texture (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_SGIX_pixel_texture */
 
-#ifdef GL_SGIX_pixel_texture_bits
+#ifdef GL_SGIX_polynomial_ffd
 
-#endif /* GL_SGIX_pixel_texture_bits */
+static GLboolean _glewInit_GL_SGIX_polynomial_ffd ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glDeformSGIX = (PFNGLDEFORMSGIXPROC)glewGetProcAddress((const GLubyte*)"glDeformSGIX")) == NULL) || r;
+  r = ((glLoadIdentityDeformationMapSGIX = (PFNGLLOADIDENTITYDEFORMATIONMAPSGIXPROC)glewGetProcAddress((const GLubyte*)"glLoadIdentityDeformationMapSGIX")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_SGIX_polynomial_ffd */
+
+#ifdef GL_SGIX_quad_mesh
+
+static GLboolean _glewInit_GL_SGIX_quad_mesh ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glMeshBreadthSGIX = (PFNGLMESHBREADTHSGIXPROC)glewGetProcAddress((const GLubyte*)"glMeshBreadthSGIX")) == NULL) || r;
+  r = ((glMeshStrideSGIX = (PFNGLMESHSTRIDESGIXPROC)glewGetProcAddress((const GLubyte*)"glMeshStrideSGIX")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_SGIX_quad_mesh */
 
 #ifdef GL_SGIX_reference_plane
 
-static GLboolean _glewInit_GL_SGIX_reference_plane (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_SGIX_reference_plane ()
 {
   GLboolean r = GL_FALSE;
 
@@ -9842,21 +15852,9 @@ static GLboolean _glewInit_GL_SGIX_reference_plane (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_SGIX_reference_plane */
 
-#ifdef GL_SGIX_resample
-
-#endif /* GL_SGIX_resample */
-
-#ifdef GL_SGIX_shadow
-
-#endif /* GL_SGIX_shadow */
-
-#ifdef GL_SGIX_shadow_ambient
-
-#endif /* GL_SGIX_shadow_ambient */
-
 #ifdef GL_SGIX_sprite
 
-static GLboolean _glewInit_GL_SGIX_sprite (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_SGIX_sprite ()
 {
   GLboolean r = GL_FALSE;
 
@@ -9872,7 +15870,7 @@ static GLboolean _glewInit_GL_SGIX_sprite (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_SGIX_tag_sample_buffer
 
-static GLboolean _glewInit_GL_SGIX_tag_sample_buffer (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_SGIX_tag_sample_buffer ()
 {
   GLboolean r = GL_FALSE;
 
@@ -9883,49 +15881,41 @@ static GLboolean _glewInit_GL_SGIX_tag_sample_buffer (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_SGIX_tag_sample_buffer */
 
-#ifdef GL_SGIX_texture_add_env
+#ifdef GL_SGIX_vector_ops
 
-#endif /* GL_SGIX_texture_add_env */
+static GLboolean _glewInit_GL_SGIX_vector_ops ()
+{
+  GLboolean r = GL_FALSE;
 
-#ifdef GL_SGIX_texture_coordinate_clamp
+  r = ((glGetVectorOperationSGIX = (PFNGLGETVECTOROPERATIONSGIXPROC)glewGetProcAddress((const GLubyte*)"glGetVectorOperationSGIX")) == NULL) || r;
+  r = ((glVectorOperationSGIX = (PFNGLVECTOROPERATIONSGIXPROC)glewGetProcAddress((const GLubyte*)"glVectorOperationSGIX")) == NULL) || r;
 
-#endif /* GL_SGIX_texture_coordinate_clamp */
+  return r;
+}
 
-#ifdef GL_SGIX_texture_lod_bias
+#endif /* GL_SGIX_vector_ops */
 
-#endif /* GL_SGIX_texture_lod_bias */
+#ifdef GL_SGIX_vertex_array_object
 
-#ifdef GL_SGIX_texture_multi_buffer
+static GLboolean _glewInit_GL_SGIX_vertex_array_object ()
+{
+  GLboolean r = GL_FALSE;
 
-#endif /* GL_SGIX_texture_multi_buffer */
+  r = ((glAreVertexArraysResidentSGIX = (PFNGLAREVERTEXARRAYSRESIDENTSGIXPROC)glewGetProcAddress((const GLubyte*)"glAreVertexArraysResidentSGIX")) == NULL) || r;
+  r = ((glBindVertexArraySGIX = (PFNGLBINDVERTEXARRAYSGIXPROC)glewGetProcAddress((const GLubyte*)"glBindVertexArraySGIX")) == NULL) || r;
+  r = ((glDeleteVertexArraysSGIX = (PFNGLDELETEVERTEXARRAYSSGIXPROC)glewGetProcAddress((const GLubyte*)"glDeleteVertexArraysSGIX")) == NULL) || r;
+  r = ((glGenVertexArraysSGIX = (PFNGLGENVERTEXARRAYSSGIXPROC)glewGetProcAddress((const GLubyte*)"glGenVertexArraysSGIX")) == NULL) || r;
+  r = ((glIsVertexArraySGIX = (PFNGLISVERTEXARRAYSGIXPROC)glewGetProcAddress((const GLubyte*)"glIsVertexArraySGIX")) == NULL) || r;
+  r = ((glPrioritizeVertexArraysSGIX = (PFNGLPRIORITIZEVERTEXARRAYSSGIXPROC)glewGetProcAddress((const GLubyte*)"glPrioritizeVertexArraysSGIX")) == NULL) || r;
 
-#ifdef GL_SGIX_texture_range
+  return r;
+}
 
-#endif /* GL_SGIX_texture_range */
-
-#ifdef GL_SGIX_texture_scale_bias
-
-#endif /* GL_SGIX_texture_scale_bias */
-
-#ifdef GL_SGIX_vertex_preclip
-
-#endif /* GL_SGIX_vertex_preclip */
-
-#ifdef GL_SGIX_vertex_preclip_hint
-
-#endif /* GL_SGIX_vertex_preclip_hint */
-
-#ifdef GL_SGIX_ycrcb
-
-#endif /* GL_SGIX_ycrcb */
-
-#ifdef GL_SGI_color_matrix
-
-#endif /* GL_SGI_color_matrix */
+#endif /* GL_SGIX_vertex_array_object */
 
 #ifdef GL_SGI_color_table
 
-static GLboolean _glewInit_GL_SGI_color_table (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_SGI_color_table ()
 {
   GLboolean r = GL_FALSE;
 
@@ -9942,13 +15932,28 @@ static GLboolean _glewInit_GL_SGI_color_table (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_SGI_color_table */
 
-#ifdef GL_SGI_texture_color_table
+#ifdef GL_SGI_fft
 
-#endif /* GL_SGI_texture_color_table */
+static GLboolean _glewInit_GL_SGI_fft ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((glGetPixelTransformParameterfvSGI = (PFNGLGETPIXELTRANSFORMPARAMETERFVSGIPROC)glewGetProcAddress((const GLubyte*)"glGetPixelTransformParameterfvSGI")) == NULL) || r;
+  r = ((glGetPixelTransformParameterivSGI = (PFNGLGETPIXELTRANSFORMPARAMETERIVSGIPROC)glewGetProcAddress((const GLubyte*)"glGetPixelTransformParameterivSGI")) == NULL) || r;
+  r = ((glPixelTransformParameterfSGI = (PFNGLPIXELTRANSFORMPARAMETERFSGIPROC)glewGetProcAddress((const GLubyte*)"glPixelTransformParameterfSGI")) == NULL) || r;
+  r = ((glPixelTransformParameterfvSGI = (PFNGLPIXELTRANSFORMPARAMETERFVSGIPROC)glewGetProcAddress((const GLubyte*)"glPixelTransformParameterfvSGI")) == NULL) || r;
+  r = ((glPixelTransformParameteriSGI = (PFNGLPIXELTRANSFORMPARAMETERISGIPROC)glewGetProcAddress((const GLubyte*)"glPixelTransformParameteriSGI")) == NULL) || r;
+  r = ((glPixelTransformParameterivSGI = (PFNGLPIXELTRANSFORMPARAMETERIVSGIPROC)glewGetProcAddress((const GLubyte*)"glPixelTransformParameterivSGI")) == NULL) || r;
+  r = ((glPixelTransformSGI = (PFNGLPIXELTRANSFORMSGIPROC)glewGetProcAddress((const GLubyte*)"glPixelTransformSGI")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* GL_SGI_fft */
 
 #ifdef GL_SUNX_constant_data
 
-static GLboolean _glewInit_GL_SUNX_constant_data (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_SUNX_constant_data ()
 {
   GLboolean r = GL_FALSE;
 
@@ -9959,13 +15964,9 @@ static GLboolean _glewInit_GL_SUNX_constant_data (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_SUNX_constant_data */
 
-#ifdef GL_SUN_convolution_border_modes
-
-#endif /* GL_SUN_convolution_border_modes */
-
 #ifdef GL_SUN_global_alpha
 
-static GLboolean _glewInit_GL_SUN_global_alpha (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_SUN_global_alpha ()
 {
   GLboolean r = GL_FALSE;
 
@@ -9983,13 +15984,9 @@ static GLboolean _glewInit_GL_SUN_global_alpha (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_SUN_global_alpha */
 
-#ifdef GL_SUN_mesh_array
-
-#endif /* GL_SUN_mesh_array */
-
 #ifdef GL_SUN_read_video_pixels
 
-static GLboolean _glewInit_GL_SUN_read_video_pixels (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_SUN_read_video_pixels ()
 {
   GLboolean r = GL_FALSE;
 
@@ -10000,13 +15997,9 @@ static GLboolean _glewInit_GL_SUN_read_video_pixels (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_SUN_read_video_pixels */
 
-#ifdef GL_SUN_slice_accum
-
-#endif /* GL_SUN_slice_accum */
-
 #ifdef GL_SUN_triangle_list
 
-static GLboolean _glewInit_GL_SUN_triangle_list (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_SUN_triangle_list ()
 {
   GLboolean r = GL_FALSE;
 
@@ -10025,7 +16018,7 @@ static GLboolean _glewInit_GL_SUN_triangle_list (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GL_SUN_vertex
 
-static GLboolean _glewInit_GL_SUN_vertex (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_SUN_vertex ()
 {
   GLboolean r = GL_FALSE;
 
@@ -10075,17 +16068,9 @@ static GLboolean _glewInit_GL_SUN_vertex (GLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GL_SUN_vertex */
 
-#ifdef GL_WIN_phong_shading
-
-#endif /* GL_WIN_phong_shading */
-
-#ifdef GL_WIN_specular_fog
-
-#endif /* GL_WIN_specular_fog */
-
 #ifdef GL_WIN_swap_hint
 
-static GLboolean _glewInit_GL_WIN_swap_hint (GLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GL_WIN_swap_hint ()
 {
   GLboolean r = GL_FALSE;
 
@@ -10098,39 +16083,101 @@ static GLboolean _glewInit_GL_WIN_swap_hint (GLEW_CONTEXT_ARG_DEF_INIT)
 
 /* ------------------------------------------------------------------------- */
 
+static int _glewExtensionCompare(const char *s1, const char *s2)
+{
+  /* http://www.chanduthedev.com/2012/07/strcmp-implementation-in-c.html */
+  while (*s1 || *s2)
+  {
+      if (*s1 > *s2)
+          return 1;
+      if (*s1 < *s2)
+          return -1;
+      s1++;
+      s2++;
+  }
+  return 0;
+}
+
+static ptrdiff_t _glewBsearchExtension(const char* name)
+{
+  ptrdiff_t lo = 0, hi = sizeof(_glewExtensionLookup) / sizeof(char*) - 2;
+
+  while (lo <= hi)
+  {
+    ptrdiff_t mid = (lo + hi) / 2;
+    const int cmp = _glewExtensionCompare(name, _glewExtensionLookup[mid]);
+    if (cmp < 0) hi = mid - 1;
+    else if (cmp > 0) lo = mid + 1;
+    else return mid;
+  }
+  return -1;
+}
+
+static GLboolean *_glewGetExtensionString(const char *name)
+{
+  ptrdiff_t n = _glewBsearchExtension(name);
+  if (n >= 0) return &_glewExtensionString[n];
+  return NULL;
+}
+
+static GLboolean *_glewGetExtensionEnable(const char *name)
+{
+  ptrdiff_t n = _glewBsearchExtension(name);
+  if (n >= 0) return _glewExtensionEnabled[n];
+  return NULL;
+}
+
+static const char *_glewNextSpace(const char *i)
+{
+  const char *j = i;
+  if (j)
+    while (*j!=' ' && *j) ++j;
+  return j;
+}
+
+static const char *_glewNextNonSpace(const char *i)
+{
+  const char *j = i;
+  if (j)
+    while (*j==' ') ++j;
+  return j;
+}
+
 GLboolean GLEWAPIENTRY glewGetExtension (const char* name)
 {
-  const GLubyte* start;
-  const GLubyte* end;
-  
-  if (ext_hashset != NULL)
-      return _glewSearchExtension(name, NULL, NULL);
-
-  start = (const GLubyte*)glGetString(GL_EXTENSIONS);
-  if (start == 0)
-    return GL_FALSE;
-  end = start + _glewStrLen(start);
-  return _glewSearchExtension(name, start, end);
+  GLboolean *enable = _glewGetExtensionString(name);
+  if (enable)
+    return *enable;
+  return GL_FALSE;
 }
 
 /* ------------------------------------------------------------------------- */
 
-#ifndef GLEW_MX
-static
-#endif
-GLenum GLEWAPIENTRY glewContextInit (GLEW_CONTEXT_ARG_DEF_LIST)
+typedef const GLubyte* (GLAPIENTRY * PFNGLGETSTRINGPROC) (GLenum name);
+typedef void (GLAPIENTRY * PFNGLGETINTEGERVPROC) (GLenum pname, GLint *params);
+
+static GLenum GLEWAPIENTRY glewContextInit ()
 {
+  PFNGLGETSTRINGPROC getString;
   const GLubyte* s;
   GLuint dot;
   GLint major, minor;
-  const GLubyte* extStart;
-  const GLubyte* extEnd;
+  size_t n;
+
+  #ifdef _WIN32
+  getString = glGetString;
+  #else
+  getString = (PFNGLGETSTRINGPROC) glewGetProcAddress((const GLubyte*)"glGetString");
+  if (!getString)
+    return GLEW_ERROR_NO_GL_VERSION;
+  #endif
+
   /* query opengl version */
-  s = glGetString(GL_VERSION);
+  s = getString(GL_VERSION);
   dot = _glewStrCLen(s, '.');
   if (dot == 0)
     return GLEW_ERROR_NO_GL_VERSION;
-  
+
   major = s[dot-1]-'0';
   minor = s[dot+1]-'0';
 
@@ -10138,7 +16185,6 @@ GLenum GLEWAPIENTRY glewContextInit (GLEW_CONTEXT_ARG_DEF_LIST)
     minor = 0;
   if (major<0 || major>9)
     return GLEW_ERROR_NO_GL_VERSION;
-  
 
   if (major == 1 && minor == 0)
   {
@@ -10146,7 +16192,8 @@ GLenum GLEWAPIENTRY glewContextInit (GLEW_CONTEXT_ARG_DEF_LIST)
   }
   else
   {
-    GLEW_VERSION_4_5   = ( major > 4 )                 || ( major == 4 && minor >= 5 ) ? GL_TRUE : GL_FALSE;
+    GLEW_VERSION_4_6   = ( major > 4 )                 || ( major == 4 && minor >= 6 ) ? GL_TRUE : GL_FALSE;
+    GLEW_VERSION_4_5   = GLEW_VERSION_4_4   == GL_TRUE || ( major == 4 && minor >= 5 ) ? GL_TRUE : GL_FALSE;
     GLEW_VERSION_4_4   = GLEW_VERSION_4_5   == GL_TRUE || ( major == 4 && minor >= 4 ) ? GL_TRUE : GL_FALSE;
     GLEW_VERSION_4_3   = GLEW_VERSION_4_4   == GL_TRUE || ( major == 4 && minor >= 3 ) ? GL_TRUE : GL_FALSE;
     GLEW_VERSION_4_2   = GLEW_VERSION_4_3   == GL_TRUE || ( major == 4 && minor >= 2 ) ? GL_TRUE : GL_FALSE;
@@ -10156,1956 +16203,2608 @@ GLenum GLEWAPIENTRY glewContextInit (GLEW_CONTEXT_ARG_DEF_LIST)
     GLEW_VERSION_3_2   = GLEW_VERSION_3_3   == GL_TRUE || ( major == 3 && minor >= 2 ) ? GL_TRUE : GL_FALSE;
     GLEW_VERSION_3_1   = GLEW_VERSION_3_2   == GL_TRUE || ( major == 3 && minor >= 1 ) ? GL_TRUE : GL_FALSE;
     GLEW_VERSION_3_0   = GLEW_VERSION_3_1   == GL_TRUE || ( major == 3               ) ? GL_TRUE : GL_FALSE;
-    GLEW_VERSION_2_1   = GLEW_VERSION_3_0   == GL_TRUE || ( major == 2 && minor >= 1 ) ? GL_TRUE : GL_FALSE;    
+    GLEW_VERSION_2_1   = GLEW_VERSION_3_0   == GL_TRUE || ( major == 2 && minor >= 1 ) ? GL_TRUE : GL_FALSE;
     GLEW_VERSION_2_0   = GLEW_VERSION_2_1   == GL_TRUE || ( major == 2               ) ? GL_TRUE : GL_FALSE;
     GLEW_VERSION_1_5   = GLEW_VERSION_2_0   == GL_TRUE || ( major == 1 && minor >= 5 ) ? GL_TRUE : GL_FALSE;
     GLEW_VERSION_1_4   = GLEW_VERSION_1_5   == GL_TRUE || ( major == 1 && minor >= 4 ) ? GL_TRUE : GL_FALSE;
     GLEW_VERSION_1_3   = GLEW_VERSION_1_4   == GL_TRUE || ( major == 1 && minor >= 3 ) ? GL_TRUE : GL_FALSE;
-    GLEW_VERSION_1_2_1 = GLEW_VERSION_1_3   == GL_TRUE                                 ? GL_TRUE : GL_FALSE; 
+    GLEW_VERSION_1_2_1 = GLEW_VERSION_1_3   == GL_TRUE                                 ? GL_TRUE : GL_FALSE;
     GLEW_VERSION_1_2   = GLEW_VERSION_1_2_1 == GL_TRUE || ( major == 1 && minor >= 2 ) ? GL_TRUE : GL_FALSE;
     GLEW_VERSION_1_1   = GLEW_VERSION_1_2   == GL_TRUE || ( major == 1 && minor >= 1 ) ? GL_TRUE : GL_FALSE;
   }
-  
-  if (major >= 3) /* glGetString method is deprecated */
+
+  for (n = 0; n < sizeof(_glewExtensionString) / sizeof(_glewExtensionString[0]); ++n)
+    _glewExtensionString[n] = GL_FALSE;
+
+  if (GLEW_VERSION_3_0)
   {
-    GLint n, i;
-    glGetIntegerv(GL_NUM_EXTENSIONS, &n);
-    glGetStringi = (PFNGLGETSTRINGIPROC)glewGetProcAddress((const GLubyte*)"glGetStringi");
+    GLint n = 0;
+    GLint i;
+    PFNGLGETINTEGERVPROC getIntegerv;
+    PFNGLGETSTRINGIPROC getStringi;
+    const char *ext;
+    GLboolean *enable;
 
-    free(ext_hashset); /* In case we get called a second time. */
+    #ifdef _WIN32
+    getIntegerv = glGetIntegerv;
+    #else
+    getIntegerv = (PFNGLGETINTEGERVPROC) glewGetProcAddress((const GLubyte*)"glGetIntegerv");
+    #endif
 
-    ext_hashset_size = (n * 3) / 2;
-    ext_hashset = calloc(ext_hashset_size, sizeof(const char *));
-    for (i = 0; i < n; ++i)
-    {
-      const char * extension;
-      unsigned hash;
- 
-      extension = (const char *)glGetStringi(GL_EXTENSIONS, i);
-      hash = hash_string(extension);
+    if (getIntegerv)
+      getIntegerv(GL_NUM_EXTENSIONS, &n);
 
-      while(ext_hashset[hash % ext_hashset_size] != NULL)
-        hash++;
-        
-      ext_hashset[hash % ext_hashset_size] = extension;
-    }
+    /* glGetStringi is OpenGL 3.0 */
+    getStringi = (PFNGLGETSTRINGIPROC) glewGetProcAddress((const GLubyte*)"glGetStringi");
+    if (getStringi)
+      for (i = 0; i<n; ++i)
+      {
+        ext = (const char *) getStringi(GL_EXTENSIONS, i);
 
-    extStart = 0;
+        /* Based on extension string(s), glewGetExtension purposes */
+        enable = _glewGetExtensionString(ext);
+        if (enable)
+          *enable = GL_TRUE;
+
+        /* Based on extension string(s), experimental mode, glewIsSupported purposes */
+        enable = _glewGetExtensionEnable(ext);
+        if (enable)
+          *enable = GL_TRUE;
+      }
   }
   else
   {
-    /* query opengl extensions string */
-    extStart = glGetString(GL_EXTENSIONS);
+    const char *extensions;
+    const char *end;
+    const char *i;
+    const char *j;
+    char ext[128];
+    GLboolean *enable;
+
+    extensions = (const char *) getString(GL_EXTENSIONS);
+
+    if (extensions)
+    {
+      end = extensions + _glewStrLen((const GLubyte *) extensions);
+      for (i=extensions; i<end; i = j + 1)
+      {
+        i = _glewNextNonSpace(i);
+        j = _glewNextSpace(i);
+
+        /* Copy extension into NUL terminated string */
+        if (j-i >= (ptrdiff_t) sizeof(ext))
+          continue;
+        _glewStrCopy(ext, i, ' ');
+
+        /* Based on extension string(s), glewGetExtension purposes */
+        enable = _glewGetExtensionString(ext);
+        if (enable)
+          *enable = GL_TRUE;
+
+        /* Based on extension string(s), experimental mode, glewIsSupported purposes */
+        enable = _glewGetExtensionEnable(ext);
+        if (enable)
+          *enable = GL_TRUE;
+      }
+    }
   }
-
-  if (extStart == 0)
-    extStart = (const GLubyte*)"";
-  extEnd = extStart + _glewStrLen(extStart);
-
-  /* initialize extensions */
 #ifdef GL_VERSION_1_2
-  if (glewExperimental || GLEW_VERSION_1_2) GLEW_VERSION_1_2 = !_glewInit_GL_VERSION_1_2(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_VERSION_1_2) GLEW_VERSION_1_2 = !_glewInit_GL_VERSION_1_2();
 #endif /* GL_VERSION_1_2 */
-#ifdef GL_VERSION_1_2_1
-#endif /* GL_VERSION_1_2_1 */
 #ifdef GL_VERSION_1_3
-  if (glewExperimental || GLEW_VERSION_1_3) GLEW_VERSION_1_3 = !_glewInit_GL_VERSION_1_3(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_VERSION_1_3) GLEW_VERSION_1_3 = !_glewInit_GL_VERSION_1_3();
 #endif /* GL_VERSION_1_3 */
 #ifdef GL_VERSION_1_4
-  if (glewExperimental || GLEW_VERSION_1_4) GLEW_VERSION_1_4 = !_glewInit_GL_VERSION_1_4(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_VERSION_1_4) GLEW_VERSION_1_4 = !_glewInit_GL_VERSION_1_4();
 #endif /* GL_VERSION_1_4 */
 #ifdef GL_VERSION_1_5
-  if (glewExperimental || GLEW_VERSION_1_5) GLEW_VERSION_1_5 = !_glewInit_GL_VERSION_1_5(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_VERSION_1_5) GLEW_VERSION_1_5 = !_glewInit_GL_VERSION_1_5();
 #endif /* GL_VERSION_1_5 */
 #ifdef GL_VERSION_2_0
-  if (glewExperimental || GLEW_VERSION_2_0) GLEW_VERSION_2_0 = !_glewInit_GL_VERSION_2_0(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_VERSION_2_0) GLEW_VERSION_2_0 = !_glewInit_GL_VERSION_2_0();
 #endif /* GL_VERSION_2_0 */
 #ifdef GL_VERSION_2_1
-  if (glewExperimental || GLEW_VERSION_2_1) GLEW_VERSION_2_1 = !_glewInit_GL_VERSION_2_1(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_VERSION_2_1) GLEW_VERSION_2_1 = !_glewInit_GL_VERSION_2_1();
 #endif /* GL_VERSION_2_1 */
 #ifdef GL_VERSION_3_0
-  if (glewExperimental || GLEW_VERSION_3_0) GLEW_VERSION_3_0 = !_glewInit_GL_VERSION_3_0(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_VERSION_3_0) GLEW_VERSION_3_0 = !_glewInit_GL_VERSION_3_0();
 #endif /* GL_VERSION_3_0 */
 #ifdef GL_VERSION_3_1
-  if (glewExperimental || GLEW_VERSION_3_1) GLEW_VERSION_3_1 = !_glewInit_GL_VERSION_3_1(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_VERSION_3_1) GLEW_VERSION_3_1 = !_glewInit_GL_VERSION_3_1();
 #endif /* GL_VERSION_3_1 */
 #ifdef GL_VERSION_3_2
-  if (glewExperimental || GLEW_VERSION_3_2) GLEW_VERSION_3_2 = !_glewInit_GL_VERSION_3_2(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_VERSION_3_2) GLEW_VERSION_3_2 = !_glewInit_GL_VERSION_3_2();
 #endif /* GL_VERSION_3_2 */
 #ifdef GL_VERSION_3_3
-  if (glewExperimental || GLEW_VERSION_3_3) GLEW_VERSION_3_3 = !_glewInit_GL_VERSION_3_3(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_VERSION_3_3) GLEW_VERSION_3_3 = !_glewInit_GL_VERSION_3_3();
 #endif /* GL_VERSION_3_3 */
 #ifdef GL_VERSION_4_0
-  if (glewExperimental || GLEW_VERSION_4_0) GLEW_VERSION_4_0 = !_glewInit_GL_VERSION_4_0(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_VERSION_4_0) GLEW_VERSION_4_0 = !_glewInit_GL_VERSION_4_0();
 #endif /* GL_VERSION_4_0 */
-#ifdef GL_VERSION_4_1
-#endif /* GL_VERSION_4_1 */
-#ifdef GL_VERSION_4_2
-#endif /* GL_VERSION_4_2 */
-#ifdef GL_VERSION_4_3
-#endif /* GL_VERSION_4_3 */
-#ifdef GL_VERSION_4_4
-#endif /* GL_VERSION_4_4 */
 #ifdef GL_VERSION_4_5
+  if (glewExperimental || GLEW_VERSION_4_5) GLEW_VERSION_4_5 = !_glewInit_GL_VERSION_4_5();
 #endif /* GL_VERSION_4_5 */
-#ifdef GL_3DFX_multisample
-  GLEW_3DFX_multisample = _glewSearchExtension("GL_3DFX_multisample", extStart, extEnd);
-#endif /* GL_3DFX_multisample */
+#ifdef GL_VERSION_4_6
+  if (glewExperimental || GLEW_VERSION_4_6) GLEW_VERSION_4_6 = !_glewInit_GL_VERSION_4_6();
+#endif /* GL_VERSION_4_6 */
 #ifdef GL_3DFX_tbuffer
-  GLEW_3DFX_tbuffer = _glewSearchExtension("GL_3DFX_tbuffer", extStart, extEnd);
-  if (glewExperimental || GLEW_3DFX_tbuffer) GLEW_3DFX_tbuffer = !_glewInit_GL_3DFX_tbuffer(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_3DFX_tbuffer) GLEW_3DFX_tbuffer = !_glewInit_GL_3DFX_tbuffer();
 #endif /* GL_3DFX_tbuffer */
-#ifdef GL_3DFX_texture_compression_FXT1
-  GLEW_3DFX_texture_compression_FXT1 = _glewSearchExtension("GL_3DFX_texture_compression_FXT1", extStart, extEnd);
-#endif /* GL_3DFX_texture_compression_FXT1 */
-#ifdef GL_AMD_blend_minmax_factor
-  GLEW_AMD_blend_minmax_factor = _glewSearchExtension("GL_AMD_blend_minmax_factor", extStart, extEnd);
-#endif /* GL_AMD_blend_minmax_factor */
-#ifdef GL_AMD_conservative_depth
-  GLEW_AMD_conservative_depth = _glewSearchExtension("GL_AMD_conservative_depth", extStart, extEnd);
-#endif /* GL_AMD_conservative_depth */
 #ifdef GL_AMD_debug_output
-  GLEW_AMD_debug_output = _glewSearchExtension("GL_AMD_debug_output", extStart, extEnd);
-  if (glewExperimental || GLEW_AMD_debug_output) GLEW_AMD_debug_output = !_glewInit_GL_AMD_debug_output(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_AMD_debug_output) GLEW_AMD_debug_output = !_glewInit_GL_AMD_debug_output();
 #endif /* GL_AMD_debug_output */
-#ifdef GL_AMD_depth_clamp_separate
-  GLEW_AMD_depth_clamp_separate = _glewSearchExtension("GL_AMD_depth_clamp_separate", extStart, extEnd);
-#endif /* GL_AMD_depth_clamp_separate */
 #ifdef GL_AMD_draw_buffers_blend
-  GLEW_AMD_draw_buffers_blend = _glewSearchExtension("GL_AMD_draw_buffers_blend", extStart, extEnd);
-  if (glewExperimental || GLEW_AMD_draw_buffers_blend) GLEW_AMD_draw_buffers_blend = !_glewInit_GL_AMD_draw_buffers_blend(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_AMD_draw_buffers_blend) GLEW_AMD_draw_buffers_blend = !_glewInit_GL_AMD_draw_buffers_blend();
 #endif /* GL_AMD_draw_buffers_blend */
-#ifdef GL_AMD_gcn_shader
-  GLEW_AMD_gcn_shader = _glewSearchExtension("GL_AMD_gcn_shader", extStart, extEnd);
-#endif /* GL_AMD_gcn_shader */
-#ifdef GL_AMD_gpu_shader_int64
-  GLEW_AMD_gpu_shader_int64 = _glewSearchExtension("GL_AMD_gpu_shader_int64", extStart, extEnd);
-#endif /* GL_AMD_gpu_shader_int64 */
+#ifdef GL_AMD_framebuffer_sample_positions
+  if (glewExperimental || GLEW_AMD_framebuffer_sample_positions) GLEW_AMD_framebuffer_sample_positions = !_glewInit_GL_AMD_framebuffer_sample_positions();
+#endif /* GL_AMD_framebuffer_sample_positions */
 #ifdef GL_AMD_interleaved_elements
-  GLEW_AMD_interleaved_elements = _glewSearchExtension("GL_AMD_interleaved_elements", extStart, extEnd);
-  if (glewExperimental || GLEW_AMD_interleaved_elements) GLEW_AMD_interleaved_elements = !_glewInit_GL_AMD_interleaved_elements(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_AMD_interleaved_elements) GLEW_AMD_interleaved_elements = !_glewInit_GL_AMD_interleaved_elements();
 #endif /* GL_AMD_interleaved_elements */
 #ifdef GL_AMD_multi_draw_indirect
-  GLEW_AMD_multi_draw_indirect = _glewSearchExtension("GL_AMD_multi_draw_indirect", extStart, extEnd);
-  if (glewExperimental || GLEW_AMD_multi_draw_indirect) GLEW_AMD_multi_draw_indirect = !_glewInit_GL_AMD_multi_draw_indirect(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_AMD_multi_draw_indirect) GLEW_AMD_multi_draw_indirect = !_glewInit_GL_AMD_multi_draw_indirect();
 #endif /* GL_AMD_multi_draw_indirect */
 #ifdef GL_AMD_name_gen_delete
-  GLEW_AMD_name_gen_delete = _glewSearchExtension("GL_AMD_name_gen_delete", extStart, extEnd);
-  if (glewExperimental || GLEW_AMD_name_gen_delete) GLEW_AMD_name_gen_delete = !_glewInit_GL_AMD_name_gen_delete(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_AMD_name_gen_delete) GLEW_AMD_name_gen_delete = !_glewInit_GL_AMD_name_gen_delete();
 #endif /* GL_AMD_name_gen_delete */
 #ifdef GL_AMD_occlusion_query_event
-  GLEW_AMD_occlusion_query_event = _glewSearchExtension("GL_AMD_occlusion_query_event", extStart, extEnd);
-  if (glewExperimental || GLEW_AMD_occlusion_query_event) GLEW_AMD_occlusion_query_event = !_glewInit_GL_AMD_occlusion_query_event(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_AMD_occlusion_query_event) GLEW_AMD_occlusion_query_event = !_glewInit_GL_AMD_occlusion_query_event();
 #endif /* GL_AMD_occlusion_query_event */
 #ifdef GL_AMD_performance_monitor
-  GLEW_AMD_performance_monitor = _glewSearchExtension("GL_AMD_performance_monitor", extStart, extEnd);
-  if (glewExperimental || GLEW_AMD_performance_monitor) GLEW_AMD_performance_monitor = !_glewInit_GL_AMD_performance_monitor(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_AMD_performance_monitor) GLEW_AMD_performance_monitor = !_glewInit_GL_AMD_performance_monitor();
 #endif /* GL_AMD_performance_monitor */
-#ifdef GL_AMD_pinned_memory
-  GLEW_AMD_pinned_memory = _glewSearchExtension("GL_AMD_pinned_memory", extStart, extEnd);
-#endif /* GL_AMD_pinned_memory */
-#ifdef GL_AMD_query_buffer_object
-  GLEW_AMD_query_buffer_object = _glewSearchExtension("GL_AMD_query_buffer_object", extStart, extEnd);
-#endif /* GL_AMD_query_buffer_object */
 #ifdef GL_AMD_sample_positions
-  GLEW_AMD_sample_positions = _glewSearchExtension("GL_AMD_sample_positions", extStart, extEnd);
-  if (glewExperimental || GLEW_AMD_sample_positions) GLEW_AMD_sample_positions = !_glewInit_GL_AMD_sample_positions(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_AMD_sample_positions) GLEW_AMD_sample_positions = !_glewInit_GL_AMD_sample_positions();
 #endif /* GL_AMD_sample_positions */
-#ifdef GL_AMD_seamless_cubemap_per_texture
-  GLEW_AMD_seamless_cubemap_per_texture = _glewSearchExtension("GL_AMD_seamless_cubemap_per_texture", extStart, extEnd);
-#endif /* GL_AMD_seamless_cubemap_per_texture */
-#ifdef GL_AMD_shader_atomic_counter_ops
-  GLEW_AMD_shader_atomic_counter_ops = _glewSearchExtension("GL_AMD_shader_atomic_counter_ops", extStart, extEnd);
-#endif /* GL_AMD_shader_atomic_counter_ops */
-#ifdef GL_AMD_shader_stencil_export
-  GLEW_AMD_shader_stencil_export = _glewSearchExtension("GL_AMD_shader_stencil_export", extStart, extEnd);
-#endif /* GL_AMD_shader_stencil_export */
-#ifdef GL_AMD_shader_stencil_value_export
-  GLEW_AMD_shader_stencil_value_export = _glewSearchExtension("GL_AMD_shader_stencil_value_export", extStart, extEnd);
-#endif /* GL_AMD_shader_stencil_value_export */
-#ifdef GL_AMD_shader_trinary_minmax
-  GLEW_AMD_shader_trinary_minmax = _glewSearchExtension("GL_AMD_shader_trinary_minmax", extStart, extEnd);
-#endif /* GL_AMD_shader_trinary_minmax */
 #ifdef GL_AMD_sparse_texture
-  GLEW_AMD_sparse_texture = _glewSearchExtension("GL_AMD_sparse_texture", extStart, extEnd);
-  if (glewExperimental || GLEW_AMD_sparse_texture) GLEW_AMD_sparse_texture = !_glewInit_GL_AMD_sparse_texture(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_AMD_sparse_texture) GLEW_AMD_sparse_texture = !_glewInit_GL_AMD_sparse_texture();
 #endif /* GL_AMD_sparse_texture */
 #ifdef GL_AMD_stencil_operation_extended
-  GLEW_AMD_stencil_operation_extended = _glewSearchExtension("GL_AMD_stencil_operation_extended", extStart, extEnd);
-  if (glewExperimental || GLEW_AMD_stencil_operation_extended) GLEW_AMD_stencil_operation_extended = !_glewInit_GL_AMD_stencil_operation_extended(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_AMD_stencil_operation_extended) GLEW_AMD_stencil_operation_extended = !_glewInit_GL_AMD_stencil_operation_extended();
 #endif /* GL_AMD_stencil_operation_extended */
-#ifdef GL_AMD_texture_texture4
-  GLEW_AMD_texture_texture4 = _glewSearchExtension("GL_AMD_texture_texture4", extStart, extEnd);
-#endif /* GL_AMD_texture_texture4 */
-#ifdef GL_AMD_transform_feedback3_lines_triangles
-  GLEW_AMD_transform_feedback3_lines_triangles = _glewSearchExtension("GL_AMD_transform_feedback3_lines_triangles", extStart, extEnd);
-#endif /* GL_AMD_transform_feedback3_lines_triangles */
-#ifdef GL_AMD_transform_feedback4
-  GLEW_AMD_transform_feedback4 = _glewSearchExtension("GL_AMD_transform_feedback4", extStart, extEnd);
-#endif /* GL_AMD_transform_feedback4 */
-#ifdef GL_AMD_vertex_shader_layer
-  GLEW_AMD_vertex_shader_layer = _glewSearchExtension("GL_AMD_vertex_shader_layer", extStart, extEnd);
-#endif /* GL_AMD_vertex_shader_layer */
 #ifdef GL_AMD_vertex_shader_tessellator
-  GLEW_AMD_vertex_shader_tessellator = _glewSearchExtension("GL_AMD_vertex_shader_tessellator", extStart, extEnd);
-  if (glewExperimental || GLEW_AMD_vertex_shader_tessellator) GLEW_AMD_vertex_shader_tessellator = !_glewInit_GL_AMD_vertex_shader_tessellator(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_AMD_vertex_shader_tessellator) GLEW_AMD_vertex_shader_tessellator = !_glewInit_GL_AMD_vertex_shader_tessellator();
 #endif /* GL_AMD_vertex_shader_tessellator */
-#ifdef GL_AMD_vertex_shader_viewport_index
-  GLEW_AMD_vertex_shader_viewport_index = _glewSearchExtension("GL_AMD_vertex_shader_viewport_index", extStart, extEnd);
-#endif /* GL_AMD_vertex_shader_viewport_index */
-#ifdef GL_ANGLE_depth_texture
-  GLEW_ANGLE_depth_texture = _glewSearchExtension("GL_ANGLE_depth_texture", extStart, extEnd);
-#endif /* GL_ANGLE_depth_texture */
 #ifdef GL_ANGLE_framebuffer_blit
-  GLEW_ANGLE_framebuffer_blit = _glewSearchExtension("GL_ANGLE_framebuffer_blit", extStart, extEnd);
-  if (glewExperimental || GLEW_ANGLE_framebuffer_blit) GLEW_ANGLE_framebuffer_blit = !_glewInit_GL_ANGLE_framebuffer_blit(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ANGLE_framebuffer_blit) GLEW_ANGLE_framebuffer_blit = !_glewInit_GL_ANGLE_framebuffer_blit();
 #endif /* GL_ANGLE_framebuffer_blit */
 #ifdef GL_ANGLE_framebuffer_multisample
-  GLEW_ANGLE_framebuffer_multisample = _glewSearchExtension("GL_ANGLE_framebuffer_multisample", extStart, extEnd);
-  if (glewExperimental || GLEW_ANGLE_framebuffer_multisample) GLEW_ANGLE_framebuffer_multisample = !_glewInit_GL_ANGLE_framebuffer_multisample(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ANGLE_framebuffer_multisample) GLEW_ANGLE_framebuffer_multisample = !_glewInit_GL_ANGLE_framebuffer_multisample();
 #endif /* GL_ANGLE_framebuffer_multisample */
 #ifdef GL_ANGLE_instanced_arrays
-  GLEW_ANGLE_instanced_arrays = _glewSearchExtension("GL_ANGLE_instanced_arrays", extStart, extEnd);
-  if (glewExperimental || GLEW_ANGLE_instanced_arrays) GLEW_ANGLE_instanced_arrays = !_glewInit_GL_ANGLE_instanced_arrays(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ANGLE_instanced_arrays) GLEW_ANGLE_instanced_arrays = !_glewInit_GL_ANGLE_instanced_arrays();
 #endif /* GL_ANGLE_instanced_arrays */
-#ifdef GL_ANGLE_pack_reverse_row_order
-  GLEW_ANGLE_pack_reverse_row_order = _glewSearchExtension("GL_ANGLE_pack_reverse_row_order", extStart, extEnd);
-#endif /* GL_ANGLE_pack_reverse_row_order */
-#ifdef GL_ANGLE_program_binary
-  GLEW_ANGLE_program_binary = _glewSearchExtension("GL_ANGLE_program_binary", extStart, extEnd);
-#endif /* GL_ANGLE_program_binary */
-#ifdef GL_ANGLE_texture_compression_dxt1
-  GLEW_ANGLE_texture_compression_dxt1 = _glewSearchExtension("GL_ANGLE_texture_compression_dxt1", extStart, extEnd);
-#endif /* GL_ANGLE_texture_compression_dxt1 */
-#ifdef GL_ANGLE_texture_compression_dxt3
-  GLEW_ANGLE_texture_compression_dxt3 = _glewSearchExtension("GL_ANGLE_texture_compression_dxt3", extStart, extEnd);
-#endif /* GL_ANGLE_texture_compression_dxt3 */
-#ifdef GL_ANGLE_texture_compression_dxt5
-  GLEW_ANGLE_texture_compression_dxt5 = _glewSearchExtension("GL_ANGLE_texture_compression_dxt5", extStart, extEnd);
-#endif /* GL_ANGLE_texture_compression_dxt5 */
-#ifdef GL_ANGLE_texture_usage
-  GLEW_ANGLE_texture_usage = _glewSearchExtension("GL_ANGLE_texture_usage", extStart, extEnd);
-#endif /* GL_ANGLE_texture_usage */
 #ifdef GL_ANGLE_timer_query
-  GLEW_ANGLE_timer_query = _glewSearchExtension("GL_ANGLE_timer_query", extStart, extEnd);
-  if (glewExperimental || GLEW_ANGLE_timer_query) GLEW_ANGLE_timer_query = !_glewInit_GL_ANGLE_timer_query(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ANGLE_timer_query) GLEW_ANGLE_timer_query = !_glewInit_GL_ANGLE_timer_query();
 #endif /* GL_ANGLE_timer_query */
 #ifdef GL_ANGLE_translated_shader_source
-  GLEW_ANGLE_translated_shader_source = _glewSearchExtension("GL_ANGLE_translated_shader_source", extStart, extEnd);
-  if (glewExperimental || GLEW_ANGLE_translated_shader_source) GLEW_ANGLE_translated_shader_source = !_glewInit_GL_ANGLE_translated_shader_source(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ANGLE_translated_shader_source) GLEW_ANGLE_translated_shader_source = !_glewInit_GL_ANGLE_translated_shader_source();
 #endif /* GL_ANGLE_translated_shader_source */
-#ifdef GL_APPLE_aux_depth_stencil
-  GLEW_APPLE_aux_depth_stencil = _glewSearchExtension("GL_APPLE_aux_depth_stencil", extStart, extEnd);
-#endif /* GL_APPLE_aux_depth_stencil */
-#ifdef GL_APPLE_client_storage
-  GLEW_APPLE_client_storage = _glewSearchExtension("GL_APPLE_client_storage", extStart, extEnd);
-#endif /* GL_APPLE_client_storage */
+#ifdef GL_APPLE_copy_texture_levels
+  if (glewExperimental || GLEW_APPLE_copy_texture_levels) GLEW_APPLE_copy_texture_levels = !_glewInit_GL_APPLE_copy_texture_levels();
+#endif /* GL_APPLE_copy_texture_levels */
 #ifdef GL_APPLE_element_array
-  GLEW_APPLE_element_array = _glewSearchExtension("GL_APPLE_element_array", extStart, extEnd);
-  if (glewExperimental || GLEW_APPLE_element_array) GLEW_APPLE_element_array = !_glewInit_GL_APPLE_element_array(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_APPLE_element_array) GLEW_APPLE_element_array = !_glewInit_GL_APPLE_element_array();
 #endif /* GL_APPLE_element_array */
 #ifdef GL_APPLE_fence
-  GLEW_APPLE_fence = _glewSearchExtension("GL_APPLE_fence", extStart, extEnd);
-  if (glewExperimental || GLEW_APPLE_fence) GLEW_APPLE_fence = !_glewInit_GL_APPLE_fence(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_APPLE_fence) GLEW_APPLE_fence = !_glewInit_GL_APPLE_fence();
 #endif /* GL_APPLE_fence */
-#ifdef GL_APPLE_float_pixels
-  GLEW_APPLE_float_pixels = _glewSearchExtension("GL_APPLE_float_pixels", extStart, extEnd);
-#endif /* GL_APPLE_float_pixels */
 #ifdef GL_APPLE_flush_buffer_range
-  GLEW_APPLE_flush_buffer_range = _glewSearchExtension("GL_APPLE_flush_buffer_range", extStart, extEnd);
-  if (glewExperimental || GLEW_APPLE_flush_buffer_range) GLEW_APPLE_flush_buffer_range = !_glewInit_GL_APPLE_flush_buffer_range(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_APPLE_flush_buffer_range) GLEW_APPLE_flush_buffer_range = !_glewInit_GL_APPLE_flush_buffer_range();
 #endif /* GL_APPLE_flush_buffer_range */
+#ifdef GL_APPLE_framebuffer_multisample
+  if (glewExperimental || GLEW_APPLE_framebuffer_multisample) GLEW_APPLE_framebuffer_multisample = !_glewInit_GL_APPLE_framebuffer_multisample();
+#endif /* GL_APPLE_framebuffer_multisample */
 #ifdef GL_APPLE_object_purgeable
-  GLEW_APPLE_object_purgeable = _glewSearchExtension("GL_APPLE_object_purgeable", extStart, extEnd);
-  if (glewExperimental || GLEW_APPLE_object_purgeable) GLEW_APPLE_object_purgeable = !_glewInit_GL_APPLE_object_purgeable(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_APPLE_object_purgeable) GLEW_APPLE_object_purgeable = !_glewInit_GL_APPLE_object_purgeable();
 #endif /* GL_APPLE_object_purgeable */
-#ifdef GL_APPLE_pixel_buffer
-  GLEW_APPLE_pixel_buffer = _glewSearchExtension("GL_APPLE_pixel_buffer", extStart, extEnd);
-#endif /* GL_APPLE_pixel_buffer */
-#ifdef GL_APPLE_rgb_422
-  GLEW_APPLE_rgb_422 = _glewSearchExtension("GL_APPLE_rgb_422", extStart, extEnd);
-#endif /* GL_APPLE_rgb_422 */
-#ifdef GL_APPLE_row_bytes
-  GLEW_APPLE_row_bytes = _glewSearchExtension("GL_APPLE_row_bytes", extStart, extEnd);
-#endif /* GL_APPLE_row_bytes */
-#ifdef GL_APPLE_specular_vector
-  GLEW_APPLE_specular_vector = _glewSearchExtension("GL_APPLE_specular_vector", extStart, extEnd);
-#endif /* GL_APPLE_specular_vector */
+#ifdef GL_APPLE_sync
+  if (glewExperimental || GLEW_APPLE_sync) GLEW_APPLE_sync = !_glewInit_GL_APPLE_sync();
+#endif /* GL_APPLE_sync */
 #ifdef GL_APPLE_texture_range
-  GLEW_APPLE_texture_range = _glewSearchExtension("GL_APPLE_texture_range", extStart, extEnd);
-  if (glewExperimental || GLEW_APPLE_texture_range) GLEW_APPLE_texture_range = !_glewInit_GL_APPLE_texture_range(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_APPLE_texture_range) GLEW_APPLE_texture_range = !_glewInit_GL_APPLE_texture_range();
 #endif /* GL_APPLE_texture_range */
-#ifdef GL_APPLE_transform_hint
-  GLEW_APPLE_transform_hint = _glewSearchExtension("GL_APPLE_transform_hint", extStart, extEnd);
-#endif /* GL_APPLE_transform_hint */
 #ifdef GL_APPLE_vertex_array_object
-  GLEW_APPLE_vertex_array_object = _glewSearchExtension("GL_APPLE_vertex_array_object", extStart, extEnd);
-  if (glewExperimental || GLEW_APPLE_vertex_array_object) GLEW_APPLE_vertex_array_object = !_glewInit_GL_APPLE_vertex_array_object(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_APPLE_vertex_array_object) GLEW_APPLE_vertex_array_object = !_glewInit_GL_APPLE_vertex_array_object();
 #endif /* GL_APPLE_vertex_array_object */
 #ifdef GL_APPLE_vertex_array_range
-  GLEW_APPLE_vertex_array_range = _glewSearchExtension("GL_APPLE_vertex_array_range", extStart, extEnd);
-  if (glewExperimental || GLEW_APPLE_vertex_array_range) GLEW_APPLE_vertex_array_range = !_glewInit_GL_APPLE_vertex_array_range(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_APPLE_vertex_array_range) GLEW_APPLE_vertex_array_range = !_glewInit_GL_APPLE_vertex_array_range();
 #endif /* GL_APPLE_vertex_array_range */
 #ifdef GL_APPLE_vertex_program_evaluators
-  GLEW_APPLE_vertex_program_evaluators = _glewSearchExtension("GL_APPLE_vertex_program_evaluators", extStart, extEnd);
-  if (glewExperimental || GLEW_APPLE_vertex_program_evaluators) GLEW_APPLE_vertex_program_evaluators = !_glewInit_GL_APPLE_vertex_program_evaluators(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_APPLE_vertex_program_evaluators) GLEW_APPLE_vertex_program_evaluators = !_glewInit_GL_APPLE_vertex_program_evaluators();
 #endif /* GL_APPLE_vertex_program_evaluators */
-#ifdef GL_APPLE_ycbcr_422
-  GLEW_APPLE_ycbcr_422 = _glewSearchExtension("GL_APPLE_ycbcr_422", extStart, extEnd);
-#endif /* GL_APPLE_ycbcr_422 */
 #ifdef GL_ARB_ES2_compatibility
-  GLEW_ARB_ES2_compatibility = _glewSearchExtension("GL_ARB_ES2_compatibility", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_ES2_compatibility) GLEW_ARB_ES2_compatibility = !_glewInit_GL_ARB_ES2_compatibility(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_ES2_compatibility) GLEW_ARB_ES2_compatibility = !_glewInit_GL_ARB_ES2_compatibility();
 #endif /* GL_ARB_ES2_compatibility */
 #ifdef GL_ARB_ES3_1_compatibility
-  GLEW_ARB_ES3_1_compatibility = _glewSearchExtension("GL_ARB_ES3_1_compatibility", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_ES3_1_compatibility) GLEW_ARB_ES3_1_compatibility = !_glewInit_GL_ARB_ES3_1_compatibility(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_ES3_1_compatibility) GLEW_ARB_ES3_1_compatibility = !_glewInit_GL_ARB_ES3_1_compatibility();
 #endif /* GL_ARB_ES3_1_compatibility */
-#ifdef GL_ARB_ES3_compatibility
-  GLEW_ARB_ES3_compatibility = _glewSearchExtension("GL_ARB_ES3_compatibility", extStart, extEnd);
-#endif /* GL_ARB_ES3_compatibility */
-#ifdef GL_ARB_arrays_of_arrays
-  GLEW_ARB_arrays_of_arrays = _glewSearchExtension("GL_ARB_arrays_of_arrays", extStart, extEnd);
-#endif /* GL_ARB_arrays_of_arrays */
+#ifdef GL_ARB_ES3_2_compatibility
+  if (glewExperimental || GLEW_ARB_ES3_2_compatibility) GLEW_ARB_ES3_2_compatibility = !_glewInit_GL_ARB_ES3_2_compatibility();
+#endif /* GL_ARB_ES3_2_compatibility */
 #ifdef GL_ARB_base_instance
-  GLEW_ARB_base_instance = _glewSearchExtension("GL_ARB_base_instance", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_base_instance) GLEW_ARB_base_instance = !_glewInit_GL_ARB_base_instance(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_base_instance) GLEW_ARB_base_instance = !_glewInit_GL_ARB_base_instance();
 #endif /* GL_ARB_base_instance */
 #ifdef GL_ARB_bindless_texture
-  GLEW_ARB_bindless_texture = _glewSearchExtension("GL_ARB_bindless_texture", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_bindless_texture) GLEW_ARB_bindless_texture = !_glewInit_GL_ARB_bindless_texture(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_bindless_texture) GLEW_ARB_bindless_texture = !_glewInit_GL_ARB_bindless_texture();
 #endif /* GL_ARB_bindless_texture */
 #ifdef GL_ARB_blend_func_extended
-  GLEW_ARB_blend_func_extended = _glewSearchExtension("GL_ARB_blend_func_extended", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_blend_func_extended) GLEW_ARB_blend_func_extended = !_glewInit_GL_ARB_blend_func_extended(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_blend_func_extended) GLEW_ARB_blend_func_extended = !_glewInit_GL_ARB_blend_func_extended();
 #endif /* GL_ARB_blend_func_extended */
 #ifdef GL_ARB_buffer_storage
-  GLEW_ARB_buffer_storage = _glewSearchExtension("GL_ARB_buffer_storage", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_buffer_storage) GLEW_ARB_buffer_storage = !_glewInit_GL_ARB_buffer_storage(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_buffer_storage) GLEW_ARB_buffer_storage = !_glewInit_GL_ARB_buffer_storage();
 #endif /* GL_ARB_buffer_storage */
 #ifdef GL_ARB_cl_event
-  GLEW_ARB_cl_event = _glewSearchExtension("GL_ARB_cl_event", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_cl_event) GLEW_ARB_cl_event = !_glewInit_GL_ARB_cl_event(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_cl_event) GLEW_ARB_cl_event = !_glewInit_GL_ARB_cl_event();
 #endif /* GL_ARB_cl_event */
 #ifdef GL_ARB_clear_buffer_object
-  GLEW_ARB_clear_buffer_object = _glewSearchExtension("GL_ARB_clear_buffer_object", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_clear_buffer_object) GLEW_ARB_clear_buffer_object = !_glewInit_GL_ARB_clear_buffer_object(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_clear_buffer_object) GLEW_ARB_clear_buffer_object = !_glewInit_GL_ARB_clear_buffer_object();
 #endif /* GL_ARB_clear_buffer_object */
 #ifdef GL_ARB_clear_texture
-  GLEW_ARB_clear_texture = _glewSearchExtension("GL_ARB_clear_texture", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_clear_texture) GLEW_ARB_clear_texture = !_glewInit_GL_ARB_clear_texture(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_clear_texture) GLEW_ARB_clear_texture = !_glewInit_GL_ARB_clear_texture();
 #endif /* GL_ARB_clear_texture */
 #ifdef GL_ARB_clip_control
-  GLEW_ARB_clip_control = _glewSearchExtension("GL_ARB_clip_control", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_clip_control) GLEW_ARB_clip_control = !_glewInit_GL_ARB_clip_control(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_clip_control) GLEW_ARB_clip_control = !_glewInit_GL_ARB_clip_control();
 #endif /* GL_ARB_clip_control */
 #ifdef GL_ARB_color_buffer_float
-  GLEW_ARB_color_buffer_float = _glewSearchExtension("GL_ARB_color_buffer_float", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_color_buffer_float) GLEW_ARB_color_buffer_float = !_glewInit_GL_ARB_color_buffer_float(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_color_buffer_float) GLEW_ARB_color_buffer_float = !_glewInit_GL_ARB_color_buffer_float();
 #endif /* GL_ARB_color_buffer_float */
-#ifdef GL_ARB_compatibility
-  GLEW_ARB_compatibility = _glewSearchExtension("GL_ARB_compatibility", extStart, extEnd);
-#endif /* GL_ARB_compatibility */
-#ifdef GL_ARB_compressed_texture_pixel_storage
-  GLEW_ARB_compressed_texture_pixel_storage = _glewSearchExtension("GL_ARB_compressed_texture_pixel_storage", extStart, extEnd);
-#endif /* GL_ARB_compressed_texture_pixel_storage */
 #ifdef GL_ARB_compute_shader
-  GLEW_ARB_compute_shader = _glewSearchExtension("GL_ARB_compute_shader", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_compute_shader) GLEW_ARB_compute_shader = !_glewInit_GL_ARB_compute_shader(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_compute_shader) GLEW_ARB_compute_shader = !_glewInit_GL_ARB_compute_shader();
 #endif /* GL_ARB_compute_shader */
 #ifdef GL_ARB_compute_variable_group_size
-  GLEW_ARB_compute_variable_group_size = _glewSearchExtension("GL_ARB_compute_variable_group_size", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_compute_variable_group_size) GLEW_ARB_compute_variable_group_size = !_glewInit_GL_ARB_compute_variable_group_size(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_compute_variable_group_size) GLEW_ARB_compute_variable_group_size = !_glewInit_GL_ARB_compute_variable_group_size();
 #endif /* GL_ARB_compute_variable_group_size */
-#ifdef GL_ARB_conditional_render_inverted
-  GLEW_ARB_conditional_render_inverted = _glewSearchExtension("GL_ARB_conditional_render_inverted", extStart, extEnd);
-#endif /* GL_ARB_conditional_render_inverted */
-#ifdef GL_ARB_conservative_depth
-  GLEW_ARB_conservative_depth = _glewSearchExtension("GL_ARB_conservative_depth", extStart, extEnd);
-#endif /* GL_ARB_conservative_depth */
 #ifdef GL_ARB_copy_buffer
-  GLEW_ARB_copy_buffer = _glewSearchExtension("GL_ARB_copy_buffer", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_copy_buffer) GLEW_ARB_copy_buffer = !_glewInit_GL_ARB_copy_buffer(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_copy_buffer) GLEW_ARB_copy_buffer = !_glewInit_GL_ARB_copy_buffer();
 #endif /* GL_ARB_copy_buffer */
 #ifdef GL_ARB_copy_image
-  GLEW_ARB_copy_image = _glewSearchExtension("GL_ARB_copy_image", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_copy_image) GLEW_ARB_copy_image = !_glewInit_GL_ARB_copy_image(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_copy_image) GLEW_ARB_copy_image = !_glewInit_GL_ARB_copy_image();
 #endif /* GL_ARB_copy_image */
-#ifdef GL_ARB_cull_distance
-  GLEW_ARB_cull_distance = _glewSearchExtension("GL_ARB_cull_distance", extStart, extEnd);
-#endif /* GL_ARB_cull_distance */
 #ifdef GL_ARB_debug_output
-  GLEW_ARB_debug_output = _glewSearchExtension("GL_ARB_debug_output", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_debug_output) GLEW_ARB_debug_output = !_glewInit_GL_ARB_debug_output(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_debug_output) GLEW_ARB_debug_output = !_glewInit_GL_ARB_debug_output();
 #endif /* GL_ARB_debug_output */
-#ifdef GL_ARB_depth_buffer_float
-  GLEW_ARB_depth_buffer_float = _glewSearchExtension("GL_ARB_depth_buffer_float", extStart, extEnd);
-#endif /* GL_ARB_depth_buffer_float */
-#ifdef GL_ARB_depth_clamp
-  GLEW_ARB_depth_clamp = _glewSearchExtension("GL_ARB_depth_clamp", extStart, extEnd);
-#endif /* GL_ARB_depth_clamp */
-#ifdef GL_ARB_depth_texture
-  GLEW_ARB_depth_texture = _glewSearchExtension("GL_ARB_depth_texture", extStart, extEnd);
-#endif /* GL_ARB_depth_texture */
-#ifdef GL_ARB_derivative_control
-  GLEW_ARB_derivative_control = _glewSearchExtension("GL_ARB_derivative_control", extStart, extEnd);
-#endif /* GL_ARB_derivative_control */
 #ifdef GL_ARB_direct_state_access
-  GLEW_ARB_direct_state_access = _glewSearchExtension("GL_ARB_direct_state_access", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_direct_state_access) GLEW_ARB_direct_state_access = !_glewInit_GL_ARB_direct_state_access(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_direct_state_access) GLEW_ARB_direct_state_access = !_glewInit_GL_ARB_direct_state_access();
 #endif /* GL_ARB_direct_state_access */
 #ifdef GL_ARB_draw_buffers
-  GLEW_ARB_draw_buffers = _glewSearchExtension("GL_ARB_draw_buffers", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_draw_buffers) GLEW_ARB_draw_buffers = !_glewInit_GL_ARB_draw_buffers(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_draw_buffers) GLEW_ARB_draw_buffers = !_glewInit_GL_ARB_draw_buffers();
 #endif /* GL_ARB_draw_buffers */
 #ifdef GL_ARB_draw_buffers_blend
-  GLEW_ARB_draw_buffers_blend = _glewSearchExtension("GL_ARB_draw_buffers_blend", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_draw_buffers_blend) GLEW_ARB_draw_buffers_blend = !_glewInit_GL_ARB_draw_buffers_blend(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_draw_buffers_blend) GLEW_ARB_draw_buffers_blend = !_glewInit_GL_ARB_draw_buffers_blend();
 #endif /* GL_ARB_draw_buffers_blend */
 #ifdef GL_ARB_draw_elements_base_vertex
-  GLEW_ARB_draw_elements_base_vertex = _glewSearchExtension("GL_ARB_draw_elements_base_vertex", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_draw_elements_base_vertex) GLEW_ARB_draw_elements_base_vertex = !_glewInit_GL_ARB_draw_elements_base_vertex(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_draw_elements_base_vertex) GLEW_ARB_draw_elements_base_vertex = !_glewInit_GL_ARB_draw_elements_base_vertex();
 #endif /* GL_ARB_draw_elements_base_vertex */
 #ifdef GL_ARB_draw_indirect
-  GLEW_ARB_draw_indirect = _glewSearchExtension("GL_ARB_draw_indirect", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_draw_indirect) GLEW_ARB_draw_indirect = !_glewInit_GL_ARB_draw_indirect(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_draw_indirect) GLEW_ARB_draw_indirect = !_glewInit_GL_ARB_draw_indirect();
 #endif /* GL_ARB_draw_indirect */
-#ifdef GL_ARB_draw_instanced
-  GLEW_ARB_draw_instanced = _glewSearchExtension("GL_ARB_draw_instanced", extStart, extEnd);
-#endif /* GL_ARB_draw_instanced */
-#ifdef GL_ARB_enhanced_layouts
-  GLEW_ARB_enhanced_layouts = _glewSearchExtension("GL_ARB_enhanced_layouts", extStart, extEnd);
-#endif /* GL_ARB_enhanced_layouts */
-#ifdef GL_ARB_explicit_attrib_location
-  GLEW_ARB_explicit_attrib_location = _glewSearchExtension("GL_ARB_explicit_attrib_location", extStart, extEnd);
-#endif /* GL_ARB_explicit_attrib_location */
-#ifdef GL_ARB_explicit_uniform_location
-  GLEW_ARB_explicit_uniform_location = _glewSearchExtension("GL_ARB_explicit_uniform_location", extStart, extEnd);
-#endif /* GL_ARB_explicit_uniform_location */
-#ifdef GL_ARB_fragment_coord_conventions
-  GLEW_ARB_fragment_coord_conventions = _glewSearchExtension("GL_ARB_fragment_coord_conventions", extStart, extEnd);
-#endif /* GL_ARB_fragment_coord_conventions */
-#ifdef GL_ARB_fragment_layer_viewport
-  GLEW_ARB_fragment_layer_viewport = _glewSearchExtension("GL_ARB_fragment_layer_viewport", extStart, extEnd);
-#endif /* GL_ARB_fragment_layer_viewport */
-#ifdef GL_ARB_fragment_program
-  GLEW_ARB_fragment_program = _glewSearchExtension("GL_ARB_fragment_program", extStart, extEnd);
-#endif /* GL_ARB_fragment_program */
-#ifdef GL_ARB_fragment_program_shadow
-  GLEW_ARB_fragment_program_shadow = _glewSearchExtension("GL_ARB_fragment_program_shadow", extStart, extEnd);
-#endif /* GL_ARB_fragment_program_shadow */
-#ifdef GL_ARB_fragment_shader
-  GLEW_ARB_fragment_shader = _glewSearchExtension("GL_ARB_fragment_shader", extStart, extEnd);
-#endif /* GL_ARB_fragment_shader */
 #ifdef GL_ARB_framebuffer_no_attachments
-  GLEW_ARB_framebuffer_no_attachments = _glewSearchExtension("GL_ARB_framebuffer_no_attachments", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_framebuffer_no_attachments) GLEW_ARB_framebuffer_no_attachments = !_glewInit_GL_ARB_framebuffer_no_attachments(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_framebuffer_no_attachments) GLEW_ARB_framebuffer_no_attachments = !_glewInit_GL_ARB_framebuffer_no_attachments();
 #endif /* GL_ARB_framebuffer_no_attachments */
 #ifdef GL_ARB_framebuffer_object
-  GLEW_ARB_framebuffer_object = _glewSearchExtension("GL_ARB_framebuffer_object", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_framebuffer_object) GLEW_ARB_framebuffer_object = !_glewInit_GL_ARB_framebuffer_object(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_framebuffer_object) GLEW_ARB_framebuffer_object = !_glewInit_GL_ARB_framebuffer_object();
 #endif /* GL_ARB_framebuffer_object */
-#ifdef GL_ARB_framebuffer_sRGB
-  GLEW_ARB_framebuffer_sRGB = _glewSearchExtension("GL_ARB_framebuffer_sRGB", extStart, extEnd);
-#endif /* GL_ARB_framebuffer_sRGB */
 #ifdef GL_ARB_geometry_shader4
-  GLEW_ARB_geometry_shader4 = _glewSearchExtension("GL_ARB_geometry_shader4", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_geometry_shader4) GLEW_ARB_geometry_shader4 = !_glewInit_GL_ARB_geometry_shader4(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_geometry_shader4) GLEW_ARB_geometry_shader4 = !_glewInit_GL_ARB_geometry_shader4();
 #endif /* GL_ARB_geometry_shader4 */
 #ifdef GL_ARB_get_program_binary
-  GLEW_ARB_get_program_binary = _glewSearchExtension("GL_ARB_get_program_binary", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_get_program_binary) GLEW_ARB_get_program_binary = !_glewInit_GL_ARB_get_program_binary(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_get_program_binary) GLEW_ARB_get_program_binary = !_glewInit_GL_ARB_get_program_binary();
 #endif /* GL_ARB_get_program_binary */
 #ifdef GL_ARB_get_texture_sub_image
-  GLEW_ARB_get_texture_sub_image = _glewSearchExtension("GL_ARB_get_texture_sub_image", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_get_texture_sub_image) GLEW_ARB_get_texture_sub_image = !_glewInit_GL_ARB_get_texture_sub_image(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_get_texture_sub_image) GLEW_ARB_get_texture_sub_image = !_glewInit_GL_ARB_get_texture_sub_image();
 #endif /* GL_ARB_get_texture_sub_image */
-#ifdef GL_ARB_gpu_shader5
-  GLEW_ARB_gpu_shader5 = _glewSearchExtension("GL_ARB_gpu_shader5", extStart, extEnd);
-#endif /* GL_ARB_gpu_shader5 */
+#ifdef GL_ARB_gl_spirv
+  if (glewExperimental || GLEW_ARB_gl_spirv) GLEW_ARB_gl_spirv = !_glewInit_GL_ARB_gl_spirv();
+#endif /* GL_ARB_gl_spirv */
 #ifdef GL_ARB_gpu_shader_fp64
-  GLEW_ARB_gpu_shader_fp64 = _glewSearchExtension("GL_ARB_gpu_shader_fp64", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_gpu_shader_fp64) GLEW_ARB_gpu_shader_fp64 = !_glewInit_GL_ARB_gpu_shader_fp64(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_gpu_shader_fp64) GLEW_ARB_gpu_shader_fp64 = !_glewInit_GL_ARB_gpu_shader_fp64();
 #endif /* GL_ARB_gpu_shader_fp64 */
-#ifdef GL_ARB_half_float_pixel
-  GLEW_ARB_half_float_pixel = _glewSearchExtension("GL_ARB_half_float_pixel", extStart, extEnd);
-#endif /* GL_ARB_half_float_pixel */
-#ifdef GL_ARB_half_float_vertex
-  GLEW_ARB_half_float_vertex = _glewSearchExtension("GL_ARB_half_float_vertex", extStart, extEnd);
-#endif /* GL_ARB_half_float_vertex */
+#ifdef GL_ARB_gpu_shader_int64
+  if (glewExperimental || GLEW_ARB_gpu_shader_int64) GLEW_ARB_gpu_shader_int64 = !_glewInit_GL_ARB_gpu_shader_int64();
+#endif /* GL_ARB_gpu_shader_int64 */
 #ifdef GL_ARB_imaging
-  GLEW_ARB_imaging = _glewSearchExtension("GL_ARB_imaging", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_imaging) GLEW_ARB_imaging = !_glewInit_GL_ARB_imaging(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_imaging) GLEW_ARB_imaging = !_glewInit_GL_ARB_imaging();
 #endif /* GL_ARB_imaging */
 #ifdef GL_ARB_indirect_parameters
-  GLEW_ARB_indirect_parameters = _glewSearchExtension("GL_ARB_indirect_parameters", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_indirect_parameters) GLEW_ARB_indirect_parameters = !_glewInit_GL_ARB_indirect_parameters(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_indirect_parameters) GLEW_ARB_indirect_parameters = !_glewInit_GL_ARB_indirect_parameters();
 #endif /* GL_ARB_indirect_parameters */
 #ifdef GL_ARB_instanced_arrays
-  GLEW_ARB_instanced_arrays = _glewSearchExtension("GL_ARB_instanced_arrays", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_instanced_arrays) GLEW_ARB_instanced_arrays = !_glewInit_GL_ARB_instanced_arrays(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_instanced_arrays) GLEW_ARB_instanced_arrays = !_glewInit_GL_ARB_instanced_arrays();
 #endif /* GL_ARB_instanced_arrays */
 #ifdef GL_ARB_internalformat_query
-  GLEW_ARB_internalformat_query = _glewSearchExtension("GL_ARB_internalformat_query", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_internalformat_query) GLEW_ARB_internalformat_query = !_glewInit_GL_ARB_internalformat_query(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_internalformat_query) GLEW_ARB_internalformat_query = !_glewInit_GL_ARB_internalformat_query();
 #endif /* GL_ARB_internalformat_query */
 #ifdef GL_ARB_internalformat_query2
-  GLEW_ARB_internalformat_query2 = _glewSearchExtension("GL_ARB_internalformat_query2", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_internalformat_query2) GLEW_ARB_internalformat_query2 = !_glewInit_GL_ARB_internalformat_query2(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_internalformat_query2) GLEW_ARB_internalformat_query2 = !_glewInit_GL_ARB_internalformat_query2();
 #endif /* GL_ARB_internalformat_query2 */
 #ifdef GL_ARB_invalidate_subdata
-  GLEW_ARB_invalidate_subdata = _glewSearchExtension("GL_ARB_invalidate_subdata", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_invalidate_subdata) GLEW_ARB_invalidate_subdata = !_glewInit_GL_ARB_invalidate_subdata(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_invalidate_subdata) GLEW_ARB_invalidate_subdata = !_glewInit_GL_ARB_invalidate_subdata();
 #endif /* GL_ARB_invalidate_subdata */
-#ifdef GL_ARB_map_buffer_alignment
-  GLEW_ARB_map_buffer_alignment = _glewSearchExtension("GL_ARB_map_buffer_alignment", extStart, extEnd);
-#endif /* GL_ARB_map_buffer_alignment */
 #ifdef GL_ARB_map_buffer_range
-  GLEW_ARB_map_buffer_range = _glewSearchExtension("GL_ARB_map_buffer_range", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_map_buffer_range) GLEW_ARB_map_buffer_range = !_glewInit_GL_ARB_map_buffer_range(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_map_buffer_range) GLEW_ARB_map_buffer_range = !_glewInit_GL_ARB_map_buffer_range();
 #endif /* GL_ARB_map_buffer_range */
 #ifdef GL_ARB_matrix_palette
-  GLEW_ARB_matrix_palette = _glewSearchExtension("GL_ARB_matrix_palette", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_matrix_palette) GLEW_ARB_matrix_palette = !_glewInit_GL_ARB_matrix_palette(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_matrix_palette) GLEW_ARB_matrix_palette = !_glewInit_GL_ARB_matrix_palette();
 #endif /* GL_ARB_matrix_palette */
 #ifdef GL_ARB_multi_bind
-  GLEW_ARB_multi_bind = _glewSearchExtension("GL_ARB_multi_bind", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_multi_bind) GLEW_ARB_multi_bind = !_glewInit_GL_ARB_multi_bind(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_multi_bind) GLEW_ARB_multi_bind = !_glewInit_GL_ARB_multi_bind();
 #endif /* GL_ARB_multi_bind */
 #ifdef GL_ARB_multi_draw_indirect
-  GLEW_ARB_multi_draw_indirect = _glewSearchExtension("GL_ARB_multi_draw_indirect", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_multi_draw_indirect) GLEW_ARB_multi_draw_indirect = !_glewInit_GL_ARB_multi_draw_indirect(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_multi_draw_indirect) GLEW_ARB_multi_draw_indirect = !_glewInit_GL_ARB_multi_draw_indirect();
 #endif /* GL_ARB_multi_draw_indirect */
 #ifdef GL_ARB_multisample
-  GLEW_ARB_multisample = _glewSearchExtension("GL_ARB_multisample", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_multisample) GLEW_ARB_multisample = !_glewInit_GL_ARB_multisample(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_multisample) GLEW_ARB_multisample = !_glewInit_GL_ARB_multisample();
 #endif /* GL_ARB_multisample */
 #ifdef GL_ARB_multitexture
-  GLEW_ARB_multitexture = _glewSearchExtension("GL_ARB_multitexture", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_multitexture) GLEW_ARB_multitexture = !_glewInit_GL_ARB_multitexture(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_multitexture) GLEW_ARB_multitexture = !_glewInit_GL_ARB_multitexture();
 #endif /* GL_ARB_multitexture */
 #ifdef GL_ARB_occlusion_query
-  GLEW_ARB_occlusion_query = _glewSearchExtension("GL_ARB_occlusion_query", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_occlusion_query) GLEW_ARB_occlusion_query = !_glewInit_GL_ARB_occlusion_query(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_occlusion_query) GLEW_ARB_occlusion_query = !_glewInit_GL_ARB_occlusion_query();
 #endif /* GL_ARB_occlusion_query */
-#ifdef GL_ARB_occlusion_query2
-  GLEW_ARB_occlusion_query2 = _glewSearchExtension("GL_ARB_occlusion_query2", extStart, extEnd);
-#endif /* GL_ARB_occlusion_query2 */
-#ifdef GL_ARB_pipeline_statistics_query
-  GLEW_ARB_pipeline_statistics_query = _glewSearchExtension("GL_ARB_pipeline_statistics_query", extStart, extEnd);
-#endif /* GL_ARB_pipeline_statistics_query */
-#ifdef GL_ARB_pixel_buffer_object
-  GLEW_ARB_pixel_buffer_object = _glewSearchExtension("GL_ARB_pixel_buffer_object", extStart, extEnd);
-#endif /* GL_ARB_pixel_buffer_object */
+#ifdef GL_ARB_parallel_shader_compile
+  if (glewExperimental || GLEW_ARB_parallel_shader_compile) GLEW_ARB_parallel_shader_compile = !_glewInit_GL_ARB_parallel_shader_compile();
+#endif /* GL_ARB_parallel_shader_compile */
 #ifdef GL_ARB_point_parameters
-  GLEW_ARB_point_parameters = _glewSearchExtension("GL_ARB_point_parameters", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_point_parameters) GLEW_ARB_point_parameters = !_glewInit_GL_ARB_point_parameters(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_point_parameters) GLEW_ARB_point_parameters = !_glewInit_GL_ARB_point_parameters();
 #endif /* GL_ARB_point_parameters */
-#ifdef GL_ARB_point_sprite
-  GLEW_ARB_point_sprite = _glewSearchExtension("GL_ARB_point_sprite", extStart, extEnd);
-#endif /* GL_ARB_point_sprite */
+#ifdef GL_ARB_polygon_offset_clamp
+  if (glewExperimental || GLEW_ARB_polygon_offset_clamp) GLEW_ARB_polygon_offset_clamp = !_glewInit_GL_ARB_polygon_offset_clamp();
+#endif /* GL_ARB_polygon_offset_clamp */
 #ifdef GL_ARB_program_interface_query
-  GLEW_ARB_program_interface_query = _glewSearchExtension("GL_ARB_program_interface_query", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_program_interface_query) GLEW_ARB_program_interface_query = !_glewInit_GL_ARB_program_interface_query(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_program_interface_query) GLEW_ARB_program_interface_query = !_glewInit_GL_ARB_program_interface_query();
 #endif /* GL_ARB_program_interface_query */
 #ifdef GL_ARB_provoking_vertex
-  GLEW_ARB_provoking_vertex = _glewSearchExtension("GL_ARB_provoking_vertex", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_provoking_vertex) GLEW_ARB_provoking_vertex = !_glewInit_GL_ARB_provoking_vertex(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_provoking_vertex) GLEW_ARB_provoking_vertex = !_glewInit_GL_ARB_provoking_vertex();
 #endif /* GL_ARB_provoking_vertex */
-#ifdef GL_ARB_query_buffer_object
-  GLEW_ARB_query_buffer_object = _glewSearchExtension("GL_ARB_query_buffer_object", extStart, extEnd);
-#endif /* GL_ARB_query_buffer_object */
-#ifdef GL_ARB_robust_buffer_access_behavior
-  GLEW_ARB_robust_buffer_access_behavior = _glewSearchExtension("GL_ARB_robust_buffer_access_behavior", extStart, extEnd);
-#endif /* GL_ARB_robust_buffer_access_behavior */
 #ifdef GL_ARB_robustness
-  GLEW_ARB_robustness = _glewSearchExtension("GL_ARB_robustness", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_robustness) GLEW_ARB_robustness = !_glewInit_GL_ARB_robustness(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_robustness) GLEW_ARB_robustness = !_glewInit_GL_ARB_robustness();
 #endif /* GL_ARB_robustness */
-#ifdef GL_ARB_robustness_application_isolation
-  GLEW_ARB_robustness_application_isolation = _glewSearchExtension("GL_ARB_robustness_application_isolation", extStart, extEnd);
-#endif /* GL_ARB_robustness_application_isolation */
-#ifdef GL_ARB_robustness_share_group_isolation
-  GLEW_ARB_robustness_share_group_isolation = _glewSearchExtension("GL_ARB_robustness_share_group_isolation", extStart, extEnd);
-#endif /* GL_ARB_robustness_share_group_isolation */
+#ifdef GL_ARB_sample_locations
+  if (glewExperimental || GLEW_ARB_sample_locations) GLEW_ARB_sample_locations = !_glewInit_GL_ARB_sample_locations();
+#endif /* GL_ARB_sample_locations */
 #ifdef GL_ARB_sample_shading
-  GLEW_ARB_sample_shading = _glewSearchExtension("GL_ARB_sample_shading", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_sample_shading) GLEW_ARB_sample_shading = !_glewInit_GL_ARB_sample_shading(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_sample_shading) GLEW_ARB_sample_shading = !_glewInit_GL_ARB_sample_shading();
 #endif /* GL_ARB_sample_shading */
 #ifdef GL_ARB_sampler_objects
-  GLEW_ARB_sampler_objects = _glewSearchExtension("GL_ARB_sampler_objects", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_sampler_objects) GLEW_ARB_sampler_objects = !_glewInit_GL_ARB_sampler_objects(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_sampler_objects) GLEW_ARB_sampler_objects = !_glewInit_GL_ARB_sampler_objects();
 #endif /* GL_ARB_sampler_objects */
-#ifdef GL_ARB_seamless_cube_map
-  GLEW_ARB_seamless_cube_map = _glewSearchExtension("GL_ARB_seamless_cube_map", extStart, extEnd);
-#endif /* GL_ARB_seamless_cube_map */
-#ifdef GL_ARB_seamless_cubemap_per_texture
-  GLEW_ARB_seamless_cubemap_per_texture = _glewSearchExtension("GL_ARB_seamless_cubemap_per_texture", extStart, extEnd);
-#endif /* GL_ARB_seamless_cubemap_per_texture */
 #ifdef GL_ARB_separate_shader_objects
-  GLEW_ARB_separate_shader_objects = _glewSearchExtension("GL_ARB_separate_shader_objects", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_separate_shader_objects) GLEW_ARB_separate_shader_objects = !_glewInit_GL_ARB_separate_shader_objects(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_separate_shader_objects) GLEW_ARB_separate_shader_objects = !_glewInit_GL_ARB_separate_shader_objects();
 #endif /* GL_ARB_separate_shader_objects */
 #ifdef GL_ARB_shader_atomic_counters
-  GLEW_ARB_shader_atomic_counters = _glewSearchExtension("GL_ARB_shader_atomic_counters", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_shader_atomic_counters) GLEW_ARB_shader_atomic_counters = !_glewInit_GL_ARB_shader_atomic_counters(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_shader_atomic_counters) GLEW_ARB_shader_atomic_counters = !_glewInit_GL_ARB_shader_atomic_counters();
 #endif /* GL_ARB_shader_atomic_counters */
-#ifdef GL_ARB_shader_bit_encoding
-  GLEW_ARB_shader_bit_encoding = _glewSearchExtension("GL_ARB_shader_bit_encoding", extStart, extEnd);
-#endif /* GL_ARB_shader_bit_encoding */
-#ifdef GL_ARB_shader_draw_parameters
-  GLEW_ARB_shader_draw_parameters = _glewSearchExtension("GL_ARB_shader_draw_parameters", extStart, extEnd);
-#endif /* GL_ARB_shader_draw_parameters */
-#ifdef GL_ARB_shader_group_vote
-  GLEW_ARB_shader_group_vote = _glewSearchExtension("GL_ARB_shader_group_vote", extStart, extEnd);
-#endif /* GL_ARB_shader_group_vote */
 #ifdef GL_ARB_shader_image_load_store
-  GLEW_ARB_shader_image_load_store = _glewSearchExtension("GL_ARB_shader_image_load_store", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_shader_image_load_store) GLEW_ARB_shader_image_load_store = !_glewInit_GL_ARB_shader_image_load_store(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_shader_image_load_store) GLEW_ARB_shader_image_load_store = !_glewInit_GL_ARB_shader_image_load_store();
 #endif /* GL_ARB_shader_image_load_store */
-#ifdef GL_ARB_shader_image_size
-  GLEW_ARB_shader_image_size = _glewSearchExtension("GL_ARB_shader_image_size", extStart, extEnd);
-#endif /* GL_ARB_shader_image_size */
 #ifdef GL_ARB_shader_objects
-  GLEW_ARB_shader_objects = _glewSearchExtension("GL_ARB_shader_objects", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_shader_objects) GLEW_ARB_shader_objects = !_glewInit_GL_ARB_shader_objects(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_shader_objects) GLEW_ARB_shader_objects = !_glewInit_GL_ARB_shader_objects();
 #endif /* GL_ARB_shader_objects */
-#ifdef GL_ARB_shader_precision
-  GLEW_ARB_shader_precision = _glewSearchExtension("GL_ARB_shader_precision", extStart, extEnd);
-#endif /* GL_ARB_shader_precision */
-#ifdef GL_ARB_shader_stencil_export
-  GLEW_ARB_shader_stencil_export = _glewSearchExtension("GL_ARB_shader_stencil_export", extStart, extEnd);
-#endif /* GL_ARB_shader_stencil_export */
 #ifdef GL_ARB_shader_storage_buffer_object
-  GLEW_ARB_shader_storage_buffer_object = _glewSearchExtension("GL_ARB_shader_storage_buffer_object", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_shader_storage_buffer_object) GLEW_ARB_shader_storage_buffer_object = !_glewInit_GL_ARB_shader_storage_buffer_object(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_shader_storage_buffer_object) GLEW_ARB_shader_storage_buffer_object = !_glewInit_GL_ARB_shader_storage_buffer_object();
 #endif /* GL_ARB_shader_storage_buffer_object */
 #ifdef GL_ARB_shader_subroutine
-  GLEW_ARB_shader_subroutine = _glewSearchExtension("GL_ARB_shader_subroutine", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_shader_subroutine) GLEW_ARB_shader_subroutine = !_glewInit_GL_ARB_shader_subroutine(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_shader_subroutine) GLEW_ARB_shader_subroutine = !_glewInit_GL_ARB_shader_subroutine();
 #endif /* GL_ARB_shader_subroutine */
-#ifdef GL_ARB_shader_texture_image_samples
-  GLEW_ARB_shader_texture_image_samples = _glewSearchExtension("GL_ARB_shader_texture_image_samples", extStart, extEnd);
-#endif /* GL_ARB_shader_texture_image_samples */
-#ifdef GL_ARB_shader_texture_lod
-  GLEW_ARB_shader_texture_lod = _glewSearchExtension("GL_ARB_shader_texture_lod", extStart, extEnd);
-#endif /* GL_ARB_shader_texture_lod */
-#ifdef GL_ARB_shading_language_100
-  GLEW_ARB_shading_language_100 = _glewSearchExtension("GL_ARB_shading_language_100", extStart, extEnd);
-#endif /* GL_ARB_shading_language_100 */
-#ifdef GL_ARB_shading_language_420pack
-  GLEW_ARB_shading_language_420pack = _glewSearchExtension("GL_ARB_shading_language_420pack", extStart, extEnd);
-#endif /* GL_ARB_shading_language_420pack */
 #ifdef GL_ARB_shading_language_include
-  GLEW_ARB_shading_language_include = _glewSearchExtension("GL_ARB_shading_language_include", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_shading_language_include) GLEW_ARB_shading_language_include = !_glewInit_GL_ARB_shading_language_include(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_shading_language_include) GLEW_ARB_shading_language_include = !_glewInit_GL_ARB_shading_language_include();
 #endif /* GL_ARB_shading_language_include */
-#ifdef GL_ARB_shading_language_packing
-  GLEW_ARB_shading_language_packing = _glewSearchExtension("GL_ARB_shading_language_packing", extStart, extEnd);
-#endif /* GL_ARB_shading_language_packing */
-#ifdef GL_ARB_shadow
-  GLEW_ARB_shadow = _glewSearchExtension("GL_ARB_shadow", extStart, extEnd);
-#endif /* GL_ARB_shadow */
-#ifdef GL_ARB_shadow_ambient
-  GLEW_ARB_shadow_ambient = _glewSearchExtension("GL_ARB_shadow_ambient", extStart, extEnd);
-#endif /* GL_ARB_shadow_ambient */
 #ifdef GL_ARB_sparse_buffer
-  GLEW_ARB_sparse_buffer = _glewSearchExtension("GL_ARB_sparse_buffer", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_sparse_buffer) GLEW_ARB_sparse_buffer = !_glewInit_GL_ARB_sparse_buffer(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_sparse_buffer) GLEW_ARB_sparse_buffer = !_glewInit_GL_ARB_sparse_buffer();
 #endif /* GL_ARB_sparse_buffer */
 #ifdef GL_ARB_sparse_texture
-  GLEW_ARB_sparse_texture = _glewSearchExtension("GL_ARB_sparse_texture", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_sparse_texture) GLEW_ARB_sparse_texture = !_glewInit_GL_ARB_sparse_texture(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_sparse_texture) GLEW_ARB_sparse_texture = !_glewInit_GL_ARB_sparse_texture();
 #endif /* GL_ARB_sparse_texture */
-#ifdef GL_ARB_stencil_texturing
-  GLEW_ARB_stencil_texturing = _glewSearchExtension("GL_ARB_stencil_texturing", extStart, extEnd);
-#endif /* GL_ARB_stencil_texturing */
 #ifdef GL_ARB_sync
-  GLEW_ARB_sync = _glewSearchExtension("GL_ARB_sync", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_sync) GLEW_ARB_sync = !_glewInit_GL_ARB_sync(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_sync) GLEW_ARB_sync = !_glewInit_GL_ARB_sync();
 #endif /* GL_ARB_sync */
 #ifdef GL_ARB_tessellation_shader
-  GLEW_ARB_tessellation_shader = _glewSearchExtension("GL_ARB_tessellation_shader", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_tessellation_shader) GLEW_ARB_tessellation_shader = !_glewInit_GL_ARB_tessellation_shader(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_tessellation_shader) GLEW_ARB_tessellation_shader = !_glewInit_GL_ARB_tessellation_shader();
 #endif /* GL_ARB_tessellation_shader */
 #ifdef GL_ARB_texture_barrier
-  GLEW_ARB_texture_barrier = _glewSearchExtension("GL_ARB_texture_barrier", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_texture_barrier) GLEW_ARB_texture_barrier = !_glewInit_GL_ARB_texture_barrier(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_texture_barrier) GLEW_ARB_texture_barrier = !_glewInit_GL_ARB_texture_barrier();
 #endif /* GL_ARB_texture_barrier */
-#ifdef GL_ARB_texture_border_clamp
-  GLEW_ARB_texture_border_clamp = _glewSearchExtension("GL_ARB_texture_border_clamp", extStart, extEnd);
-#endif /* GL_ARB_texture_border_clamp */
 #ifdef GL_ARB_texture_buffer_object
-  GLEW_ARB_texture_buffer_object = _glewSearchExtension("GL_ARB_texture_buffer_object", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_texture_buffer_object) GLEW_ARB_texture_buffer_object = !_glewInit_GL_ARB_texture_buffer_object(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_texture_buffer_object) GLEW_ARB_texture_buffer_object = !_glewInit_GL_ARB_texture_buffer_object();
 #endif /* GL_ARB_texture_buffer_object */
-#ifdef GL_ARB_texture_buffer_object_rgb32
-  GLEW_ARB_texture_buffer_object_rgb32 = _glewSearchExtension("GL_ARB_texture_buffer_object_rgb32", extStart, extEnd);
-#endif /* GL_ARB_texture_buffer_object_rgb32 */
 #ifdef GL_ARB_texture_buffer_range
-  GLEW_ARB_texture_buffer_range = _glewSearchExtension("GL_ARB_texture_buffer_range", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_texture_buffer_range) GLEW_ARB_texture_buffer_range = !_glewInit_GL_ARB_texture_buffer_range(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_texture_buffer_range) GLEW_ARB_texture_buffer_range = !_glewInit_GL_ARB_texture_buffer_range();
 #endif /* GL_ARB_texture_buffer_range */
 #ifdef GL_ARB_texture_compression
-  GLEW_ARB_texture_compression = _glewSearchExtension("GL_ARB_texture_compression", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_texture_compression) GLEW_ARB_texture_compression = !_glewInit_GL_ARB_texture_compression(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_texture_compression) GLEW_ARB_texture_compression = !_glewInit_GL_ARB_texture_compression();
 #endif /* GL_ARB_texture_compression */
-#ifdef GL_ARB_texture_compression_bptc
-  GLEW_ARB_texture_compression_bptc = _glewSearchExtension("GL_ARB_texture_compression_bptc", extStart, extEnd);
-#endif /* GL_ARB_texture_compression_bptc */
-#ifdef GL_ARB_texture_compression_rgtc
-  GLEW_ARB_texture_compression_rgtc = _glewSearchExtension("GL_ARB_texture_compression_rgtc", extStart, extEnd);
-#endif /* GL_ARB_texture_compression_rgtc */
-#ifdef GL_ARB_texture_cube_map
-  GLEW_ARB_texture_cube_map = _glewSearchExtension("GL_ARB_texture_cube_map", extStart, extEnd);
-#endif /* GL_ARB_texture_cube_map */
-#ifdef GL_ARB_texture_cube_map_array
-  GLEW_ARB_texture_cube_map_array = _glewSearchExtension("GL_ARB_texture_cube_map_array", extStart, extEnd);
-#endif /* GL_ARB_texture_cube_map_array */
-#ifdef GL_ARB_texture_env_add
-  GLEW_ARB_texture_env_add = _glewSearchExtension("GL_ARB_texture_env_add", extStart, extEnd);
-#endif /* GL_ARB_texture_env_add */
-#ifdef GL_ARB_texture_env_combine
-  GLEW_ARB_texture_env_combine = _glewSearchExtension("GL_ARB_texture_env_combine", extStart, extEnd);
-#endif /* GL_ARB_texture_env_combine */
-#ifdef GL_ARB_texture_env_crossbar
-  GLEW_ARB_texture_env_crossbar = _glewSearchExtension("GL_ARB_texture_env_crossbar", extStart, extEnd);
-#endif /* GL_ARB_texture_env_crossbar */
-#ifdef GL_ARB_texture_env_dot3
-  GLEW_ARB_texture_env_dot3 = _glewSearchExtension("GL_ARB_texture_env_dot3", extStart, extEnd);
-#endif /* GL_ARB_texture_env_dot3 */
-#ifdef GL_ARB_texture_float
-  GLEW_ARB_texture_float = _glewSearchExtension("GL_ARB_texture_float", extStart, extEnd);
-#endif /* GL_ARB_texture_float */
-#ifdef GL_ARB_texture_gather
-  GLEW_ARB_texture_gather = _glewSearchExtension("GL_ARB_texture_gather", extStart, extEnd);
-#endif /* GL_ARB_texture_gather */
-#ifdef GL_ARB_texture_mirror_clamp_to_edge
-  GLEW_ARB_texture_mirror_clamp_to_edge = _glewSearchExtension("GL_ARB_texture_mirror_clamp_to_edge", extStart, extEnd);
-#endif /* GL_ARB_texture_mirror_clamp_to_edge */
-#ifdef GL_ARB_texture_mirrored_repeat
-  GLEW_ARB_texture_mirrored_repeat = _glewSearchExtension("GL_ARB_texture_mirrored_repeat", extStart, extEnd);
-#endif /* GL_ARB_texture_mirrored_repeat */
 #ifdef GL_ARB_texture_multisample
-  GLEW_ARB_texture_multisample = _glewSearchExtension("GL_ARB_texture_multisample", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_texture_multisample) GLEW_ARB_texture_multisample = !_glewInit_GL_ARB_texture_multisample(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_texture_multisample) GLEW_ARB_texture_multisample = !_glewInit_GL_ARB_texture_multisample();
 #endif /* GL_ARB_texture_multisample */
-#ifdef GL_ARB_texture_non_power_of_two
-  GLEW_ARB_texture_non_power_of_two = _glewSearchExtension("GL_ARB_texture_non_power_of_two", extStart, extEnd);
-#endif /* GL_ARB_texture_non_power_of_two */
-#ifdef GL_ARB_texture_query_levels
-  GLEW_ARB_texture_query_levels = _glewSearchExtension("GL_ARB_texture_query_levels", extStart, extEnd);
-#endif /* GL_ARB_texture_query_levels */
-#ifdef GL_ARB_texture_query_lod
-  GLEW_ARB_texture_query_lod = _glewSearchExtension("GL_ARB_texture_query_lod", extStart, extEnd);
-#endif /* GL_ARB_texture_query_lod */
-#ifdef GL_ARB_texture_rectangle
-  GLEW_ARB_texture_rectangle = _glewSearchExtension("GL_ARB_texture_rectangle", extStart, extEnd);
-#endif /* GL_ARB_texture_rectangle */
-#ifdef GL_ARB_texture_rg
-  GLEW_ARB_texture_rg = _glewSearchExtension("GL_ARB_texture_rg", extStart, extEnd);
-#endif /* GL_ARB_texture_rg */
-#ifdef GL_ARB_texture_rgb10_a2ui
-  GLEW_ARB_texture_rgb10_a2ui = _glewSearchExtension("GL_ARB_texture_rgb10_a2ui", extStart, extEnd);
-#endif /* GL_ARB_texture_rgb10_a2ui */
-#ifdef GL_ARB_texture_stencil8
-  GLEW_ARB_texture_stencil8 = _glewSearchExtension("GL_ARB_texture_stencil8", extStart, extEnd);
-#endif /* GL_ARB_texture_stencil8 */
 #ifdef GL_ARB_texture_storage
-  GLEW_ARB_texture_storage = _glewSearchExtension("GL_ARB_texture_storage", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_texture_storage) GLEW_ARB_texture_storage = !_glewInit_GL_ARB_texture_storage(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_texture_storage) GLEW_ARB_texture_storage = !_glewInit_GL_ARB_texture_storage();
 #endif /* GL_ARB_texture_storage */
 #ifdef GL_ARB_texture_storage_multisample
-  GLEW_ARB_texture_storage_multisample = _glewSearchExtension("GL_ARB_texture_storage_multisample", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_texture_storage_multisample) GLEW_ARB_texture_storage_multisample = !_glewInit_GL_ARB_texture_storage_multisample(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_texture_storage_multisample) GLEW_ARB_texture_storage_multisample = !_glewInit_GL_ARB_texture_storage_multisample();
 #endif /* GL_ARB_texture_storage_multisample */
-#ifdef GL_ARB_texture_swizzle
-  GLEW_ARB_texture_swizzle = _glewSearchExtension("GL_ARB_texture_swizzle", extStart, extEnd);
-#endif /* GL_ARB_texture_swizzle */
 #ifdef GL_ARB_texture_view
-  GLEW_ARB_texture_view = _glewSearchExtension("GL_ARB_texture_view", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_texture_view) GLEW_ARB_texture_view = !_glewInit_GL_ARB_texture_view(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_texture_view) GLEW_ARB_texture_view = !_glewInit_GL_ARB_texture_view();
 #endif /* GL_ARB_texture_view */
 #ifdef GL_ARB_timer_query
-  GLEW_ARB_timer_query = _glewSearchExtension("GL_ARB_timer_query", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_timer_query) GLEW_ARB_timer_query = !_glewInit_GL_ARB_timer_query(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_timer_query) GLEW_ARB_timer_query = !_glewInit_GL_ARB_timer_query();
 #endif /* GL_ARB_timer_query */
 #ifdef GL_ARB_transform_feedback2
-  GLEW_ARB_transform_feedback2 = _glewSearchExtension("GL_ARB_transform_feedback2", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_transform_feedback2) GLEW_ARB_transform_feedback2 = !_glewInit_GL_ARB_transform_feedback2(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_transform_feedback2) GLEW_ARB_transform_feedback2 = !_glewInit_GL_ARB_transform_feedback2();
 #endif /* GL_ARB_transform_feedback2 */
 #ifdef GL_ARB_transform_feedback3
-  GLEW_ARB_transform_feedback3 = _glewSearchExtension("GL_ARB_transform_feedback3", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_transform_feedback3) GLEW_ARB_transform_feedback3 = !_glewInit_GL_ARB_transform_feedback3(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_transform_feedback3) GLEW_ARB_transform_feedback3 = !_glewInit_GL_ARB_transform_feedback3();
 #endif /* GL_ARB_transform_feedback3 */
 #ifdef GL_ARB_transform_feedback_instanced
-  GLEW_ARB_transform_feedback_instanced = _glewSearchExtension("GL_ARB_transform_feedback_instanced", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_transform_feedback_instanced) GLEW_ARB_transform_feedback_instanced = !_glewInit_GL_ARB_transform_feedback_instanced(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_transform_feedback_instanced) GLEW_ARB_transform_feedback_instanced = !_glewInit_GL_ARB_transform_feedback_instanced();
 #endif /* GL_ARB_transform_feedback_instanced */
-#ifdef GL_ARB_transform_feedback_overflow_query
-  GLEW_ARB_transform_feedback_overflow_query = _glewSearchExtension("GL_ARB_transform_feedback_overflow_query", extStart, extEnd);
-#endif /* GL_ARB_transform_feedback_overflow_query */
 #ifdef GL_ARB_transpose_matrix
-  GLEW_ARB_transpose_matrix = _glewSearchExtension("GL_ARB_transpose_matrix", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_transpose_matrix) GLEW_ARB_transpose_matrix = !_glewInit_GL_ARB_transpose_matrix(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_transpose_matrix) GLEW_ARB_transpose_matrix = !_glewInit_GL_ARB_transpose_matrix();
 #endif /* GL_ARB_transpose_matrix */
 #ifdef GL_ARB_uniform_buffer_object
-  GLEW_ARB_uniform_buffer_object = _glewSearchExtension("GL_ARB_uniform_buffer_object", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_uniform_buffer_object) GLEW_ARB_uniform_buffer_object = !_glewInit_GL_ARB_uniform_buffer_object(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_uniform_buffer_object) GLEW_ARB_uniform_buffer_object = !_glewInit_GL_ARB_uniform_buffer_object();
 #endif /* GL_ARB_uniform_buffer_object */
-#ifdef GL_ARB_vertex_array_bgra
-  GLEW_ARB_vertex_array_bgra = _glewSearchExtension("GL_ARB_vertex_array_bgra", extStart, extEnd);
-#endif /* GL_ARB_vertex_array_bgra */
 #ifdef GL_ARB_vertex_array_object
-  GLEW_ARB_vertex_array_object = _glewSearchExtension("GL_ARB_vertex_array_object", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_vertex_array_object) GLEW_ARB_vertex_array_object = !_glewInit_GL_ARB_vertex_array_object(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_vertex_array_object) GLEW_ARB_vertex_array_object = !_glewInit_GL_ARB_vertex_array_object();
 #endif /* GL_ARB_vertex_array_object */
 #ifdef GL_ARB_vertex_attrib_64bit
-  GLEW_ARB_vertex_attrib_64bit = _glewSearchExtension("GL_ARB_vertex_attrib_64bit", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_vertex_attrib_64bit) GLEW_ARB_vertex_attrib_64bit = !_glewInit_GL_ARB_vertex_attrib_64bit(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_vertex_attrib_64bit) GLEW_ARB_vertex_attrib_64bit = !_glewInit_GL_ARB_vertex_attrib_64bit();
 #endif /* GL_ARB_vertex_attrib_64bit */
 #ifdef GL_ARB_vertex_attrib_binding
-  GLEW_ARB_vertex_attrib_binding = _glewSearchExtension("GL_ARB_vertex_attrib_binding", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_vertex_attrib_binding) GLEW_ARB_vertex_attrib_binding = !_glewInit_GL_ARB_vertex_attrib_binding(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_vertex_attrib_binding) GLEW_ARB_vertex_attrib_binding = !_glewInit_GL_ARB_vertex_attrib_binding();
 #endif /* GL_ARB_vertex_attrib_binding */
 #ifdef GL_ARB_vertex_blend
-  GLEW_ARB_vertex_blend = _glewSearchExtension("GL_ARB_vertex_blend", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_vertex_blend) GLEW_ARB_vertex_blend = !_glewInit_GL_ARB_vertex_blend(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_vertex_blend) GLEW_ARB_vertex_blend = !_glewInit_GL_ARB_vertex_blend();
 #endif /* GL_ARB_vertex_blend */
 #ifdef GL_ARB_vertex_buffer_object
-  GLEW_ARB_vertex_buffer_object = _glewSearchExtension("GL_ARB_vertex_buffer_object", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_vertex_buffer_object) GLEW_ARB_vertex_buffer_object = !_glewInit_GL_ARB_vertex_buffer_object(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_vertex_buffer_object) GLEW_ARB_vertex_buffer_object = !_glewInit_GL_ARB_vertex_buffer_object();
 #endif /* GL_ARB_vertex_buffer_object */
 #ifdef GL_ARB_vertex_program
-  GLEW_ARB_vertex_program = _glewSearchExtension("GL_ARB_vertex_program", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_vertex_program) GLEW_ARB_vertex_program = !_glewInit_GL_ARB_vertex_program(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_vertex_program) GLEW_ARB_vertex_program = !_glewInit_GL_ARB_vertex_program();
 #endif /* GL_ARB_vertex_program */
 #ifdef GL_ARB_vertex_shader
-  GLEW_ARB_vertex_shader = _glewSearchExtension("GL_ARB_vertex_shader", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_vertex_shader) { GLEW_ARB_vertex_shader = !_glewInit_GL_ARB_vertex_shader(GLEW_CONTEXT_ARG_VAR_INIT); _glewInit_GL_ARB_vertex_program(GLEW_CONTEXT_ARG_VAR_INIT); }
+  if (glewExperimental || GLEW_ARB_vertex_shader) { GLEW_ARB_vertex_shader = !_glewInit_GL_ARB_vertex_shader(); _glewInit_GL_ARB_vertex_program(); }
 #endif /* GL_ARB_vertex_shader */
-#ifdef GL_ARB_vertex_type_10f_11f_11f_rev
-  GLEW_ARB_vertex_type_10f_11f_11f_rev = _glewSearchExtension("GL_ARB_vertex_type_10f_11f_11f_rev", extStart, extEnd);
-#endif /* GL_ARB_vertex_type_10f_11f_11f_rev */
 #ifdef GL_ARB_vertex_type_2_10_10_10_rev
-  GLEW_ARB_vertex_type_2_10_10_10_rev = _glewSearchExtension("GL_ARB_vertex_type_2_10_10_10_rev", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_vertex_type_2_10_10_10_rev) GLEW_ARB_vertex_type_2_10_10_10_rev = !_glewInit_GL_ARB_vertex_type_2_10_10_10_rev(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_vertex_type_2_10_10_10_rev) GLEW_ARB_vertex_type_2_10_10_10_rev = !_glewInit_GL_ARB_vertex_type_2_10_10_10_rev();
 #endif /* GL_ARB_vertex_type_2_10_10_10_rev */
 #ifdef GL_ARB_viewport_array
-  GLEW_ARB_viewport_array = _glewSearchExtension("GL_ARB_viewport_array", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_viewport_array) GLEW_ARB_viewport_array = !_glewInit_GL_ARB_viewport_array(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_viewport_array) GLEW_ARB_viewport_array = !_glewInit_GL_ARB_viewport_array();
 #endif /* GL_ARB_viewport_array */
 #ifdef GL_ARB_window_pos
-  GLEW_ARB_window_pos = _glewSearchExtension("GL_ARB_window_pos", extStart, extEnd);
-  if (glewExperimental || GLEW_ARB_window_pos) GLEW_ARB_window_pos = !_glewInit_GL_ARB_window_pos(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ARB_window_pos) GLEW_ARB_window_pos = !_glewInit_GL_ARB_window_pos();
 #endif /* GL_ARB_window_pos */
-#ifdef GL_ATIX_point_sprites
-  GLEW_ATIX_point_sprites = _glewSearchExtension("GL_ATIX_point_sprites", extStart, extEnd);
-#endif /* GL_ATIX_point_sprites */
-#ifdef GL_ATIX_texture_env_combine3
-  GLEW_ATIX_texture_env_combine3 = _glewSearchExtension("GL_ATIX_texture_env_combine3", extStart, extEnd);
-#endif /* GL_ATIX_texture_env_combine3 */
-#ifdef GL_ATIX_texture_env_route
-  GLEW_ATIX_texture_env_route = _glewSearchExtension("GL_ATIX_texture_env_route", extStart, extEnd);
-#endif /* GL_ATIX_texture_env_route */
-#ifdef GL_ATIX_vertex_shader_output_point_size
-  GLEW_ATIX_vertex_shader_output_point_size = _glewSearchExtension("GL_ATIX_vertex_shader_output_point_size", extStart, extEnd);
-#endif /* GL_ATIX_vertex_shader_output_point_size */
 #ifdef GL_ATI_draw_buffers
-  GLEW_ATI_draw_buffers = _glewSearchExtension("GL_ATI_draw_buffers", extStart, extEnd);
-  if (glewExperimental || GLEW_ATI_draw_buffers) GLEW_ATI_draw_buffers = !_glewInit_GL_ATI_draw_buffers(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ATI_draw_buffers) GLEW_ATI_draw_buffers = !_glewInit_GL_ATI_draw_buffers();
 #endif /* GL_ATI_draw_buffers */
 #ifdef GL_ATI_element_array
-  GLEW_ATI_element_array = _glewSearchExtension("GL_ATI_element_array", extStart, extEnd);
-  if (glewExperimental || GLEW_ATI_element_array) GLEW_ATI_element_array = !_glewInit_GL_ATI_element_array(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ATI_element_array) GLEW_ATI_element_array = !_glewInit_GL_ATI_element_array();
 #endif /* GL_ATI_element_array */
 #ifdef GL_ATI_envmap_bumpmap
-  GLEW_ATI_envmap_bumpmap = _glewSearchExtension("GL_ATI_envmap_bumpmap", extStart, extEnd);
-  if (glewExperimental || GLEW_ATI_envmap_bumpmap) GLEW_ATI_envmap_bumpmap = !_glewInit_GL_ATI_envmap_bumpmap(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ATI_envmap_bumpmap) GLEW_ATI_envmap_bumpmap = !_glewInit_GL_ATI_envmap_bumpmap();
 #endif /* GL_ATI_envmap_bumpmap */
 #ifdef GL_ATI_fragment_shader
-  GLEW_ATI_fragment_shader = _glewSearchExtension("GL_ATI_fragment_shader", extStart, extEnd);
-  if (glewExperimental || GLEW_ATI_fragment_shader) GLEW_ATI_fragment_shader = !_glewInit_GL_ATI_fragment_shader(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ATI_fragment_shader) GLEW_ATI_fragment_shader = !_glewInit_GL_ATI_fragment_shader();
 #endif /* GL_ATI_fragment_shader */
 #ifdef GL_ATI_map_object_buffer
-  GLEW_ATI_map_object_buffer = _glewSearchExtension("GL_ATI_map_object_buffer", extStart, extEnd);
-  if (glewExperimental || GLEW_ATI_map_object_buffer) GLEW_ATI_map_object_buffer = !_glewInit_GL_ATI_map_object_buffer(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ATI_map_object_buffer) GLEW_ATI_map_object_buffer = !_glewInit_GL_ATI_map_object_buffer();
 #endif /* GL_ATI_map_object_buffer */
-#ifdef GL_ATI_meminfo
-  GLEW_ATI_meminfo = _glewSearchExtension("GL_ATI_meminfo", extStart, extEnd);
-#endif /* GL_ATI_meminfo */
 #ifdef GL_ATI_pn_triangles
-  GLEW_ATI_pn_triangles = _glewSearchExtension("GL_ATI_pn_triangles", extStart, extEnd);
-  if (glewExperimental || GLEW_ATI_pn_triangles) GLEW_ATI_pn_triangles = !_glewInit_GL_ATI_pn_triangles(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ATI_pn_triangles) GLEW_ATI_pn_triangles = !_glewInit_GL_ATI_pn_triangles();
 #endif /* GL_ATI_pn_triangles */
 #ifdef GL_ATI_separate_stencil
-  GLEW_ATI_separate_stencil = _glewSearchExtension("GL_ATI_separate_stencil", extStart, extEnd);
-  if (glewExperimental || GLEW_ATI_separate_stencil) GLEW_ATI_separate_stencil = !_glewInit_GL_ATI_separate_stencil(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ATI_separate_stencil) GLEW_ATI_separate_stencil = !_glewInit_GL_ATI_separate_stencil();
 #endif /* GL_ATI_separate_stencil */
-#ifdef GL_ATI_shader_texture_lod
-  GLEW_ATI_shader_texture_lod = _glewSearchExtension("GL_ATI_shader_texture_lod", extStart, extEnd);
-#endif /* GL_ATI_shader_texture_lod */
-#ifdef GL_ATI_text_fragment_shader
-  GLEW_ATI_text_fragment_shader = _glewSearchExtension("GL_ATI_text_fragment_shader", extStart, extEnd);
-#endif /* GL_ATI_text_fragment_shader */
-#ifdef GL_ATI_texture_compression_3dc
-  GLEW_ATI_texture_compression_3dc = _glewSearchExtension("GL_ATI_texture_compression_3dc", extStart, extEnd);
-#endif /* GL_ATI_texture_compression_3dc */
-#ifdef GL_ATI_texture_env_combine3
-  GLEW_ATI_texture_env_combine3 = _glewSearchExtension("GL_ATI_texture_env_combine3", extStart, extEnd);
-#endif /* GL_ATI_texture_env_combine3 */
-#ifdef GL_ATI_texture_float
-  GLEW_ATI_texture_float = _glewSearchExtension("GL_ATI_texture_float", extStart, extEnd);
-#endif /* GL_ATI_texture_float */
-#ifdef GL_ATI_texture_mirror_once
-  GLEW_ATI_texture_mirror_once = _glewSearchExtension("GL_ATI_texture_mirror_once", extStart, extEnd);
-#endif /* GL_ATI_texture_mirror_once */
 #ifdef GL_ATI_vertex_array_object
-  GLEW_ATI_vertex_array_object = _glewSearchExtension("GL_ATI_vertex_array_object", extStart, extEnd);
-  if (glewExperimental || GLEW_ATI_vertex_array_object) GLEW_ATI_vertex_array_object = !_glewInit_GL_ATI_vertex_array_object(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ATI_vertex_array_object) GLEW_ATI_vertex_array_object = !_glewInit_GL_ATI_vertex_array_object();
 #endif /* GL_ATI_vertex_array_object */
 #ifdef GL_ATI_vertex_attrib_array_object
-  GLEW_ATI_vertex_attrib_array_object = _glewSearchExtension("GL_ATI_vertex_attrib_array_object", extStart, extEnd);
-  if (glewExperimental || GLEW_ATI_vertex_attrib_array_object) GLEW_ATI_vertex_attrib_array_object = !_glewInit_GL_ATI_vertex_attrib_array_object(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ATI_vertex_attrib_array_object) GLEW_ATI_vertex_attrib_array_object = !_glewInit_GL_ATI_vertex_attrib_array_object();
 #endif /* GL_ATI_vertex_attrib_array_object */
 #ifdef GL_ATI_vertex_streams
-  GLEW_ATI_vertex_streams = _glewSearchExtension("GL_ATI_vertex_streams", extStart, extEnd);
-  if (glewExperimental || GLEW_ATI_vertex_streams) GLEW_ATI_vertex_streams = !_glewInit_GL_ATI_vertex_streams(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_ATI_vertex_streams) GLEW_ATI_vertex_streams = !_glewInit_GL_ATI_vertex_streams();
 #endif /* GL_ATI_vertex_streams */
-#ifdef GL_EXT_422_pixels
-  GLEW_EXT_422_pixels = _glewSearchExtension("GL_EXT_422_pixels", extStart, extEnd);
-#endif /* GL_EXT_422_pixels */
-#ifdef GL_EXT_Cg_shader
-  GLEW_EXT_Cg_shader = _glewSearchExtension("GL_EXT_Cg_shader", extStart, extEnd);
-#endif /* GL_EXT_Cg_shader */
-#ifdef GL_EXT_abgr
-  GLEW_EXT_abgr = _glewSearchExtension("GL_EXT_abgr", extStart, extEnd);
-#endif /* GL_EXT_abgr */
-#ifdef GL_EXT_bgra
-  GLEW_EXT_bgra = _glewSearchExtension("GL_EXT_bgra", extStart, extEnd);
-#endif /* GL_EXT_bgra */
+#ifdef GL_EXT_base_instance
+  if (glewExperimental || GLEW_EXT_base_instance) GLEW_EXT_base_instance = !_glewInit_GL_EXT_base_instance();
+#endif /* GL_EXT_base_instance */
 #ifdef GL_EXT_bindable_uniform
-  GLEW_EXT_bindable_uniform = _glewSearchExtension("GL_EXT_bindable_uniform", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_bindable_uniform) GLEW_EXT_bindable_uniform = !_glewInit_GL_EXT_bindable_uniform(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_bindable_uniform) GLEW_EXT_bindable_uniform = !_glewInit_GL_EXT_bindable_uniform();
 #endif /* GL_EXT_bindable_uniform */
 #ifdef GL_EXT_blend_color
-  GLEW_EXT_blend_color = _glewSearchExtension("GL_EXT_blend_color", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_blend_color) GLEW_EXT_blend_color = !_glewInit_GL_EXT_blend_color(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_blend_color) GLEW_EXT_blend_color = !_glewInit_GL_EXT_blend_color();
 #endif /* GL_EXT_blend_color */
 #ifdef GL_EXT_blend_equation_separate
-  GLEW_EXT_blend_equation_separate = _glewSearchExtension("GL_EXT_blend_equation_separate", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_blend_equation_separate) GLEW_EXT_blend_equation_separate = !_glewInit_GL_EXT_blend_equation_separate(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_blend_equation_separate) GLEW_EXT_blend_equation_separate = !_glewInit_GL_EXT_blend_equation_separate();
 #endif /* GL_EXT_blend_equation_separate */
+#ifdef GL_EXT_blend_func_extended
+  if (glewExperimental || GLEW_EXT_blend_func_extended) GLEW_EXT_blend_func_extended = !_glewInit_GL_EXT_blend_func_extended();
+#endif /* GL_EXT_blend_func_extended */
 #ifdef GL_EXT_blend_func_separate
-  GLEW_EXT_blend_func_separate = _glewSearchExtension("GL_EXT_blend_func_separate", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_blend_func_separate) GLEW_EXT_blend_func_separate = !_glewInit_GL_EXT_blend_func_separate(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_blend_func_separate) GLEW_EXT_blend_func_separate = !_glewInit_GL_EXT_blend_func_separate();
 #endif /* GL_EXT_blend_func_separate */
-#ifdef GL_EXT_blend_logic_op
-  GLEW_EXT_blend_logic_op = _glewSearchExtension("GL_EXT_blend_logic_op", extStart, extEnd);
-#endif /* GL_EXT_blend_logic_op */
 #ifdef GL_EXT_blend_minmax
-  GLEW_EXT_blend_minmax = _glewSearchExtension("GL_EXT_blend_minmax", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_blend_minmax) GLEW_EXT_blend_minmax = !_glewInit_GL_EXT_blend_minmax(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_blend_minmax) GLEW_EXT_blend_minmax = !_glewInit_GL_EXT_blend_minmax();
 #endif /* GL_EXT_blend_minmax */
-#ifdef GL_EXT_blend_subtract
-  GLEW_EXT_blend_subtract = _glewSearchExtension("GL_EXT_blend_subtract", extStart, extEnd);
-#endif /* GL_EXT_blend_subtract */
-#ifdef GL_EXT_clip_volume_hint
-  GLEW_EXT_clip_volume_hint = _glewSearchExtension("GL_EXT_clip_volume_hint", extStart, extEnd);
-#endif /* GL_EXT_clip_volume_hint */
-#ifdef GL_EXT_cmyka
-  GLEW_EXT_cmyka = _glewSearchExtension("GL_EXT_cmyka", extStart, extEnd);
-#endif /* GL_EXT_cmyka */
+#ifdef GL_EXT_buffer_storage
+  if (glewExperimental || GLEW_EXT_buffer_storage) GLEW_EXT_buffer_storage = !_glewInit_GL_EXT_buffer_storage();
+#endif /* GL_EXT_buffer_storage */
+#ifdef GL_EXT_clear_texture
+  if (glewExperimental || GLEW_EXT_clear_texture) GLEW_EXT_clear_texture = !_glewInit_GL_EXT_clear_texture();
+#endif /* GL_EXT_clear_texture */
 #ifdef GL_EXT_color_subtable
-  GLEW_EXT_color_subtable = _glewSearchExtension("GL_EXT_color_subtable", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_color_subtable) GLEW_EXT_color_subtable = !_glewInit_GL_EXT_color_subtable(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_color_subtable) GLEW_EXT_color_subtable = !_glewInit_GL_EXT_color_subtable();
 #endif /* GL_EXT_color_subtable */
 #ifdef GL_EXT_compiled_vertex_array
-  GLEW_EXT_compiled_vertex_array = _glewSearchExtension("GL_EXT_compiled_vertex_array", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_compiled_vertex_array) GLEW_EXT_compiled_vertex_array = !_glewInit_GL_EXT_compiled_vertex_array(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_compiled_vertex_array) GLEW_EXT_compiled_vertex_array = !_glewInit_GL_EXT_compiled_vertex_array();
 #endif /* GL_EXT_compiled_vertex_array */
 #ifdef GL_EXT_convolution
-  GLEW_EXT_convolution = _glewSearchExtension("GL_EXT_convolution", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_convolution) GLEW_EXT_convolution = !_glewInit_GL_EXT_convolution(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_convolution) GLEW_EXT_convolution = !_glewInit_GL_EXT_convolution();
 #endif /* GL_EXT_convolution */
 #ifdef GL_EXT_coordinate_frame
-  GLEW_EXT_coordinate_frame = _glewSearchExtension("GL_EXT_coordinate_frame", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_coordinate_frame) GLEW_EXT_coordinate_frame = !_glewInit_GL_EXT_coordinate_frame(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_coordinate_frame) GLEW_EXT_coordinate_frame = !_glewInit_GL_EXT_coordinate_frame();
 #endif /* GL_EXT_coordinate_frame */
+#ifdef GL_EXT_copy_image
+  if (glewExperimental || GLEW_EXT_copy_image) GLEW_EXT_copy_image = !_glewInit_GL_EXT_copy_image();
+#endif /* GL_EXT_copy_image */
 #ifdef GL_EXT_copy_texture
-  GLEW_EXT_copy_texture = _glewSearchExtension("GL_EXT_copy_texture", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_copy_texture) GLEW_EXT_copy_texture = !_glewInit_GL_EXT_copy_texture(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_copy_texture) GLEW_EXT_copy_texture = !_glewInit_GL_EXT_copy_texture();
 #endif /* GL_EXT_copy_texture */
 #ifdef GL_EXT_cull_vertex
-  GLEW_EXT_cull_vertex = _glewSearchExtension("GL_EXT_cull_vertex", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_cull_vertex) GLEW_EXT_cull_vertex = !_glewInit_GL_EXT_cull_vertex(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_cull_vertex) GLEW_EXT_cull_vertex = !_glewInit_GL_EXT_cull_vertex();
 #endif /* GL_EXT_cull_vertex */
 #ifdef GL_EXT_debug_label
-  GLEW_EXT_debug_label = _glewSearchExtension("GL_EXT_debug_label", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_debug_label) GLEW_EXT_debug_label = !_glewInit_GL_EXT_debug_label(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_debug_label) GLEW_EXT_debug_label = !_glewInit_GL_EXT_debug_label();
 #endif /* GL_EXT_debug_label */
 #ifdef GL_EXT_debug_marker
-  GLEW_EXT_debug_marker = _glewSearchExtension("GL_EXT_debug_marker", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_debug_marker) GLEW_EXT_debug_marker = !_glewInit_GL_EXT_debug_marker(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_debug_marker) GLEW_EXT_debug_marker = !_glewInit_GL_EXT_debug_marker();
 #endif /* GL_EXT_debug_marker */
 #ifdef GL_EXT_depth_bounds_test
-  GLEW_EXT_depth_bounds_test = _glewSearchExtension("GL_EXT_depth_bounds_test", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_depth_bounds_test) GLEW_EXT_depth_bounds_test = !_glewInit_GL_EXT_depth_bounds_test(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_depth_bounds_test) GLEW_EXT_depth_bounds_test = !_glewInit_GL_EXT_depth_bounds_test();
 #endif /* GL_EXT_depth_bounds_test */
 #ifdef GL_EXT_direct_state_access
-  GLEW_EXT_direct_state_access = _glewSearchExtension("GL_EXT_direct_state_access", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_direct_state_access) GLEW_EXT_direct_state_access = !_glewInit_GL_EXT_direct_state_access(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_direct_state_access) GLEW_EXT_direct_state_access = !_glewInit_GL_EXT_direct_state_access();
 #endif /* GL_EXT_direct_state_access */
+#ifdef GL_EXT_discard_framebuffer
+  if (glewExperimental || GLEW_EXT_discard_framebuffer) GLEW_EXT_discard_framebuffer = !_glewInit_GL_EXT_discard_framebuffer();
+#endif /* GL_EXT_discard_framebuffer */
+#ifdef GL_EXT_draw_buffers
+  if (glewExperimental || GLEW_EXT_draw_buffers) GLEW_EXT_draw_buffers = !_glewInit_GL_EXT_draw_buffers();
+#endif /* GL_EXT_draw_buffers */
 #ifdef GL_EXT_draw_buffers2
-  GLEW_EXT_draw_buffers2 = _glewSearchExtension("GL_EXT_draw_buffers2", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_draw_buffers2) GLEW_EXT_draw_buffers2 = !_glewInit_GL_EXT_draw_buffers2(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_draw_buffers2) GLEW_EXT_draw_buffers2 = !_glewInit_GL_EXT_draw_buffers2();
 #endif /* GL_EXT_draw_buffers2 */
+#ifdef GL_EXT_draw_buffers_indexed
+  if (glewExperimental || GLEW_EXT_draw_buffers_indexed) GLEW_EXT_draw_buffers_indexed = !_glewInit_GL_EXT_draw_buffers_indexed();
+#endif /* GL_EXT_draw_buffers_indexed */
+#ifdef GL_EXT_draw_elements_base_vertex
+  if (glewExperimental || GLEW_EXT_draw_elements_base_vertex) GLEW_EXT_draw_elements_base_vertex = !_glewInit_GL_EXT_draw_elements_base_vertex();
+#endif /* GL_EXT_draw_elements_base_vertex */
 #ifdef GL_EXT_draw_instanced
-  GLEW_EXT_draw_instanced = _glewSearchExtension("GL_EXT_draw_instanced", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_draw_instanced) GLEW_EXT_draw_instanced = !_glewInit_GL_EXT_draw_instanced(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_draw_instanced) GLEW_EXT_draw_instanced = !_glewInit_GL_EXT_draw_instanced();
 #endif /* GL_EXT_draw_instanced */
 #ifdef GL_EXT_draw_range_elements
-  GLEW_EXT_draw_range_elements = _glewSearchExtension("GL_EXT_draw_range_elements", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_draw_range_elements) GLEW_EXT_draw_range_elements = !_glewInit_GL_EXT_draw_range_elements(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_draw_range_elements) GLEW_EXT_draw_range_elements = !_glewInit_GL_EXT_draw_range_elements();
 #endif /* GL_EXT_draw_range_elements */
+#ifdef GL_EXT_external_buffer
+  if (glewExperimental || GLEW_EXT_external_buffer) GLEW_EXT_external_buffer = !_glewInit_GL_EXT_external_buffer();
+#endif /* GL_EXT_external_buffer */
 #ifdef GL_EXT_fog_coord
-  GLEW_EXT_fog_coord = _glewSearchExtension("GL_EXT_fog_coord", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_fog_coord) GLEW_EXT_fog_coord = !_glewInit_GL_EXT_fog_coord(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_fog_coord) GLEW_EXT_fog_coord = !_glewInit_GL_EXT_fog_coord();
 #endif /* GL_EXT_fog_coord */
 #ifdef GL_EXT_fragment_lighting
-  GLEW_EXT_fragment_lighting = _glewSearchExtension("GL_EXT_fragment_lighting", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_fragment_lighting) GLEW_EXT_fragment_lighting = !_glewInit_GL_EXT_fragment_lighting(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_fragment_lighting) GLEW_EXT_fragment_lighting = !_glewInit_GL_EXT_fragment_lighting();
 #endif /* GL_EXT_fragment_lighting */
 #ifdef GL_EXT_framebuffer_blit
-  GLEW_EXT_framebuffer_blit = _glewSearchExtension("GL_EXT_framebuffer_blit", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_framebuffer_blit) GLEW_EXT_framebuffer_blit = !_glewInit_GL_EXT_framebuffer_blit(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_framebuffer_blit) GLEW_EXT_framebuffer_blit = !_glewInit_GL_EXT_framebuffer_blit();
 #endif /* GL_EXT_framebuffer_blit */
 #ifdef GL_EXT_framebuffer_multisample
-  GLEW_EXT_framebuffer_multisample = _glewSearchExtension("GL_EXT_framebuffer_multisample", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_framebuffer_multisample) GLEW_EXT_framebuffer_multisample = !_glewInit_GL_EXT_framebuffer_multisample(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_framebuffer_multisample) GLEW_EXT_framebuffer_multisample = !_glewInit_GL_EXT_framebuffer_multisample();
 #endif /* GL_EXT_framebuffer_multisample */
-#ifdef GL_EXT_framebuffer_multisample_blit_scaled
-  GLEW_EXT_framebuffer_multisample_blit_scaled = _glewSearchExtension("GL_EXT_framebuffer_multisample_blit_scaled", extStart, extEnd);
-#endif /* GL_EXT_framebuffer_multisample_blit_scaled */
 #ifdef GL_EXT_framebuffer_object
-  GLEW_EXT_framebuffer_object = _glewSearchExtension("GL_EXT_framebuffer_object", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_framebuffer_object) GLEW_EXT_framebuffer_object = !_glewInit_GL_EXT_framebuffer_object(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_framebuffer_object) GLEW_EXT_framebuffer_object = !_glewInit_GL_EXT_framebuffer_object();
 #endif /* GL_EXT_framebuffer_object */
-#ifdef GL_EXT_framebuffer_sRGB
-  GLEW_EXT_framebuffer_sRGB = _glewSearchExtension("GL_EXT_framebuffer_sRGB", extStart, extEnd);
-#endif /* GL_EXT_framebuffer_sRGB */
 #ifdef GL_EXT_geometry_shader4
-  GLEW_EXT_geometry_shader4 = _glewSearchExtension("GL_EXT_geometry_shader4", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_geometry_shader4) GLEW_EXT_geometry_shader4 = !_glewInit_GL_EXT_geometry_shader4(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_geometry_shader4) GLEW_EXT_geometry_shader4 = !_glewInit_GL_EXT_geometry_shader4();
 #endif /* GL_EXT_geometry_shader4 */
 #ifdef GL_EXT_gpu_program_parameters
-  GLEW_EXT_gpu_program_parameters = _glewSearchExtension("GL_EXT_gpu_program_parameters", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_gpu_program_parameters) GLEW_EXT_gpu_program_parameters = !_glewInit_GL_EXT_gpu_program_parameters(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_gpu_program_parameters) GLEW_EXT_gpu_program_parameters = !_glewInit_GL_EXT_gpu_program_parameters();
 #endif /* GL_EXT_gpu_program_parameters */
 #ifdef GL_EXT_gpu_shader4
-  GLEW_EXT_gpu_shader4 = _glewSearchExtension("GL_EXT_gpu_shader4", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_gpu_shader4) GLEW_EXT_gpu_shader4 = !_glewInit_GL_EXT_gpu_shader4(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_gpu_shader4) GLEW_EXT_gpu_shader4 = !_glewInit_GL_EXT_gpu_shader4();
 #endif /* GL_EXT_gpu_shader4 */
 #ifdef GL_EXT_histogram
-  GLEW_EXT_histogram = _glewSearchExtension("GL_EXT_histogram", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_histogram) GLEW_EXT_histogram = !_glewInit_GL_EXT_histogram(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_histogram) GLEW_EXT_histogram = !_glewInit_GL_EXT_histogram();
 #endif /* GL_EXT_histogram */
-#ifdef GL_EXT_index_array_formats
-  GLEW_EXT_index_array_formats = _glewSearchExtension("GL_EXT_index_array_formats", extStart, extEnd);
-#endif /* GL_EXT_index_array_formats */
 #ifdef GL_EXT_index_func
-  GLEW_EXT_index_func = _glewSearchExtension("GL_EXT_index_func", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_index_func) GLEW_EXT_index_func = !_glewInit_GL_EXT_index_func(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_index_func) GLEW_EXT_index_func = !_glewInit_GL_EXT_index_func();
 #endif /* GL_EXT_index_func */
 #ifdef GL_EXT_index_material
-  GLEW_EXT_index_material = _glewSearchExtension("GL_EXT_index_material", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_index_material) GLEW_EXT_index_material = !_glewInit_GL_EXT_index_material(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_index_material) GLEW_EXT_index_material = !_glewInit_GL_EXT_index_material();
 #endif /* GL_EXT_index_material */
-#ifdef GL_EXT_index_texture
-  GLEW_EXT_index_texture = _glewSearchExtension("GL_EXT_index_texture", extStart, extEnd);
-#endif /* GL_EXT_index_texture */
+#ifdef GL_EXT_instanced_arrays
+  if (glewExperimental || GLEW_EXT_instanced_arrays) GLEW_EXT_instanced_arrays = !_glewInit_GL_EXT_instanced_arrays();
+#endif /* GL_EXT_instanced_arrays */
 #ifdef GL_EXT_light_texture
-  GLEW_EXT_light_texture = _glewSearchExtension("GL_EXT_light_texture", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_light_texture) GLEW_EXT_light_texture = !_glewInit_GL_EXT_light_texture(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_light_texture) GLEW_EXT_light_texture = !_glewInit_GL_EXT_light_texture();
 #endif /* GL_EXT_light_texture */
-#ifdef GL_EXT_misc_attribute
-  GLEW_EXT_misc_attribute = _glewSearchExtension("GL_EXT_misc_attribute", extStart, extEnd);
-#endif /* GL_EXT_misc_attribute */
+#ifdef GL_EXT_map_buffer_range
+  if (glewExperimental || GLEW_EXT_map_buffer_range) GLEW_EXT_map_buffer_range = !_glewInit_GL_EXT_map_buffer_range();
+#endif /* GL_EXT_map_buffer_range */
+#ifdef GL_EXT_memory_object
+  if (glewExperimental || GLEW_EXT_memory_object) GLEW_EXT_memory_object = !_glewInit_GL_EXT_memory_object();
+#endif /* GL_EXT_memory_object */
+#ifdef GL_EXT_memory_object_fd
+  if (glewExperimental || GLEW_EXT_memory_object_fd) GLEW_EXT_memory_object_fd = !_glewInit_GL_EXT_memory_object_fd();
+#endif /* GL_EXT_memory_object_fd */
+#ifdef GL_EXT_memory_object_win32
+  if (glewExperimental || GLEW_EXT_memory_object_win32) GLEW_EXT_memory_object_win32 = !_glewInit_GL_EXT_memory_object_win32();
+#endif /* GL_EXT_memory_object_win32 */
 #ifdef GL_EXT_multi_draw_arrays
-  GLEW_EXT_multi_draw_arrays = _glewSearchExtension("GL_EXT_multi_draw_arrays", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_multi_draw_arrays) GLEW_EXT_multi_draw_arrays = !_glewInit_GL_EXT_multi_draw_arrays(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_multi_draw_arrays) GLEW_EXT_multi_draw_arrays = !_glewInit_GL_EXT_multi_draw_arrays();
 #endif /* GL_EXT_multi_draw_arrays */
+#ifdef GL_EXT_multi_draw_indirect
+  if (glewExperimental || GLEW_EXT_multi_draw_indirect) GLEW_EXT_multi_draw_indirect = !_glewInit_GL_EXT_multi_draw_indirect();
+#endif /* GL_EXT_multi_draw_indirect */
 #ifdef GL_EXT_multisample
-  GLEW_EXT_multisample = _glewSearchExtension("GL_EXT_multisample", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_multisample) GLEW_EXT_multisample = !_glewInit_GL_EXT_multisample(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_multisample) GLEW_EXT_multisample = !_glewInit_GL_EXT_multisample();
 #endif /* GL_EXT_multisample */
-#ifdef GL_EXT_packed_depth_stencil
-  GLEW_EXT_packed_depth_stencil = _glewSearchExtension("GL_EXT_packed_depth_stencil", extStart, extEnd);
-#endif /* GL_EXT_packed_depth_stencil */
-#ifdef GL_EXT_packed_float
-  GLEW_EXT_packed_float = _glewSearchExtension("GL_EXT_packed_float", extStart, extEnd);
-#endif /* GL_EXT_packed_float */
-#ifdef GL_EXT_packed_pixels
-  GLEW_EXT_packed_pixels = _glewSearchExtension("GL_EXT_packed_pixels", extStart, extEnd);
-#endif /* GL_EXT_packed_pixels */
+#ifdef GL_EXT_multisampled_render_to_texture
+  if (glewExperimental || GLEW_EXT_multisampled_render_to_texture) GLEW_EXT_multisampled_render_to_texture = !_glewInit_GL_EXT_multisampled_render_to_texture();
+#endif /* GL_EXT_multisampled_render_to_texture */
+#ifdef GL_EXT_multiview_draw_buffers
+  if (glewExperimental || GLEW_EXT_multiview_draw_buffers) GLEW_EXT_multiview_draw_buffers = !_glewInit_GL_EXT_multiview_draw_buffers();
+#endif /* GL_EXT_multiview_draw_buffers */
 #ifdef GL_EXT_paletted_texture
-  GLEW_EXT_paletted_texture = _glewSearchExtension("GL_EXT_paletted_texture", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_paletted_texture) GLEW_EXT_paletted_texture = !_glewInit_GL_EXT_paletted_texture(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_paletted_texture) GLEW_EXT_paletted_texture = !_glewInit_GL_EXT_paletted_texture();
 #endif /* GL_EXT_paletted_texture */
-#ifdef GL_EXT_pixel_buffer_object
-  GLEW_EXT_pixel_buffer_object = _glewSearchExtension("GL_EXT_pixel_buffer_object", extStart, extEnd);
-#endif /* GL_EXT_pixel_buffer_object */
 #ifdef GL_EXT_pixel_transform
-  GLEW_EXT_pixel_transform = _glewSearchExtension("GL_EXT_pixel_transform", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_pixel_transform) GLEW_EXT_pixel_transform = !_glewInit_GL_EXT_pixel_transform(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_pixel_transform) GLEW_EXT_pixel_transform = !_glewInit_GL_EXT_pixel_transform();
 #endif /* GL_EXT_pixel_transform */
-#ifdef GL_EXT_pixel_transform_color_table
-  GLEW_EXT_pixel_transform_color_table = _glewSearchExtension("GL_EXT_pixel_transform_color_table", extStart, extEnd);
-#endif /* GL_EXT_pixel_transform_color_table */
 #ifdef GL_EXT_point_parameters
-  GLEW_EXT_point_parameters = _glewSearchExtension("GL_EXT_point_parameters", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_point_parameters) GLEW_EXT_point_parameters = !_glewInit_GL_EXT_point_parameters(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_point_parameters) GLEW_EXT_point_parameters = !_glewInit_GL_EXT_point_parameters();
 #endif /* GL_EXT_point_parameters */
 #ifdef GL_EXT_polygon_offset
-  GLEW_EXT_polygon_offset = _glewSearchExtension("GL_EXT_polygon_offset", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_polygon_offset) GLEW_EXT_polygon_offset = !_glewInit_GL_EXT_polygon_offset(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_polygon_offset) GLEW_EXT_polygon_offset = !_glewInit_GL_EXT_polygon_offset();
 #endif /* GL_EXT_polygon_offset */
+#ifdef GL_EXT_polygon_offset_clamp
+  if (glewExperimental || GLEW_EXT_polygon_offset_clamp) GLEW_EXT_polygon_offset_clamp = !_glewInit_GL_EXT_polygon_offset_clamp();
+#endif /* GL_EXT_polygon_offset_clamp */
 #ifdef GL_EXT_provoking_vertex
-  GLEW_EXT_provoking_vertex = _glewSearchExtension("GL_EXT_provoking_vertex", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_provoking_vertex) GLEW_EXT_provoking_vertex = !_glewInit_GL_EXT_provoking_vertex(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_provoking_vertex) GLEW_EXT_provoking_vertex = !_glewInit_GL_EXT_provoking_vertex();
 #endif /* GL_EXT_provoking_vertex */
-#ifdef GL_EXT_rescale_normal
-  GLEW_EXT_rescale_normal = _glewSearchExtension("GL_EXT_rescale_normal", extStart, extEnd);
-#endif /* GL_EXT_rescale_normal */
+#ifdef GL_EXT_raster_multisample
+  if (glewExperimental || GLEW_EXT_raster_multisample) GLEW_EXT_raster_multisample = !_glewInit_GL_EXT_raster_multisample();
+#endif /* GL_EXT_raster_multisample */
 #ifdef GL_EXT_scene_marker
-  GLEW_EXT_scene_marker = _glewSearchExtension("GL_EXT_scene_marker", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_scene_marker) GLEW_EXT_scene_marker = !_glewInit_GL_EXT_scene_marker(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_scene_marker) GLEW_EXT_scene_marker = !_glewInit_GL_EXT_scene_marker();
 #endif /* GL_EXT_scene_marker */
 #ifdef GL_EXT_secondary_color
-  GLEW_EXT_secondary_color = _glewSearchExtension("GL_EXT_secondary_color", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_secondary_color) GLEW_EXT_secondary_color = !_glewInit_GL_EXT_secondary_color(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_secondary_color) GLEW_EXT_secondary_color = !_glewInit_GL_EXT_secondary_color();
 #endif /* GL_EXT_secondary_color */
+#ifdef GL_EXT_semaphore
+  if (glewExperimental || GLEW_EXT_semaphore) GLEW_EXT_semaphore = !_glewInit_GL_EXT_semaphore();
+#endif /* GL_EXT_semaphore */
+#ifdef GL_EXT_semaphore_fd
+  if (glewExperimental || GLEW_EXT_semaphore_fd) GLEW_EXT_semaphore_fd = !_glewInit_GL_EXT_semaphore_fd();
+#endif /* GL_EXT_semaphore_fd */
+#ifdef GL_EXT_semaphore_win32
+  if (glewExperimental || GLEW_EXT_semaphore_win32) GLEW_EXT_semaphore_win32 = !_glewInit_GL_EXT_semaphore_win32();
+#endif /* GL_EXT_semaphore_win32 */
 #ifdef GL_EXT_separate_shader_objects
-  GLEW_EXT_separate_shader_objects = _glewSearchExtension("GL_EXT_separate_shader_objects", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_separate_shader_objects) GLEW_EXT_separate_shader_objects = !_glewInit_GL_EXT_separate_shader_objects(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_separate_shader_objects) GLEW_EXT_separate_shader_objects = !_glewInit_GL_EXT_separate_shader_objects();
 #endif /* GL_EXT_separate_shader_objects */
-#ifdef GL_EXT_separate_specular_color
-  GLEW_EXT_separate_specular_color = _glewSearchExtension("GL_EXT_separate_specular_color", extStart, extEnd);
-#endif /* GL_EXT_separate_specular_color */
-#ifdef GL_EXT_shader_image_load_formatted
-  GLEW_EXT_shader_image_load_formatted = _glewSearchExtension("GL_EXT_shader_image_load_formatted", extStart, extEnd);
-#endif /* GL_EXT_shader_image_load_formatted */
 #ifdef GL_EXT_shader_image_load_store
-  GLEW_EXT_shader_image_load_store = _glewSearchExtension("GL_EXT_shader_image_load_store", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_shader_image_load_store) GLEW_EXT_shader_image_load_store = !_glewInit_GL_EXT_shader_image_load_store(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_shader_image_load_store) GLEW_EXT_shader_image_load_store = !_glewInit_GL_EXT_shader_image_load_store();
 #endif /* GL_EXT_shader_image_load_store */
-#ifdef GL_EXT_shader_integer_mix
-  GLEW_EXT_shader_integer_mix = _glewSearchExtension("GL_EXT_shader_integer_mix", extStart, extEnd);
-#endif /* GL_EXT_shader_integer_mix */
-#ifdef GL_EXT_shadow_funcs
-  GLEW_EXT_shadow_funcs = _glewSearchExtension("GL_EXT_shadow_funcs", extStart, extEnd);
-#endif /* GL_EXT_shadow_funcs */
-#ifdef GL_EXT_shared_texture_palette
-  GLEW_EXT_shared_texture_palette = _glewSearchExtension("GL_EXT_shared_texture_palette", extStart, extEnd);
-#endif /* GL_EXT_shared_texture_palette */
-#ifdef GL_EXT_stencil_clear_tag
-  GLEW_EXT_stencil_clear_tag = _glewSearchExtension("GL_EXT_stencil_clear_tag", extStart, extEnd);
-#endif /* GL_EXT_stencil_clear_tag */
+#ifdef GL_EXT_shader_pixel_local_storage2
+  if (glewExperimental || GLEW_EXT_shader_pixel_local_storage2) GLEW_EXT_shader_pixel_local_storage2 = !_glewInit_GL_EXT_shader_pixel_local_storage2();
+#endif /* GL_EXT_shader_pixel_local_storage2 */
+#ifdef GL_EXT_sparse_texture
+  if (glewExperimental || GLEW_EXT_sparse_texture) GLEW_EXT_sparse_texture = !_glewInit_GL_EXT_sparse_texture();
+#endif /* GL_EXT_sparse_texture */
 #ifdef GL_EXT_stencil_two_side
-  GLEW_EXT_stencil_two_side = _glewSearchExtension("GL_EXT_stencil_two_side", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_stencil_two_side) GLEW_EXT_stencil_two_side = !_glewInit_GL_EXT_stencil_two_side(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_stencil_two_side) GLEW_EXT_stencil_two_side = !_glewInit_GL_EXT_stencil_two_side();
 #endif /* GL_EXT_stencil_two_side */
-#ifdef GL_EXT_stencil_wrap
-  GLEW_EXT_stencil_wrap = _glewSearchExtension("GL_EXT_stencil_wrap", extStart, extEnd);
-#endif /* GL_EXT_stencil_wrap */
 #ifdef GL_EXT_subtexture
-  GLEW_EXT_subtexture = _glewSearchExtension("GL_EXT_subtexture", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_subtexture) GLEW_EXT_subtexture = !_glewInit_GL_EXT_subtexture(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_subtexture) GLEW_EXT_subtexture = !_glewInit_GL_EXT_subtexture();
 #endif /* GL_EXT_subtexture */
-#ifdef GL_EXT_texture
-  GLEW_EXT_texture = _glewSearchExtension("GL_EXT_texture", extStart, extEnd);
-#endif /* GL_EXT_texture */
 #ifdef GL_EXT_texture3D
-  GLEW_EXT_texture3D = _glewSearchExtension("GL_EXT_texture3D", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_texture3D) GLEW_EXT_texture3D = !_glewInit_GL_EXT_texture3D(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_texture3D) GLEW_EXT_texture3D = !_glewInit_GL_EXT_texture3D();
 #endif /* GL_EXT_texture3D */
 #ifdef GL_EXT_texture_array
-  GLEW_EXT_texture_array = _glewSearchExtension("GL_EXT_texture_array", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_texture_array) GLEW_EXT_texture_array = !_glewInit_GL_EXT_texture_array(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_texture_array) GLEW_EXT_texture_array = !_glewInit_GL_EXT_texture_array();
 #endif /* GL_EXT_texture_array */
 #ifdef GL_EXT_texture_buffer_object
-  GLEW_EXT_texture_buffer_object = _glewSearchExtension("GL_EXT_texture_buffer_object", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_texture_buffer_object) GLEW_EXT_texture_buffer_object = !_glewInit_GL_EXT_texture_buffer_object(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_texture_buffer_object) GLEW_EXT_texture_buffer_object = !_glewInit_GL_EXT_texture_buffer_object();
 #endif /* GL_EXT_texture_buffer_object */
-#ifdef GL_EXT_texture_compression_dxt1
-  GLEW_EXT_texture_compression_dxt1 = _glewSearchExtension("GL_EXT_texture_compression_dxt1", extStart, extEnd);
-#endif /* GL_EXT_texture_compression_dxt1 */
-#ifdef GL_EXT_texture_compression_latc
-  GLEW_EXT_texture_compression_latc = _glewSearchExtension("GL_EXT_texture_compression_latc", extStart, extEnd);
-#endif /* GL_EXT_texture_compression_latc */
-#ifdef GL_EXT_texture_compression_rgtc
-  GLEW_EXT_texture_compression_rgtc = _glewSearchExtension("GL_EXT_texture_compression_rgtc", extStart, extEnd);
-#endif /* GL_EXT_texture_compression_rgtc */
-#ifdef GL_EXT_texture_compression_s3tc
-  GLEW_EXT_texture_compression_s3tc = _glewSearchExtension("GL_EXT_texture_compression_s3tc", extStart, extEnd);
-#endif /* GL_EXT_texture_compression_s3tc */
-#ifdef GL_EXT_texture_cube_map
-  GLEW_EXT_texture_cube_map = _glewSearchExtension("GL_EXT_texture_cube_map", extStart, extEnd);
-#endif /* GL_EXT_texture_cube_map */
-#ifdef GL_EXT_texture_edge_clamp
-  GLEW_EXT_texture_edge_clamp = _glewSearchExtension("GL_EXT_texture_edge_clamp", extStart, extEnd);
-#endif /* GL_EXT_texture_edge_clamp */
-#ifdef GL_EXT_texture_env
-  GLEW_EXT_texture_env = _glewSearchExtension("GL_EXT_texture_env", extStart, extEnd);
-#endif /* GL_EXT_texture_env */
-#ifdef GL_EXT_texture_env_add
-  GLEW_EXT_texture_env_add = _glewSearchExtension("GL_EXT_texture_env_add", extStart, extEnd);
-#endif /* GL_EXT_texture_env_add */
-#ifdef GL_EXT_texture_env_combine
-  GLEW_EXT_texture_env_combine = _glewSearchExtension("GL_EXT_texture_env_combine", extStart, extEnd);
-#endif /* GL_EXT_texture_env_combine */
-#ifdef GL_EXT_texture_env_dot3
-  GLEW_EXT_texture_env_dot3 = _glewSearchExtension("GL_EXT_texture_env_dot3", extStart, extEnd);
-#endif /* GL_EXT_texture_env_dot3 */
-#ifdef GL_EXT_texture_filter_anisotropic
-  GLEW_EXT_texture_filter_anisotropic = _glewSearchExtension("GL_EXT_texture_filter_anisotropic", extStart, extEnd);
-#endif /* GL_EXT_texture_filter_anisotropic */
 #ifdef GL_EXT_texture_integer
-  GLEW_EXT_texture_integer = _glewSearchExtension("GL_EXT_texture_integer", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_texture_integer) GLEW_EXT_texture_integer = !_glewInit_GL_EXT_texture_integer(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_texture_integer) GLEW_EXT_texture_integer = !_glewInit_GL_EXT_texture_integer();
 #endif /* GL_EXT_texture_integer */
-#ifdef GL_EXT_texture_lod_bias
-  GLEW_EXT_texture_lod_bias = _glewSearchExtension("GL_EXT_texture_lod_bias", extStart, extEnd);
-#endif /* GL_EXT_texture_lod_bias */
-#ifdef GL_EXT_texture_mirror_clamp
-  GLEW_EXT_texture_mirror_clamp = _glewSearchExtension("GL_EXT_texture_mirror_clamp", extStart, extEnd);
-#endif /* GL_EXT_texture_mirror_clamp */
 #ifdef GL_EXT_texture_object
-  GLEW_EXT_texture_object = _glewSearchExtension("GL_EXT_texture_object", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_texture_object) GLEW_EXT_texture_object = !_glewInit_GL_EXT_texture_object(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_texture_object) GLEW_EXT_texture_object = !_glewInit_GL_EXT_texture_object();
 #endif /* GL_EXT_texture_object */
 #ifdef GL_EXT_texture_perturb_normal
-  GLEW_EXT_texture_perturb_normal = _glewSearchExtension("GL_EXT_texture_perturb_normal", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_texture_perturb_normal) GLEW_EXT_texture_perturb_normal = !_glewInit_GL_EXT_texture_perturb_normal(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_texture_perturb_normal) GLEW_EXT_texture_perturb_normal = !_glewInit_GL_EXT_texture_perturb_normal();
 #endif /* GL_EXT_texture_perturb_normal */
-#ifdef GL_EXT_texture_rectangle
-  GLEW_EXT_texture_rectangle = _glewSearchExtension("GL_EXT_texture_rectangle", extStart, extEnd);
-#endif /* GL_EXT_texture_rectangle */
-#ifdef GL_EXT_texture_sRGB
-  GLEW_EXT_texture_sRGB = _glewSearchExtension("GL_EXT_texture_sRGB", extStart, extEnd);
-#endif /* GL_EXT_texture_sRGB */
-#ifdef GL_EXT_texture_sRGB_decode
-  GLEW_EXT_texture_sRGB_decode = _glewSearchExtension("GL_EXT_texture_sRGB_decode", extStart, extEnd);
-#endif /* GL_EXT_texture_sRGB_decode */
-#ifdef GL_EXT_texture_shared_exponent
-  GLEW_EXT_texture_shared_exponent = _glewSearchExtension("GL_EXT_texture_shared_exponent", extStart, extEnd);
-#endif /* GL_EXT_texture_shared_exponent */
-#ifdef GL_EXT_texture_snorm
-  GLEW_EXT_texture_snorm = _glewSearchExtension("GL_EXT_texture_snorm", extStart, extEnd);
-#endif /* GL_EXT_texture_snorm */
-#ifdef GL_EXT_texture_swizzle
-  GLEW_EXT_texture_swizzle = _glewSearchExtension("GL_EXT_texture_swizzle", extStart, extEnd);
-#endif /* GL_EXT_texture_swizzle */
+#ifdef GL_EXT_texture_storage
+  if (glewExperimental || GLEW_EXT_texture_storage) GLEW_EXT_texture_storage = !_glewInit_GL_EXT_texture_storage();
+#endif /* GL_EXT_texture_storage */
+#ifdef GL_EXT_texture_view
+  if (glewExperimental || GLEW_EXT_texture_view) GLEW_EXT_texture_view = !_glewInit_GL_EXT_texture_view();
+#endif /* GL_EXT_texture_view */
 #ifdef GL_EXT_timer_query
-  GLEW_EXT_timer_query = _glewSearchExtension("GL_EXT_timer_query", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_timer_query) GLEW_EXT_timer_query = !_glewInit_GL_EXT_timer_query(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_timer_query) GLEW_EXT_timer_query = !_glewInit_GL_EXT_timer_query();
 #endif /* GL_EXT_timer_query */
 #ifdef GL_EXT_transform_feedback
-  GLEW_EXT_transform_feedback = _glewSearchExtension("GL_EXT_transform_feedback", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_transform_feedback) GLEW_EXT_transform_feedback = !_glewInit_GL_EXT_transform_feedback(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_transform_feedback) GLEW_EXT_transform_feedback = !_glewInit_GL_EXT_transform_feedback();
 #endif /* GL_EXT_transform_feedback */
 #ifdef GL_EXT_vertex_array
-  GLEW_EXT_vertex_array = _glewSearchExtension("GL_EXT_vertex_array", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_vertex_array) GLEW_EXT_vertex_array = !_glewInit_GL_EXT_vertex_array(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_vertex_array) GLEW_EXT_vertex_array = !_glewInit_GL_EXT_vertex_array();
 #endif /* GL_EXT_vertex_array */
-#ifdef GL_EXT_vertex_array_bgra
-  GLEW_EXT_vertex_array_bgra = _glewSearchExtension("GL_EXT_vertex_array_bgra", extStart, extEnd);
-#endif /* GL_EXT_vertex_array_bgra */
+#ifdef GL_EXT_vertex_array_setXXX
+  if (glewExperimental || GLEW_EXT_vertex_array_setXXX) GLEW_EXT_vertex_array_setXXX = !_glewInit_GL_EXT_vertex_array_setXXX();
+#endif /* GL_EXT_vertex_array_setXXX */
 #ifdef GL_EXT_vertex_attrib_64bit
-  GLEW_EXT_vertex_attrib_64bit = _glewSearchExtension("GL_EXT_vertex_attrib_64bit", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_vertex_attrib_64bit) GLEW_EXT_vertex_attrib_64bit = !_glewInit_GL_EXT_vertex_attrib_64bit(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_vertex_attrib_64bit) GLEW_EXT_vertex_attrib_64bit = !_glewInit_GL_EXT_vertex_attrib_64bit();
 #endif /* GL_EXT_vertex_attrib_64bit */
 #ifdef GL_EXT_vertex_shader
-  GLEW_EXT_vertex_shader = _glewSearchExtension("GL_EXT_vertex_shader", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_vertex_shader) GLEW_EXT_vertex_shader = !_glewInit_GL_EXT_vertex_shader(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_vertex_shader) GLEW_EXT_vertex_shader = !_glewInit_GL_EXT_vertex_shader();
 #endif /* GL_EXT_vertex_shader */
 #ifdef GL_EXT_vertex_weighting
-  GLEW_EXT_vertex_weighting = _glewSearchExtension("GL_EXT_vertex_weighting", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_vertex_weighting) GLEW_EXT_vertex_weighting = !_glewInit_GL_EXT_vertex_weighting(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_vertex_weighting) GLEW_EXT_vertex_weighting = !_glewInit_GL_EXT_vertex_weighting();
 #endif /* GL_EXT_vertex_weighting */
+#ifdef GL_EXT_win32_keyed_mutex
+  if (glewExperimental || GLEW_EXT_win32_keyed_mutex) GLEW_EXT_win32_keyed_mutex = !_glewInit_GL_EXT_win32_keyed_mutex();
+#endif /* GL_EXT_win32_keyed_mutex */
+#ifdef GL_EXT_window_rectangles
+  if (glewExperimental || GLEW_EXT_window_rectangles) GLEW_EXT_window_rectangles = !_glewInit_GL_EXT_window_rectangles();
+#endif /* GL_EXT_window_rectangles */
 #ifdef GL_EXT_x11_sync_object
-  GLEW_EXT_x11_sync_object = _glewSearchExtension("GL_EXT_x11_sync_object", extStart, extEnd);
-  if (glewExperimental || GLEW_EXT_x11_sync_object) GLEW_EXT_x11_sync_object = !_glewInit_GL_EXT_x11_sync_object(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_EXT_x11_sync_object) GLEW_EXT_x11_sync_object = !_glewInit_GL_EXT_x11_sync_object();
 #endif /* GL_EXT_x11_sync_object */
 #ifdef GL_GREMEDY_frame_terminator
-  GLEW_GREMEDY_frame_terminator = _glewSearchExtension("GL_GREMEDY_frame_terminator", extStart, extEnd);
-  if (glewExperimental || GLEW_GREMEDY_frame_terminator) GLEW_GREMEDY_frame_terminator = !_glewInit_GL_GREMEDY_frame_terminator(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_GREMEDY_frame_terminator) GLEW_GREMEDY_frame_terminator = !_glewInit_GL_GREMEDY_frame_terminator();
 #endif /* GL_GREMEDY_frame_terminator */
 #ifdef GL_GREMEDY_string_marker
-  GLEW_GREMEDY_string_marker = _glewSearchExtension("GL_GREMEDY_string_marker", extStart, extEnd);
-  if (glewExperimental || GLEW_GREMEDY_string_marker) GLEW_GREMEDY_string_marker = !_glewInit_GL_GREMEDY_string_marker(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_GREMEDY_string_marker) GLEW_GREMEDY_string_marker = !_glewInit_GL_GREMEDY_string_marker();
 #endif /* GL_GREMEDY_string_marker */
-#ifdef GL_HP_convolution_border_modes
-  GLEW_HP_convolution_border_modes = _glewSearchExtension("GL_HP_convolution_border_modes", extStart, extEnd);
-#endif /* GL_HP_convolution_border_modes */
 #ifdef GL_HP_image_transform
-  GLEW_HP_image_transform = _glewSearchExtension("GL_HP_image_transform", extStart, extEnd);
-  if (glewExperimental || GLEW_HP_image_transform) GLEW_HP_image_transform = !_glewInit_GL_HP_image_transform(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_HP_image_transform) GLEW_HP_image_transform = !_glewInit_GL_HP_image_transform();
 #endif /* GL_HP_image_transform */
-#ifdef GL_HP_occlusion_test
-  GLEW_HP_occlusion_test = _glewSearchExtension("GL_HP_occlusion_test", extStart, extEnd);
-#endif /* GL_HP_occlusion_test */
-#ifdef GL_HP_texture_lighting
-  GLEW_HP_texture_lighting = _glewSearchExtension("GL_HP_texture_lighting", extStart, extEnd);
-#endif /* GL_HP_texture_lighting */
-#ifdef GL_IBM_cull_vertex
-  GLEW_IBM_cull_vertex = _glewSearchExtension("GL_IBM_cull_vertex", extStart, extEnd);
-#endif /* GL_IBM_cull_vertex */
 #ifdef GL_IBM_multimode_draw_arrays
-  GLEW_IBM_multimode_draw_arrays = _glewSearchExtension("GL_IBM_multimode_draw_arrays", extStart, extEnd);
-  if (glewExperimental || GLEW_IBM_multimode_draw_arrays) GLEW_IBM_multimode_draw_arrays = !_glewInit_GL_IBM_multimode_draw_arrays(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_IBM_multimode_draw_arrays) GLEW_IBM_multimode_draw_arrays = !_glewInit_GL_IBM_multimode_draw_arrays();
 #endif /* GL_IBM_multimode_draw_arrays */
-#ifdef GL_IBM_rasterpos_clip
-  GLEW_IBM_rasterpos_clip = _glewSearchExtension("GL_IBM_rasterpos_clip", extStart, extEnd);
-#endif /* GL_IBM_rasterpos_clip */
-#ifdef GL_IBM_static_data
-  GLEW_IBM_static_data = _glewSearchExtension("GL_IBM_static_data", extStart, extEnd);
-#endif /* GL_IBM_static_data */
-#ifdef GL_IBM_texture_mirrored_repeat
-  GLEW_IBM_texture_mirrored_repeat = _glewSearchExtension("GL_IBM_texture_mirrored_repeat", extStart, extEnd);
-#endif /* GL_IBM_texture_mirrored_repeat */
 #ifdef GL_IBM_vertex_array_lists
-  GLEW_IBM_vertex_array_lists = _glewSearchExtension("GL_IBM_vertex_array_lists", extStart, extEnd);
-  if (glewExperimental || GLEW_IBM_vertex_array_lists) GLEW_IBM_vertex_array_lists = !_glewInit_GL_IBM_vertex_array_lists(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_IBM_vertex_array_lists) GLEW_IBM_vertex_array_lists = !_glewInit_GL_IBM_vertex_array_lists();
 #endif /* GL_IBM_vertex_array_lists */
-#ifdef GL_INGR_color_clamp
-  GLEW_INGR_color_clamp = _glewSearchExtension("GL_INGR_color_clamp", extStart, extEnd);
-#endif /* GL_INGR_color_clamp */
-#ifdef GL_INGR_interlace_read
-  GLEW_INGR_interlace_read = _glewSearchExtension("GL_INGR_interlace_read", extStart, extEnd);
-#endif /* GL_INGR_interlace_read */
-#ifdef GL_INTEL_fragment_shader_ordering
-  GLEW_INTEL_fragment_shader_ordering = _glewSearchExtension("GL_INTEL_fragment_shader_ordering", extStart, extEnd);
-#endif /* GL_INTEL_fragment_shader_ordering */
 #ifdef GL_INTEL_map_texture
-  GLEW_INTEL_map_texture = _glewSearchExtension("GL_INTEL_map_texture", extStart, extEnd);
-  if (glewExperimental || GLEW_INTEL_map_texture) GLEW_INTEL_map_texture = !_glewInit_GL_INTEL_map_texture(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_INTEL_map_texture) GLEW_INTEL_map_texture = !_glewInit_GL_INTEL_map_texture();
 #endif /* GL_INTEL_map_texture */
 #ifdef GL_INTEL_parallel_arrays
-  GLEW_INTEL_parallel_arrays = _glewSearchExtension("GL_INTEL_parallel_arrays", extStart, extEnd);
-  if (glewExperimental || GLEW_INTEL_parallel_arrays) GLEW_INTEL_parallel_arrays = !_glewInit_GL_INTEL_parallel_arrays(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_INTEL_parallel_arrays) GLEW_INTEL_parallel_arrays = !_glewInit_GL_INTEL_parallel_arrays();
 #endif /* GL_INTEL_parallel_arrays */
 #ifdef GL_INTEL_performance_query
-  GLEW_INTEL_performance_query = _glewSearchExtension("GL_INTEL_performance_query", extStart, extEnd);
-  if (glewExperimental || GLEW_INTEL_performance_query) GLEW_INTEL_performance_query = !_glewInit_GL_INTEL_performance_query(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_INTEL_performance_query) GLEW_INTEL_performance_query = !_glewInit_GL_INTEL_performance_query();
 #endif /* GL_INTEL_performance_query */
 #ifdef GL_INTEL_texture_scissor
-  GLEW_INTEL_texture_scissor = _glewSearchExtension("GL_INTEL_texture_scissor", extStart, extEnd);
-  if (glewExperimental || GLEW_INTEL_texture_scissor) GLEW_INTEL_texture_scissor = !_glewInit_GL_INTEL_texture_scissor(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_INTEL_texture_scissor) GLEW_INTEL_texture_scissor = !_glewInit_GL_INTEL_texture_scissor();
 #endif /* GL_INTEL_texture_scissor */
 #ifdef GL_KHR_blend_equation_advanced
-  GLEW_KHR_blend_equation_advanced = _glewSearchExtension("GL_KHR_blend_equation_advanced", extStart, extEnd);
-  if (glewExperimental || GLEW_KHR_blend_equation_advanced) GLEW_KHR_blend_equation_advanced = !_glewInit_GL_KHR_blend_equation_advanced(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_KHR_blend_equation_advanced) GLEW_KHR_blend_equation_advanced = !_glewInit_GL_KHR_blend_equation_advanced();
 #endif /* GL_KHR_blend_equation_advanced */
-#ifdef GL_KHR_blend_equation_advanced_coherent
-  GLEW_KHR_blend_equation_advanced_coherent = _glewSearchExtension("GL_KHR_blend_equation_advanced_coherent", extStart, extEnd);
-#endif /* GL_KHR_blend_equation_advanced_coherent */
-#ifdef GL_KHR_context_flush_control
-  GLEW_KHR_context_flush_control = _glewSearchExtension("GL_KHR_context_flush_control", extStart, extEnd);
-#endif /* GL_KHR_context_flush_control */
 #ifdef GL_KHR_debug
-  GLEW_KHR_debug = _glewSearchExtension("GL_KHR_debug", extStart, extEnd);
-  if (glewExperimental || GLEW_KHR_debug) GLEW_KHR_debug = !_glewInit_GL_KHR_debug(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_KHR_debug) GLEW_KHR_debug = !_glewInit_GL_KHR_debug();
 #endif /* GL_KHR_debug */
-#ifdef GL_KHR_robust_buffer_access_behavior
-  GLEW_KHR_robust_buffer_access_behavior = _glewSearchExtension("GL_KHR_robust_buffer_access_behavior", extStart, extEnd);
-#endif /* GL_KHR_robust_buffer_access_behavior */
+#ifdef GL_KHR_parallel_shader_compile
+  if (glewExperimental || GLEW_KHR_parallel_shader_compile) GLEW_KHR_parallel_shader_compile = !_glewInit_GL_KHR_parallel_shader_compile();
+#endif /* GL_KHR_parallel_shader_compile */
 #ifdef GL_KHR_robustness
-  GLEW_KHR_robustness = _glewSearchExtension("GL_KHR_robustness", extStart, extEnd);
-  if (glewExperimental || GLEW_KHR_robustness) GLEW_KHR_robustness = !_glewInit_GL_KHR_robustness(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_KHR_robustness) GLEW_KHR_robustness = !_glewInit_GL_KHR_robustness();
 #endif /* GL_KHR_robustness */
-#ifdef GL_KHR_texture_compression_astc_hdr
-  GLEW_KHR_texture_compression_astc_hdr = _glewSearchExtension("GL_KHR_texture_compression_astc_hdr", extStart, extEnd);
-#endif /* GL_KHR_texture_compression_astc_hdr */
-#ifdef GL_KHR_texture_compression_astc_ldr
-  GLEW_KHR_texture_compression_astc_ldr = _glewSearchExtension("GL_KHR_texture_compression_astc_ldr", extStart, extEnd);
-#endif /* GL_KHR_texture_compression_astc_ldr */
 #ifdef GL_KTX_buffer_region
-  GLEW_KTX_buffer_region = _glewSearchExtension("GL_KTX_buffer_region", extStart, extEnd);
-  if (glewExperimental || GLEW_KTX_buffer_region) GLEW_KTX_buffer_region = !_glewInit_GL_KTX_buffer_region(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_KTX_buffer_region) GLEW_KTX_buffer_region = !_glewInit_GL_KTX_buffer_region();
 #endif /* GL_KTX_buffer_region */
-#ifdef GL_MESAX_texture_stack
-  GLEW_MESAX_texture_stack = _glewSearchExtension("GL_MESAX_texture_stack", extStart, extEnd);
-#endif /* GL_MESAX_texture_stack */
-#ifdef GL_MESA_pack_invert
-  GLEW_MESA_pack_invert = _glewSearchExtension("GL_MESA_pack_invert", extStart, extEnd);
-#endif /* GL_MESA_pack_invert */
 #ifdef GL_MESA_resize_buffers
-  GLEW_MESA_resize_buffers = _glewSearchExtension("GL_MESA_resize_buffers", extStart, extEnd);
-  if (glewExperimental || GLEW_MESA_resize_buffers) GLEW_MESA_resize_buffers = !_glewInit_GL_MESA_resize_buffers(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_MESA_resize_buffers) GLEW_MESA_resize_buffers = !_glewInit_GL_MESA_resize_buffers();
 #endif /* GL_MESA_resize_buffers */
 #ifdef GL_MESA_window_pos
-  GLEW_MESA_window_pos = _glewSearchExtension("GL_MESA_window_pos", extStart, extEnd);
-  if (glewExperimental || GLEW_MESA_window_pos) GLEW_MESA_window_pos = !_glewInit_GL_MESA_window_pos(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_MESA_window_pos) GLEW_MESA_window_pos = !_glewInit_GL_MESA_window_pos();
 #endif /* GL_MESA_window_pos */
-#ifdef GL_MESA_ycbcr_texture
-  GLEW_MESA_ycbcr_texture = _glewSearchExtension("GL_MESA_ycbcr_texture", extStart, extEnd);
-#endif /* GL_MESA_ycbcr_texture */
 #ifdef GL_NVX_conditional_render
-  GLEW_NVX_conditional_render = _glewSearchExtension("GL_NVX_conditional_render", extStart, extEnd);
-  if (glewExperimental || GLEW_NVX_conditional_render) GLEW_NVX_conditional_render = !_glewInit_GL_NVX_conditional_render(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_NVX_conditional_render) GLEW_NVX_conditional_render = !_glewInit_GL_NVX_conditional_render();
 #endif /* GL_NVX_conditional_render */
-#ifdef GL_NVX_gpu_memory_info
-  GLEW_NVX_gpu_memory_info = _glewSearchExtension("GL_NVX_gpu_memory_info", extStart, extEnd);
-#endif /* GL_NVX_gpu_memory_info */
+#ifdef GL_NVX_linked_gpu_multicast
+  if (glewExperimental || GLEW_NVX_linked_gpu_multicast) GLEW_NVX_linked_gpu_multicast = !_glewInit_GL_NVX_linked_gpu_multicast();
+#endif /* GL_NVX_linked_gpu_multicast */
+#ifdef GL_NV_3dvision_settings
+  if (glewExperimental || GLEW_NV_3dvision_settings) GLEW_NV_3dvision_settings = !_glewInit_GL_NV_3dvision_settings();
+#endif /* GL_NV_3dvision_settings */
 #ifdef GL_NV_bindless_multi_draw_indirect
-  GLEW_NV_bindless_multi_draw_indirect = _glewSearchExtension("GL_NV_bindless_multi_draw_indirect", extStart, extEnd);
-  if (glewExperimental || GLEW_NV_bindless_multi_draw_indirect) GLEW_NV_bindless_multi_draw_indirect = !_glewInit_GL_NV_bindless_multi_draw_indirect(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_NV_bindless_multi_draw_indirect) GLEW_NV_bindless_multi_draw_indirect = !_glewInit_GL_NV_bindless_multi_draw_indirect();
 #endif /* GL_NV_bindless_multi_draw_indirect */
 #ifdef GL_NV_bindless_multi_draw_indirect_count
-  GLEW_NV_bindless_multi_draw_indirect_count = _glewSearchExtension("GL_NV_bindless_multi_draw_indirect_count", extStart, extEnd);
-  if (glewExperimental || GLEW_NV_bindless_multi_draw_indirect_count) GLEW_NV_bindless_multi_draw_indirect_count = !_glewInit_GL_NV_bindless_multi_draw_indirect_count(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_NV_bindless_multi_draw_indirect_count) GLEW_NV_bindless_multi_draw_indirect_count = !_glewInit_GL_NV_bindless_multi_draw_indirect_count();
 #endif /* GL_NV_bindless_multi_draw_indirect_count */
 #ifdef GL_NV_bindless_texture
-  GLEW_NV_bindless_texture = _glewSearchExtension("GL_NV_bindless_texture", extStart, extEnd);
-  if (glewExperimental || GLEW_NV_bindless_texture) GLEW_NV_bindless_texture = !_glewInit_GL_NV_bindless_texture(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_NV_bindless_texture) GLEW_NV_bindless_texture = !_glewInit_GL_NV_bindless_texture();
 #endif /* GL_NV_bindless_texture */
 #ifdef GL_NV_blend_equation_advanced
-  GLEW_NV_blend_equation_advanced = _glewSearchExtension("GL_NV_blend_equation_advanced", extStart, extEnd);
-  if (glewExperimental || GLEW_NV_blend_equation_advanced) GLEW_NV_blend_equation_advanced = !_glewInit_GL_NV_blend_equation_advanced(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_NV_blend_equation_advanced) GLEW_NV_blend_equation_advanced = !_glewInit_GL_NV_blend_equation_advanced();
 #endif /* GL_NV_blend_equation_advanced */
-#ifdef GL_NV_blend_equation_advanced_coherent
-  GLEW_NV_blend_equation_advanced_coherent = _glewSearchExtension("GL_NV_blend_equation_advanced_coherent", extStart, extEnd);
-#endif /* GL_NV_blend_equation_advanced_coherent */
-#ifdef GL_NV_blend_square
-  GLEW_NV_blend_square = _glewSearchExtension("GL_NV_blend_square", extStart, extEnd);
-#endif /* GL_NV_blend_square */
-#ifdef GL_NV_compute_program5
-  GLEW_NV_compute_program5 = _glewSearchExtension("GL_NV_compute_program5", extStart, extEnd);
-#endif /* GL_NV_compute_program5 */
+#ifdef GL_NV_clip_space_w_scaling
+  if (glewExperimental || GLEW_NV_clip_space_w_scaling) GLEW_NV_clip_space_w_scaling = !_glewInit_GL_NV_clip_space_w_scaling();
+#endif /* GL_NV_clip_space_w_scaling */
+#ifdef GL_NV_command_list
+  if (glewExperimental || GLEW_NV_command_list) GLEW_NV_command_list = !_glewInit_GL_NV_command_list();
+#endif /* GL_NV_command_list */
 #ifdef GL_NV_conditional_render
-  GLEW_NV_conditional_render = _glewSearchExtension("GL_NV_conditional_render", extStart, extEnd);
-  if (glewExperimental || GLEW_NV_conditional_render) GLEW_NV_conditional_render = !_glewInit_GL_NV_conditional_render(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_NV_conditional_render) GLEW_NV_conditional_render = !_glewInit_GL_NV_conditional_render();
 #endif /* GL_NV_conditional_render */
-#ifdef GL_NV_copy_depth_to_color
-  GLEW_NV_copy_depth_to_color = _glewSearchExtension("GL_NV_copy_depth_to_color", extStart, extEnd);
-#endif /* GL_NV_copy_depth_to_color */
+#ifdef GL_NV_conservative_raster
+  if (glewExperimental || GLEW_NV_conservative_raster) GLEW_NV_conservative_raster = !_glewInit_GL_NV_conservative_raster();
+#endif /* GL_NV_conservative_raster */
+#ifdef GL_NV_conservative_raster_dilate
+  if (glewExperimental || GLEW_NV_conservative_raster_dilate) GLEW_NV_conservative_raster_dilate = !_glewInit_GL_NV_conservative_raster_dilate();
+#endif /* GL_NV_conservative_raster_dilate */
+#ifdef GL_NV_conservative_raster_pre_snap_triangles
+  if (glewExperimental || GLEW_NV_conservative_raster_pre_snap_triangles) GLEW_NV_conservative_raster_pre_snap_triangles = !_glewInit_GL_NV_conservative_raster_pre_snap_triangles();
+#endif /* GL_NV_conservative_raster_pre_snap_triangles */
+#ifdef GL_NV_copy_buffer
+  if (glewExperimental || GLEW_NV_copy_buffer) GLEW_NV_copy_buffer = !_glewInit_GL_NV_copy_buffer();
+#endif /* GL_NV_copy_buffer */
 #ifdef GL_NV_copy_image
-  GLEW_NV_copy_image = _glewSearchExtension("GL_NV_copy_image", extStart, extEnd);
-  if (glewExperimental || GLEW_NV_copy_image) GLEW_NV_copy_image = !_glewInit_GL_NV_copy_image(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_NV_copy_image) GLEW_NV_copy_image = !_glewInit_GL_NV_copy_image();
 #endif /* GL_NV_copy_image */
-#ifdef GL_NV_deep_texture3D
-  GLEW_NV_deep_texture3D = _glewSearchExtension("GL_NV_deep_texture3D", extStart, extEnd);
-#endif /* GL_NV_deep_texture3D */
 #ifdef GL_NV_depth_buffer_float
-  GLEW_NV_depth_buffer_float = _glewSearchExtension("GL_NV_depth_buffer_float", extStart, extEnd);
-  if (glewExperimental || GLEW_NV_depth_buffer_float) GLEW_NV_depth_buffer_float = !_glewInit_GL_NV_depth_buffer_float(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_NV_depth_buffer_float) GLEW_NV_depth_buffer_float = !_glewInit_GL_NV_depth_buffer_float();
 #endif /* GL_NV_depth_buffer_float */
-#ifdef GL_NV_depth_clamp
-  GLEW_NV_depth_clamp = _glewSearchExtension("GL_NV_depth_clamp", extStart, extEnd);
-#endif /* GL_NV_depth_clamp */
-#ifdef GL_NV_depth_range_unclamped
-  GLEW_NV_depth_range_unclamped = _glewSearchExtension("GL_NV_depth_range_unclamped", extStart, extEnd);
-#endif /* GL_NV_depth_range_unclamped */
+#ifdef GL_NV_draw_buffers
+  if (glewExperimental || GLEW_NV_draw_buffers) GLEW_NV_draw_buffers = !_glewInit_GL_NV_draw_buffers();
+#endif /* GL_NV_draw_buffers */
+#ifdef GL_NV_draw_instanced
+  if (glewExperimental || GLEW_NV_draw_instanced) GLEW_NV_draw_instanced = !_glewInit_GL_NV_draw_instanced();
+#endif /* GL_NV_draw_instanced */
 #ifdef GL_NV_draw_texture
-  GLEW_NV_draw_texture = _glewSearchExtension("GL_NV_draw_texture", extStart, extEnd);
-  if (glewExperimental || GLEW_NV_draw_texture) GLEW_NV_draw_texture = !_glewInit_GL_NV_draw_texture(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_NV_draw_texture) GLEW_NV_draw_texture = !_glewInit_GL_NV_draw_texture();
 #endif /* GL_NV_draw_texture */
+#ifdef GL_NV_draw_vulkan_image
+  if (glewExperimental || GLEW_NV_draw_vulkan_image) GLEW_NV_draw_vulkan_image = !_glewInit_GL_NV_draw_vulkan_image();
+#endif /* GL_NV_draw_vulkan_image */
 #ifdef GL_NV_evaluators
-  GLEW_NV_evaluators = _glewSearchExtension("GL_NV_evaluators", extStart, extEnd);
-  if (glewExperimental || GLEW_NV_evaluators) GLEW_NV_evaluators = !_glewInit_GL_NV_evaluators(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_NV_evaluators) GLEW_NV_evaluators = !_glewInit_GL_NV_evaluators();
 #endif /* GL_NV_evaluators */
 #ifdef GL_NV_explicit_multisample
-  GLEW_NV_explicit_multisample = _glewSearchExtension("GL_NV_explicit_multisample", extStart, extEnd);
-  if (glewExperimental || GLEW_NV_explicit_multisample) GLEW_NV_explicit_multisample = !_glewInit_GL_NV_explicit_multisample(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_NV_explicit_multisample) GLEW_NV_explicit_multisample = !_glewInit_GL_NV_explicit_multisample();
 #endif /* GL_NV_explicit_multisample */
 #ifdef GL_NV_fence
-  GLEW_NV_fence = _glewSearchExtension("GL_NV_fence", extStart, extEnd);
-  if (glewExperimental || GLEW_NV_fence) GLEW_NV_fence = !_glewInit_GL_NV_fence(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_NV_fence) GLEW_NV_fence = !_glewInit_GL_NV_fence();
 #endif /* GL_NV_fence */
-#ifdef GL_NV_float_buffer
-  GLEW_NV_float_buffer = _glewSearchExtension("GL_NV_float_buffer", extStart, extEnd);
-#endif /* GL_NV_float_buffer */
-#ifdef GL_NV_fog_distance
-  GLEW_NV_fog_distance = _glewSearchExtension("GL_NV_fog_distance", extStart, extEnd);
-#endif /* GL_NV_fog_distance */
+#ifdef GL_NV_fragment_coverage_to_color
+  if (glewExperimental || GLEW_NV_fragment_coverage_to_color) GLEW_NV_fragment_coverage_to_color = !_glewInit_GL_NV_fragment_coverage_to_color();
+#endif /* GL_NV_fragment_coverage_to_color */
 #ifdef GL_NV_fragment_program
-  GLEW_NV_fragment_program = _glewSearchExtension("GL_NV_fragment_program", extStart, extEnd);
-  if (glewExperimental || GLEW_NV_fragment_program) GLEW_NV_fragment_program = !_glewInit_GL_NV_fragment_program(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_NV_fragment_program) GLEW_NV_fragment_program = !_glewInit_GL_NV_fragment_program();
 #endif /* GL_NV_fragment_program */
-#ifdef GL_NV_fragment_program2
-  GLEW_NV_fragment_program2 = _glewSearchExtension("GL_NV_fragment_program2", extStart, extEnd);
-#endif /* GL_NV_fragment_program2 */
-#ifdef GL_NV_fragment_program4
-  GLEW_NV_fragment_program4 = _glewSearchExtension("GL_NV_gpu_program4", extStart, extEnd);
-#endif /* GL_NV_fragment_program4 */
-#ifdef GL_NV_fragment_program_option
-  GLEW_NV_fragment_program_option = _glewSearchExtension("GL_NV_fragment_program_option", extStart, extEnd);
-#endif /* GL_NV_fragment_program_option */
+#ifdef GL_NV_framebuffer_blit
+  if (glewExperimental || GLEW_NV_framebuffer_blit) GLEW_NV_framebuffer_blit = !_glewInit_GL_NV_framebuffer_blit();
+#endif /* GL_NV_framebuffer_blit */
+#ifdef GL_NV_framebuffer_multisample
+  if (glewExperimental || GLEW_NV_framebuffer_multisample) GLEW_NV_framebuffer_multisample = !_glewInit_GL_NV_framebuffer_multisample();
+#endif /* GL_NV_framebuffer_multisample */
 #ifdef GL_NV_framebuffer_multisample_coverage
-  GLEW_NV_framebuffer_multisample_coverage = _glewSearchExtension("GL_NV_framebuffer_multisample_coverage", extStart, extEnd);
-  if (glewExperimental || GLEW_NV_framebuffer_multisample_coverage) GLEW_NV_framebuffer_multisample_coverage = !_glewInit_GL_NV_framebuffer_multisample_coverage(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_NV_framebuffer_multisample_coverage) GLEW_NV_framebuffer_multisample_coverage = !_glewInit_GL_NV_framebuffer_multisample_coverage();
 #endif /* GL_NV_framebuffer_multisample_coverage */
 #ifdef GL_NV_geometry_program4
-  GLEW_NV_geometry_program4 = _glewSearchExtension("GL_NV_gpu_program4", extStart, extEnd);
-  if (glewExperimental || GLEW_NV_geometry_program4) GLEW_NV_geometry_program4 = !_glewInit_GL_NV_geometry_program4(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_NV_geometry_program4) GLEW_NV_geometry_program4 = !_glewInit_GL_NV_geometry_program4();
 #endif /* GL_NV_geometry_program4 */
-#ifdef GL_NV_geometry_shader4
-  GLEW_NV_geometry_shader4 = _glewSearchExtension("GL_NV_geometry_shader4", extStart, extEnd);
-#endif /* GL_NV_geometry_shader4 */
+#ifdef GL_NV_gpu_multicast
+  if (glewExperimental || GLEW_NV_gpu_multicast) GLEW_NV_gpu_multicast = !_glewInit_GL_NV_gpu_multicast();
+#endif /* GL_NV_gpu_multicast */
 #ifdef GL_NV_gpu_program4
-  GLEW_NV_gpu_program4 = _glewSearchExtension("GL_NV_gpu_program4", extStart, extEnd);
-  if (glewExperimental || GLEW_NV_gpu_program4) GLEW_NV_gpu_program4 = !_glewInit_GL_NV_gpu_program4(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_NV_gpu_program4) GLEW_NV_gpu_program4 = !_glewInit_GL_NV_gpu_program4();
 #endif /* GL_NV_gpu_program4 */
-#ifdef GL_NV_gpu_program5
-  GLEW_NV_gpu_program5 = _glewSearchExtension("GL_NV_gpu_program5", extStart, extEnd);
-#endif /* GL_NV_gpu_program5 */
-#ifdef GL_NV_gpu_program5_mem_extended
-  GLEW_NV_gpu_program5_mem_extended = _glewSearchExtension("GL_NV_gpu_program5_mem_extended", extStart, extEnd);
-#endif /* GL_NV_gpu_program5_mem_extended */
-#ifdef GL_NV_gpu_program_fp64
-  GLEW_NV_gpu_program_fp64 = _glewSearchExtension("GL_NV_gpu_program_fp64", extStart, extEnd);
-#endif /* GL_NV_gpu_program_fp64 */
 #ifdef GL_NV_gpu_shader5
-  GLEW_NV_gpu_shader5 = _glewSearchExtension("GL_NV_gpu_shader5", extStart, extEnd);
-  if (glewExperimental || GLEW_NV_gpu_shader5) GLEW_NV_gpu_shader5 = !_glewInit_GL_NV_gpu_shader5(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_NV_gpu_shader5) GLEW_NV_gpu_shader5 = !_glewInit_GL_NV_gpu_shader5();
 #endif /* GL_NV_gpu_shader5 */
 #ifdef GL_NV_half_float
-  GLEW_NV_half_float = _glewSearchExtension("GL_NV_half_float", extStart, extEnd);
-  if (glewExperimental || GLEW_NV_half_float) GLEW_NV_half_float = !_glewInit_GL_NV_half_float(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_NV_half_float) GLEW_NV_half_float = !_glewInit_GL_NV_half_float();
 #endif /* GL_NV_half_float */
-#ifdef GL_NV_light_max_exponent
-  GLEW_NV_light_max_exponent = _glewSearchExtension("GL_NV_light_max_exponent", extStart, extEnd);
-#endif /* GL_NV_light_max_exponent */
-#ifdef GL_NV_multisample_coverage
-  GLEW_NV_multisample_coverage = _glewSearchExtension("GL_NV_multisample_coverage", extStart, extEnd);
-#endif /* GL_NV_multisample_coverage */
-#ifdef GL_NV_multisample_filter_hint
-  GLEW_NV_multisample_filter_hint = _glewSearchExtension("GL_NV_multisample_filter_hint", extStart, extEnd);
-#endif /* GL_NV_multisample_filter_hint */
+#ifdef GL_NV_instanced_arrays
+  if (glewExperimental || GLEW_NV_instanced_arrays) GLEW_NV_instanced_arrays = !_glewInit_GL_NV_instanced_arrays();
+#endif /* GL_NV_instanced_arrays */
+#ifdef GL_NV_internalformat_sample_query
+  if (glewExperimental || GLEW_NV_internalformat_sample_query) GLEW_NV_internalformat_sample_query = !_glewInit_GL_NV_internalformat_sample_query();
+#endif /* GL_NV_internalformat_sample_query */
+#ifdef GL_NV_non_square_matrices
+  if (glewExperimental || GLEW_NV_non_square_matrices) GLEW_NV_non_square_matrices = !_glewInit_GL_NV_non_square_matrices();
+#endif /* GL_NV_non_square_matrices */
 #ifdef GL_NV_occlusion_query
-  GLEW_NV_occlusion_query = _glewSearchExtension("GL_NV_occlusion_query", extStart, extEnd);
-  if (glewExperimental || GLEW_NV_occlusion_query) GLEW_NV_occlusion_query = !_glewInit_GL_NV_occlusion_query(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_NV_occlusion_query) GLEW_NV_occlusion_query = !_glewInit_GL_NV_occlusion_query();
 #endif /* GL_NV_occlusion_query */
-#ifdef GL_NV_packed_depth_stencil
-  GLEW_NV_packed_depth_stencil = _glewSearchExtension("GL_NV_packed_depth_stencil", extStart, extEnd);
-#endif /* GL_NV_packed_depth_stencil */
 #ifdef GL_NV_parameter_buffer_object
-  GLEW_NV_parameter_buffer_object = _glewSearchExtension("GL_NV_parameter_buffer_object", extStart, extEnd);
-  if (glewExperimental || GLEW_NV_parameter_buffer_object) GLEW_NV_parameter_buffer_object = !_glewInit_GL_NV_parameter_buffer_object(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_NV_parameter_buffer_object) GLEW_NV_parameter_buffer_object = !_glewInit_GL_NV_parameter_buffer_object();
 #endif /* GL_NV_parameter_buffer_object */
-#ifdef GL_NV_parameter_buffer_object2
-  GLEW_NV_parameter_buffer_object2 = _glewSearchExtension("GL_NV_parameter_buffer_object2", extStart, extEnd);
-#endif /* GL_NV_parameter_buffer_object2 */
 #ifdef GL_NV_path_rendering
-  GLEW_NV_path_rendering = _glewSearchExtension("GL_NV_path_rendering", extStart, extEnd);
-  if (glewExperimental || GLEW_NV_path_rendering) GLEW_NV_path_rendering = !_glewInit_GL_NV_path_rendering(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_NV_path_rendering) GLEW_NV_path_rendering = !_glewInit_GL_NV_path_rendering();
 #endif /* GL_NV_path_rendering */
 #ifdef GL_NV_pixel_data_range
-  GLEW_NV_pixel_data_range = _glewSearchExtension("GL_NV_pixel_data_range", extStart, extEnd);
-  if (glewExperimental || GLEW_NV_pixel_data_range) GLEW_NV_pixel_data_range = !_glewInit_GL_NV_pixel_data_range(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_NV_pixel_data_range) GLEW_NV_pixel_data_range = !_glewInit_GL_NV_pixel_data_range();
 #endif /* GL_NV_pixel_data_range */
 #ifdef GL_NV_point_sprite
-  GLEW_NV_point_sprite = _glewSearchExtension("GL_NV_point_sprite", extStart, extEnd);
-  if (glewExperimental || GLEW_NV_point_sprite) GLEW_NV_point_sprite = !_glewInit_GL_NV_point_sprite(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_NV_point_sprite) GLEW_NV_point_sprite = !_glewInit_GL_NV_point_sprite();
 #endif /* GL_NV_point_sprite */
+#ifdef GL_NV_polygon_mode
+  if (glewExperimental || GLEW_NV_polygon_mode) GLEW_NV_polygon_mode = !_glewInit_GL_NV_polygon_mode();
+#endif /* GL_NV_polygon_mode */
 #ifdef GL_NV_present_video
-  GLEW_NV_present_video = _glewSearchExtension("GL_NV_present_video", extStart, extEnd);
-  if (glewExperimental || GLEW_NV_present_video) GLEW_NV_present_video = !_glewInit_GL_NV_present_video(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_NV_present_video) GLEW_NV_present_video = !_glewInit_GL_NV_present_video();
 #endif /* GL_NV_present_video */
 #ifdef GL_NV_primitive_restart
-  GLEW_NV_primitive_restart = _glewSearchExtension("GL_NV_primitive_restart", extStart, extEnd);
-  if (glewExperimental || GLEW_NV_primitive_restart) GLEW_NV_primitive_restart = !_glewInit_GL_NV_primitive_restart(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_NV_primitive_restart) GLEW_NV_primitive_restart = !_glewInit_GL_NV_primitive_restart();
 #endif /* GL_NV_primitive_restart */
 #ifdef GL_NV_register_combiners
-  GLEW_NV_register_combiners = _glewSearchExtension("GL_NV_register_combiners", extStart, extEnd);
-  if (glewExperimental || GLEW_NV_register_combiners) GLEW_NV_register_combiners = !_glewInit_GL_NV_register_combiners(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_NV_register_combiners) GLEW_NV_register_combiners = !_glewInit_GL_NV_register_combiners();
 #endif /* GL_NV_register_combiners */
 #ifdef GL_NV_register_combiners2
-  GLEW_NV_register_combiners2 = _glewSearchExtension("GL_NV_register_combiners2", extStart, extEnd);
-  if (glewExperimental || GLEW_NV_register_combiners2) GLEW_NV_register_combiners2 = !_glewInit_GL_NV_register_combiners2(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_NV_register_combiners2) GLEW_NV_register_combiners2 = !_glewInit_GL_NV_register_combiners2();
 #endif /* GL_NV_register_combiners2 */
-#ifdef GL_NV_shader_atomic_counters
-  GLEW_NV_shader_atomic_counters = _glewSearchExtension("GL_NV_shader_atomic_counters", extStart, extEnd);
-#endif /* GL_NV_shader_atomic_counters */
-#ifdef GL_NV_shader_atomic_float
-  GLEW_NV_shader_atomic_float = _glewSearchExtension("GL_NV_shader_atomic_float", extStart, extEnd);
-#endif /* GL_NV_shader_atomic_float */
-#ifdef GL_NV_shader_atomic_int64
-  GLEW_NV_shader_atomic_int64 = _glewSearchExtension("GL_NV_shader_atomic_int64", extStart, extEnd);
-#endif /* GL_NV_shader_atomic_int64 */
+#ifdef GL_NV_sample_locations
+  if (glewExperimental || GLEW_NV_sample_locations) GLEW_NV_sample_locations = !_glewInit_GL_NV_sample_locations();
+#endif /* GL_NV_sample_locations */
 #ifdef GL_NV_shader_buffer_load
-  GLEW_NV_shader_buffer_load = _glewSearchExtension("GL_NV_shader_buffer_load", extStart, extEnd);
-  if (glewExperimental || GLEW_NV_shader_buffer_load) GLEW_NV_shader_buffer_load = !_glewInit_GL_NV_shader_buffer_load(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_NV_shader_buffer_load) GLEW_NV_shader_buffer_load = !_glewInit_GL_NV_shader_buffer_load();
 #endif /* GL_NV_shader_buffer_load */
-#ifdef GL_NV_shader_storage_buffer_object
-  GLEW_NV_shader_storage_buffer_object = _glewSearchExtension("GL_NV_shader_storage_buffer_object", extStart, extEnd);
-#endif /* GL_NV_shader_storage_buffer_object */
-#ifdef GL_NV_shader_thread_group
-  GLEW_NV_shader_thread_group = _glewSearchExtension("GL_NV_shader_thread_group", extStart, extEnd);
-#endif /* GL_NV_shader_thread_group */
-#ifdef GL_NV_shader_thread_shuffle
-  GLEW_NV_shader_thread_shuffle = _glewSearchExtension("GL_NV_shader_thread_shuffle", extStart, extEnd);
-#endif /* GL_NV_shader_thread_shuffle */
-#ifdef GL_NV_tessellation_program5
-  GLEW_NV_tessellation_program5 = _glewSearchExtension("GL_NV_gpu_program5", extStart, extEnd);
-#endif /* GL_NV_tessellation_program5 */
-#ifdef GL_NV_texgen_emboss
-  GLEW_NV_texgen_emboss = _glewSearchExtension("GL_NV_texgen_emboss", extStart, extEnd);
-#endif /* GL_NV_texgen_emboss */
-#ifdef GL_NV_texgen_reflection
-  GLEW_NV_texgen_reflection = _glewSearchExtension("GL_NV_texgen_reflection", extStart, extEnd);
-#endif /* GL_NV_texgen_reflection */
+#ifdef GL_NV_texture_array
+  if (glewExperimental || GLEW_NV_texture_array) GLEW_NV_texture_array = !_glewInit_GL_NV_texture_array();
+#endif /* GL_NV_texture_array */
 #ifdef GL_NV_texture_barrier
-  GLEW_NV_texture_barrier = _glewSearchExtension("GL_NV_texture_barrier", extStart, extEnd);
-  if (glewExperimental || GLEW_NV_texture_barrier) GLEW_NV_texture_barrier = !_glewInit_GL_NV_texture_barrier(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_NV_texture_barrier) GLEW_NV_texture_barrier = !_glewInit_GL_NV_texture_barrier();
 #endif /* GL_NV_texture_barrier */
-#ifdef GL_NV_texture_compression_vtc
-  GLEW_NV_texture_compression_vtc = _glewSearchExtension("GL_NV_texture_compression_vtc", extStart, extEnd);
-#endif /* GL_NV_texture_compression_vtc */
-#ifdef GL_NV_texture_env_combine4
-  GLEW_NV_texture_env_combine4 = _glewSearchExtension("GL_NV_texture_env_combine4", extStart, extEnd);
-#endif /* GL_NV_texture_env_combine4 */
-#ifdef GL_NV_texture_expand_normal
-  GLEW_NV_texture_expand_normal = _glewSearchExtension("GL_NV_texture_expand_normal", extStart, extEnd);
-#endif /* GL_NV_texture_expand_normal */
 #ifdef GL_NV_texture_multisample
-  GLEW_NV_texture_multisample = _glewSearchExtension("GL_NV_texture_multisample", extStart, extEnd);
-  if (glewExperimental || GLEW_NV_texture_multisample) GLEW_NV_texture_multisample = !_glewInit_GL_NV_texture_multisample(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_NV_texture_multisample) GLEW_NV_texture_multisample = !_glewInit_GL_NV_texture_multisample();
 #endif /* GL_NV_texture_multisample */
-#ifdef GL_NV_texture_rectangle
-  GLEW_NV_texture_rectangle = _glewSearchExtension("GL_NV_texture_rectangle", extStart, extEnd);
-#endif /* GL_NV_texture_rectangle */
-#ifdef GL_NV_texture_shader
-  GLEW_NV_texture_shader = _glewSearchExtension("GL_NV_texture_shader", extStart, extEnd);
-#endif /* GL_NV_texture_shader */
-#ifdef GL_NV_texture_shader2
-  GLEW_NV_texture_shader2 = _glewSearchExtension("GL_NV_texture_shader2", extStart, extEnd);
-#endif /* GL_NV_texture_shader2 */
-#ifdef GL_NV_texture_shader3
-  GLEW_NV_texture_shader3 = _glewSearchExtension("GL_NV_texture_shader3", extStart, extEnd);
-#endif /* GL_NV_texture_shader3 */
 #ifdef GL_NV_transform_feedback
-  GLEW_NV_transform_feedback = _glewSearchExtension("GL_NV_transform_feedback", extStart, extEnd);
-  if (glewExperimental || GLEW_NV_transform_feedback) GLEW_NV_transform_feedback = !_glewInit_GL_NV_transform_feedback(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_NV_transform_feedback) GLEW_NV_transform_feedback = !_glewInit_GL_NV_transform_feedback();
 #endif /* GL_NV_transform_feedback */
 #ifdef GL_NV_transform_feedback2
-  GLEW_NV_transform_feedback2 = _glewSearchExtension("GL_NV_transform_feedback2", extStart, extEnd);
-  if (glewExperimental || GLEW_NV_transform_feedback2) GLEW_NV_transform_feedback2 = !_glewInit_GL_NV_transform_feedback2(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_NV_transform_feedback2) GLEW_NV_transform_feedback2 = !_glewInit_GL_NV_transform_feedback2();
 #endif /* GL_NV_transform_feedback2 */
 #ifdef GL_NV_vdpau_interop
-  GLEW_NV_vdpau_interop = _glewSearchExtension("GL_NV_vdpau_interop", extStart, extEnd);
-  if (glewExperimental || GLEW_NV_vdpau_interop) GLEW_NV_vdpau_interop = !_glewInit_GL_NV_vdpau_interop(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_NV_vdpau_interop) GLEW_NV_vdpau_interop = !_glewInit_GL_NV_vdpau_interop();
 #endif /* GL_NV_vdpau_interop */
 #ifdef GL_NV_vertex_array_range
-  GLEW_NV_vertex_array_range = _glewSearchExtension("GL_NV_vertex_array_range", extStart, extEnd);
-  if (glewExperimental || GLEW_NV_vertex_array_range) GLEW_NV_vertex_array_range = !_glewInit_GL_NV_vertex_array_range(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_NV_vertex_array_range) GLEW_NV_vertex_array_range = !_glewInit_GL_NV_vertex_array_range();
 #endif /* GL_NV_vertex_array_range */
-#ifdef GL_NV_vertex_array_range2
-  GLEW_NV_vertex_array_range2 = _glewSearchExtension("GL_NV_vertex_array_range2", extStart, extEnd);
-#endif /* GL_NV_vertex_array_range2 */
 #ifdef GL_NV_vertex_attrib_integer_64bit
-  GLEW_NV_vertex_attrib_integer_64bit = _glewSearchExtension("GL_NV_vertex_attrib_integer_64bit", extStart, extEnd);
-  if (glewExperimental || GLEW_NV_vertex_attrib_integer_64bit) GLEW_NV_vertex_attrib_integer_64bit = !_glewInit_GL_NV_vertex_attrib_integer_64bit(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_NV_vertex_attrib_integer_64bit) GLEW_NV_vertex_attrib_integer_64bit = !_glewInit_GL_NV_vertex_attrib_integer_64bit();
 #endif /* GL_NV_vertex_attrib_integer_64bit */
 #ifdef GL_NV_vertex_buffer_unified_memory
-  GLEW_NV_vertex_buffer_unified_memory = _glewSearchExtension("GL_NV_vertex_buffer_unified_memory", extStart, extEnd);
-  if (glewExperimental || GLEW_NV_vertex_buffer_unified_memory) GLEW_NV_vertex_buffer_unified_memory = !_glewInit_GL_NV_vertex_buffer_unified_memory(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_NV_vertex_buffer_unified_memory) GLEW_NV_vertex_buffer_unified_memory = !_glewInit_GL_NV_vertex_buffer_unified_memory();
 #endif /* GL_NV_vertex_buffer_unified_memory */
 #ifdef GL_NV_vertex_program
-  GLEW_NV_vertex_program = _glewSearchExtension("GL_NV_vertex_program", extStart, extEnd);
-  if (glewExperimental || GLEW_NV_vertex_program) GLEW_NV_vertex_program = !_glewInit_GL_NV_vertex_program(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_NV_vertex_program) GLEW_NV_vertex_program = !_glewInit_GL_NV_vertex_program();
 #endif /* GL_NV_vertex_program */
-#ifdef GL_NV_vertex_program1_1
-  GLEW_NV_vertex_program1_1 = _glewSearchExtension("GL_NV_vertex_program1_1", extStart, extEnd);
-#endif /* GL_NV_vertex_program1_1 */
-#ifdef GL_NV_vertex_program2
-  GLEW_NV_vertex_program2 = _glewSearchExtension("GL_NV_vertex_program2", extStart, extEnd);
-#endif /* GL_NV_vertex_program2 */
-#ifdef GL_NV_vertex_program2_option
-  GLEW_NV_vertex_program2_option = _glewSearchExtension("GL_NV_vertex_program2_option", extStart, extEnd);
-#endif /* GL_NV_vertex_program2_option */
-#ifdef GL_NV_vertex_program3
-  GLEW_NV_vertex_program3 = _glewSearchExtension("GL_NV_vertex_program3", extStart, extEnd);
-#endif /* GL_NV_vertex_program3 */
-#ifdef GL_NV_vertex_program4
-  GLEW_NV_vertex_program4 = _glewSearchExtension("GL_NV_gpu_program4", extStart, extEnd);
-#endif /* GL_NV_vertex_program4 */
 #ifdef GL_NV_video_capture
-  GLEW_NV_video_capture = _glewSearchExtension("GL_NV_video_capture", extStart, extEnd);
-  if (glewExperimental || GLEW_NV_video_capture) GLEW_NV_video_capture = !_glewInit_GL_NV_video_capture(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_NV_video_capture) GLEW_NV_video_capture = !_glewInit_GL_NV_video_capture();
 #endif /* GL_NV_video_capture */
-#ifdef GL_OES_byte_coordinates
-  GLEW_OES_byte_coordinates = _glewSearchExtension("GL_OES_byte_coordinates", extStart, extEnd);
-#endif /* GL_OES_byte_coordinates */
-#ifdef GL_OES_compressed_paletted_texture
-  GLEW_OES_compressed_paletted_texture = _glewSearchExtension("GL_OES_compressed_paletted_texture", extStart, extEnd);
-#endif /* GL_OES_compressed_paletted_texture */
-#ifdef GL_OES_read_format
-  GLEW_OES_read_format = _glewSearchExtension("GL_OES_read_format", extStart, extEnd);
-#endif /* GL_OES_read_format */
-#ifdef GL_OES_single_precision
-  GLEW_OES_single_precision = _glewSearchExtension("GL_OES_single_precision", extStart, extEnd);
-  if (glewExperimental || GLEW_OES_single_precision) GLEW_OES_single_precision = !_glewInit_GL_OES_single_precision(GLEW_CONTEXT_ARG_VAR_INIT);
-#endif /* GL_OES_single_precision */
-#ifdef GL_OML_interlace
-  GLEW_OML_interlace = _glewSearchExtension("GL_OML_interlace", extStart, extEnd);
-#endif /* GL_OML_interlace */
-#ifdef GL_OML_resample
-  GLEW_OML_resample = _glewSearchExtension("GL_OML_resample", extStart, extEnd);
-#endif /* GL_OML_resample */
-#ifdef GL_OML_subsample
-  GLEW_OML_subsample = _glewSearchExtension("GL_OML_subsample", extStart, extEnd);
-#endif /* GL_OML_subsample */
-#ifdef GL_PGI_misc_hints
-  GLEW_PGI_misc_hints = _glewSearchExtension("GL_PGI_misc_hints", extStart, extEnd);
-#endif /* GL_PGI_misc_hints */
-#ifdef GL_PGI_vertex_hints
-  GLEW_PGI_vertex_hints = _glewSearchExtension("GL_PGI_vertex_hints", extStart, extEnd);
-#endif /* GL_PGI_vertex_hints */
+#ifdef GL_NV_viewport_array
+  if (glewExperimental || GLEW_NV_viewport_array) GLEW_NV_viewport_array = !_glewInit_GL_NV_viewport_array();
+#endif /* GL_NV_viewport_array */
+#ifdef GL_NV_viewport_swizzle
+  if (glewExperimental || GLEW_NV_viewport_swizzle) GLEW_NV_viewport_swizzle = !_glewInit_GL_NV_viewport_swizzle();
+#endif /* GL_NV_viewport_swizzle */
+#ifdef GL_OVR_multiview
+  if (glewExperimental || GLEW_OVR_multiview) GLEW_OVR_multiview = !_glewInit_GL_OVR_multiview();
+#endif /* GL_OVR_multiview */
+#ifdef GL_OVR_multiview_multisampled_render_to_texture
+  if (glewExperimental || GLEW_OVR_multiview_multisampled_render_to_texture) GLEW_OVR_multiview_multisampled_render_to_texture = !_glewInit_GL_OVR_multiview_multisampled_render_to_texture();
+#endif /* GL_OVR_multiview_multisampled_render_to_texture */
+#ifdef GL_QCOM_alpha_test
+  if (glewExperimental || GLEW_QCOM_alpha_test) GLEW_QCOM_alpha_test = !_glewInit_GL_QCOM_alpha_test();
+#endif /* GL_QCOM_alpha_test */
+#ifdef GL_QCOM_driver_control
+  if (glewExperimental || GLEW_QCOM_driver_control) GLEW_QCOM_driver_control = !_glewInit_GL_QCOM_driver_control();
+#endif /* GL_QCOM_driver_control */
+#ifdef GL_QCOM_extended_get
+  if (glewExperimental || GLEW_QCOM_extended_get) GLEW_QCOM_extended_get = !_glewInit_GL_QCOM_extended_get();
+#endif /* GL_QCOM_extended_get */
+#ifdef GL_QCOM_extended_get2
+  if (glewExperimental || GLEW_QCOM_extended_get2) GLEW_QCOM_extended_get2 = !_glewInit_GL_QCOM_extended_get2();
+#endif /* GL_QCOM_extended_get2 */
+#ifdef GL_QCOM_framebuffer_foveated
+  if (glewExperimental || GLEW_QCOM_framebuffer_foveated) GLEW_QCOM_framebuffer_foveated = !_glewInit_GL_QCOM_framebuffer_foveated();
+#endif /* GL_QCOM_framebuffer_foveated */
+#ifdef GL_QCOM_shader_framebuffer_fetch_noncoherent
+  if (glewExperimental || GLEW_QCOM_shader_framebuffer_fetch_noncoherent) GLEW_QCOM_shader_framebuffer_fetch_noncoherent = !_glewInit_GL_QCOM_shader_framebuffer_fetch_noncoherent();
+#endif /* GL_QCOM_shader_framebuffer_fetch_noncoherent */
+#ifdef GL_QCOM_tiled_rendering
+  if (glewExperimental || GLEW_QCOM_tiled_rendering) GLEW_QCOM_tiled_rendering = !_glewInit_GL_QCOM_tiled_rendering();
+#endif /* GL_QCOM_tiled_rendering */
 #ifdef GL_REGAL_ES1_0_compatibility
-  GLEW_REGAL_ES1_0_compatibility = _glewSearchExtension("GL_REGAL_ES1_0_compatibility", extStart, extEnd);
-  if (glewExperimental || GLEW_REGAL_ES1_0_compatibility) GLEW_REGAL_ES1_0_compatibility = !_glewInit_GL_REGAL_ES1_0_compatibility(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_REGAL_ES1_0_compatibility) GLEW_REGAL_ES1_0_compatibility = !_glewInit_GL_REGAL_ES1_0_compatibility();
 #endif /* GL_REGAL_ES1_0_compatibility */
 #ifdef GL_REGAL_ES1_1_compatibility
-  GLEW_REGAL_ES1_1_compatibility = _glewSearchExtension("GL_REGAL_ES1_1_compatibility", extStart, extEnd);
-  if (glewExperimental || GLEW_REGAL_ES1_1_compatibility) GLEW_REGAL_ES1_1_compatibility = !_glewInit_GL_REGAL_ES1_1_compatibility(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_REGAL_ES1_1_compatibility) GLEW_REGAL_ES1_1_compatibility = !_glewInit_GL_REGAL_ES1_1_compatibility();
 #endif /* GL_REGAL_ES1_1_compatibility */
-#ifdef GL_REGAL_enable
-  GLEW_REGAL_enable = _glewSearchExtension("GL_REGAL_enable", extStart, extEnd);
-#endif /* GL_REGAL_enable */
 #ifdef GL_REGAL_error_string
-  GLEW_REGAL_error_string = _glewSearchExtension("GL_REGAL_error_string", extStart, extEnd);
-  if (glewExperimental || GLEW_REGAL_error_string) GLEW_REGAL_error_string = !_glewInit_GL_REGAL_error_string(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_REGAL_error_string) GLEW_REGAL_error_string = !_glewInit_GL_REGAL_error_string();
 #endif /* GL_REGAL_error_string */
 #ifdef GL_REGAL_extension_query
-  GLEW_REGAL_extension_query = _glewSearchExtension("GL_REGAL_extension_query", extStart, extEnd);
-  if (glewExperimental || GLEW_REGAL_extension_query) GLEW_REGAL_extension_query = !_glewInit_GL_REGAL_extension_query(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_REGAL_extension_query) GLEW_REGAL_extension_query = !_glewInit_GL_REGAL_extension_query();
 #endif /* GL_REGAL_extension_query */
 #ifdef GL_REGAL_log
-  GLEW_REGAL_log = _glewSearchExtension("GL_REGAL_log", extStart, extEnd);
-  if (glewExperimental || GLEW_REGAL_log) GLEW_REGAL_log = !_glewInit_GL_REGAL_log(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_REGAL_log) GLEW_REGAL_log = !_glewInit_GL_REGAL_log();
 #endif /* GL_REGAL_log */
 #ifdef GL_REGAL_proc_address
-  GLEW_REGAL_proc_address = _glewSearchExtension("GL_REGAL_proc_address", extStart, extEnd);
-  if (glewExperimental || GLEW_REGAL_proc_address) GLEW_REGAL_proc_address = !_glewInit_GL_REGAL_proc_address(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_REGAL_proc_address) GLEW_REGAL_proc_address = !_glewInit_GL_REGAL_proc_address();
 #endif /* GL_REGAL_proc_address */
-#ifdef GL_REND_screen_coordinates
-  GLEW_REND_screen_coordinates = _glewSearchExtension("GL_REND_screen_coordinates", extStart, extEnd);
-#endif /* GL_REND_screen_coordinates */
-#ifdef GL_S3_s3tc
-  GLEW_S3_s3tc = _glewSearchExtension("GL_S3_s3tc", extStart, extEnd);
-#endif /* GL_S3_s3tc */
-#ifdef GL_SGIS_color_range
-  GLEW_SGIS_color_range = _glewSearchExtension("GL_SGIS_color_range", extStart, extEnd);
-#endif /* GL_SGIS_color_range */
 #ifdef GL_SGIS_detail_texture
-  GLEW_SGIS_detail_texture = _glewSearchExtension("GL_SGIS_detail_texture", extStart, extEnd);
-  if (glewExperimental || GLEW_SGIS_detail_texture) GLEW_SGIS_detail_texture = !_glewInit_GL_SGIS_detail_texture(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_SGIS_detail_texture) GLEW_SGIS_detail_texture = !_glewInit_GL_SGIS_detail_texture();
 #endif /* GL_SGIS_detail_texture */
 #ifdef GL_SGIS_fog_function
-  GLEW_SGIS_fog_function = _glewSearchExtension("GL_SGIS_fog_function", extStart, extEnd);
-  if (glewExperimental || GLEW_SGIS_fog_function) GLEW_SGIS_fog_function = !_glewInit_GL_SGIS_fog_function(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_SGIS_fog_function) GLEW_SGIS_fog_function = !_glewInit_GL_SGIS_fog_function();
 #endif /* GL_SGIS_fog_function */
-#ifdef GL_SGIS_generate_mipmap
-  GLEW_SGIS_generate_mipmap = _glewSearchExtension("GL_SGIS_generate_mipmap", extStart, extEnd);
-#endif /* GL_SGIS_generate_mipmap */
 #ifdef GL_SGIS_multisample
-  GLEW_SGIS_multisample = _glewSearchExtension("GL_SGIS_multisample", extStart, extEnd);
-  if (glewExperimental || GLEW_SGIS_multisample) GLEW_SGIS_multisample = !_glewInit_GL_SGIS_multisample(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_SGIS_multisample) GLEW_SGIS_multisample = !_glewInit_GL_SGIS_multisample();
 #endif /* GL_SGIS_multisample */
-#ifdef GL_SGIS_pixel_texture
-  GLEW_SGIS_pixel_texture = _glewSearchExtension("GL_SGIS_pixel_texture", extStart, extEnd);
-#endif /* GL_SGIS_pixel_texture */
-#ifdef GL_SGIS_point_line_texgen
-  GLEW_SGIS_point_line_texgen = _glewSearchExtension("GL_SGIS_point_line_texgen", extStart, extEnd);
-#endif /* GL_SGIS_point_line_texgen */
+#ifdef GL_SGIS_multitexture
+  if (glewExperimental || GLEW_SGIS_multitexture) GLEW_SGIS_multitexture = !_glewInit_GL_SGIS_multitexture();
+#endif /* GL_SGIS_multitexture */
+#ifdef GL_SGIS_shared_multisample
+  if (glewExperimental || GLEW_SGIS_shared_multisample) GLEW_SGIS_shared_multisample = !_glewInit_GL_SGIS_shared_multisample();
+#endif /* GL_SGIS_shared_multisample */
 #ifdef GL_SGIS_sharpen_texture
-  GLEW_SGIS_sharpen_texture = _glewSearchExtension("GL_SGIS_sharpen_texture", extStart, extEnd);
-  if (glewExperimental || GLEW_SGIS_sharpen_texture) GLEW_SGIS_sharpen_texture = !_glewInit_GL_SGIS_sharpen_texture(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_SGIS_sharpen_texture) GLEW_SGIS_sharpen_texture = !_glewInit_GL_SGIS_sharpen_texture();
 #endif /* GL_SGIS_sharpen_texture */
 #ifdef GL_SGIS_texture4D
-  GLEW_SGIS_texture4D = _glewSearchExtension("GL_SGIS_texture4D", extStart, extEnd);
-  if (glewExperimental || GLEW_SGIS_texture4D) GLEW_SGIS_texture4D = !_glewInit_GL_SGIS_texture4D(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_SGIS_texture4D) GLEW_SGIS_texture4D = !_glewInit_GL_SGIS_texture4D();
 #endif /* GL_SGIS_texture4D */
-#ifdef GL_SGIS_texture_border_clamp
-  GLEW_SGIS_texture_border_clamp = _glewSearchExtension("GL_SGIS_texture_border_clamp", extStart, extEnd);
-#endif /* GL_SGIS_texture_border_clamp */
-#ifdef GL_SGIS_texture_edge_clamp
-  GLEW_SGIS_texture_edge_clamp = _glewSearchExtension("GL_SGIS_texture_edge_clamp", extStart, extEnd);
-#endif /* GL_SGIS_texture_edge_clamp */
 #ifdef GL_SGIS_texture_filter4
-  GLEW_SGIS_texture_filter4 = _glewSearchExtension("GL_SGIS_texture_filter4", extStart, extEnd);
-  if (glewExperimental || GLEW_SGIS_texture_filter4) GLEW_SGIS_texture_filter4 = !_glewInit_GL_SGIS_texture_filter4(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_SGIS_texture_filter4) GLEW_SGIS_texture_filter4 = !_glewInit_GL_SGIS_texture_filter4();
 #endif /* GL_SGIS_texture_filter4 */
-#ifdef GL_SGIS_texture_lod
-  GLEW_SGIS_texture_lod = _glewSearchExtension("GL_SGIS_texture_lod", extStart, extEnd);
-#endif /* GL_SGIS_texture_lod */
-#ifdef GL_SGIS_texture_select
-  GLEW_SGIS_texture_select = _glewSearchExtension("GL_SGIS_texture_select", extStart, extEnd);
-#endif /* GL_SGIS_texture_select */
 #ifdef GL_SGIX_async
-  GLEW_SGIX_async = _glewSearchExtension("GL_SGIX_async", extStart, extEnd);
-  if (glewExperimental || GLEW_SGIX_async) GLEW_SGIX_async = !_glewInit_GL_SGIX_async(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_SGIX_async) GLEW_SGIX_async = !_glewInit_GL_SGIX_async();
 #endif /* GL_SGIX_async */
-#ifdef GL_SGIX_async_histogram
-  GLEW_SGIX_async_histogram = _glewSearchExtension("GL_SGIX_async_histogram", extStart, extEnd);
-#endif /* GL_SGIX_async_histogram */
-#ifdef GL_SGIX_async_pixel
-  GLEW_SGIX_async_pixel = _glewSearchExtension("GL_SGIX_async_pixel", extStart, extEnd);
-#endif /* GL_SGIX_async_pixel */
-#ifdef GL_SGIX_blend_alpha_minmax
-  GLEW_SGIX_blend_alpha_minmax = _glewSearchExtension("GL_SGIX_blend_alpha_minmax", extStart, extEnd);
-#endif /* GL_SGIX_blend_alpha_minmax */
-#ifdef GL_SGIX_clipmap
-  GLEW_SGIX_clipmap = _glewSearchExtension("GL_SGIX_clipmap", extStart, extEnd);
-#endif /* GL_SGIX_clipmap */
-#ifdef GL_SGIX_convolution_accuracy
-  GLEW_SGIX_convolution_accuracy = _glewSearchExtension("GL_SGIX_convolution_accuracy", extStart, extEnd);
-#endif /* GL_SGIX_convolution_accuracy */
-#ifdef GL_SGIX_depth_texture
-  GLEW_SGIX_depth_texture = _glewSearchExtension("GL_SGIX_depth_texture", extStart, extEnd);
-#endif /* GL_SGIX_depth_texture */
+#ifdef GL_SGIX_datapipe
+  if (glewExperimental || GLEW_SGIX_datapipe) GLEW_SGIX_datapipe = !_glewInit_GL_SGIX_datapipe();
+#endif /* GL_SGIX_datapipe */
 #ifdef GL_SGIX_flush_raster
-  GLEW_SGIX_flush_raster = _glewSearchExtension("GL_SGIX_flush_raster", extStart, extEnd);
-  if (glewExperimental || GLEW_SGIX_flush_raster) GLEW_SGIX_flush_raster = !_glewInit_GL_SGIX_flush_raster(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_SGIX_flush_raster) GLEW_SGIX_flush_raster = !_glewInit_GL_SGIX_flush_raster();
 #endif /* GL_SGIX_flush_raster */
-#ifdef GL_SGIX_fog_offset
-  GLEW_SGIX_fog_offset = _glewSearchExtension("GL_SGIX_fog_offset", extStart, extEnd);
-#endif /* GL_SGIX_fog_offset */
+#ifdef GL_SGIX_fog_layers
+  if (glewExperimental || GLEW_SGIX_fog_layers) GLEW_SGIX_fog_layers = !_glewInit_GL_SGIX_fog_layers();
+#endif /* GL_SGIX_fog_layers */
 #ifdef GL_SGIX_fog_texture
-  GLEW_SGIX_fog_texture = _glewSearchExtension("GL_SGIX_fog_texture", extStart, extEnd);
-  if (glewExperimental || GLEW_SGIX_fog_texture) GLEW_SGIX_fog_texture = !_glewInit_GL_SGIX_fog_texture(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_SGIX_fog_texture) GLEW_SGIX_fog_texture = !_glewInit_GL_SGIX_fog_texture();
 #endif /* GL_SGIX_fog_texture */
 #ifdef GL_SGIX_fragment_specular_lighting
-  GLEW_SGIX_fragment_specular_lighting = _glewSearchExtension("GL_SGIX_fragment_specular_lighting", extStart, extEnd);
-  if (glewExperimental || GLEW_SGIX_fragment_specular_lighting) GLEW_SGIX_fragment_specular_lighting = !_glewInit_GL_SGIX_fragment_specular_lighting(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_SGIX_fragment_specular_lighting) GLEW_SGIX_fragment_specular_lighting = !_glewInit_GL_SGIX_fragment_specular_lighting();
 #endif /* GL_SGIX_fragment_specular_lighting */
 #ifdef GL_SGIX_framezoom
-  GLEW_SGIX_framezoom = _glewSearchExtension("GL_SGIX_framezoom", extStart, extEnd);
-  if (glewExperimental || GLEW_SGIX_framezoom) GLEW_SGIX_framezoom = !_glewInit_GL_SGIX_framezoom(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_SGIX_framezoom) GLEW_SGIX_framezoom = !_glewInit_GL_SGIX_framezoom();
 #endif /* GL_SGIX_framezoom */
-#ifdef GL_SGIX_interlace
-  GLEW_SGIX_interlace = _glewSearchExtension("GL_SGIX_interlace", extStart, extEnd);
-#endif /* GL_SGIX_interlace */
-#ifdef GL_SGIX_ir_instrument1
-  GLEW_SGIX_ir_instrument1 = _glewSearchExtension("GL_SGIX_ir_instrument1", extStart, extEnd);
-#endif /* GL_SGIX_ir_instrument1 */
-#ifdef GL_SGIX_list_priority
-  GLEW_SGIX_list_priority = _glewSearchExtension("GL_SGIX_list_priority", extStart, extEnd);
-#endif /* GL_SGIX_list_priority */
+#ifdef GL_SGIX_igloo_interface
+  if (glewExperimental || GLEW_SGIX_igloo_interface) GLEW_SGIX_igloo_interface = !_glewInit_GL_SGIX_igloo_interface();
+#endif /* GL_SGIX_igloo_interface */
+#ifdef GL_SGIX_mpeg1
+  if (glewExperimental || GLEW_SGIX_mpeg1) GLEW_SGIX_mpeg1 = !_glewInit_GL_SGIX_mpeg1();
+#endif /* GL_SGIX_mpeg1 */
+#ifdef GL_SGIX_nonlinear_lighting_pervertex
+  if (glewExperimental || GLEW_SGIX_nonlinear_lighting_pervertex) GLEW_SGIX_nonlinear_lighting_pervertex = !_glewInit_GL_SGIX_nonlinear_lighting_pervertex();
+#endif /* GL_SGIX_nonlinear_lighting_pervertex */
 #ifdef GL_SGIX_pixel_texture
-  GLEW_SGIX_pixel_texture = _glewSearchExtension("GL_SGIX_pixel_texture", extStart, extEnd);
-  if (glewExperimental || GLEW_SGIX_pixel_texture) GLEW_SGIX_pixel_texture = !_glewInit_GL_SGIX_pixel_texture(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_SGIX_pixel_texture) GLEW_SGIX_pixel_texture = !_glewInit_GL_SGIX_pixel_texture();
 #endif /* GL_SGIX_pixel_texture */
-#ifdef GL_SGIX_pixel_texture_bits
-  GLEW_SGIX_pixel_texture_bits = _glewSearchExtension("GL_SGIX_pixel_texture_bits", extStart, extEnd);
-#endif /* GL_SGIX_pixel_texture_bits */
+#ifdef GL_SGIX_polynomial_ffd
+  if (glewExperimental || GLEW_SGIX_polynomial_ffd) GLEW_SGIX_polynomial_ffd = !_glewInit_GL_SGIX_polynomial_ffd();
+#endif /* GL_SGIX_polynomial_ffd */
+#ifdef GL_SGIX_quad_mesh
+  if (glewExperimental || GLEW_SGIX_quad_mesh) GLEW_SGIX_quad_mesh = !_glewInit_GL_SGIX_quad_mesh();
+#endif /* GL_SGIX_quad_mesh */
 #ifdef GL_SGIX_reference_plane
-  GLEW_SGIX_reference_plane = _glewSearchExtension("GL_SGIX_reference_plane", extStart, extEnd);
-  if (glewExperimental || GLEW_SGIX_reference_plane) GLEW_SGIX_reference_plane = !_glewInit_GL_SGIX_reference_plane(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_SGIX_reference_plane) GLEW_SGIX_reference_plane = !_glewInit_GL_SGIX_reference_plane();
 #endif /* GL_SGIX_reference_plane */
-#ifdef GL_SGIX_resample
-  GLEW_SGIX_resample = _glewSearchExtension("GL_SGIX_resample", extStart, extEnd);
-#endif /* GL_SGIX_resample */
-#ifdef GL_SGIX_shadow
-  GLEW_SGIX_shadow = _glewSearchExtension("GL_SGIX_shadow", extStart, extEnd);
-#endif /* GL_SGIX_shadow */
-#ifdef GL_SGIX_shadow_ambient
-  GLEW_SGIX_shadow_ambient = _glewSearchExtension("GL_SGIX_shadow_ambient", extStart, extEnd);
-#endif /* GL_SGIX_shadow_ambient */
 #ifdef GL_SGIX_sprite
-  GLEW_SGIX_sprite = _glewSearchExtension("GL_SGIX_sprite", extStart, extEnd);
-  if (glewExperimental || GLEW_SGIX_sprite) GLEW_SGIX_sprite = !_glewInit_GL_SGIX_sprite(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_SGIX_sprite) GLEW_SGIX_sprite = !_glewInit_GL_SGIX_sprite();
 #endif /* GL_SGIX_sprite */
 #ifdef GL_SGIX_tag_sample_buffer
-  GLEW_SGIX_tag_sample_buffer = _glewSearchExtension("GL_SGIX_tag_sample_buffer", extStart, extEnd);
-  if (glewExperimental || GLEW_SGIX_tag_sample_buffer) GLEW_SGIX_tag_sample_buffer = !_glewInit_GL_SGIX_tag_sample_buffer(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_SGIX_tag_sample_buffer) GLEW_SGIX_tag_sample_buffer = !_glewInit_GL_SGIX_tag_sample_buffer();
 #endif /* GL_SGIX_tag_sample_buffer */
-#ifdef GL_SGIX_texture_add_env
-  GLEW_SGIX_texture_add_env = _glewSearchExtension("GL_SGIX_texture_add_env", extStart, extEnd);
-#endif /* GL_SGIX_texture_add_env */
-#ifdef GL_SGIX_texture_coordinate_clamp
-  GLEW_SGIX_texture_coordinate_clamp = _glewSearchExtension("GL_SGIX_texture_coordinate_clamp", extStart, extEnd);
-#endif /* GL_SGIX_texture_coordinate_clamp */
-#ifdef GL_SGIX_texture_lod_bias
-  GLEW_SGIX_texture_lod_bias = _glewSearchExtension("GL_SGIX_texture_lod_bias", extStart, extEnd);
-#endif /* GL_SGIX_texture_lod_bias */
-#ifdef GL_SGIX_texture_multi_buffer
-  GLEW_SGIX_texture_multi_buffer = _glewSearchExtension("GL_SGIX_texture_multi_buffer", extStart, extEnd);
-#endif /* GL_SGIX_texture_multi_buffer */
-#ifdef GL_SGIX_texture_range
-  GLEW_SGIX_texture_range = _glewSearchExtension("GL_SGIX_texture_range", extStart, extEnd);
-#endif /* GL_SGIX_texture_range */
-#ifdef GL_SGIX_texture_scale_bias
-  GLEW_SGIX_texture_scale_bias = _glewSearchExtension("GL_SGIX_texture_scale_bias", extStart, extEnd);
-#endif /* GL_SGIX_texture_scale_bias */
-#ifdef GL_SGIX_vertex_preclip
-  GLEW_SGIX_vertex_preclip = _glewSearchExtension("GL_SGIX_vertex_preclip", extStart, extEnd);
-#endif /* GL_SGIX_vertex_preclip */
-#ifdef GL_SGIX_vertex_preclip_hint
-  GLEW_SGIX_vertex_preclip_hint = _glewSearchExtension("GL_SGIX_vertex_preclip_hint", extStart, extEnd);
-#endif /* GL_SGIX_vertex_preclip_hint */
-#ifdef GL_SGIX_ycrcb
-  GLEW_SGIX_ycrcb = _glewSearchExtension("GL_SGIX_ycrcb", extStart, extEnd);
-#endif /* GL_SGIX_ycrcb */
-#ifdef GL_SGI_color_matrix
-  GLEW_SGI_color_matrix = _glewSearchExtension("GL_SGI_color_matrix", extStart, extEnd);
-#endif /* GL_SGI_color_matrix */
+#ifdef GL_SGIX_vector_ops
+  if (glewExperimental || GLEW_SGIX_vector_ops) GLEW_SGIX_vector_ops = !_glewInit_GL_SGIX_vector_ops();
+#endif /* GL_SGIX_vector_ops */
+#ifdef GL_SGIX_vertex_array_object
+  if (glewExperimental || GLEW_SGIX_vertex_array_object) GLEW_SGIX_vertex_array_object = !_glewInit_GL_SGIX_vertex_array_object();
+#endif /* GL_SGIX_vertex_array_object */
 #ifdef GL_SGI_color_table
-  GLEW_SGI_color_table = _glewSearchExtension("GL_SGI_color_table", extStart, extEnd);
-  if (glewExperimental || GLEW_SGI_color_table) GLEW_SGI_color_table = !_glewInit_GL_SGI_color_table(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_SGI_color_table) GLEW_SGI_color_table = !_glewInit_GL_SGI_color_table();
 #endif /* GL_SGI_color_table */
-#ifdef GL_SGI_texture_color_table
-  GLEW_SGI_texture_color_table = _glewSearchExtension("GL_SGI_texture_color_table", extStart, extEnd);
-#endif /* GL_SGI_texture_color_table */
+#ifdef GL_SGI_fft
+  if (glewExperimental || GLEW_SGI_fft) GLEW_SGI_fft = !_glewInit_GL_SGI_fft();
+#endif /* GL_SGI_fft */
 #ifdef GL_SUNX_constant_data
-  GLEW_SUNX_constant_data = _glewSearchExtension("GL_SUNX_constant_data", extStart, extEnd);
-  if (glewExperimental || GLEW_SUNX_constant_data) GLEW_SUNX_constant_data = !_glewInit_GL_SUNX_constant_data(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_SUNX_constant_data) GLEW_SUNX_constant_data = !_glewInit_GL_SUNX_constant_data();
 #endif /* GL_SUNX_constant_data */
-#ifdef GL_SUN_convolution_border_modes
-  GLEW_SUN_convolution_border_modes = _glewSearchExtension("GL_SUN_convolution_border_modes", extStart, extEnd);
-#endif /* GL_SUN_convolution_border_modes */
 #ifdef GL_SUN_global_alpha
-  GLEW_SUN_global_alpha = _glewSearchExtension("GL_SUN_global_alpha", extStart, extEnd);
-  if (glewExperimental || GLEW_SUN_global_alpha) GLEW_SUN_global_alpha = !_glewInit_GL_SUN_global_alpha(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_SUN_global_alpha) GLEW_SUN_global_alpha = !_glewInit_GL_SUN_global_alpha();
 #endif /* GL_SUN_global_alpha */
-#ifdef GL_SUN_mesh_array
-  GLEW_SUN_mesh_array = _glewSearchExtension("GL_SUN_mesh_array", extStart, extEnd);
-#endif /* GL_SUN_mesh_array */
 #ifdef GL_SUN_read_video_pixels
-  GLEW_SUN_read_video_pixels = _glewSearchExtension("GL_SUN_read_video_pixels", extStart, extEnd);
-  if (glewExperimental || GLEW_SUN_read_video_pixels) GLEW_SUN_read_video_pixels = !_glewInit_GL_SUN_read_video_pixels(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_SUN_read_video_pixels) GLEW_SUN_read_video_pixels = !_glewInit_GL_SUN_read_video_pixels();
 #endif /* GL_SUN_read_video_pixels */
-#ifdef GL_SUN_slice_accum
-  GLEW_SUN_slice_accum = _glewSearchExtension("GL_SUN_slice_accum", extStart, extEnd);
-#endif /* GL_SUN_slice_accum */
 #ifdef GL_SUN_triangle_list
-  GLEW_SUN_triangle_list = _glewSearchExtension("GL_SUN_triangle_list", extStart, extEnd);
-  if (glewExperimental || GLEW_SUN_triangle_list) GLEW_SUN_triangle_list = !_glewInit_GL_SUN_triangle_list(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_SUN_triangle_list) GLEW_SUN_triangle_list = !_glewInit_GL_SUN_triangle_list();
 #endif /* GL_SUN_triangle_list */
 #ifdef GL_SUN_vertex
-  GLEW_SUN_vertex = _glewSearchExtension("GL_SUN_vertex", extStart, extEnd);
-  if (glewExperimental || GLEW_SUN_vertex) GLEW_SUN_vertex = !_glewInit_GL_SUN_vertex(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_SUN_vertex) GLEW_SUN_vertex = !_glewInit_GL_SUN_vertex();
 #endif /* GL_SUN_vertex */
-#ifdef GL_WIN_phong_shading
-  GLEW_WIN_phong_shading = _glewSearchExtension("GL_WIN_phong_shading", extStart, extEnd);
-#endif /* GL_WIN_phong_shading */
-#ifdef GL_WIN_specular_fog
-  GLEW_WIN_specular_fog = _glewSearchExtension("GL_WIN_specular_fog", extStart, extEnd);
-#endif /* GL_WIN_specular_fog */
 #ifdef GL_WIN_swap_hint
-  GLEW_WIN_swap_hint = _glewSearchExtension("GL_WIN_swap_hint", extStart, extEnd);
-  if (glewExperimental || GLEW_WIN_swap_hint) GLEW_WIN_swap_hint = !_glewInit_GL_WIN_swap_hint(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLEW_WIN_swap_hint) GLEW_WIN_swap_hint = !_glewInit_GL_WIN_swap_hint();
 #endif /* GL_WIN_swap_hint */
+#ifdef GL_NV_fragment_program4
+  GLEW_NV_fragment_program4 = GLEW_NV_gpu_program4;
+#endif /* GL_NV_fragment_program4 */
+#ifdef GL_NV_geometry_program4
+  GLEW_NV_geometry_program4 = GLEW_NV_gpu_program4;
+#endif /* GL_NV_geometry_program4 */
+#ifdef GL_NV_tessellation_program5
+  GLEW_NV_tessellation_program5 = GLEW_NV_gpu_program5;
+#endif /* GL_NV_tessellation_program5 */
+#ifdef GL_NV_vertex_program4
+  GLEW_NV_vertex_program4 = GLEW_NV_gpu_program4;
+#endif /* GL_NV_vertex_program4 */
 
   return GLEW_OK;
 }
 
 
-#if defined(_WIN32)
+#if defined(GLEW_OSMESA)
 
-#if !defined(GLEW_MX)
+#elif defined(GLEW_EGL)
+
+PFNEGLCHOOSECONFIGPROC __eglewChooseConfig = NULL;
+PFNEGLCOPYBUFFERSPROC __eglewCopyBuffers = NULL;
+PFNEGLCREATECONTEXTPROC __eglewCreateContext = NULL;
+PFNEGLCREATEPBUFFERSURFACEPROC __eglewCreatePbufferSurface = NULL;
+PFNEGLCREATEPIXMAPSURFACEPROC __eglewCreatePixmapSurface = NULL;
+PFNEGLCREATEWINDOWSURFACEPROC __eglewCreateWindowSurface = NULL;
+PFNEGLDESTROYCONTEXTPROC __eglewDestroyContext = NULL;
+PFNEGLDESTROYSURFACEPROC __eglewDestroySurface = NULL;
+PFNEGLGETCONFIGATTRIBPROC __eglewGetConfigAttrib = NULL;
+PFNEGLGETCONFIGSPROC __eglewGetConfigs = NULL;
+PFNEGLGETCURRENTDISPLAYPROC __eglewGetCurrentDisplay = NULL;
+PFNEGLGETCURRENTSURFACEPROC __eglewGetCurrentSurface = NULL;
+PFNEGLGETDISPLAYPROC __eglewGetDisplay = NULL;
+PFNEGLGETERRORPROC __eglewGetError = NULL;
+PFNEGLINITIALIZEPROC __eglewInitialize = NULL;
+PFNEGLMAKECURRENTPROC __eglewMakeCurrent = NULL;
+PFNEGLQUERYCONTEXTPROC __eglewQueryContext = NULL;
+PFNEGLQUERYSTRINGPROC __eglewQueryString = NULL;
+PFNEGLQUERYSURFACEPROC __eglewQuerySurface = NULL;
+PFNEGLSWAPBUFFERSPROC __eglewSwapBuffers = NULL;
+PFNEGLTERMINATEPROC __eglewTerminate = NULL;
+PFNEGLWAITGLPROC __eglewWaitGL = NULL;
+PFNEGLWAITNATIVEPROC __eglewWaitNative = NULL;
+
+PFNEGLBINDTEXIMAGEPROC __eglewBindTexImage = NULL;
+PFNEGLRELEASETEXIMAGEPROC __eglewReleaseTexImage = NULL;
+PFNEGLSURFACEATTRIBPROC __eglewSurfaceAttrib = NULL;
+PFNEGLSWAPINTERVALPROC __eglewSwapInterval = NULL;
+
+PFNEGLBINDAPIPROC __eglewBindAPI = NULL;
+PFNEGLCREATEPBUFFERFROMCLIENTBUFFERPROC __eglewCreatePbufferFromClientBuffer = NULL;
+PFNEGLQUERYAPIPROC __eglewQueryAPI = NULL;
+PFNEGLRELEASETHREADPROC __eglewReleaseThread = NULL;
+PFNEGLWAITCLIENTPROC __eglewWaitClient = NULL;
+
+PFNEGLGETCURRENTCONTEXTPROC __eglewGetCurrentContext = NULL;
+
+PFNEGLCLIENTWAITSYNCPROC __eglewClientWaitSync = NULL;
+PFNEGLCREATEIMAGEPROC __eglewCreateImage = NULL;
+PFNEGLCREATEPLATFORMPIXMAPSURFACEPROC __eglewCreatePlatformPixmapSurface = NULL;
+PFNEGLCREATEPLATFORMWINDOWSURFACEPROC __eglewCreatePlatformWindowSurface = NULL;
+PFNEGLCREATESYNCPROC __eglewCreateSync = NULL;
+PFNEGLDESTROYIMAGEPROC __eglewDestroyImage = NULL;
+PFNEGLDESTROYSYNCPROC __eglewDestroySync = NULL;
+PFNEGLGETPLATFORMDISPLAYPROC __eglewGetPlatformDisplay = NULL;
+PFNEGLGETSYNCATTRIBPROC __eglewGetSyncAttrib = NULL;
+PFNEGLWAITSYNCPROC __eglewWaitSync = NULL;
+
+PFNEGLSETBLOBCACHEFUNCSANDROIDPROC __eglewSetBlobCacheFuncsANDROID = NULL;
+
+PFNEGLCREATENATIVECLIENTBUFFERANDROIDPROC __eglewCreateNativeClientBufferANDROID = NULL;
+
+PFNEGLDUPNATIVEFENCEFDANDROIDPROC __eglewDupNativeFenceFDANDROID = NULL;
+
+PFNEGLPRESENTATIONTIMEANDROIDPROC __eglewPresentationTimeANDROID = NULL;
+
+PFNEGLQUERYSURFACEPOINTERANGLEPROC __eglewQuerySurfacePointerANGLE = NULL;
+
+PFNEGLQUERYDEVICESEXTPROC __eglewQueryDevicesEXT = NULL;
+
+PFNEGLQUERYDEVICEATTRIBEXTPROC __eglewQueryDeviceAttribEXT = NULL;
+PFNEGLQUERYDEVICESTRINGEXTPROC __eglewQueryDeviceStringEXT = NULL;
+PFNEGLQUERYDISPLAYATTRIBEXTPROC __eglewQueryDisplayAttribEXT = NULL;
+
+PFNEGLQUERYDMABUFFORMATSEXTPROC __eglewQueryDmaBufFormatsEXT = NULL;
+PFNEGLQUERYDMABUFMODIFIERSEXTPROC __eglewQueryDmaBufModifiersEXT = NULL;
+
+PFNEGLGETOUTPUTLAYERSEXTPROC __eglewGetOutputLayersEXT = NULL;
+PFNEGLGETOUTPUTPORTSEXTPROC __eglewGetOutputPortsEXT = NULL;
+PFNEGLOUTPUTLAYERATTRIBEXTPROC __eglewOutputLayerAttribEXT = NULL;
+PFNEGLOUTPUTPORTATTRIBEXTPROC __eglewOutputPortAttribEXT = NULL;
+PFNEGLQUERYOUTPUTLAYERATTRIBEXTPROC __eglewQueryOutputLayerAttribEXT = NULL;
+PFNEGLQUERYOUTPUTLAYERSTRINGEXTPROC __eglewQueryOutputLayerStringEXT = NULL;
+PFNEGLQUERYOUTPUTPORTATTRIBEXTPROC __eglewQueryOutputPortAttribEXT = NULL;
+PFNEGLQUERYOUTPUTPORTSTRINGEXTPROC __eglewQueryOutputPortStringEXT = NULL;
+
+PFNEGLCREATEPLATFORMPIXMAPSURFACEEXTPROC __eglewCreatePlatformPixmapSurfaceEXT = NULL;
+PFNEGLCREATEPLATFORMWINDOWSURFACEEXTPROC __eglewCreatePlatformWindowSurfaceEXT = NULL;
+PFNEGLGETPLATFORMDISPLAYEXTPROC __eglewGetPlatformDisplayEXT = NULL;
+
+PFNEGLSTREAMCONSUMEROUTPUTEXTPROC __eglewStreamConsumerOutputEXT = NULL;
+
+PFNEGLSWAPBUFFERSWITHDAMAGEEXTPROC __eglewSwapBuffersWithDamageEXT = NULL;
+
+PFNEGLCREATEPIXMAPSURFACEHIPROC __eglewCreatePixmapSurfaceHI = NULL;
+
+PFNEGLCREATESYNC64KHRPROC __eglewCreateSync64KHR = NULL;
+
+PFNEGLDEBUGMESSAGECONTROLKHRPROC __eglewDebugMessageControlKHR = NULL;
+PFNEGLLABELOBJECTKHRPROC __eglewLabelObjectKHR = NULL;
+PFNEGLQUERYDEBUGKHRPROC __eglewQueryDebugKHR = NULL;
+
+PFNEGLCREATEIMAGEKHRPROC __eglewCreateImageKHR = NULL;
+PFNEGLDESTROYIMAGEKHRPROC __eglewDestroyImageKHR = NULL;
+
+PFNEGLLOCKSURFACEKHRPROC __eglewLockSurfaceKHR = NULL;
+PFNEGLUNLOCKSURFACEKHRPROC __eglewUnlockSurfaceKHR = NULL;
+
+PFNEGLQUERYSURFACE64KHRPROC __eglewQuerySurface64KHR = NULL;
+
+PFNEGLSETDAMAGEREGIONKHRPROC __eglewSetDamageRegionKHR = NULL;
+
+PFNEGLCLIENTWAITSYNCKHRPROC __eglewClientWaitSyncKHR = NULL;
+PFNEGLCREATESYNCKHRPROC __eglewCreateSyncKHR = NULL;
+PFNEGLDESTROYSYNCKHRPROC __eglewDestroySyncKHR = NULL;
+PFNEGLGETSYNCATTRIBKHRPROC __eglewGetSyncAttribKHR = NULL;
+PFNEGLSIGNALSYNCKHRPROC __eglewSignalSyncKHR = NULL;
+
+PFNEGLCREATESTREAMKHRPROC __eglewCreateStreamKHR = NULL;
+PFNEGLDESTROYSTREAMKHRPROC __eglewDestroyStreamKHR = NULL;
+PFNEGLQUERYSTREAMKHRPROC __eglewQueryStreamKHR = NULL;
+PFNEGLQUERYSTREAMU64KHRPROC __eglewQueryStreamu64KHR = NULL;
+PFNEGLSTREAMATTRIBKHRPROC __eglewStreamAttribKHR = NULL;
+
+PFNEGLCREATESTREAMATTRIBKHRPROC __eglewCreateStreamAttribKHR = NULL;
+PFNEGLQUERYSTREAMATTRIBKHRPROC __eglewQueryStreamAttribKHR = NULL;
+PFNEGLSETSTREAMATTRIBKHRPROC __eglewSetStreamAttribKHR = NULL;
+PFNEGLSTREAMCONSUMERACQUIREATTRIBKHRPROC __eglewStreamConsumerAcquireAttribKHR = NULL;
+PFNEGLSTREAMCONSUMERRELEASEATTRIBKHRPROC __eglewStreamConsumerReleaseAttribKHR = NULL;
+
+PFNEGLSTREAMCONSUMERACQUIREKHRPROC __eglewStreamConsumerAcquireKHR = NULL;
+PFNEGLSTREAMCONSUMERGLTEXTUREEXTERNALKHRPROC __eglewStreamConsumerGLTextureExternalKHR = NULL;
+PFNEGLSTREAMCONSUMERRELEASEKHRPROC __eglewStreamConsumerReleaseKHR = NULL;
+
+PFNEGLCREATESTREAMFROMFILEDESCRIPTORKHRPROC __eglewCreateStreamFromFileDescriptorKHR = NULL;
+PFNEGLGETSTREAMFILEDESCRIPTORKHRPROC __eglewGetStreamFileDescriptorKHR = NULL;
+
+PFNEGLQUERYSTREAMTIMEKHRPROC __eglewQueryStreamTimeKHR = NULL;
+
+PFNEGLCREATESTREAMPRODUCERSURFACEKHRPROC __eglewCreateStreamProducerSurfaceKHR = NULL;
+
+PFNEGLSWAPBUFFERSWITHDAMAGEKHRPROC __eglewSwapBuffersWithDamageKHR = NULL;
+
+PFNEGLWAITSYNCKHRPROC __eglewWaitSyncKHR = NULL;
+
+PFNEGLCREATEDRMIMAGEMESAPROC __eglewCreateDRMImageMESA = NULL;
+PFNEGLEXPORTDRMIMAGEMESAPROC __eglewExportDRMImageMESA = NULL;
+
+PFNEGLEXPORTDMABUFIMAGEMESAPROC __eglewExportDMABUFImageMESA = NULL;
+PFNEGLEXPORTDMABUFIMAGEQUERYMESAPROC __eglewExportDMABUFImageQueryMESA = NULL;
+
+PFNEGLSWAPBUFFERSREGIONNOKPROC __eglewSwapBuffersRegionNOK = NULL;
+
+PFNEGLSWAPBUFFERSREGION2NOKPROC __eglewSwapBuffersRegion2NOK = NULL;
+
+PFNEGLQUERYNATIVEDISPLAYNVPROC __eglewQueryNativeDisplayNV = NULL;
+PFNEGLQUERYNATIVEPIXMAPNVPROC __eglewQueryNativePixmapNV = NULL;
+PFNEGLQUERYNATIVEWINDOWNVPROC __eglewQueryNativeWindowNV = NULL;
+
+PFNEGLPOSTSUBBUFFERNVPROC __eglewPostSubBufferNV = NULL;
+
+PFNEGLSTREAMCONSUMERGLTEXTUREEXTERNALATTRIBSNVPROC __eglewStreamConsumerGLTextureExternalAttribsNV = NULL;
+
+PFNEGLQUERYDISPLAYATTRIBNVPROC __eglewQueryDisplayAttribNV = NULL;
+PFNEGLQUERYSTREAMMETADATANVPROC __eglewQueryStreamMetadataNV = NULL;
+PFNEGLSETSTREAMMETADATANVPROC __eglewSetStreamMetadataNV = NULL;
+
+PFNEGLRESETSTREAMNVPROC __eglewResetStreamNV = NULL;
+
+PFNEGLCREATESTREAMSYNCNVPROC __eglewCreateStreamSyncNV = NULL;
+
+PFNEGLCLIENTWAITSYNCNVPROC __eglewClientWaitSyncNV = NULL;
+PFNEGLCREATEFENCESYNCNVPROC __eglewCreateFenceSyncNV = NULL;
+PFNEGLDESTROYSYNCNVPROC __eglewDestroySyncNV = NULL;
+PFNEGLFENCENVPROC __eglewFenceNV = NULL;
+PFNEGLGETSYNCATTRIBNVPROC __eglewGetSyncAttribNV = NULL;
+PFNEGLSIGNALSYNCNVPROC __eglewSignalSyncNV = NULL;
+
+PFNEGLGETSYSTEMTIMEFREQUENCYNVPROC __eglewGetSystemTimeFrequencyNV = NULL;
+PFNEGLGETSYSTEMTIMENVPROC __eglewGetSystemTimeNV = NULL;
+GLboolean __EGLEW_VERSION_1_0 = GL_FALSE;
+GLboolean __EGLEW_VERSION_1_1 = GL_FALSE;
+GLboolean __EGLEW_VERSION_1_2 = GL_FALSE;
+GLboolean __EGLEW_VERSION_1_3 = GL_FALSE;
+GLboolean __EGLEW_VERSION_1_4 = GL_FALSE;
+GLboolean __EGLEW_VERSION_1_5 = GL_FALSE;
+GLboolean __EGLEW_ANDROID_blob_cache = GL_FALSE;
+GLboolean __EGLEW_ANDROID_create_native_client_buffer = GL_FALSE;
+GLboolean __EGLEW_ANDROID_framebuffer_target = GL_FALSE;
+GLboolean __EGLEW_ANDROID_front_buffer_auto_refresh = GL_FALSE;
+GLboolean __EGLEW_ANDROID_image_native_buffer = GL_FALSE;
+GLboolean __EGLEW_ANDROID_native_fence_sync = GL_FALSE;
+GLboolean __EGLEW_ANDROID_presentation_time = GL_FALSE;
+GLboolean __EGLEW_ANDROID_recordable = GL_FALSE;
+GLboolean __EGLEW_ANGLE_d3d_share_handle_client_buffer = GL_FALSE;
+GLboolean __EGLEW_ANGLE_device_d3d = GL_FALSE;
+GLboolean __EGLEW_ANGLE_query_surface_pointer = GL_FALSE;
+GLboolean __EGLEW_ANGLE_surface_d3d_texture_2d_share_handle = GL_FALSE;
+GLboolean __EGLEW_ANGLE_window_fixed_size = GL_FALSE;
+GLboolean __EGLEW_ARM_implicit_external_sync = GL_FALSE;
+GLboolean __EGLEW_ARM_pixmap_multisample_discard = GL_FALSE;
+GLboolean __EGLEW_EXT_buffer_age = GL_FALSE;
+GLboolean __EGLEW_EXT_client_extensions = GL_FALSE;
+GLboolean __EGLEW_EXT_create_context_robustness = GL_FALSE;
+GLboolean __EGLEW_EXT_device_base = GL_FALSE;
+GLboolean __EGLEW_EXT_device_drm = GL_FALSE;
+GLboolean __EGLEW_EXT_device_enumeration = GL_FALSE;
+GLboolean __EGLEW_EXT_device_openwf = GL_FALSE;
+GLboolean __EGLEW_EXT_device_query = GL_FALSE;
+GLboolean __EGLEW_EXT_gl_colorspace_bt2020_linear = GL_FALSE;
+GLboolean __EGLEW_EXT_gl_colorspace_bt2020_pq = GL_FALSE;
+GLboolean __EGLEW_EXT_gl_colorspace_scrgb_linear = GL_FALSE;
+GLboolean __EGLEW_EXT_image_dma_buf_import = GL_FALSE;
+GLboolean __EGLEW_EXT_image_dma_buf_import_modifiers = GL_FALSE;
+GLboolean __EGLEW_EXT_multiview_window = GL_FALSE;
+GLboolean __EGLEW_EXT_output_base = GL_FALSE;
+GLboolean __EGLEW_EXT_output_drm = GL_FALSE;
+GLboolean __EGLEW_EXT_output_openwf = GL_FALSE;
+GLboolean __EGLEW_EXT_pixel_format_float = GL_FALSE;
+GLboolean __EGLEW_EXT_platform_base = GL_FALSE;
+GLboolean __EGLEW_EXT_platform_device = GL_FALSE;
+GLboolean __EGLEW_EXT_platform_wayland = GL_FALSE;
+GLboolean __EGLEW_EXT_platform_x11 = GL_FALSE;
+GLboolean __EGLEW_EXT_protected_content = GL_FALSE;
+GLboolean __EGLEW_EXT_protected_surface = GL_FALSE;
+GLboolean __EGLEW_EXT_stream_consumer_egloutput = GL_FALSE;
+GLboolean __EGLEW_EXT_surface_SMPTE2086_metadata = GL_FALSE;
+GLboolean __EGLEW_EXT_swap_buffers_with_damage = GL_FALSE;
+GLboolean __EGLEW_EXT_yuv_surface = GL_FALSE;
+GLboolean __EGLEW_HI_clientpixmap = GL_FALSE;
+GLboolean __EGLEW_HI_colorformats = GL_FALSE;
+GLboolean __EGLEW_IMG_context_priority = GL_FALSE;
+GLboolean __EGLEW_IMG_image_plane_attribs = GL_FALSE;
+GLboolean __EGLEW_KHR_cl_event = GL_FALSE;
+GLboolean __EGLEW_KHR_cl_event2 = GL_FALSE;
+GLboolean __EGLEW_KHR_client_get_all_proc_addresses = GL_FALSE;
+GLboolean __EGLEW_KHR_config_attribs = GL_FALSE;
+GLboolean __EGLEW_KHR_context_flush_control = GL_FALSE;
+GLboolean __EGLEW_KHR_create_context = GL_FALSE;
+GLboolean __EGLEW_KHR_create_context_no_error = GL_FALSE;
+GLboolean __EGLEW_KHR_debug = GL_FALSE;
+GLboolean __EGLEW_KHR_fence_sync = GL_FALSE;
+GLboolean __EGLEW_KHR_get_all_proc_addresses = GL_FALSE;
+GLboolean __EGLEW_KHR_gl_colorspace = GL_FALSE;
+GLboolean __EGLEW_KHR_gl_renderbuffer_image = GL_FALSE;
+GLboolean __EGLEW_KHR_gl_texture_2D_image = GL_FALSE;
+GLboolean __EGLEW_KHR_gl_texture_3D_image = GL_FALSE;
+GLboolean __EGLEW_KHR_gl_texture_cubemap_image = GL_FALSE;
+GLboolean __EGLEW_KHR_image = GL_FALSE;
+GLboolean __EGLEW_KHR_image_base = GL_FALSE;
+GLboolean __EGLEW_KHR_image_pixmap = GL_FALSE;
+GLboolean __EGLEW_KHR_lock_surface = GL_FALSE;
+GLboolean __EGLEW_KHR_lock_surface2 = GL_FALSE;
+GLboolean __EGLEW_KHR_lock_surface3 = GL_FALSE;
+GLboolean __EGLEW_KHR_mutable_render_buffer = GL_FALSE;
+GLboolean __EGLEW_KHR_no_config_context = GL_FALSE;
+GLboolean __EGLEW_KHR_partial_update = GL_FALSE;
+GLboolean __EGLEW_KHR_platform_android = GL_FALSE;
+GLboolean __EGLEW_KHR_platform_gbm = GL_FALSE;
+GLboolean __EGLEW_KHR_platform_wayland = GL_FALSE;
+GLboolean __EGLEW_KHR_platform_x11 = GL_FALSE;
+GLboolean __EGLEW_KHR_reusable_sync = GL_FALSE;
+GLboolean __EGLEW_KHR_stream = GL_FALSE;
+GLboolean __EGLEW_KHR_stream_attrib = GL_FALSE;
+GLboolean __EGLEW_KHR_stream_consumer_gltexture = GL_FALSE;
+GLboolean __EGLEW_KHR_stream_cross_process_fd = GL_FALSE;
+GLboolean __EGLEW_KHR_stream_fifo = GL_FALSE;
+GLboolean __EGLEW_KHR_stream_producer_aldatalocator = GL_FALSE;
+GLboolean __EGLEW_KHR_stream_producer_eglsurface = GL_FALSE;
+GLboolean __EGLEW_KHR_surfaceless_context = GL_FALSE;
+GLboolean __EGLEW_KHR_swap_buffers_with_damage = GL_FALSE;
+GLboolean __EGLEW_KHR_vg_parent_image = GL_FALSE;
+GLboolean __EGLEW_KHR_wait_sync = GL_FALSE;
+GLboolean __EGLEW_MESA_drm_image = GL_FALSE;
+GLboolean __EGLEW_MESA_image_dma_buf_export = GL_FALSE;
+GLboolean __EGLEW_MESA_platform_gbm = GL_FALSE;
+GLboolean __EGLEW_MESA_platform_surfaceless = GL_FALSE;
+GLboolean __EGLEW_NOK_swap_region = GL_FALSE;
+GLboolean __EGLEW_NOK_swap_region2 = GL_FALSE;
+GLboolean __EGLEW_NOK_texture_from_pixmap = GL_FALSE;
+GLboolean __EGLEW_NV_3dvision_surface = GL_FALSE;
+GLboolean __EGLEW_NV_coverage_sample = GL_FALSE;
+GLboolean __EGLEW_NV_coverage_sample_resolve = GL_FALSE;
+GLboolean __EGLEW_NV_cuda_event = GL_FALSE;
+GLboolean __EGLEW_NV_depth_nonlinear = GL_FALSE;
+GLboolean __EGLEW_NV_device_cuda = GL_FALSE;
+GLboolean __EGLEW_NV_native_query = GL_FALSE;
+GLboolean __EGLEW_NV_post_convert_rounding = GL_FALSE;
+GLboolean __EGLEW_NV_post_sub_buffer = GL_FALSE;
+GLboolean __EGLEW_NV_robustness_video_memory_purge = GL_FALSE;
+GLboolean __EGLEW_NV_stream_consumer_gltexture_yuv = GL_FALSE;
+GLboolean __EGLEW_NV_stream_cross_display = GL_FALSE;
+GLboolean __EGLEW_NV_stream_cross_object = GL_FALSE;
+GLboolean __EGLEW_NV_stream_cross_partition = GL_FALSE;
+GLboolean __EGLEW_NV_stream_cross_process = GL_FALSE;
+GLboolean __EGLEW_NV_stream_cross_system = GL_FALSE;
+GLboolean __EGLEW_NV_stream_fifo_next = GL_FALSE;
+GLboolean __EGLEW_NV_stream_fifo_synchronous = GL_FALSE;
+GLboolean __EGLEW_NV_stream_frame_limits = GL_FALSE;
+GLboolean __EGLEW_NV_stream_metadata = GL_FALSE;
+GLboolean __EGLEW_NV_stream_remote = GL_FALSE;
+GLboolean __EGLEW_NV_stream_reset = GL_FALSE;
+GLboolean __EGLEW_NV_stream_socket = GL_FALSE;
+GLboolean __EGLEW_NV_stream_socket_inet = GL_FALSE;
+GLboolean __EGLEW_NV_stream_socket_unix = GL_FALSE;
+GLboolean __EGLEW_NV_stream_sync = GL_FALSE;
+GLboolean __EGLEW_NV_sync = GL_FALSE;
+GLboolean __EGLEW_NV_system_time = GL_FALSE;
+GLboolean __EGLEW_TIZEN_image_native_buffer = GL_FALSE;
+GLboolean __EGLEW_TIZEN_image_native_surface = GL_FALSE;
+#ifdef EGL_VERSION_1_0
+
+static GLboolean _glewInit_EGL_VERSION_1_0 ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((eglChooseConfig = (PFNEGLCHOOSECONFIGPROC)glewGetProcAddress((const GLubyte*)"eglChooseConfig")) == NULL) || r;
+  r = ((eglCopyBuffers = (PFNEGLCOPYBUFFERSPROC)glewGetProcAddress((const GLubyte*)"eglCopyBuffers")) == NULL) || r;
+  r = ((eglCreateContext = (PFNEGLCREATECONTEXTPROC)glewGetProcAddress((const GLubyte*)"eglCreateContext")) == NULL) || r;
+  r = ((eglCreatePbufferSurface = (PFNEGLCREATEPBUFFERSURFACEPROC)glewGetProcAddress((const GLubyte*)"eglCreatePbufferSurface")) == NULL) || r;
+  r = ((eglCreatePixmapSurface = (PFNEGLCREATEPIXMAPSURFACEPROC)glewGetProcAddress((const GLubyte*)"eglCreatePixmapSurface")) == NULL) || r;
+  r = ((eglCreateWindowSurface = (PFNEGLCREATEWINDOWSURFACEPROC)glewGetProcAddress((const GLubyte*)"eglCreateWindowSurface")) == NULL) || r;
+  r = ((eglDestroyContext = (PFNEGLDESTROYCONTEXTPROC)glewGetProcAddress((const GLubyte*)"eglDestroyContext")) == NULL) || r;
+  r = ((eglDestroySurface = (PFNEGLDESTROYSURFACEPROC)glewGetProcAddress((const GLubyte*)"eglDestroySurface")) == NULL) || r;
+  r = ((eglGetConfigAttrib = (PFNEGLGETCONFIGATTRIBPROC)glewGetProcAddress((const GLubyte*)"eglGetConfigAttrib")) == NULL) || r;
+  r = ((eglGetConfigs = (PFNEGLGETCONFIGSPROC)glewGetProcAddress((const GLubyte*)"eglGetConfigs")) == NULL) || r;
+  r = ((eglGetCurrentDisplay = (PFNEGLGETCURRENTDISPLAYPROC)glewGetProcAddress((const GLubyte*)"eglGetCurrentDisplay")) == NULL) || r;
+  r = ((eglGetCurrentSurface = (PFNEGLGETCURRENTSURFACEPROC)glewGetProcAddress((const GLubyte*)"eglGetCurrentSurface")) == NULL) || r;
+  r = ((eglGetDisplay = (PFNEGLGETDISPLAYPROC)glewGetProcAddress((const GLubyte*)"eglGetDisplay")) == NULL) || r;
+  r = ((eglGetError = (PFNEGLGETERRORPROC)glewGetProcAddress((const GLubyte*)"eglGetError")) == NULL) || r;
+  r = ((eglInitialize = (PFNEGLINITIALIZEPROC)glewGetProcAddress((const GLubyte*)"eglInitialize")) == NULL) || r;
+  r = ((eglMakeCurrent = (PFNEGLMAKECURRENTPROC)glewGetProcAddress((const GLubyte*)"eglMakeCurrent")) == NULL) || r;
+  r = ((eglQueryContext = (PFNEGLQUERYCONTEXTPROC)glewGetProcAddress((const GLubyte*)"eglQueryContext")) == NULL) || r;
+  r = ((eglQueryString = (PFNEGLQUERYSTRINGPROC)glewGetProcAddress((const GLubyte*)"eglQueryString")) == NULL) || r;
+  r = ((eglQuerySurface = (PFNEGLQUERYSURFACEPROC)glewGetProcAddress((const GLubyte*)"eglQuerySurface")) == NULL) || r;
+  r = ((eglSwapBuffers = (PFNEGLSWAPBUFFERSPROC)glewGetProcAddress((const GLubyte*)"eglSwapBuffers")) == NULL) || r;
+  r = ((eglTerminate = (PFNEGLTERMINATEPROC)glewGetProcAddress((const GLubyte*)"eglTerminate")) == NULL) || r;
+  r = ((eglWaitGL = (PFNEGLWAITGLPROC)glewGetProcAddress((const GLubyte*)"eglWaitGL")) == NULL) || r;
+  r = ((eglWaitNative = (PFNEGLWAITNATIVEPROC)glewGetProcAddress((const GLubyte*)"eglWaitNative")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* EGL_VERSION_1_0 */
+
+#ifdef EGL_VERSION_1_1
+
+static GLboolean _glewInit_EGL_VERSION_1_1 ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((eglBindTexImage = (PFNEGLBINDTEXIMAGEPROC)glewGetProcAddress((const GLubyte*)"eglBindTexImage")) == NULL) || r;
+  r = ((eglReleaseTexImage = (PFNEGLRELEASETEXIMAGEPROC)glewGetProcAddress((const GLubyte*)"eglReleaseTexImage")) == NULL) || r;
+  r = ((eglSurfaceAttrib = (PFNEGLSURFACEATTRIBPROC)glewGetProcAddress((const GLubyte*)"eglSurfaceAttrib")) == NULL) || r;
+  r = ((eglSwapInterval = (PFNEGLSWAPINTERVALPROC)glewGetProcAddress((const GLubyte*)"eglSwapInterval")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* EGL_VERSION_1_1 */
+
+#ifdef EGL_VERSION_1_2
+
+static GLboolean _glewInit_EGL_VERSION_1_2 ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((eglBindAPI = (PFNEGLBINDAPIPROC)glewGetProcAddress((const GLubyte*)"eglBindAPI")) == NULL) || r;
+  r = ((eglCreatePbufferFromClientBuffer = (PFNEGLCREATEPBUFFERFROMCLIENTBUFFERPROC)glewGetProcAddress((const GLubyte*)"eglCreatePbufferFromClientBuffer")) == NULL) || r;
+  r = ((eglQueryAPI = (PFNEGLQUERYAPIPROC)glewGetProcAddress((const GLubyte*)"eglQueryAPI")) == NULL) || r;
+  r = ((eglReleaseThread = (PFNEGLRELEASETHREADPROC)glewGetProcAddress((const GLubyte*)"eglReleaseThread")) == NULL) || r;
+  r = ((eglWaitClient = (PFNEGLWAITCLIENTPROC)glewGetProcAddress((const GLubyte*)"eglWaitClient")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* EGL_VERSION_1_2 */
+
+#ifdef EGL_VERSION_1_4
+
+static GLboolean _glewInit_EGL_VERSION_1_4 ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((eglGetCurrentContext = (PFNEGLGETCURRENTCONTEXTPROC)glewGetProcAddress((const GLubyte*)"eglGetCurrentContext")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* EGL_VERSION_1_4 */
+
+#ifdef EGL_VERSION_1_5
+
+static GLboolean _glewInit_EGL_VERSION_1_5 ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((eglClientWaitSync = (PFNEGLCLIENTWAITSYNCPROC)glewGetProcAddress((const GLubyte*)"eglClientWaitSync")) == NULL) || r;
+  r = ((eglCreateImage = (PFNEGLCREATEIMAGEPROC)glewGetProcAddress((const GLubyte*)"eglCreateImage")) == NULL) || r;
+  r = ((eglCreatePlatformPixmapSurface = (PFNEGLCREATEPLATFORMPIXMAPSURFACEPROC)glewGetProcAddress((const GLubyte*)"eglCreatePlatformPixmapSurface")) == NULL) || r;
+  r = ((eglCreatePlatformWindowSurface = (PFNEGLCREATEPLATFORMWINDOWSURFACEPROC)glewGetProcAddress((const GLubyte*)"eglCreatePlatformWindowSurface")) == NULL) || r;
+  r = ((eglCreateSync = (PFNEGLCREATESYNCPROC)glewGetProcAddress((const GLubyte*)"eglCreateSync")) == NULL) || r;
+  r = ((eglDestroyImage = (PFNEGLDESTROYIMAGEPROC)glewGetProcAddress((const GLubyte*)"eglDestroyImage")) == NULL) || r;
+  r = ((eglDestroySync = (PFNEGLDESTROYSYNCPROC)glewGetProcAddress((const GLubyte*)"eglDestroySync")) == NULL) || r;
+  r = ((eglGetPlatformDisplay = (PFNEGLGETPLATFORMDISPLAYPROC)glewGetProcAddress((const GLubyte*)"eglGetPlatformDisplay")) == NULL) || r;
+  r = ((eglGetSyncAttrib = (PFNEGLGETSYNCATTRIBPROC)glewGetProcAddress((const GLubyte*)"eglGetSyncAttrib")) == NULL) || r;
+  r = ((eglWaitSync = (PFNEGLWAITSYNCPROC)glewGetProcAddress((const GLubyte*)"eglWaitSync")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* EGL_VERSION_1_5 */
+
+#ifdef EGL_ANDROID_blob_cache
+
+static GLboolean _glewInit_EGL_ANDROID_blob_cache ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((eglSetBlobCacheFuncsANDROID = (PFNEGLSETBLOBCACHEFUNCSANDROIDPROC)glewGetProcAddress((const GLubyte*)"eglSetBlobCacheFuncsANDROID")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* EGL_ANDROID_blob_cache */
+
+#ifdef EGL_ANDROID_create_native_client_buffer
+
+static GLboolean _glewInit_EGL_ANDROID_create_native_client_buffer ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((eglCreateNativeClientBufferANDROID = (PFNEGLCREATENATIVECLIENTBUFFERANDROIDPROC)glewGetProcAddress((const GLubyte*)"eglCreateNativeClientBufferANDROID")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* EGL_ANDROID_create_native_client_buffer */
+
+#ifdef EGL_ANDROID_native_fence_sync
+
+static GLboolean _glewInit_EGL_ANDROID_native_fence_sync ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((eglDupNativeFenceFDANDROID = (PFNEGLDUPNATIVEFENCEFDANDROIDPROC)glewGetProcAddress((const GLubyte*)"eglDupNativeFenceFDANDROID")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* EGL_ANDROID_native_fence_sync */
+
+#ifdef EGL_ANDROID_presentation_time
+
+static GLboolean _glewInit_EGL_ANDROID_presentation_time ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((eglPresentationTimeANDROID = (PFNEGLPRESENTATIONTIMEANDROIDPROC)glewGetProcAddress((const GLubyte*)"eglPresentationTimeANDROID")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* EGL_ANDROID_presentation_time */
+
+#ifdef EGL_ANGLE_query_surface_pointer
+
+static GLboolean _glewInit_EGL_ANGLE_query_surface_pointer ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((eglQuerySurfacePointerANGLE = (PFNEGLQUERYSURFACEPOINTERANGLEPROC)glewGetProcAddress((const GLubyte*)"eglQuerySurfacePointerANGLE")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* EGL_ANGLE_query_surface_pointer */
+
+#ifdef EGL_EXT_device_enumeration
+
+static GLboolean _glewInit_EGL_EXT_device_enumeration ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((eglQueryDevicesEXT = (PFNEGLQUERYDEVICESEXTPROC)glewGetProcAddress((const GLubyte*)"eglQueryDevicesEXT")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* EGL_EXT_device_enumeration */
+
+#ifdef EGL_EXT_device_query
+
+static GLboolean _glewInit_EGL_EXT_device_query ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((eglQueryDeviceAttribEXT = (PFNEGLQUERYDEVICEATTRIBEXTPROC)glewGetProcAddress((const GLubyte*)"eglQueryDeviceAttribEXT")) == NULL) || r;
+  r = ((eglQueryDeviceStringEXT = (PFNEGLQUERYDEVICESTRINGEXTPROC)glewGetProcAddress((const GLubyte*)"eglQueryDeviceStringEXT")) == NULL) || r;
+  r = ((eglQueryDisplayAttribEXT = (PFNEGLQUERYDISPLAYATTRIBEXTPROC)glewGetProcAddress((const GLubyte*)"eglQueryDisplayAttribEXT")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* EGL_EXT_device_query */
+
+#ifdef EGL_EXT_image_dma_buf_import_modifiers
+
+static GLboolean _glewInit_EGL_EXT_image_dma_buf_import_modifiers ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((eglQueryDmaBufFormatsEXT = (PFNEGLQUERYDMABUFFORMATSEXTPROC)glewGetProcAddress((const GLubyte*)"eglQueryDmaBufFormatsEXT")) == NULL) || r;
+  r = ((eglQueryDmaBufModifiersEXT = (PFNEGLQUERYDMABUFMODIFIERSEXTPROC)glewGetProcAddress((const GLubyte*)"eglQueryDmaBufModifiersEXT")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* EGL_EXT_image_dma_buf_import_modifiers */
+
+#ifdef EGL_EXT_output_base
+
+static GLboolean _glewInit_EGL_EXT_output_base ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((eglGetOutputLayersEXT = (PFNEGLGETOUTPUTLAYERSEXTPROC)glewGetProcAddress((const GLubyte*)"eglGetOutputLayersEXT")) == NULL) || r;
+  r = ((eglGetOutputPortsEXT = (PFNEGLGETOUTPUTPORTSEXTPROC)glewGetProcAddress((const GLubyte*)"eglGetOutputPortsEXT")) == NULL) || r;
+  r = ((eglOutputLayerAttribEXT = (PFNEGLOUTPUTLAYERATTRIBEXTPROC)glewGetProcAddress((const GLubyte*)"eglOutputLayerAttribEXT")) == NULL) || r;
+  r = ((eglOutputPortAttribEXT = (PFNEGLOUTPUTPORTATTRIBEXTPROC)glewGetProcAddress((const GLubyte*)"eglOutputPortAttribEXT")) == NULL) || r;
+  r = ((eglQueryOutputLayerAttribEXT = (PFNEGLQUERYOUTPUTLAYERATTRIBEXTPROC)glewGetProcAddress((const GLubyte*)"eglQueryOutputLayerAttribEXT")) == NULL) || r;
+  r = ((eglQueryOutputLayerStringEXT = (PFNEGLQUERYOUTPUTLAYERSTRINGEXTPROC)glewGetProcAddress((const GLubyte*)"eglQueryOutputLayerStringEXT")) == NULL) || r;
+  r = ((eglQueryOutputPortAttribEXT = (PFNEGLQUERYOUTPUTPORTATTRIBEXTPROC)glewGetProcAddress((const GLubyte*)"eglQueryOutputPortAttribEXT")) == NULL) || r;
+  r = ((eglQueryOutputPortStringEXT = (PFNEGLQUERYOUTPUTPORTSTRINGEXTPROC)glewGetProcAddress((const GLubyte*)"eglQueryOutputPortStringEXT")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* EGL_EXT_output_base */
+
+#ifdef EGL_EXT_platform_base
+
+static GLboolean _glewInit_EGL_EXT_platform_base ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((eglCreatePlatformPixmapSurfaceEXT = (PFNEGLCREATEPLATFORMPIXMAPSURFACEEXTPROC)glewGetProcAddress((const GLubyte*)"eglCreatePlatformPixmapSurfaceEXT")) == NULL) || r;
+  r = ((eglCreatePlatformWindowSurfaceEXT = (PFNEGLCREATEPLATFORMWINDOWSURFACEEXTPROC)glewGetProcAddress((const GLubyte*)"eglCreatePlatformWindowSurfaceEXT")) == NULL) || r;
+  r = ((eglGetPlatformDisplayEXT = (PFNEGLGETPLATFORMDISPLAYEXTPROC)glewGetProcAddress((const GLubyte*)"eglGetPlatformDisplayEXT")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* EGL_EXT_platform_base */
+
+#ifdef EGL_EXT_stream_consumer_egloutput
+
+static GLboolean _glewInit_EGL_EXT_stream_consumer_egloutput ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((eglStreamConsumerOutputEXT = (PFNEGLSTREAMCONSUMEROUTPUTEXTPROC)glewGetProcAddress((const GLubyte*)"eglStreamConsumerOutputEXT")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* EGL_EXT_stream_consumer_egloutput */
+
+#ifdef EGL_EXT_swap_buffers_with_damage
+
+static GLboolean _glewInit_EGL_EXT_swap_buffers_with_damage ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((eglSwapBuffersWithDamageEXT = (PFNEGLSWAPBUFFERSWITHDAMAGEEXTPROC)glewGetProcAddress((const GLubyte*)"eglSwapBuffersWithDamageEXT")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* EGL_EXT_swap_buffers_with_damage */
+
+#ifdef EGL_HI_clientpixmap
+
+static GLboolean _glewInit_EGL_HI_clientpixmap ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((eglCreatePixmapSurfaceHI = (PFNEGLCREATEPIXMAPSURFACEHIPROC)glewGetProcAddress((const GLubyte*)"eglCreatePixmapSurfaceHI")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* EGL_HI_clientpixmap */
+
+#ifdef EGL_KHR_cl_event2
+
+static GLboolean _glewInit_EGL_KHR_cl_event2 ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((eglCreateSync64KHR = (PFNEGLCREATESYNC64KHRPROC)glewGetProcAddress((const GLubyte*)"eglCreateSync64KHR")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* EGL_KHR_cl_event2 */
+
+#ifdef EGL_KHR_debug
+
+static GLboolean _glewInit_EGL_KHR_debug ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((eglDebugMessageControlKHR = (PFNEGLDEBUGMESSAGECONTROLKHRPROC)glewGetProcAddress((const GLubyte*)"eglDebugMessageControlKHR")) == NULL) || r;
+  r = ((eglLabelObjectKHR = (PFNEGLLABELOBJECTKHRPROC)glewGetProcAddress((const GLubyte*)"eglLabelObjectKHR")) == NULL) || r;
+  r = ((eglQueryDebugKHR = (PFNEGLQUERYDEBUGKHRPROC)glewGetProcAddress((const GLubyte*)"eglQueryDebugKHR")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* EGL_KHR_debug */
+
+#ifdef EGL_KHR_image
+
+static GLboolean _glewInit_EGL_KHR_image ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((eglCreateImageKHR = (PFNEGLCREATEIMAGEKHRPROC)glewGetProcAddress((const GLubyte*)"eglCreateImageKHR")) == NULL) || r;
+  r = ((eglDestroyImageKHR = (PFNEGLDESTROYIMAGEKHRPROC)glewGetProcAddress((const GLubyte*)"eglDestroyImageKHR")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* EGL_KHR_image */
+
+#ifdef EGL_KHR_lock_surface
+
+static GLboolean _glewInit_EGL_KHR_lock_surface ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((eglLockSurfaceKHR = (PFNEGLLOCKSURFACEKHRPROC)glewGetProcAddress((const GLubyte*)"eglLockSurfaceKHR")) == NULL) || r;
+  r = ((eglUnlockSurfaceKHR = (PFNEGLUNLOCKSURFACEKHRPROC)glewGetProcAddress((const GLubyte*)"eglUnlockSurfaceKHR")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* EGL_KHR_lock_surface */
+
+#ifdef EGL_KHR_lock_surface3
+
+static GLboolean _glewInit_EGL_KHR_lock_surface3 ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((eglQuerySurface64KHR = (PFNEGLQUERYSURFACE64KHRPROC)glewGetProcAddress((const GLubyte*)"eglQuerySurface64KHR")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* EGL_KHR_lock_surface3 */
+
+#ifdef EGL_KHR_partial_update
+
+static GLboolean _glewInit_EGL_KHR_partial_update ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((eglSetDamageRegionKHR = (PFNEGLSETDAMAGEREGIONKHRPROC)glewGetProcAddress((const GLubyte*)"eglSetDamageRegionKHR")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* EGL_KHR_partial_update */
+
+#ifdef EGL_KHR_reusable_sync
+
+static GLboolean _glewInit_EGL_KHR_reusable_sync ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((eglClientWaitSyncKHR = (PFNEGLCLIENTWAITSYNCKHRPROC)glewGetProcAddress((const GLubyte*)"eglClientWaitSyncKHR")) == NULL) || r;
+  r = ((eglCreateSyncKHR = (PFNEGLCREATESYNCKHRPROC)glewGetProcAddress((const GLubyte*)"eglCreateSyncKHR")) == NULL) || r;
+  r = ((eglDestroySyncKHR = (PFNEGLDESTROYSYNCKHRPROC)glewGetProcAddress((const GLubyte*)"eglDestroySyncKHR")) == NULL) || r;
+  r = ((eglGetSyncAttribKHR = (PFNEGLGETSYNCATTRIBKHRPROC)glewGetProcAddress((const GLubyte*)"eglGetSyncAttribKHR")) == NULL) || r;
+  r = ((eglSignalSyncKHR = (PFNEGLSIGNALSYNCKHRPROC)glewGetProcAddress((const GLubyte*)"eglSignalSyncKHR")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* EGL_KHR_reusable_sync */
+
+#ifdef EGL_KHR_stream
+
+static GLboolean _glewInit_EGL_KHR_stream ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((eglCreateStreamKHR = (PFNEGLCREATESTREAMKHRPROC)glewGetProcAddress((const GLubyte*)"eglCreateStreamKHR")) == NULL) || r;
+  r = ((eglDestroyStreamKHR = (PFNEGLDESTROYSTREAMKHRPROC)glewGetProcAddress((const GLubyte*)"eglDestroyStreamKHR")) == NULL) || r;
+  r = ((eglQueryStreamKHR = (PFNEGLQUERYSTREAMKHRPROC)glewGetProcAddress((const GLubyte*)"eglQueryStreamKHR")) == NULL) || r;
+  r = ((eglQueryStreamu64KHR = (PFNEGLQUERYSTREAMU64KHRPROC)glewGetProcAddress((const GLubyte*)"eglQueryStreamu64KHR")) == NULL) || r;
+  r = ((eglStreamAttribKHR = (PFNEGLSTREAMATTRIBKHRPROC)glewGetProcAddress((const GLubyte*)"eglStreamAttribKHR")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* EGL_KHR_stream */
+
+#ifdef EGL_KHR_stream_attrib
+
+static GLboolean _glewInit_EGL_KHR_stream_attrib ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((eglCreateStreamAttribKHR = (PFNEGLCREATESTREAMATTRIBKHRPROC)glewGetProcAddress((const GLubyte*)"eglCreateStreamAttribKHR")) == NULL) || r;
+  r = ((eglQueryStreamAttribKHR = (PFNEGLQUERYSTREAMATTRIBKHRPROC)glewGetProcAddress((const GLubyte*)"eglQueryStreamAttribKHR")) == NULL) || r;
+  r = ((eglSetStreamAttribKHR = (PFNEGLSETSTREAMATTRIBKHRPROC)glewGetProcAddress((const GLubyte*)"eglSetStreamAttribKHR")) == NULL) || r;
+  r = ((eglStreamConsumerAcquireAttribKHR = (PFNEGLSTREAMCONSUMERACQUIREATTRIBKHRPROC)glewGetProcAddress((const GLubyte*)"eglStreamConsumerAcquireAttribKHR")) == NULL) || r;
+  r = ((eglStreamConsumerReleaseAttribKHR = (PFNEGLSTREAMCONSUMERRELEASEATTRIBKHRPROC)glewGetProcAddress((const GLubyte*)"eglStreamConsumerReleaseAttribKHR")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* EGL_KHR_stream_attrib */
+
+#ifdef EGL_KHR_stream_consumer_gltexture
+
+static GLboolean _glewInit_EGL_KHR_stream_consumer_gltexture ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((eglStreamConsumerAcquireKHR = (PFNEGLSTREAMCONSUMERACQUIREKHRPROC)glewGetProcAddress((const GLubyte*)"eglStreamConsumerAcquireKHR")) == NULL) || r;
+  r = ((eglStreamConsumerGLTextureExternalKHR = (PFNEGLSTREAMCONSUMERGLTEXTUREEXTERNALKHRPROC)glewGetProcAddress((const GLubyte*)"eglStreamConsumerGLTextureExternalKHR")) == NULL) || r;
+  r = ((eglStreamConsumerReleaseKHR = (PFNEGLSTREAMCONSUMERRELEASEKHRPROC)glewGetProcAddress((const GLubyte*)"eglStreamConsumerReleaseKHR")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* EGL_KHR_stream_consumer_gltexture */
+
+#ifdef EGL_KHR_stream_cross_process_fd
+
+static GLboolean _glewInit_EGL_KHR_stream_cross_process_fd ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((eglCreateStreamFromFileDescriptorKHR = (PFNEGLCREATESTREAMFROMFILEDESCRIPTORKHRPROC)glewGetProcAddress((const GLubyte*)"eglCreateStreamFromFileDescriptorKHR")) == NULL) || r;
+  r = ((eglGetStreamFileDescriptorKHR = (PFNEGLGETSTREAMFILEDESCRIPTORKHRPROC)glewGetProcAddress((const GLubyte*)"eglGetStreamFileDescriptorKHR")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* EGL_KHR_stream_cross_process_fd */
+
+#ifdef EGL_KHR_stream_fifo
+
+static GLboolean _glewInit_EGL_KHR_stream_fifo ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((eglQueryStreamTimeKHR = (PFNEGLQUERYSTREAMTIMEKHRPROC)glewGetProcAddress((const GLubyte*)"eglQueryStreamTimeKHR")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* EGL_KHR_stream_fifo */
+
+#ifdef EGL_KHR_stream_producer_eglsurface
+
+static GLboolean _glewInit_EGL_KHR_stream_producer_eglsurface ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((eglCreateStreamProducerSurfaceKHR = (PFNEGLCREATESTREAMPRODUCERSURFACEKHRPROC)glewGetProcAddress((const GLubyte*)"eglCreateStreamProducerSurfaceKHR")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* EGL_KHR_stream_producer_eglsurface */
+
+#ifdef EGL_KHR_swap_buffers_with_damage
+
+static GLboolean _glewInit_EGL_KHR_swap_buffers_with_damage ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((eglSwapBuffersWithDamageKHR = (PFNEGLSWAPBUFFERSWITHDAMAGEKHRPROC)glewGetProcAddress((const GLubyte*)"eglSwapBuffersWithDamageKHR")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* EGL_KHR_swap_buffers_with_damage */
+
+#ifdef EGL_KHR_wait_sync
+
+static GLboolean _glewInit_EGL_KHR_wait_sync ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((eglWaitSyncKHR = (PFNEGLWAITSYNCKHRPROC)glewGetProcAddress((const GLubyte*)"eglWaitSyncKHR")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* EGL_KHR_wait_sync */
+
+#ifdef EGL_MESA_drm_image
+
+static GLboolean _glewInit_EGL_MESA_drm_image ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((eglCreateDRMImageMESA = (PFNEGLCREATEDRMIMAGEMESAPROC)glewGetProcAddress((const GLubyte*)"eglCreateDRMImageMESA")) == NULL) || r;
+  r = ((eglExportDRMImageMESA = (PFNEGLEXPORTDRMIMAGEMESAPROC)glewGetProcAddress((const GLubyte*)"eglExportDRMImageMESA")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* EGL_MESA_drm_image */
+
+#ifdef EGL_MESA_image_dma_buf_export
+
+static GLboolean _glewInit_EGL_MESA_image_dma_buf_export ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((eglExportDMABUFImageMESA = (PFNEGLEXPORTDMABUFIMAGEMESAPROC)glewGetProcAddress((const GLubyte*)"eglExportDMABUFImageMESA")) == NULL) || r;
+  r = ((eglExportDMABUFImageQueryMESA = (PFNEGLEXPORTDMABUFIMAGEQUERYMESAPROC)glewGetProcAddress((const GLubyte*)"eglExportDMABUFImageQueryMESA")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* EGL_MESA_image_dma_buf_export */
+
+#ifdef EGL_NOK_swap_region
+
+static GLboolean _glewInit_EGL_NOK_swap_region ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((eglSwapBuffersRegionNOK = (PFNEGLSWAPBUFFERSREGIONNOKPROC)glewGetProcAddress((const GLubyte*)"eglSwapBuffersRegionNOK")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* EGL_NOK_swap_region */
+
+#ifdef EGL_NOK_swap_region2
+
+static GLboolean _glewInit_EGL_NOK_swap_region2 ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((eglSwapBuffersRegion2NOK = (PFNEGLSWAPBUFFERSREGION2NOKPROC)glewGetProcAddress((const GLubyte*)"eglSwapBuffersRegion2NOK")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* EGL_NOK_swap_region2 */
+
+#ifdef EGL_NV_native_query
+
+static GLboolean _glewInit_EGL_NV_native_query ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((eglQueryNativeDisplayNV = (PFNEGLQUERYNATIVEDISPLAYNVPROC)glewGetProcAddress((const GLubyte*)"eglQueryNativeDisplayNV")) == NULL) || r;
+  r = ((eglQueryNativePixmapNV = (PFNEGLQUERYNATIVEPIXMAPNVPROC)glewGetProcAddress((const GLubyte*)"eglQueryNativePixmapNV")) == NULL) || r;
+  r = ((eglQueryNativeWindowNV = (PFNEGLQUERYNATIVEWINDOWNVPROC)glewGetProcAddress((const GLubyte*)"eglQueryNativeWindowNV")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* EGL_NV_native_query */
+
+#ifdef EGL_NV_post_sub_buffer
+
+static GLboolean _glewInit_EGL_NV_post_sub_buffer ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((eglPostSubBufferNV = (PFNEGLPOSTSUBBUFFERNVPROC)glewGetProcAddress((const GLubyte*)"eglPostSubBufferNV")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* EGL_NV_post_sub_buffer */
+
+#ifdef EGL_NV_stream_consumer_gltexture_yuv
+
+static GLboolean _glewInit_EGL_NV_stream_consumer_gltexture_yuv ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((eglStreamConsumerGLTextureExternalAttribsNV = (PFNEGLSTREAMCONSUMERGLTEXTUREEXTERNALATTRIBSNVPROC)glewGetProcAddress((const GLubyte*)"eglStreamConsumerGLTextureExternalAttribsNV")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* EGL_NV_stream_consumer_gltexture_yuv */
+
+#ifdef EGL_NV_stream_metadata
+
+static GLboolean _glewInit_EGL_NV_stream_metadata ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((eglQueryDisplayAttribNV = (PFNEGLQUERYDISPLAYATTRIBNVPROC)glewGetProcAddress((const GLubyte*)"eglQueryDisplayAttribNV")) == NULL) || r;
+  r = ((eglQueryStreamMetadataNV = (PFNEGLQUERYSTREAMMETADATANVPROC)glewGetProcAddress((const GLubyte*)"eglQueryStreamMetadataNV")) == NULL) || r;
+  r = ((eglSetStreamMetadataNV = (PFNEGLSETSTREAMMETADATANVPROC)glewGetProcAddress((const GLubyte*)"eglSetStreamMetadataNV")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* EGL_NV_stream_metadata */
+
+#ifdef EGL_NV_stream_reset
+
+static GLboolean _glewInit_EGL_NV_stream_reset ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((eglResetStreamNV = (PFNEGLRESETSTREAMNVPROC)glewGetProcAddress((const GLubyte*)"eglResetStreamNV")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* EGL_NV_stream_reset */
+
+#ifdef EGL_NV_stream_sync
+
+static GLboolean _glewInit_EGL_NV_stream_sync ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((eglCreateStreamSyncNV = (PFNEGLCREATESTREAMSYNCNVPROC)glewGetProcAddress((const GLubyte*)"eglCreateStreamSyncNV")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* EGL_NV_stream_sync */
+
+#ifdef EGL_NV_sync
+
+static GLboolean _glewInit_EGL_NV_sync ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((eglClientWaitSyncNV = (PFNEGLCLIENTWAITSYNCNVPROC)glewGetProcAddress((const GLubyte*)"eglClientWaitSyncNV")) == NULL) || r;
+  r = ((eglCreateFenceSyncNV = (PFNEGLCREATEFENCESYNCNVPROC)glewGetProcAddress((const GLubyte*)"eglCreateFenceSyncNV")) == NULL) || r;
+  r = ((eglDestroySyncNV = (PFNEGLDESTROYSYNCNVPROC)glewGetProcAddress((const GLubyte*)"eglDestroySyncNV")) == NULL) || r;
+  r = ((eglFenceNV = (PFNEGLFENCENVPROC)glewGetProcAddress((const GLubyte*)"eglFenceNV")) == NULL) || r;
+  r = ((eglGetSyncAttribNV = (PFNEGLGETSYNCATTRIBNVPROC)glewGetProcAddress((const GLubyte*)"eglGetSyncAttribNV")) == NULL) || r;
+  r = ((eglSignalSyncNV = (PFNEGLSIGNALSYNCNVPROC)glewGetProcAddress((const GLubyte*)"eglSignalSyncNV")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* EGL_NV_sync */
+
+#ifdef EGL_NV_system_time
+
+static GLboolean _glewInit_EGL_NV_system_time ()
+{
+  GLboolean r = GL_FALSE;
+
+  r = ((eglGetSystemTimeFrequencyNV = (PFNEGLGETSYSTEMTIMEFREQUENCYNVPROC)glewGetProcAddress((const GLubyte*)"eglGetSystemTimeFrequencyNV")) == NULL) || r;
+  r = ((eglGetSystemTimeNV = (PFNEGLGETSYSTEMTIMENVPROC)glewGetProcAddress((const GLubyte*)"eglGetSystemTimeNV")) == NULL) || r;
+
+  return r;
+}
+
+#endif /* EGL_NV_system_time */
+
+  /* ------------------------------------------------------------------------ */
+
+GLboolean eglewGetExtension (const char* name)
+{
+  const GLubyte* start;
+  const GLubyte* end;
+
+  start = (const GLubyte*) eglQueryString(eglGetCurrentDisplay(), EGL_EXTENSIONS);
+  if (0 == start) return GL_FALSE;
+  end = start + _glewStrLen(start);
+  return _glewSearchExtension(name, start, end);
+}
+
+GLenum eglewInit (EGLDisplay display)
+{
+  EGLint major, minor;
+  const GLubyte* extStart;
+  const GLubyte* extEnd;
+  PFNEGLINITIALIZEPROC initialize = NULL;
+  PFNEGLQUERYSTRINGPROC queryString = NULL;
+
+  /* Load necessary entry points */
+  initialize = (PFNEGLINITIALIZEPROC)   glewGetProcAddress("eglInitialize");
+  queryString = (PFNEGLQUERYSTRINGPROC) glewGetProcAddress("eglQueryString");
+  if (!initialize || !queryString)
+    return 1;
+
+  /* query EGK version */
+  if (initialize(display, &major, &minor) != EGL_TRUE)
+    return 1;
+
+  EGLEW_VERSION_1_5   = ( major > 1 )                || ( major == 1 && minor >= 5 ) ? GL_TRUE : GL_FALSE;
+  EGLEW_VERSION_1_4   = EGLEW_VERSION_1_5 == GL_TRUE || ( major == 1 && minor >= 4 ) ? GL_TRUE : GL_FALSE;
+  EGLEW_VERSION_1_3   = EGLEW_VERSION_1_4 == GL_TRUE || ( major == 1 && minor >= 3 ) ? GL_TRUE : GL_FALSE;
+  EGLEW_VERSION_1_2   = EGLEW_VERSION_1_3 == GL_TRUE || ( major == 1 && minor >= 2 ) ? GL_TRUE : GL_FALSE;
+  EGLEW_VERSION_1_1   = EGLEW_VERSION_1_2 == GL_TRUE || ( major == 1 && minor >= 1 ) ? GL_TRUE : GL_FALSE;
+  EGLEW_VERSION_1_0   = EGLEW_VERSION_1_1 == GL_TRUE || ( major == 1 && minor >= 0 ) ? GL_TRUE : GL_FALSE;
+
+  /* query EGL extension string */
+  extStart = (const GLubyte*) queryString(display, EGL_EXTENSIONS);
+  if (extStart == 0)
+    extStart = (const GLubyte *)"";
+  extEnd = extStart + _glewStrLen(extStart);
+
+  /* initialize extensions */
+#ifdef EGL_VERSION_1_0
+  if (glewExperimental || EGLEW_VERSION_1_0) EGLEW_VERSION_1_0 = !_glewInit_EGL_VERSION_1_0();
+#endif /* EGL_VERSION_1_0 */
+#ifdef EGL_VERSION_1_1
+  if (glewExperimental || EGLEW_VERSION_1_1) EGLEW_VERSION_1_1 = !_glewInit_EGL_VERSION_1_1();
+#endif /* EGL_VERSION_1_1 */
+#ifdef EGL_VERSION_1_2
+  if (glewExperimental || EGLEW_VERSION_1_2) EGLEW_VERSION_1_2 = !_glewInit_EGL_VERSION_1_2();
+#endif /* EGL_VERSION_1_2 */
+#ifdef EGL_VERSION_1_4
+  if (glewExperimental || EGLEW_VERSION_1_4) EGLEW_VERSION_1_4 = !_glewInit_EGL_VERSION_1_4();
+#endif /* EGL_VERSION_1_4 */
+#ifdef EGL_VERSION_1_5
+  if (glewExperimental || EGLEW_VERSION_1_5) EGLEW_VERSION_1_5 = !_glewInit_EGL_VERSION_1_5();
+#endif /* EGL_VERSION_1_5 */
+#ifdef EGL_ANDROID_blob_cache
+  EGLEW_ANDROID_blob_cache = _glewSearchExtension("EGL_ANDROID_blob_cache", extStart, extEnd);
+  if (glewExperimental || EGLEW_ANDROID_blob_cache) EGLEW_ANDROID_blob_cache = !_glewInit_EGL_ANDROID_blob_cache();
+#endif /* EGL_ANDROID_blob_cache */
+#ifdef EGL_ANDROID_create_native_client_buffer
+  EGLEW_ANDROID_create_native_client_buffer = _glewSearchExtension("EGL_ANDROID_create_native_client_buffer", extStart, extEnd);
+  if (glewExperimental || EGLEW_ANDROID_create_native_client_buffer) EGLEW_ANDROID_create_native_client_buffer = !_glewInit_EGL_ANDROID_create_native_client_buffer();
+#endif /* EGL_ANDROID_create_native_client_buffer */
+#ifdef EGL_ANDROID_framebuffer_target
+  EGLEW_ANDROID_framebuffer_target = _glewSearchExtension("EGL_ANDROID_framebuffer_target", extStart, extEnd);
+#endif /* EGL_ANDROID_framebuffer_target */
+#ifdef EGL_ANDROID_front_buffer_auto_refresh
+  EGLEW_ANDROID_front_buffer_auto_refresh = _glewSearchExtension("EGL_ANDROID_front_buffer_auto_refresh", extStart, extEnd);
+#endif /* EGL_ANDROID_front_buffer_auto_refresh */
+#ifdef EGL_ANDROID_image_native_buffer
+  EGLEW_ANDROID_image_native_buffer = _glewSearchExtension("EGL_ANDROID_image_native_buffer", extStart, extEnd);
+#endif /* EGL_ANDROID_image_native_buffer */
+#ifdef EGL_ANDROID_native_fence_sync
+  EGLEW_ANDROID_native_fence_sync = _glewSearchExtension("EGL_ANDROID_native_fence_sync", extStart, extEnd);
+  if (glewExperimental || EGLEW_ANDROID_native_fence_sync) EGLEW_ANDROID_native_fence_sync = !_glewInit_EGL_ANDROID_native_fence_sync();
+#endif /* EGL_ANDROID_native_fence_sync */
+#ifdef EGL_ANDROID_presentation_time
+  EGLEW_ANDROID_presentation_time = _glewSearchExtension("EGL_ANDROID_presentation_time", extStart, extEnd);
+  if (glewExperimental || EGLEW_ANDROID_presentation_time) EGLEW_ANDROID_presentation_time = !_glewInit_EGL_ANDROID_presentation_time();
+#endif /* EGL_ANDROID_presentation_time */
+#ifdef EGL_ANDROID_recordable
+  EGLEW_ANDROID_recordable = _glewSearchExtension("EGL_ANDROID_recordable", extStart, extEnd);
+#endif /* EGL_ANDROID_recordable */
+#ifdef EGL_ANGLE_d3d_share_handle_client_buffer
+  EGLEW_ANGLE_d3d_share_handle_client_buffer = _glewSearchExtension("EGL_ANGLE_d3d_share_handle_client_buffer", extStart, extEnd);
+#endif /* EGL_ANGLE_d3d_share_handle_client_buffer */
+#ifdef EGL_ANGLE_device_d3d
+  EGLEW_ANGLE_device_d3d = _glewSearchExtension("EGL_ANGLE_device_d3d", extStart, extEnd);
+#endif /* EGL_ANGLE_device_d3d */
+#ifdef EGL_ANGLE_query_surface_pointer
+  EGLEW_ANGLE_query_surface_pointer = _glewSearchExtension("EGL_ANGLE_query_surface_pointer", extStart, extEnd);
+  if (glewExperimental || EGLEW_ANGLE_query_surface_pointer) EGLEW_ANGLE_query_surface_pointer = !_glewInit_EGL_ANGLE_query_surface_pointer();
+#endif /* EGL_ANGLE_query_surface_pointer */
+#ifdef EGL_ANGLE_surface_d3d_texture_2d_share_handle
+  EGLEW_ANGLE_surface_d3d_texture_2d_share_handle = _glewSearchExtension("EGL_ANGLE_surface_d3d_texture_2d_share_handle", extStart, extEnd);
+#endif /* EGL_ANGLE_surface_d3d_texture_2d_share_handle */
+#ifdef EGL_ANGLE_window_fixed_size
+  EGLEW_ANGLE_window_fixed_size = _glewSearchExtension("EGL_ANGLE_window_fixed_size", extStart, extEnd);
+#endif /* EGL_ANGLE_window_fixed_size */
+#ifdef EGL_ARM_implicit_external_sync
+  EGLEW_ARM_implicit_external_sync = _glewSearchExtension("EGL_ARM_implicit_external_sync", extStart, extEnd);
+#endif /* EGL_ARM_implicit_external_sync */
+#ifdef EGL_ARM_pixmap_multisample_discard
+  EGLEW_ARM_pixmap_multisample_discard = _glewSearchExtension("EGL_ARM_pixmap_multisample_discard", extStart, extEnd);
+#endif /* EGL_ARM_pixmap_multisample_discard */
+#ifdef EGL_EXT_buffer_age
+  EGLEW_EXT_buffer_age = _glewSearchExtension("EGL_EXT_buffer_age", extStart, extEnd);
+#endif /* EGL_EXT_buffer_age */
+#ifdef EGL_EXT_client_extensions
+  EGLEW_EXT_client_extensions = _glewSearchExtension("EGL_EXT_client_extensions", extStart, extEnd);
+#endif /* EGL_EXT_client_extensions */
+#ifdef EGL_EXT_create_context_robustness
+  EGLEW_EXT_create_context_robustness = _glewSearchExtension("EGL_EXT_create_context_robustness", extStart, extEnd);
+#endif /* EGL_EXT_create_context_robustness */
+#ifdef EGL_EXT_device_base
+  EGLEW_EXT_device_base = _glewSearchExtension("EGL_EXT_device_base", extStart, extEnd);
+#endif /* EGL_EXT_device_base */
+#ifdef EGL_EXT_device_drm
+  EGLEW_EXT_device_drm = _glewSearchExtension("EGL_EXT_device_drm", extStart, extEnd);
+#endif /* EGL_EXT_device_drm */
+#ifdef EGL_EXT_device_enumeration
+  EGLEW_EXT_device_enumeration = _glewSearchExtension("EGL_EXT_device_enumeration", extStart, extEnd);
+  if (glewExperimental || EGLEW_EXT_device_enumeration) EGLEW_EXT_device_enumeration = !_glewInit_EGL_EXT_device_enumeration();
+#endif /* EGL_EXT_device_enumeration */
+#ifdef EGL_EXT_device_openwf
+  EGLEW_EXT_device_openwf = _glewSearchExtension("EGL_EXT_device_openwf", extStart, extEnd);
+#endif /* EGL_EXT_device_openwf */
+#ifdef EGL_EXT_device_query
+  EGLEW_EXT_device_query = _glewSearchExtension("EGL_EXT_device_query", extStart, extEnd);
+  if (glewExperimental || EGLEW_EXT_device_query) EGLEW_EXT_device_query = !_glewInit_EGL_EXT_device_query();
+#endif /* EGL_EXT_device_query */
+#ifdef EGL_EXT_gl_colorspace_bt2020_linear
+  EGLEW_EXT_gl_colorspace_bt2020_linear = _glewSearchExtension("EGL_EXT_gl_colorspace_bt2020_linear", extStart, extEnd);
+#endif /* EGL_EXT_gl_colorspace_bt2020_linear */
+#ifdef EGL_EXT_gl_colorspace_bt2020_pq
+  EGLEW_EXT_gl_colorspace_bt2020_pq = _glewSearchExtension("EGL_EXT_gl_colorspace_bt2020_pq", extStart, extEnd);
+#endif /* EGL_EXT_gl_colorspace_bt2020_pq */
+#ifdef EGL_EXT_gl_colorspace_scrgb_linear
+  EGLEW_EXT_gl_colorspace_scrgb_linear = _glewSearchExtension("EGL_EXT_gl_colorspace_scrgb_linear", extStart, extEnd);
+#endif /* EGL_EXT_gl_colorspace_scrgb_linear */
+#ifdef EGL_EXT_image_dma_buf_import
+  EGLEW_EXT_image_dma_buf_import = _glewSearchExtension("EGL_EXT_image_dma_buf_import", extStart, extEnd);
+#endif /* EGL_EXT_image_dma_buf_import */
+#ifdef EGL_EXT_image_dma_buf_import_modifiers
+  EGLEW_EXT_image_dma_buf_import_modifiers = _glewSearchExtension("EGL_EXT_image_dma_buf_import_modifiers", extStart, extEnd);
+  if (glewExperimental || EGLEW_EXT_image_dma_buf_import_modifiers) EGLEW_EXT_image_dma_buf_import_modifiers = !_glewInit_EGL_EXT_image_dma_buf_import_modifiers();
+#endif /* EGL_EXT_image_dma_buf_import_modifiers */
+#ifdef EGL_EXT_multiview_window
+  EGLEW_EXT_multiview_window = _glewSearchExtension("EGL_EXT_multiview_window", extStart, extEnd);
+#endif /* EGL_EXT_multiview_window */
+#ifdef EGL_EXT_output_base
+  EGLEW_EXT_output_base = _glewSearchExtension("EGL_EXT_output_base", extStart, extEnd);
+  if (glewExperimental || EGLEW_EXT_output_base) EGLEW_EXT_output_base = !_glewInit_EGL_EXT_output_base();
+#endif /* EGL_EXT_output_base */
+#ifdef EGL_EXT_output_drm
+  EGLEW_EXT_output_drm = _glewSearchExtension("EGL_EXT_output_drm", extStart, extEnd);
+#endif /* EGL_EXT_output_drm */
+#ifdef EGL_EXT_output_openwf
+  EGLEW_EXT_output_openwf = _glewSearchExtension("EGL_EXT_output_openwf", extStart, extEnd);
+#endif /* EGL_EXT_output_openwf */
+#ifdef EGL_EXT_pixel_format_float
+  EGLEW_EXT_pixel_format_float = _glewSearchExtension("EGL_EXT_pixel_format_float", extStart, extEnd);
+#endif /* EGL_EXT_pixel_format_float */
+#ifdef EGL_EXT_platform_base
+  EGLEW_EXT_platform_base = _glewSearchExtension("EGL_EXT_platform_base", extStart, extEnd);
+  if (glewExperimental || EGLEW_EXT_platform_base) EGLEW_EXT_platform_base = !_glewInit_EGL_EXT_platform_base();
+#endif /* EGL_EXT_platform_base */
+#ifdef EGL_EXT_platform_device
+  EGLEW_EXT_platform_device = _glewSearchExtension("EGL_EXT_platform_device", extStart, extEnd);
+#endif /* EGL_EXT_platform_device */
+#ifdef EGL_EXT_platform_wayland
+  EGLEW_EXT_platform_wayland = _glewSearchExtension("EGL_EXT_platform_wayland", extStart, extEnd);
+#endif /* EGL_EXT_platform_wayland */
+#ifdef EGL_EXT_platform_x11
+  EGLEW_EXT_platform_x11 = _glewSearchExtension("EGL_EXT_platform_x11", extStart, extEnd);
+#endif /* EGL_EXT_platform_x11 */
+#ifdef EGL_EXT_protected_content
+  EGLEW_EXT_protected_content = _glewSearchExtension("EGL_EXT_protected_content", extStart, extEnd);
+#endif /* EGL_EXT_protected_content */
+#ifdef EGL_EXT_protected_surface
+  EGLEW_EXT_protected_surface = _glewSearchExtension("EGL_EXT_protected_surface", extStart, extEnd);
+#endif /* EGL_EXT_protected_surface */
+#ifdef EGL_EXT_stream_consumer_egloutput
+  EGLEW_EXT_stream_consumer_egloutput = _glewSearchExtension("EGL_EXT_stream_consumer_egloutput", extStart, extEnd);
+  if (glewExperimental || EGLEW_EXT_stream_consumer_egloutput) EGLEW_EXT_stream_consumer_egloutput = !_glewInit_EGL_EXT_stream_consumer_egloutput();
+#endif /* EGL_EXT_stream_consumer_egloutput */
+#ifdef EGL_EXT_surface_SMPTE2086_metadata
+  EGLEW_EXT_surface_SMPTE2086_metadata = _glewSearchExtension("EGL_EXT_surface_SMPTE2086_metadata", extStart, extEnd);
+#endif /* EGL_EXT_surface_SMPTE2086_metadata */
+#ifdef EGL_EXT_swap_buffers_with_damage
+  EGLEW_EXT_swap_buffers_with_damage = _glewSearchExtension("EGL_EXT_swap_buffers_with_damage", extStart, extEnd);
+  if (glewExperimental || EGLEW_EXT_swap_buffers_with_damage) EGLEW_EXT_swap_buffers_with_damage = !_glewInit_EGL_EXT_swap_buffers_with_damage();
+#endif /* EGL_EXT_swap_buffers_with_damage */
+#ifdef EGL_EXT_yuv_surface
+  EGLEW_EXT_yuv_surface = _glewSearchExtension("EGL_EXT_yuv_surface", extStart, extEnd);
+#endif /* EGL_EXT_yuv_surface */
+#ifdef EGL_HI_clientpixmap
+  EGLEW_HI_clientpixmap = _glewSearchExtension("EGL_HI_clientpixmap", extStart, extEnd);
+  if (glewExperimental || EGLEW_HI_clientpixmap) EGLEW_HI_clientpixmap = !_glewInit_EGL_HI_clientpixmap();
+#endif /* EGL_HI_clientpixmap */
+#ifdef EGL_HI_colorformats
+  EGLEW_HI_colorformats = _glewSearchExtension("EGL_HI_colorformats", extStart, extEnd);
+#endif /* EGL_HI_colorformats */
+#ifdef EGL_IMG_context_priority
+  EGLEW_IMG_context_priority = _glewSearchExtension("EGL_IMG_context_priority", extStart, extEnd);
+#endif /* EGL_IMG_context_priority */
+#ifdef EGL_IMG_image_plane_attribs
+  EGLEW_IMG_image_plane_attribs = _glewSearchExtension("EGL_IMG_image_plane_attribs", extStart, extEnd);
+#endif /* EGL_IMG_image_plane_attribs */
+#ifdef EGL_KHR_cl_event
+  EGLEW_KHR_cl_event = _glewSearchExtension("EGL_KHR_cl_event", extStart, extEnd);
+#endif /* EGL_KHR_cl_event */
+#ifdef EGL_KHR_cl_event2
+  EGLEW_KHR_cl_event2 = _glewSearchExtension("EGL_KHR_cl_event2", extStart, extEnd);
+  if (glewExperimental || EGLEW_KHR_cl_event2) EGLEW_KHR_cl_event2 = !_glewInit_EGL_KHR_cl_event2();
+#endif /* EGL_KHR_cl_event2 */
+#ifdef EGL_KHR_client_get_all_proc_addresses
+  EGLEW_KHR_client_get_all_proc_addresses = _glewSearchExtension("EGL_KHR_client_get_all_proc_addresses", extStart, extEnd);
+#endif /* EGL_KHR_client_get_all_proc_addresses */
+#ifdef EGL_KHR_config_attribs
+  EGLEW_KHR_config_attribs = _glewSearchExtension("EGL_KHR_config_attribs", extStart, extEnd);
+#endif /* EGL_KHR_config_attribs */
+#ifdef EGL_KHR_context_flush_control
+  EGLEW_KHR_context_flush_control = _glewSearchExtension("EGL_KHR_context_flush_control", extStart, extEnd);
+#endif /* EGL_KHR_context_flush_control */
+#ifdef EGL_KHR_create_context
+  EGLEW_KHR_create_context = _glewSearchExtension("EGL_KHR_create_context", extStart, extEnd);
+#endif /* EGL_KHR_create_context */
+#ifdef EGL_KHR_create_context_no_error
+  EGLEW_KHR_create_context_no_error = _glewSearchExtension("EGL_KHR_create_context_no_error", extStart, extEnd);
+#endif /* EGL_KHR_create_context_no_error */
+#ifdef EGL_KHR_debug
+  EGLEW_KHR_debug = _glewSearchExtension("EGL_KHR_debug", extStart, extEnd);
+  if (glewExperimental || EGLEW_KHR_debug) EGLEW_KHR_debug = !_glewInit_EGL_KHR_debug();
+#endif /* EGL_KHR_debug */
+#ifdef EGL_KHR_fence_sync
+  EGLEW_KHR_fence_sync = _glewSearchExtension("EGL_KHR_fence_sync", extStart, extEnd);
+#endif /* EGL_KHR_fence_sync */
+#ifdef EGL_KHR_get_all_proc_addresses
+  EGLEW_KHR_get_all_proc_addresses = _glewSearchExtension("EGL_KHR_get_all_proc_addresses", extStart, extEnd);
+#endif /* EGL_KHR_get_all_proc_addresses */
+#ifdef EGL_KHR_gl_colorspace
+  EGLEW_KHR_gl_colorspace = _glewSearchExtension("EGL_KHR_gl_colorspace", extStart, extEnd);
+#endif /* EGL_KHR_gl_colorspace */
+#ifdef EGL_KHR_gl_renderbuffer_image
+  EGLEW_KHR_gl_renderbuffer_image = _glewSearchExtension("EGL_KHR_gl_renderbuffer_image", extStart, extEnd);
+#endif /* EGL_KHR_gl_renderbuffer_image */
+#ifdef EGL_KHR_gl_texture_2D_image
+  EGLEW_KHR_gl_texture_2D_image = _glewSearchExtension("EGL_KHR_gl_texture_2D_image", extStart, extEnd);
+#endif /* EGL_KHR_gl_texture_2D_image */
+#ifdef EGL_KHR_gl_texture_3D_image
+  EGLEW_KHR_gl_texture_3D_image = _glewSearchExtension("EGL_KHR_gl_texture_3D_image", extStart, extEnd);
+#endif /* EGL_KHR_gl_texture_3D_image */
+#ifdef EGL_KHR_gl_texture_cubemap_image
+  EGLEW_KHR_gl_texture_cubemap_image = _glewSearchExtension("EGL_KHR_gl_texture_cubemap_image", extStart, extEnd);
+#endif /* EGL_KHR_gl_texture_cubemap_image */
+#ifdef EGL_KHR_image
+  EGLEW_KHR_image = _glewSearchExtension("EGL_KHR_image", extStart, extEnd);
+  if (glewExperimental || EGLEW_KHR_image) EGLEW_KHR_image = !_glewInit_EGL_KHR_image();
+#endif /* EGL_KHR_image */
+#ifdef EGL_KHR_image_base
+  EGLEW_KHR_image_base = _glewSearchExtension("EGL_KHR_image_base", extStart, extEnd);
+#endif /* EGL_KHR_image_base */
+#ifdef EGL_KHR_image_pixmap
+  EGLEW_KHR_image_pixmap = _glewSearchExtension("EGL_KHR_image_pixmap", extStart, extEnd);
+#endif /* EGL_KHR_image_pixmap */
+#ifdef EGL_KHR_lock_surface
+  EGLEW_KHR_lock_surface = _glewSearchExtension("EGL_KHR_lock_surface", extStart, extEnd);
+  if (glewExperimental || EGLEW_KHR_lock_surface) EGLEW_KHR_lock_surface = !_glewInit_EGL_KHR_lock_surface();
+#endif /* EGL_KHR_lock_surface */
+#ifdef EGL_KHR_lock_surface2
+  EGLEW_KHR_lock_surface2 = _glewSearchExtension("EGL_KHR_lock_surface2", extStart, extEnd);
+#endif /* EGL_KHR_lock_surface2 */
+#ifdef EGL_KHR_lock_surface3
+  EGLEW_KHR_lock_surface3 = _glewSearchExtension("EGL_KHR_lock_surface3", extStart, extEnd);
+  if (glewExperimental || EGLEW_KHR_lock_surface3) EGLEW_KHR_lock_surface3 = !_glewInit_EGL_KHR_lock_surface3();
+#endif /* EGL_KHR_lock_surface3 */
+#ifdef EGL_KHR_mutable_render_buffer
+  EGLEW_KHR_mutable_render_buffer = _glewSearchExtension("EGL_KHR_mutable_render_buffer", extStart, extEnd);
+#endif /* EGL_KHR_mutable_render_buffer */
+#ifdef EGL_KHR_no_config_context
+  EGLEW_KHR_no_config_context = _glewSearchExtension("EGL_KHR_no_config_context", extStart, extEnd);
+#endif /* EGL_KHR_no_config_context */
+#ifdef EGL_KHR_partial_update
+  EGLEW_KHR_partial_update = _glewSearchExtension("EGL_KHR_partial_update", extStart, extEnd);
+  if (glewExperimental || EGLEW_KHR_partial_update) EGLEW_KHR_partial_update = !_glewInit_EGL_KHR_partial_update();
+#endif /* EGL_KHR_partial_update */
+#ifdef EGL_KHR_platform_android
+  EGLEW_KHR_platform_android = _glewSearchExtension("EGL_KHR_platform_android", extStart, extEnd);
+#endif /* EGL_KHR_platform_android */
+#ifdef EGL_KHR_platform_gbm
+  EGLEW_KHR_platform_gbm = _glewSearchExtension("EGL_KHR_platform_gbm", extStart, extEnd);
+#endif /* EGL_KHR_platform_gbm */
+#ifdef EGL_KHR_platform_wayland
+  EGLEW_KHR_platform_wayland = _glewSearchExtension("EGL_KHR_platform_wayland", extStart, extEnd);
+#endif /* EGL_KHR_platform_wayland */
+#ifdef EGL_KHR_platform_x11
+  EGLEW_KHR_platform_x11 = _glewSearchExtension("EGL_KHR_platform_x11", extStart, extEnd);
+#endif /* EGL_KHR_platform_x11 */
+#ifdef EGL_KHR_reusable_sync
+  EGLEW_KHR_reusable_sync = _glewSearchExtension("EGL_KHR_reusable_sync", extStart, extEnd);
+  if (glewExperimental || EGLEW_KHR_reusable_sync) EGLEW_KHR_reusable_sync = !_glewInit_EGL_KHR_reusable_sync();
+#endif /* EGL_KHR_reusable_sync */
+#ifdef EGL_KHR_stream
+  EGLEW_KHR_stream = _glewSearchExtension("EGL_KHR_stream", extStart, extEnd);
+  if (glewExperimental || EGLEW_KHR_stream) EGLEW_KHR_stream = !_glewInit_EGL_KHR_stream();
+#endif /* EGL_KHR_stream */
+#ifdef EGL_KHR_stream_attrib
+  EGLEW_KHR_stream_attrib = _glewSearchExtension("EGL_KHR_stream_attrib", extStart, extEnd);
+  if (glewExperimental || EGLEW_KHR_stream_attrib) EGLEW_KHR_stream_attrib = !_glewInit_EGL_KHR_stream_attrib();
+#endif /* EGL_KHR_stream_attrib */
+#ifdef EGL_KHR_stream_consumer_gltexture
+  EGLEW_KHR_stream_consumer_gltexture = _glewSearchExtension("EGL_KHR_stream_consumer_gltexture", extStart, extEnd);
+  if (glewExperimental || EGLEW_KHR_stream_consumer_gltexture) EGLEW_KHR_stream_consumer_gltexture = !_glewInit_EGL_KHR_stream_consumer_gltexture();
+#endif /* EGL_KHR_stream_consumer_gltexture */
+#ifdef EGL_KHR_stream_cross_process_fd
+  EGLEW_KHR_stream_cross_process_fd = _glewSearchExtension("EGL_KHR_stream_cross_process_fd", extStart, extEnd);
+  if (glewExperimental || EGLEW_KHR_stream_cross_process_fd) EGLEW_KHR_stream_cross_process_fd = !_glewInit_EGL_KHR_stream_cross_process_fd();
+#endif /* EGL_KHR_stream_cross_process_fd */
+#ifdef EGL_KHR_stream_fifo
+  EGLEW_KHR_stream_fifo = _glewSearchExtension("EGL_KHR_stream_fifo", extStart, extEnd);
+  if (glewExperimental || EGLEW_KHR_stream_fifo) EGLEW_KHR_stream_fifo = !_glewInit_EGL_KHR_stream_fifo();
+#endif /* EGL_KHR_stream_fifo */
+#ifdef EGL_KHR_stream_producer_aldatalocator
+  EGLEW_KHR_stream_producer_aldatalocator = _glewSearchExtension("EGL_KHR_stream_producer_aldatalocator", extStart, extEnd);
+#endif /* EGL_KHR_stream_producer_aldatalocator */
+#ifdef EGL_KHR_stream_producer_eglsurface
+  EGLEW_KHR_stream_producer_eglsurface = _glewSearchExtension("EGL_KHR_stream_producer_eglsurface", extStart, extEnd);
+  if (glewExperimental || EGLEW_KHR_stream_producer_eglsurface) EGLEW_KHR_stream_producer_eglsurface = !_glewInit_EGL_KHR_stream_producer_eglsurface();
+#endif /* EGL_KHR_stream_producer_eglsurface */
+#ifdef EGL_KHR_surfaceless_context
+  EGLEW_KHR_surfaceless_context = _glewSearchExtension("EGL_KHR_surfaceless_context", extStart, extEnd);
+#endif /* EGL_KHR_surfaceless_context */
+#ifdef EGL_KHR_swap_buffers_with_damage
+  EGLEW_KHR_swap_buffers_with_damage = _glewSearchExtension("EGL_KHR_swap_buffers_with_damage", extStart, extEnd);
+  if (glewExperimental || EGLEW_KHR_swap_buffers_with_damage) EGLEW_KHR_swap_buffers_with_damage = !_glewInit_EGL_KHR_swap_buffers_with_damage();
+#endif /* EGL_KHR_swap_buffers_with_damage */
+#ifdef EGL_KHR_vg_parent_image
+  EGLEW_KHR_vg_parent_image = _glewSearchExtension("EGL_KHR_vg_parent_image", extStart, extEnd);
+#endif /* EGL_KHR_vg_parent_image */
+#ifdef EGL_KHR_wait_sync
+  EGLEW_KHR_wait_sync = _glewSearchExtension("EGL_KHR_wait_sync", extStart, extEnd);
+  if (glewExperimental || EGLEW_KHR_wait_sync) EGLEW_KHR_wait_sync = !_glewInit_EGL_KHR_wait_sync();
+#endif /* EGL_KHR_wait_sync */
+#ifdef EGL_MESA_drm_image
+  EGLEW_MESA_drm_image = _glewSearchExtension("EGL_MESA_drm_image", extStart, extEnd);
+  if (glewExperimental || EGLEW_MESA_drm_image) EGLEW_MESA_drm_image = !_glewInit_EGL_MESA_drm_image();
+#endif /* EGL_MESA_drm_image */
+#ifdef EGL_MESA_image_dma_buf_export
+  EGLEW_MESA_image_dma_buf_export = _glewSearchExtension("EGL_MESA_image_dma_buf_export", extStart, extEnd);
+  if (glewExperimental || EGLEW_MESA_image_dma_buf_export) EGLEW_MESA_image_dma_buf_export = !_glewInit_EGL_MESA_image_dma_buf_export();
+#endif /* EGL_MESA_image_dma_buf_export */
+#ifdef EGL_MESA_platform_gbm
+  EGLEW_MESA_platform_gbm = _glewSearchExtension("EGL_MESA_platform_gbm", extStart, extEnd);
+#endif /* EGL_MESA_platform_gbm */
+#ifdef EGL_MESA_platform_surfaceless
+  EGLEW_MESA_platform_surfaceless = _glewSearchExtension("EGL_MESA_platform_surfaceless", extStart, extEnd);
+#endif /* EGL_MESA_platform_surfaceless */
+#ifdef EGL_NOK_swap_region
+  EGLEW_NOK_swap_region = _glewSearchExtension("EGL_NOK_swap_region", extStart, extEnd);
+  if (glewExperimental || EGLEW_NOK_swap_region) EGLEW_NOK_swap_region = !_glewInit_EGL_NOK_swap_region();
+#endif /* EGL_NOK_swap_region */
+#ifdef EGL_NOK_swap_region2
+  EGLEW_NOK_swap_region2 = _glewSearchExtension("EGL_NOK_swap_region2", extStart, extEnd);
+  if (glewExperimental || EGLEW_NOK_swap_region2) EGLEW_NOK_swap_region2 = !_glewInit_EGL_NOK_swap_region2();
+#endif /* EGL_NOK_swap_region2 */
+#ifdef EGL_NOK_texture_from_pixmap
+  EGLEW_NOK_texture_from_pixmap = _glewSearchExtension("EGL_NOK_texture_from_pixmap", extStart, extEnd);
+#endif /* EGL_NOK_texture_from_pixmap */
+#ifdef EGL_NV_3dvision_surface
+  EGLEW_NV_3dvision_surface = _glewSearchExtension("EGL_NV_3dvision_surface", extStart, extEnd);
+#endif /* EGL_NV_3dvision_surface */
+#ifdef EGL_NV_coverage_sample
+  EGLEW_NV_coverage_sample = _glewSearchExtension("EGL_NV_coverage_sample", extStart, extEnd);
+#endif /* EGL_NV_coverage_sample */
+#ifdef EGL_NV_coverage_sample_resolve
+  EGLEW_NV_coverage_sample_resolve = _glewSearchExtension("EGL_NV_coverage_sample_resolve", extStart, extEnd);
+#endif /* EGL_NV_coverage_sample_resolve */
+#ifdef EGL_NV_cuda_event
+  EGLEW_NV_cuda_event = _glewSearchExtension("EGL_NV_cuda_event", extStart, extEnd);
+#endif /* EGL_NV_cuda_event */
+#ifdef EGL_NV_depth_nonlinear
+  EGLEW_NV_depth_nonlinear = _glewSearchExtension("EGL_NV_depth_nonlinear", extStart, extEnd);
+#endif /* EGL_NV_depth_nonlinear */
+#ifdef EGL_NV_device_cuda
+  EGLEW_NV_device_cuda = _glewSearchExtension("EGL_NV_device_cuda", extStart, extEnd);
+#endif /* EGL_NV_device_cuda */
+#ifdef EGL_NV_native_query
+  EGLEW_NV_native_query = _glewSearchExtension("EGL_NV_native_query", extStart, extEnd);
+  if (glewExperimental || EGLEW_NV_native_query) EGLEW_NV_native_query = !_glewInit_EGL_NV_native_query();
+#endif /* EGL_NV_native_query */
+#ifdef EGL_NV_post_convert_rounding
+  EGLEW_NV_post_convert_rounding = _glewSearchExtension("EGL_NV_post_convert_rounding", extStart, extEnd);
+#endif /* EGL_NV_post_convert_rounding */
+#ifdef EGL_NV_post_sub_buffer
+  EGLEW_NV_post_sub_buffer = _glewSearchExtension("EGL_NV_post_sub_buffer", extStart, extEnd);
+  if (glewExperimental || EGLEW_NV_post_sub_buffer) EGLEW_NV_post_sub_buffer = !_glewInit_EGL_NV_post_sub_buffer();
+#endif /* EGL_NV_post_sub_buffer */
+#ifdef EGL_NV_robustness_video_memory_purge
+  EGLEW_NV_robustness_video_memory_purge = _glewSearchExtension("EGL_NV_robustness_video_memory_purge", extStart, extEnd);
+#endif /* EGL_NV_robustness_video_memory_purge */
+#ifdef EGL_NV_stream_consumer_gltexture_yuv
+  EGLEW_NV_stream_consumer_gltexture_yuv = _glewSearchExtension("EGL_NV_stream_consumer_gltexture_yuv", extStart, extEnd);
+  if (glewExperimental || EGLEW_NV_stream_consumer_gltexture_yuv) EGLEW_NV_stream_consumer_gltexture_yuv = !_glewInit_EGL_NV_stream_consumer_gltexture_yuv();
+#endif /* EGL_NV_stream_consumer_gltexture_yuv */
+#ifdef EGL_NV_stream_cross_display
+  EGLEW_NV_stream_cross_display = _glewSearchExtension("EGL_NV_stream_cross_display", extStart, extEnd);
+#endif /* EGL_NV_stream_cross_display */
+#ifdef EGL_NV_stream_cross_object
+  EGLEW_NV_stream_cross_object = _glewSearchExtension("EGL_NV_stream_cross_object", extStart, extEnd);
+#endif /* EGL_NV_stream_cross_object */
+#ifdef EGL_NV_stream_cross_partition
+  EGLEW_NV_stream_cross_partition = _glewSearchExtension("EGL_NV_stream_cross_partition", extStart, extEnd);
+#endif /* EGL_NV_stream_cross_partition */
+#ifdef EGL_NV_stream_cross_process
+  EGLEW_NV_stream_cross_process = _glewSearchExtension("EGL_NV_stream_cross_process", extStart, extEnd);
+#endif /* EGL_NV_stream_cross_process */
+#ifdef EGL_NV_stream_cross_system
+  EGLEW_NV_stream_cross_system = _glewSearchExtension("EGL_NV_stream_cross_system", extStart, extEnd);
+#endif /* EGL_NV_stream_cross_system */
+#ifdef EGL_NV_stream_fifo_next
+  EGLEW_NV_stream_fifo_next = _glewSearchExtension("EGL_NV_stream_fifo_next", extStart, extEnd);
+#endif /* EGL_NV_stream_fifo_next */
+#ifdef EGL_NV_stream_fifo_synchronous
+  EGLEW_NV_stream_fifo_synchronous = _glewSearchExtension("EGL_NV_stream_fifo_synchronous", extStart, extEnd);
+#endif /* EGL_NV_stream_fifo_synchronous */
+#ifdef EGL_NV_stream_frame_limits
+  EGLEW_NV_stream_frame_limits = _glewSearchExtension("EGL_NV_stream_frame_limits", extStart, extEnd);
+#endif /* EGL_NV_stream_frame_limits */
+#ifdef EGL_NV_stream_metadata
+  EGLEW_NV_stream_metadata = _glewSearchExtension("EGL_NV_stream_metadata", extStart, extEnd);
+  if (glewExperimental || EGLEW_NV_stream_metadata) EGLEW_NV_stream_metadata = !_glewInit_EGL_NV_stream_metadata();
+#endif /* EGL_NV_stream_metadata */
+#ifdef EGL_NV_stream_remote
+  EGLEW_NV_stream_remote = _glewSearchExtension("EGL_NV_stream_remote", extStart, extEnd);
+#endif /* EGL_NV_stream_remote */
+#ifdef EGL_NV_stream_reset
+  EGLEW_NV_stream_reset = _glewSearchExtension("EGL_NV_stream_reset", extStart, extEnd);
+  if (glewExperimental || EGLEW_NV_stream_reset) EGLEW_NV_stream_reset = !_glewInit_EGL_NV_stream_reset();
+#endif /* EGL_NV_stream_reset */
+#ifdef EGL_NV_stream_socket
+  EGLEW_NV_stream_socket = _glewSearchExtension("EGL_NV_stream_socket", extStart, extEnd);
+#endif /* EGL_NV_stream_socket */
+#ifdef EGL_NV_stream_socket_inet
+  EGLEW_NV_stream_socket_inet = _glewSearchExtension("EGL_NV_stream_socket_inet", extStart, extEnd);
+#endif /* EGL_NV_stream_socket_inet */
+#ifdef EGL_NV_stream_socket_unix
+  EGLEW_NV_stream_socket_unix = _glewSearchExtension("EGL_NV_stream_socket_unix", extStart, extEnd);
+#endif /* EGL_NV_stream_socket_unix */
+#ifdef EGL_NV_stream_sync
+  EGLEW_NV_stream_sync = _glewSearchExtension("EGL_NV_stream_sync", extStart, extEnd);
+  if (glewExperimental || EGLEW_NV_stream_sync) EGLEW_NV_stream_sync = !_glewInit_EGL_NV_stream_sync();
+#endif /* EGL_NV_stream_sync */
+#ifdef EGL_NV_sync
+  EGLEW_NV_sync = _glewSearchExtension("EGL_NV_sync", extStart, extEnd);
+  if (glewExperimental || EGLEW_NV_sync) EGLEW_NV_sync = !_glewInit_EGL_NV_sync();
+#endif /* EGL_NV_sync */
+#ifdef EGL_NV_system_time
+  EGLEW_NV_system_time = _glewSearchExtension("EGL_NV_system_time", extStart, extEnd);
+  if (glewExperimental || EGLEW_NV_system_time) EGLEW_NV_system_time = !_glewInit_EGL_NV_system_time();
+#endif /* EGL_NV_system_time */
+#ifdef EGL_TIZEN_image_native_buffer
+  EGLEW_TIZEN_image_native_buffer = _glewSearchExtension("EGL_TIZEN_image_native_buffer", extStart, extEnd);
+#endif /* EGL_TIZEN_image_native_buffer */
+#ifdef EGL_TIZEN_image_native_surface
+  EGLEW_TIZEN_image_native_surface = _glewSearchExtension("EGL_TIZEN_image_native_surface", extStart, extEnd);
+#endif /* EGL_TIZEN_image_native_surface */
+
+  return GLEW_OK;
+}
+
+#elif defined(_WIN32)
 
 PFNWGLSETSTEREOEMITTERSTATE3DLPROC __wglewSetStereoEmitterState3DL = NULL;
 
@@ -12262,6 +18961,7 @@ GLboolean __WGLEW_AMD_gpu_association = GL_FALSE;
 GLboolean __WGLEW_ARB_buffer_region = GL_FALSE;
 GLboolean __WGLEW_ARB_context_flush_control = GL_FALSE;
 GLboolean __WGLEW_ARB_create_context = GL_FALSE;
+GLboolean __WGLEW_ARB_create_context_no_error = GL_FALSE;
 GLboolean __WGLEW_ARB_create_context_profile = GL_FALSE;
 GLboolean __WGLEW_ARB_create_context_robustness = GL_FALSE;
 GLboolean __WGLEW_ARB_extensions_string = GL_FALSE;
@@ -12276,6 +18976,7 @@ GLboolean __WGLEW_ARB_robustness_application_isolation = GL_FALSE;
 GLboolean __WGLEW_ARB_robustness_share_group_isolation = GL_FALSE;
 GLboolean __WGLEW_ATI_pixel_format_float = GL_FALSE;
 GLboolean __WGLEW_ATI_render_texture_rectangle = GL_FALSE;
+GLboolean __WGLEW_EXT_colorspace = GL_FALSE;
 GLboolean __WGLEW_EXT_create_context_es2_profile = GL_FALSE;
 GLboolean __WGLEW_EXT_create_context_es_profile = GL_FALSE;
 GLboolean __WGLEW_EXT_depth_float = GL_FALSE;
@@ -12310,16 +19011,9 @@ GLboolean __WGLEW_NV_vertex_array_range = GL_FALSE;
 GLboolean __WGLEW_NV_video_capture = GL_FALSE;
 GLboolean __WGLEW_NV_video_output = GL_FALSE;
 GLboolean __WGLEW_OML_sync_control = GL_FALSE;
-
-#endif /* !GLEW_MX */
-
-#ifdef WGL_3DFX_multisample
-
-#endif /* WGL_3DFX_multisample */
-
 #ifdef WGL_3DL_stereo_control
 
-static GLboolean _glewInit_WGL_3DL_stereo_control (WGLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_WGL_3DL_stereo_control ()
 {
   GLboolean r = GL_FALSE;
 
@@ -12332,7 +19026,7 @@ static GLboolean _glewInit_WGL_3DL_stereo_control (WGLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef WGL_AMD_gpu_association
 
-static GLboolean _glewInit_WGL_AMD_gpu_association (WGLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_WGL_AMD_gpu_association ()
 {
   GLboolean r = GL_FALSE;
 
@@ -12353,7 +19047,7 @@ static GLboolean _glewInit_WGL_AMD_gpu_association (WGLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef WGL_ARB_buffer_region
 
-static GLboolean _glewInit_WGL_ARB_buffer_region (WGLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_WGL_ARB_buffer_region ()
 {
   GLboolean r = GL_FALSE;
 
@@ -12367,13 +19061,9 @@ static GLboolean _glewInit_WGL_ARB_buffer_region (WGLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* WGL_ARB_buffer_region */
 
-#ifdef WGL_ARB_context_flush_control
-
-#endif /* WGL_ARB_context_flush_control */
-
 #ifdef WGL_ARB_create_context
 
-static GLboolean _glewInit_WGL_ARB_create_context (WGLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_WGL_ARB_create_context ()
 {
   GLboolean r = GL_FALSE;
 
@@ -12384,17 +19074,9 @@ static GLboolean _glewInit_WGL_ARB_create_context (WGLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* WGL_ARB_create_context */
 
-#ifdef WGL_ARB_create_context_profile
-
-#endif /* WGL_ARB_create_context_profile */
-
-#ifdef WGL_ARB_create_context_robustness
-
-#endif /* WGL_ARB_create_context_robustness */
-
 #ifdef WGL_ARB_extensions_string
 
-static GLboolean _glewInit_WGL_ARB_extensions_string (WGLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_WGL_ARB_extensions_string ()
 {
   GLboolean r = GL_FALSE;
 
@@ -12405,13 +19087,9 @@ static GLboolean _glewInit_WGL_ARB_extensions_string (WGLEW_CONTEXT_ARG_DEF_INIT
 
 #endif /* WGL_ARB_extensions_string */
 
-#ifdef WGL_ARB_framebuffer_sRGB
-
-#endif /* WGL_ARB_framebuffer_sRGB */
-
 #ifdef WGL_ARB_make_current_read
 
-static GLboolean _glewInit_WGL_ARB_make_current_read (WGLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_WGL_ARB_make_current_read ()
 {
   GLboolean r = GL_FALSE;
 
@@ -12423,13 +19101,9 @@ static GLboolean _glewInit_WGL_ARB_make_current_read (WGLEW_CONTEXT_ARG_DEF_INIT
 
 #endif /* WGL_ARB_make_current_read */
 
-#ifdef WGL_ARB_multisample
-
-#endif /* WGL_ARB_multisample */
-
 #ifdef WGL_ARB_pbuffer
 
-static GLboolean _glewInit_WGL_ARB_pbuffer (WGLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_WGL_ARB_pbuffer ()
 {
   GLboolean r = GL_FALSE;
 
@@ -12446,7 +19120,7 @@ static GLboolean _glewInit_WGL_ARB_pbuffer (WGLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef WGL_ARB_pixel_format
 
-static GLboolean _glewInit_WGL_ARB_pixel_format (WGLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_WGL_ARB_pixel_format ()
 {
   GLboolean r = GL_FALSE;
 
@@ -12459,13 +19133,9 @@ static GLboolean _glewInit_WGL_ARB_pixel_format (WGLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* WGL_ARB_pixel_format */
 
-#ifdef WGL_ARB_pixel_format_float
-
-#endif /* WGL_ARB_pixel_format_float */
-
 #ifdef WGL_ARB_render_texture
 
-static GLboolean _glewInit_WGL_ARB_render_texture (WGLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_WGL_ARB_render_texture ()
 {
   GLboolean r = GL_FALSE;
 
@@ -12478,37 +19148,9 @@ static GLboolean _glewInit_WGL_ARB_render_texture (WGLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* WGL_ARB_render_texture */
 
-#ifdef WGL_ARB_robustness_application_isolation
-
-#endif /* WGL_ARB_robustness_application_isolation */
-
-#ifdef WGL_ARB_robustness_share_group_isolation
-
-#endif /* WGL_ARB_robustness_share_group_isolation */
-
-#ifdef WGL_ATI_pixel_format_float
-
-#endif /* WGL_ATI_pixel_format_float */
-
-#ifdef WGL_ATI_render_texture_rectangle
-
-#endif /* WGL_ATI_render_texture_rectangle */
-
-#ifdef WGL_EXT_create_context_es2_profile
-
-#endif /* WGL_EXT_create_context_es2_profile */
-
-#ifdef WGL_EXT_create_context_es_profile
-
-#endif /* WGL_EXT_create_context_es_profile */
-
-#ifdef WGL_EXT_depth_float
-
-#endif /* WGL_EXT_depth_float */
-
 #ifdef WGL_EXT_display_color_table
 
-static GLboolean _glewInit_WGL_EXT_display_color_table (WGLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_WGL_EXT_display_color_table ()
 {
   GLboolean r = GL_FALSE;
 
@@ -12524,7 +19166,7 @@ static GLboolean _glewInit_WGL_EXT_display_color_table (WGLEW_CONTEXT_ARG_DEF_IN
 
 #ifdef WGL_EXT_extensions_string
 
-static GLboolean _glewInit_WGL_EXT_extensions_string (WGLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_WGL_EXT_extensions_string ()
 {
   GLboolean r = GL_FALSE;
 
@@ -12535,13 +19177,9 @@ static GLboolean _glewInit_WGL_EXT_extensions_string (WGLEW_CONTEXT_ARG_DEF_INIT
 
 #endif /* WGL_EXT_extensions_string */
 
-#ifdef WGL_EXT_framebuffer_sRGB
-
-#endif /* WGL_EXT_framebuffer_sRGB */
-
 #ifdef WGL_EXT_make_current_read
 
-static GLboolean _glewInit_WGL_EXT_make_current_read (WGLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_WGL_EXT_make_current_read ()
 {
   GLboolean r = GL_FALSE;
 
@@ -12553,13 +19191,9 @@ static GLboolean _glewInit_WGL_EXT_make_current_read (WGLEW_CONTEXT_ARG_DEF_INIT
 
 #endif /* WGL_EXT_make_current_read */
 
-#ifdef WGL_EXT_multisample
-
-#endif /* WGL_EXT_multisample */
-
 #ifdef WGL_EXT_pbuffer
 
-static GLboolean _glewInit_WGL_EXT_pbuffer (WGLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_WGL_EXT_pbuffer ()
 {
   GLboolean r = GL_FALSE;
 
@@ -12576,7 +19210,7 @@ static GLboolean _glewInit_WGL_EXT_pbuffer (WGLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef WGL_EXT_pixel_format
 
-static GLboolean _glewInit_WGL_EXT_pixel_format (WGLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_WGL_EXT_pixel_format ()
 {
   GLboolean r = GL_FALSE;
 
@@ -12589,13 +19223,9 @@ static GLboolean _glewInit_WGL_EXT_pixel_format (WGLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* WGL_EXT_pixel_format */
 
-#ifdef WGL_EXT_pixel_format_packed_float
-
-#endif /* WGL_EXT_pixel_format_packed_float */
-
 #ifdef WGL_EXT_swap_control
 
-static GLboolean _glewInit_WGL_EXT_swap_control (WGLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_WGL_EXT_swap_control ()
 {
   GLboolean r = GL_FALSE;
 
@@ -12607,13 +19237,9 @@ static GLboolean _glewInit_WGL_EXT_swap_control (WGLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* WGL_EXT_swap_control */
 
-#ifdef WGL_EXT_swap_control_tear
-
-#endif /* WGL_EXT_swap_control_tear */
-
 #ifdef WGL_I3D_digital_video_control
 
-static GLboolean _glewInit_WGL_I3D_digital_video_control (WGLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_WGL_I3D_digital_video_control ()
 {
   GLboolean r = GL_FALSE;
 
@@ -12627,7 +19253,7 @@ static GLboolean _glewInit_WGL_I3D_digital_video_control (WGLEW_CONTEXT_ARG_DEF_
 
 #ifdef WGL_I3D_gamma
 
-static GLboolean _glewInit_WGL_I3D_gamma (WGLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_WGL_I3D_gamma ()
 {
   GLboolean r = GL_FALSE;
 
@@ -12643,7 +19269,7 @@ static GLboolean _glewInit_WGL_I3D_gamma (WGLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef WGL_I3D_genlock
 
-static GLboolean _glewInit_WGL_I3D_genlock (WGLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_WGL_I3D_genlock ()
 {
   GLboolean r = GL_FALSE;
 
@@ -12667,7 +19293,7 @@ static GLboolean _glewInit_WGL_I3D_genlock (WGLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef WGL_I3D_image_buffer
 
-static GLboolean _glewInit_WGL_I3D_image_buffer (WGLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_WGL_I3D_image_buffer ()
 {
   GLboolean r = GL_FALSE;
 
@@ -12683,7 +19309,7 @@ static GLboolean _glewInit_WGL_I3D_image_buffer (WGLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef WGL_I3D_swap_frame_lock
 
-static GLboolean _glewInit_WGL_I3D_swap_frame_lock (WGLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_WGL_I3D_swap_frame_lock ()
 {
   GLboolean r = GL_FALSE;
 
@@ -12699,7 +19325,7 @@ static GLboolean _glewInit_WGL_I3D_swap_frame_lock (WGLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef WGL_I3D_swap_frame_usage
 
-static GLboolean _glewInit_WGL_I3D_swap_frame_usage (WGLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_WGL_I3D_swap_frame_usage ()
 {
   GLboolean r = GL_FALSE;
 
@@ -12715,7 +19341,7 @@ static GLboolean _glewInit_WGL_I3D_swap_frame_usage (WGLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef WGL_NV_DX_interop
 
-static GLboolean _glewInit_WGL_NV_DX_interop (WGLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_WGL_NV_DX_interop ()
 {
   GLboolean r = GL_FALSE;
 
@@ -12733,13 +19359,9 @@ static GLboolean _glewInit_WGL_NV_DX_interop (WGLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* WGL_NV_DX_interop */
 
-#ifdef WGL_NV_DX_interop2
-
-#endif /* WGL_NV_DX_interop2 */
-
 #ifdef WGL_NV_copy_image
 
-static GLboolean _glewInit_WGL_NV_copy_image (WGLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_WGL_NV_copy_image ()
 {
   GLboolean r = GL_FALSE;
 
@@ -12752,7 +19374,7 @@ static GLboolean _glewInit_WGL_NV_copy_image (WGLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef WGL_NV_delay_before_swap
 
-static GLboolean _glewInit_WGL_NV_delay_before_swap (WGLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_WGL_NV_delay_before_swap ()
 {
   GLboolean r = GL_FALSE;
 
@@ -12763,13 +19385,9 @@ static GLboolean _glewInit_WGL_NV_delay_before_swap (WGLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* WGL_NV_delay_before_swap */
 
-#ifdef WGL_NV_float_buffer
-
-#endif /* WGL_NV_float_buffer */
-
 #ifdef WGL_NV_gpu_affinity
 
-static GLboolean _glewInit_WGL_NV_gpu_affinity (WGLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_WGL_NV_gpu_affinity ()
 {
   GLboolean r = GL_FALSE;
 
@@ -12784,13 +19402,9 @@ static GLboolean _glewInit_WGL_NV_gpu_affinity (WGLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* WGL_NV_gpu_affinity */
 
-#ifdef WGL_NV_multisample_coverage
-
-#endif /* WGL_NV_multisample_coverage */
-
 #ifdef WGL_NV_present_video
 
-static GLboolean _glewInit_WGL_NV_present_video (WGLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_WGL_NV_present_video ()
 {
   GLboolean r = GL_FALSE;
 
@@ -12803,17 +19417,9 @@ static GLboolean _glewInit_WGL_NV_present_video (WGLEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* WGL_NV_present_video */
 
-#ifdef WGL_NV_render_depth_texture
-
-#endif /* WGL_NV_render_depth_texture */
-
-#ifdef WGL_NV_render_texture_rectangle
-
-#endif /* WGL_NV_render_texture_rectangle */
-
 #ifdef WGL_NV_swap_group
 
-static GLboolean _glewInit_WGL_NV_swap_group (WGLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_WGL_NV_swap_group ()
 {
   GLboolean r = GL_FALSE;
 
@@ -12831,7 +19437,7 @@ static GLboolean _glewInit_WGL_NV_swap_group (WGLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef WGL_NV_vertex_array_range
 
-static GLboolean _glewInit_WGL_NV_vertex_array_range (WGLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_WGL_NV_vertex_array_range ()
 {
   GLboolean r = GL_FALSE;
 
@@ -12845,7 +19451,7 @@ static GLboolean _glewInit_WGL_NV_vertex_array_range (WGLEW_CONTEXT_ARG_DEF_INIT
 
 #ifdef WGL_NV_video_capture
 
-static GLboolean _glewInit_WGL_NV_video_capture (WGLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_WGL_NV_video_capture ()
 {
   GLboolean r = GL_FALSE;
 
@@ -12862,7 +19468,7 @@ static GLboolean _glewInit_WGL_NV_video_capture (WGLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef WGL_NV_video_output
 
-static GLboolean _glewInit_WGL_NV_video_output (WGLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_WGL_NV_video_output ()
 {
   GLboolean r = GL_FALSE;
 
@@ -12880,7 +19486,7 @@ static GLboolean _glewInit_WGL_NV_video_output (WGLEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef WGL_OML_sync_control
 
-static GLboolean _glewInit_WGL_OML_sync_control (WGLEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_WGL_OML_sync_control ()
 {
   GLboolean r = GL_FALSE;
 
@@ -12918,7 +19524,7 @@ GLboolean GLEWAPIENTRY wglewGetExtension (const char* name)
   return _glewSearchExtension(name, start, end);
 }
 
-GLenum GLEWAPIENTRY wglewContextInit (WGLEW_CONTEXT_ARG_DEF_LIST)
+GLenum GLEWAPIENTRY wglewInit ()
 {
   GLboolean crippled;
   const GLubyte* extStart;
@@ -12942,23 +19548,26 @@ GLenum GLEWAPIENTRY wglewContextInit (WGLEW_CONTEXT_ARG_DEF_LIST)
 #endif /* WGL_3DFX_multisample */
 #ifdef WGL_3DL_stereo_control
   WGLEW_3DL_stereo_control = _glewSearchExtension("WGL_3DL_stereo_control", extStart, extEnd);
-  if (glewExperimental || WGLEW_3DL_stereo_control|| crippled) WGLEW_3DL_stereo_control= !_glewInit_WGL_3DL_stereo_control(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || WGLEW_3DL_stereo_control|| crippled) WGLEW_3DL_stereo_control= !_glewInit_WGL_3DL_stereo_control();
 #endif /* WGL_3DL_stereo_control */
 #ifdef WGL_AMD_gpu_association
   WGLEW_AMD_gpu_association = _glewSearchExtension("WGL_AMD_gpu_association", extStart, extEnd);
-  if (glewExperimental || WGLEW_AMD_gpu_association|| crippled) WGLEW_AMD_gpu_association= !_glewInit_WGL_AMD_gpu_association(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || WGLEW_AMD_gpu_association|| crippled) WGLEW_AMD_gpu_association= !_glewInit_WGL_AMD_gpu_association();
 #endif /* WGL_AMD_gpu_association */
 #ifdef WGL_ARB_buffer_region
   WGLEW_ARB_buffer_region = _glewSearchExtension("WGL_ARB_buffer_region", extStart, extEnd);
-  if (glewExperimental || WGLEW_ARB_buffer_region|| crippled) WGLEW_ARB_buffer_region= !_glewInit_WGL_ARB_buffer_region(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || WGLEW_ARB_buffer_region|| crippled) WGLEW_ARB_buffer_region= !_glewInit_WGL_ARB_buffer_region();
 #endif /* WGL_ARB_buffer_region */
 #ifdef WGL_ARB_context_flush_control
   WGLEW_ARB_context_flush_control = _glewSearchExtension("WGL_ARB_context_flush_control", extStart, extEnd);
 #endif /* WGL_ARB_context_flush_control */
 #ifdef WGL_ARB_create_context
   WGLEW_ARB_create_context = _glewSearchExtension("WGL_ARB_create_context", extStart, extEnd);
-  if (glewExperimental || WGLEW_ARB_create_context|| crippled) WGLEW_ARB_create_context= !_glewInit_WGL_ARB_create_context(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || WGLEW_ARB_create_context|| crippled) WGLEW_ARB_create_context= !_glewInit_WGL_ARB_create_context();
 #endif /* WGL_ARB_create_context */
+#ifdef WGL_ARB_create_context_no_error
+  WGLEW_ARB_create_context_no_error = _glewSearchExtension("WGL_ARB_create_context_no_error", extStart, extEnd);
+#endif /* WGL_ARB_create_context_no_error */
 #ifdef WGL_ARB_create_context_profile
   WGLEW_ARB_create_context_profile = _glewSearchExtension("WGL_ARB_create_context_profile", extStart, extEnd);
 #endif /* WGL_ARB_create_context_profile */
@@ -12967,32 +19576,32 @@ GLenum GLEWAPIENTRY wglewContextInit (WGLEW_CONTEXT_ARG_DEF_LIST)
 #endif /* WGL_ARB_create_context_robustness */
 #ifdef WGL_ARB_extensions_string
   WGLEW_ARB_extensions_string = _glewSearchExtension("WGL_ARB_extensions_string", extStart, extEnd);
-  if (glewExperimental || WGLEW_ARB_extensions_string|| crippled) WGLEW_ARB_extensions_string= !_glewInit_WGL_ARB_extensions_string(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || WGLEW_ARB_extensions_string|| crippled) WGLEW_ARB_extensions_string= !_glewInit_WGL_ARB_extensions_string();
 #endif /* WGL_ARB_extensions_string */
 #ifdef WGL_ARB_framebuffer_sRGB
   WGLEW_ARB_framebuffer_sRGB = _glewSearchExtension("WGL_ARB_framebuffer_sRGB", extStart, extEnd);
 #endif /* WGL_ARB_framebuffer_sRGB */
 #ifdef WGL_ARB_make_current_read
   WGLEW_ARB_make_current_read = _glewSearchExtension("WGL_ARB_make_current_read", extStart, extEnd);
-  if (glewExperimental || WGLEW_ARB_make_current_read|| crippled) WGLEW_ARB_make_current_read= !_glewInit_WGL_ARB_make_current_read(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || WGLEW_ARB_make_current_read|| crippled) WGLEW_ARB_make_current_read= !_glewInit_WGL_ARB_make_current_read();
 #endif /* WGL_ARB_make_current_read */
 #ifdef WGL_ARB_multisample
   WGLEW_ARB_multisample = _glewSearchExtension("WGL_ARB_multisample", extStart, extEnd);
 #endif /* WGL_ARB_multisample */
 #ifdef WGL_ARB_pbuffer
   WGLEW_ARB_pbuffer = _glewSearchExtension("WGL_ARB_pbuffer", extStart, extEnd);
-  if (glewExperimental || WGLEW_ARB_pbuffer|| crippled) WGLEW_ARB_pbuffer= !_glewInit_WGL_ARB_pbuffer(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || WGLEW_ARB_pbuffer|| crippled) WGLEW_ARB_pbuffer= !_glewInit_WGL_ARB_pbuffer();
 #endif /* WGL_ARB_pbuffer */
 #ifdef WGL_ARB_pixel_format
   WGLEW_ARB_pixel_format = _glewSearchExtension("WGL_ARB_pixel_format", extStart, extEnd);
-  if (glewExperimental || WGLEW_ARB_pixel_format|| crippled) WGLEW_ARB_pixel_format= !_glewInit_WGL_ARB_pixel_format(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || WGLEW_ARB_pixel_format|| crippled) WGLEW_ARB_pixel_format= !_glewInit_WGL_ARB_pixel_format();
 #endif /* WGL_ARB_pixel_format */
 #ifdef WGL_ARB_pixel_format_float
   WGLEW_ARB_pixel_format_float = _glewSearchExtension("WGL_ARB_pixel_format_float", extStart, extEnd);
 #endif /* WGL_ARB_pixel_format_float */
 #ifdef WGL_ARB_render_texture
   WGLEW_ARB_render_texture = _glewSearchExtension("WGL_ARB_render_texture", extStart, extEnd);
-  if (glewExperimental || WGLEW_ARB_render_texture|| crippled) WGLEW_ARB_render_texture= !_glewInit_WGL_ARB_render_texture(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || WGLEW_ARB_render_texture|| crippled) WGLEW_ARB_render_texture= !_glewInit_WGL_ARB_render_texture();
 #endif /* WGL_ARB_render_texture */
 #ifdef WGL_ARB_robustness_application_isolation
   WGLEW_ARB_robustness_application_isolation = _glewSearchExtension("WGL_ARB_robustness_application_isolation", extStart, extEnd);
@@ -13006,6 +19615,9 @@ GLenum GLEWAPIENTRY wglewContextInit (WGLEW_CONTEXT_ARG_DEF_LIST)
 #ifdef WGL_ATI_render_texture_rectangle
   WGLEW_ATI_render_texture_rectangle = _glewSearchExtension("WGL_ATI_render_texture_rectangle", extStart, extEnd);
 #endif /* WGL_ATI_render_texture_rectangle */
+#ifdef WGL_EXT_colorspace
+  WGLEW_EXT_colorspace = _glewSearchExtension("WGL_EXT_colorspace", extStart, extEnd);
+#endif /* WGL_EXT_colorspace */
 #ifdef WGL_EXT_create_context_es2_profile
   WGLEW_EXT_create_context_es2_profile = _glewSearchExtension("WGL_EXT_create_context_es2_profile", extStart, extEnd);
 #endif /* WGL_EXT_create_context_es2_profile */
@@ -13017,92 +19629,92 @@ GLenum GLEWAPIENTRY wglewContextInit (WGLEW_CONTEXT_ARG_DEF_LIST)
 #endif /* WGL_EXT_depth_float */
 #ifdef WGL_EXT_display_color_table
   WGLEW_EXT_display_color_table = _glewSearchExtension("WGL_EXT_display_color_table", extStart, extEnd);
-  if (glewExperimental || WGLEW_EXT_display_color_table|| crippled) WGLEW_EXT_display_color_table= !_glewInit_WGL_EXT_display_color_table(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || WGLEW_EXT_display_color_table|| crippled) WGLEW_EXT_display_color_table= !_glewInit_WGL_EXT_display_color_table();
 #endif /* WGL_EXT_display_color_table */
 #ifdef WGL_EXT_extensions_string
   WGLEW_EXT_extensions_string = _glewSearchExtension("WGL_EXT_extensions_string", extStart, extEnd);
-  if (glewExperimental || WGLEW_EXT_extensions_string|| crippled) WGLEW_EXT_extensions_string= !_glewInit_WGL_EXT_extensions_string(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || WGLEW_EXT_extensions_string|| crippled) WGLEW_EXT_extensions_string= !_glewInit_WGL_EXT_extensions_string();
 #endif /* WGL_EXT_extensions_string */
 #ifdef WGL_EXT_framebuffer_sRGB
   WGLEW_EXT_framebuffer_sRGB = _glewSearchExtension("WGL_EXT_framebuffer_sRGB", extStart, extEnd);
 #endif /* WGL_EXT_framebuffer_sRGB */
 #ifdef WGL_EXT_make_current_read
   WGLEW_EXT_make_current_read = _glewSearchExtension("WGL_EXT_make_current_read", extStart, extEnd);
-  if (glewExperimental || WGLEW_EXT_make_current_read|| crippled) WGLEW_EXT_make_current_read= !_glewInit_WGL_EXT_make_current_read(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || WGLEW_EXT_make_current_read|| crippled) WGLEW_EXT_make_current_read= !_glewInit_WGL_EXT_make_current_read();
 #endif /* WGL_EXT_make_current_read */
 #ifdef WGL_EXT_multisample
   WGLEW_EXT_multisample = _glewSearchExtension("WGL_EXT_multisample", extStart, extEnd);
 #endif /* WGL_EXT_multisample */
 #ifdef WGL_EXT_pbuffer
   WGLEW_EXT_pbuffer = _glewSearchExtension("WGL_EXT_pbuffer", extStart, extEnd);
-  if (glewExperimental || WGLEW_EXT_pbuffer|| crippled) WGLEW_EXT_pbuffer= !_glewInit_WGL_EXT_pbuffer(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || WGLEW_EXT_pbuffer|| crippled) WGLEW_EXT_pbuffer= !_glewInit_WGL_EXT_pbuffer();
 #endif /* WGL_EXT_pbuffer */
 #ifdef WGL_EXT_pixel_format
   WGLEW_EXT_pixel_format = _glewSearchExtension("WGL_EXT_pixel_format", extStart, extEnd);
-  if (glewExperimental || WGLEW_EXT_pixel_format|| crippled) WGLEW_EXT_pixel_format= !_glewInit_WGL_EXT_pixel_format(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || WGLEW_EXT_pixel_format|| crippled) WGLEW_EXT_pixel_format= !_glewInit_WGL_EXT_pixel_format();
 #endif /* WGL_EXT_pixel_format */
 #ifdef WGL_EXT_pixel_format_packed_float
   WGLEW_EXT_pixel_format_packed_float = _glewSearchExtension("WGL_EXT_pixel_format_packed_float", extStart, extEnd);
 #endif /* WGL_EXT_pixel_format_packed_float */
 #ifdef WGL_EXT_swap_control
   WGLEW_EXT_swap_control = _glewSearchExtension("WGL_EXT_swap_control", extStart, extEnd);
-  if (glewExperimental || WGLEW_EXT_swap_control|| crippled) WGLEW_EXT_swap_control= !_glewInit_WGL_EXT_swap_control(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || WGLEW_EXT_swap_control|| crippled) WGLEW_EXT_swap_control= !_glewInit_WGL_EXT_swap_control();
 #endif /* WGL_EXT_swap_control */
 #ifdef WGL_EXT_swap_control_tear
   WGLEW_EXT_swap_control_tear = _glewSearchExtension("WGL_EXT_swap_control_tear", extStart, extEnd);
 #endif /* WGL_EXT_swap_control_tear */
 #ifdef WGL_I3D_digital_video_control
   WGLEW_I3D_digital_video_control = _glewSearchExtension("WGL_I3D_digital_video_control", extStart, extEnd);
-  if (glewExperimental || WGLEW_I3D_digital_video_control|| crippled) WGLEW_I3D_digital_video_control= !_glewInit_WGL_I3D_digital_video_control(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || WGLEW_I3D_digital_video_control|| crippled) WGLEW_I3D_digital_video_control= !_glewInit_WGL_I3D_digital_video_control();
 #endif /* WGL_I3D_digital_video_control */
 #ifdef WGL_I3D_gamma
   WGLEW_I3D_gamma = _glewSearchExtension("WGL_I3D_gamma", extStart, extEnd);
-  if (glewExperimental || WGLEW_I3D_gamma|| crippled) WGLEW_I3D_gamma= !_glewInit_WGL_I3D_gamma(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || WGLEW_I3D_gamma|| crippled) WGLEW_I3D_gamma= !_glewInit_WGL_I3D_gamma();
 #endif /* WGL_I3D_gamma */
 #ifdef WGL_I3D_genlock
   WGLEW_I3D_genlock = _glewSearchExtension("WGL_I3D_genlock", extStart, extEnd);
-  if (glewExperimental || WGLEW_I3D_genlock|| crippled) WGLEW_I3D_genlock= !_glewInit_WGL_I3D_genlock(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || WGLEW_I3D_genlock|| crippled) WGLEW_I3D_genlock= !_glewInit_WGL_I3D_genlock();
 #endif /* WGL_I3D_genlock */
 #ifdef WGL_I3D_image_buffer
   WGLEW_I3D_image_buffer = _glewSearchExtension("WGL_I3D_image_buffer", extStart, extEnd);
-  if (glewExperimental || WGLEW_I3D_image_buffer|| crippled) WGLEW_I3D_image_buffer= !_glewInit_WGL_I3D_image_buffer(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || WGLEW_I3D_image_buffer|| crippled) WGLEW_I3D_image_buffer= !_glewInit_WGL_I3D_image_buffer();
 #endif /* WGL_I3D_image_buffer */
 #ifdef WGL_I3D_swap_frame_lock
   WGLEW_I3D_swap_frame_lock = _glewSearchExtension("WGL_I3D_swap_frame_lock", extStart, extEnd);
-  if (glewExperimental || WGLEW_I3D_swap_frame_lock|| crippled) WGLEW_I3D_swap_frame_lock= !_glewInit_WGL_I3D_swap_frame_lock(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || WGLEW_I3D_swap_frame_lock|| crippled) WGLEW_I3D_swap_frame_lock= !_glewInit_WGL_I3D_swap_frame_lock();
 #endif /* WGL_I3D_swap_frame_lock */
 #ifdef WGL_I3D_swap_frame_usage
   WGLEW_I3D_swap_frame_usage = _glewSearchExtension("WGL_I3D_swap_frame_usage", extStart, extEnd);
-  if (glewExperimental || WGLEW_I3D_swap_frame_usage|| crippled) WGLEW_I3D_swap_frame_usage= !_glewInit_WGL_I3D_swap_frame_usage(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || WGLEW_I3D_swap_frame_usage|| crippled) WGLEW_I3D_swap_frame_usage= !_glewInit_WGL_I3D_swap_frame_usage();
 #endif /* WGL_I3D_swap_frame_usage */
 #ifdef WGL_NV_DX_interop
   WGLEW_NV_DX_interop = _glewSearchExtension("WGL_NV_DX_interop", extStart, extEnd);
-  if (glewExperimental || WGLEW_NV_DX_interop|| crippled) WGLEW_NV_DX_interop= !_glewInit_WGL_NV_DX_interop(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || WGLEW_NV_DX_interop|| crippled) WGLEW_NV_DX_interop= !_glewInit_WGL_NV_DX_interop();
 #endif /* WGL_NV_DX_interop */
 #ifdef WGL_NV_DX_interop2
   WGLEW_NV_DX_interop2 = _glewSearchExtension("WGL_NV_DX_interop2", extStart, extEnd);
 #endif /* WGL_NV_DX_interop2 */
 #ifdef WGL_NV_copy_image
   WGLEW_NV_copy_image = _glewSearchExtension("WGL_NV_copy_image", extStart, extEnd);
-  if (glewExperimental || WGLEW_NV_copy_image|| crippled) WGLEW_NV_copy_image= !_glewInit_WGL_NV_copy_image(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || WGLEW_NV_copy_image|| crippled) WGLEW_NV_copy_image= !_glewInit_WGL_NV_copy_image();
 #endif /* WGL_NV_copy_image */
 #ifdef WGL_NV_delay_before_swap
   WGLEW_NV_delay_before_swap = _glewSearchExtension("WGL_NV_delay_before_swap", extStart, extEnd);
-  if (glewExperimental || WGLEW_NV_delay_before_swap|| crippled) WGLEW_NV_delay_before_swap= !_glewInit_WGL_NV_delay_before_swap(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || WGLEW_NV_delay_before_swap|| crippled) WGLEW_NV_delay_before_swap= !_glewInit_WGL_NV_delay_before_swap();
 #endif /* WGL_NV_delay_before_swap */
 #ifdef WGL_NV_float_buffer
   WGLEW_NV_float_buffer = _glewSearchExtension("WGL_NV_float_buffer", extStart, extEnd);
 #endif /* WGL_NV_float_buffer */
 #ifdef WGL_NV_gpu_affinity
   WGLEW_NV_gpu_affinity = _glewSearchExtension("WGL_NV_gpu_affinity", extStart, extEnd);
-  if (glewExperimental || WGLEW_NV_gpu_affinity|| crippled) WGLEW_NV_gpu_affinity= !_glewInit_WGL_NV_gpu_affinity(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || WGLEW_NV_gpu_affinity|| crippled) WGLEW_NV_gpu_affinity= !_glewInit_WGL_NV_gpu_affinity();
 #endif /* WGL_NV_gpu_affinity */
 #ifdef WGL_NV_multisample_coverage
   WGLEW_NV_multisample_coverage = _glewSearchExtension("WGL_NV_multisample_coverage", extStart, extEnd);
 #endif /* WGL_NV_multisample_coverage */
 #ifdef WGL_NV_present_video
   WGLEW_NV_present_video = _glewSearchExtension("WGL_NV_present_video", extStart, extEnd);
-  if (glewExperimental || WGLEW_NV_present_video|| crippled) WGLEW_NV_present_video= !_glewInit_WGL_NV_present_video(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || WGLEW_NV_present_video|| crippled) WGLEW_NV_present_video= !_glewInit_WGL_NV_present_video();
 #endif /* WGL_NV_present_video */
 #ifdef WGL_NV_render_depth_texture
   WGLEW_NV_render_depth_texture = _glewSearchExtension("WGL_NV_render_depth_texture", extStart, extEnd);
@@ -13112,23 +19724,23 @@ GLenum GLEWAPIENTRY wglewContextInit (WGLEW_CONTEXT_ARG_DEF_LIST)
 #endif /* WGL_NV_render_texture_rectangle */
 #ifdef WGL_NV_swap_group
   WGLEW_NV_swap_group = _glewSearchExtension("WGL_NV_swap_group", extStart, extEnd);
-  if (glewExperimental || WGLEW_NV_swap_group|| crippled) WGLEW_NV_swap_group= !_glewInit_WGL_NV_swap_group(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || WGLEW_NV_swap_group|| crippled) WGLEW_NV_swap_group= !_glewInit_WGL_NV_swap_group();
 #endif /* WGL_NV_swap_group */
 #ifdef WGL_NV_vertex_array_range
   WGLEW_NV_vertex_array_range = _glewSearchExtension("WGL_NV_vertex_array_range", extStart, extEnd);
-  if (glewExperimental || WGLEW_NV_vertex_array_range|| crippled) WGLEW_NV_vertex_array_range= !_glewInit_WGL_NV_vertex_array_range(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || WGLEW_NV_vertex_array_range|| crippled) WGLEW_NV_vertex_array_range= !_glewInit_WGL_NV_vertex_array_range();
 #endif /* WGL_NV_vertex_array_range */
 #ifdef WGL_NV_video_capture
   WGLEW_NV_video_capture = _glewSearchExtension("WGL_NV_video_capture", extStart, extEnd);
-  if (glewExperimental || WGLEW_NV_video_capture|| crippled) WGLEW_NV_video_capture= !_glewInit_WGL_NV_video_capture(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || WGLEW_NV_video_capture|| crippled) WGLEW_NV_video_capture= !_glewInit_WGL_NV_video_capture();
 #endif /* WGL_NV_video_capture */
 #ifdef WGL_NV_video_output
   WGLEW_NV_video_output = _glewSearchExtension("WGL_NV_video_output", extStart, extEnd);
-  if (glewExperimental || WGLEW_NV_video_output|| crippled) WGLEW_NV_video_output= !_glewInit_WGL_NV_video_output(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || WGLEW_NV_video_output|| crippled) WGLEW_NV_video_output= !_glewInit_WGL_NV_video_output();
 #endif /* WGL_NV_video_output */
 #ifdef WGL_OML_sync_control
   WGLEW_OML_sync_control = _glewSearchExtension("WGL_OML_sync_control", extStart, extEnd);
-  if (glewExperimental || WGLEW_OML_sync_control|| crippled) WGLEW_OML_sync_control= !_glewInit_WGL_OML_sync_control(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || WGLEW_OML_sync_control|| crippled) WGLEW_OML_sync_control= !_glewInit_WGL_OML_sync_control();
 #endif /* WGL_OML_sync_control */
 
   return GLEW_OK;
@@ -13287,8 +19899,6 @@ PFNGLXGETTRANSPARENTINDEXSUNPROC __glewXGetTransparentIndexSUN = NULL;
 PFNGLXGETVIDEORESIZESUNPROC __glewXGetVideoResizeSUN = NULL;
 PFNGLXVIDEORESIZESUNPROC __glewXVideoResizeSUN = NULL;
 
-#if !defined(GLEW_MX)
-
 GLboolean __GLXEW_VERSION_1_0 = GL_FALSE;
 GLboolean __GLXEW_VERSION_1_1 = GL_FALSE;
 GLboolean __GLXEW_VERSION_1_2 = GL_FALSE;
@@ -13298,6 +19908,7 @@ GLboolean __GLXEW_3DFX_multisample = GL_FALSE;
 GLboolean __GLXEW_AMD_gpu_association = GL_FALSE;
 GLboolean __GLXEW_ARB_context_flush_control = GL_FALSE;
 GLboolean __GLXEW_ARB_create_context = GL_FALSE;
+GLboolean __GLXEW_ARB_create_context_no_error = GL_FALSE;
 GLboolean __GLXEW_ARB_create_context_profile = GL_FALSE;
 GLboolean __GLXEW_ARB_create_context_robustness = GL_FALSE;
 GLboolean __GLXEW_ARB_fbconfig_float = GL_FALSE;
@@ -13315,6 +19926,7 @@ GLboolean __GLXEW_EXT_create_context_es_profile = GL_FALSE;
 GLboolean __GLXEW_EXT_fbconfig_packed_float = GL_FALSE;
 GLboolean __GLXEW_EXT_framebuffer_sRGB = GL_FALSE;
 GLboolean __GLXEW_EXT_import_context = GL_FALSE;
+GLboolean __GLXEW_EXT_libglvnd = GL_FALSE;
 GLboolean __GLXEW_EXT_scene_marker = GL_FALSE;
 GLboolean __GLXEW_EXT_stereo_tree = GL_FALSE;
 GLboolean __GLXEW_EXT_swap_control = GL_FALSE;
@@ -13336,6 +19948,7 @@ GLboolean __GLXEW_NV_delay_before_swap = GL_FALSE;
 GLboolean __GLXEW_NV_float_buffer = GL_FALSE;
 GLboolean __GLXEW_NV_multisample_coverage = GL_FALSE;
 GLboolean __GLXEW_NV_present_video = GL_FALSE;
+GLboolean __GLXEW_NV_robustness_video_memory_purge = GL_FALSE;
 GLboolean __GLXEW_NV_swap_group = GL_FALSE;
 GLboolean __GLXEW_NV_vertex_array_range = GL_FALSE;
 GLboolean __GLXEW_NV_video_capture = GL_FALSE;
@@ -13359,12 +19972,9 @@ GLboolean __GLXEW_SGI_swap_control = GL_FALSE;
 GLboolean __GLXEW_SGI_video_sync = GL_FALSE;
 GLboolean __GLXEW_SUN_get_transparent_index = GL_FALSE;
 GLboolean __GLXEW_SUN_video_resize = GL_FALSE;
-
-#endif /* !GLEW_MX */
-
 #ifdef GLX_VERSION_1_2
 
-static GLboolean _glewInit_GLX_VERSION_1_2 (GLXEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GLX_VERSION_1_2 ()
 {
   GLboolean r = GL_FALSE;
 
@@ -13377,7 +19987,7 @@ static GLboolean _glewInit_GLX_VERSION_1_2 (GLXEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GLX_VERSION_1_3
 
-static GLboolean _glewInit_GLX_VERSION_1_3 (GLXEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GLX_VERSION_1_3 ()
 {
   GLboolean r = GL_FALSE;
 
@@ -13404,17 +20014,9 @@ static GLboolean _glewInit_GLX_VERSION_1_3 (GLXEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GLX_VERSION_1_3 */
 
-#ifdef GLX_VERSION_1_4
-
-#endif /* GLX_VERSION_1_4 */
-
-#ifdef GLX_3DFX_multisample
-
-#endif /* GLX_3DFX_multisample */
-
 #ifdef GLX_AMD_gpu_association
 
-static GLboolean _glewInit_GLX_AMD_gpu_association (GLXEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GLX_AMD_gpu_association ()
 {
   GLboolean r = GL_FALSE;
 
@@ -13433,13 +20035,9 @@ static GLboolean _glewInit_GLX_AMD_gpu_association (GLXEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GLX_AMD_gpu_association */
 
-#ifdef GLX_ARB_context_flush_control
-
-#endif /* GLX_ARB_context_flush_control */
-
 #ifdef GLX_ARB_create_context
 
-static GLboolean _glewInit_GLX_ARB_create_context (GLXEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GLX_ARB_create_context ()
 {
   GLboolean r = GL_FALSE;
 
@@ -13450,49 +20048,9 @@ static GLboolean _glewInit_GLX_ARB_create_context (GLXEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GLX_ARB_create_context */
 
-#ifdef GLX_ARB_create_context_profile
-
-#endif /* GLX_ARB_create_context_profile */
-
-#ifdef GLX_ARB_create_context_robustness
-
-#endif /* GLX_ARB_create_context_robustness */
-
-#ifdef GLX_ARB_fbconfig_float
-
-#endif /* GLX_ARB_fbconfig_float */
-
-#ifdef GLX_ARB_framebuffer_sRGB
-
-#endif /* GLX_ARB_framebuffer_sRGB */
-
-#ifdef GLX_ARB_get_proc_address
-
-#endif /* GLX_ARB_get_proc_address */
-
-#ifdef GLX_ARB_multisample
-
-#endif /* GLX_ARB_multisample */
-
-#ifdef GLX_ARB_robustness_application_isolation
-
-#endif /* GLX_ARB_robustness_application_isolation */
-
-#ifdef GLX_ARB_robustness_share_group_isolation
-
-#endif /* GLX_ARB_robustness_share_group_isolation */
-
-#ifdef GLX_ARB_vertex_buffer_object
-
-#endif /* GLX_ARB_vertex_buffer_object */
-
-#ifdef GLX_ATI_pixel_format_float
-
-#endif /* GLX_ATI_pixel_format_float */
-
 #ifdef GLX_ATI_render_texture
 
-static GLboolean _glewInit_GLX_ATI_render_texture (GLXEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GLX_ATI_render_texture ()
 {
   GLboolean r = GL_FALSE;
 
@@ -13505,29 +20063,9 @@ static GLboolean _glewInit_GLX_ATI_render_texture (GLXEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GLX_ATI_render_texture */
 
-#ifdef GLX_EXT_buffer_age
-
-#endif /* GLX_EXT_buffer_age */
-
-#ifdef GLX_EXT_create_context_es2_profile
-
-#endif /* GLX_EXT_create_context_es2_profile */
-
-#ifdef GLX_EXT_create_context_es_profile
-
-#endif /* GLX_EXT_create_context_es_profile */
-
-#ifdef GLX_EXT_fbconfig_packed_float
-
-#endif /* GLX_EXT_fbconfig_packed_float */
-
-#ifdef GLX_EXT_framebuffer_sRGB
-
-#endif /* GLX_EXT_framebuffer_sRGB */
-
 #ifdef GLX_EXT_import_context
 
-static GLboolean _glewInit_GLX_EXT_import_context (GLXEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GLX_EXT_import_context ()
 {
   GLboolean r = GL_FALSE;
 
@@ -13541,17 +20079,9 @@ static GLboolean _glewInit_GLX_EXT_import_context (GLXEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GLX_EXT_import_context */
 
-#ifdef GLX_EXT_scene_marker
-
-#endif /* GLX_EXT_scene_marker */
-
-#ifdef GLX_EXT_stereo_tree
-
-#endif /* GLX_EXT_stereo_tree */
-
 #ifdef GLX_EXT_swap_control
 
-static GLboolean _glewInit_GLX_EXT_swap_control (GLXEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GLX_EXT_swap_control ()
 {
   GLboolean r = GL_FALSE;
 
@@ -13562,13 +20092,9 @@ static GLboolean _glewInit_GLX_EXT_swap_control (GLXEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GLX_EXT_swap_control */
 
-#ifdef GLX_EXT_swap_control_tear
-
-#endif /* GLX_EXT_swap_control_tear */
-
 #ifdef GLX_EXT_texture_from_pixmap
 
-static GLboolean _glewInit_GLX_EXT_texture_from_pixmap (GLXEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GLX_EXT_texture_from_pixmap ()
 {
   GLboolean r = GL_FALSE;
 
@@ -13580,21 +20106,9 @@ static GLboolean _glewInit_GLX_EXT_texture_from_pixmap (GLXEW_CONTEXT_ARG_DEF_IN
 
 #endif /* GLX_EXT_texture_from_pixmap */
 
-#ifdef GLX_EXT_visual_info
-
-#endif /* GLX_EXT_visual_info */
-
-#ifdef GLX_EXT_visual_rating
-
-#endif /* GLX_EXT_visual_rating */
-
-#ifdef GLX_INTEL_swap_event
-
-#endif /* GLX_INTEL_swap_event */
-
 #ifdef GLX_MESA_agp_offset
 
-static GLboolean _glewInit_GLX_MESA_agp_offset (GLXEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GLX_MESA_agp_offset ()
 {
   GLboolean r = GL_FALSE;
 
@@ -13607,7 +20121,7 @@ static GLboolean _glewInit_GLX_MESA_agp_offset (GLXEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GLX_MESA_copy_sub_buffer
 
-static GLboolean _glewInit_GLX_MESA_copy_sub_buffer (GLXEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GLX_MESA_copy_sub_buffer ()
 {
   GLboolean r = GL_FALSE;
 
@@ -13620,7 +20134,7 @@ static GLboolean _glewInit_GLX_MESA_copy_sub_buffer (GLXEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GLX_MESA_pixmap_colormap
 
-static GLboolean _glewInit_GLX_MESA_pixmap_colormap (GLXEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GLX_MESA_pixmap_colormap ()
 {
   GLboolean r = GL_FALSE;
 
@@ -13633,7 +20147,7 @@ static GLboolean _glewInit_GLX_MESA_pixmap_colormap (GLXEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GLX_MESA_query_renderer
 
-static GLboolean _glewInit_GLX_MESA_query_renderer (GLXEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GLX_MESA_query_renderer ()
 {
   GLboolean r = GL_FALSE;
 
@@ -13649,7 +20163,7 @@ static GLboolean _glewInit_GLX_MESA_query_renderer (GLXEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GLX_MESA_release_buffers
 
-static GLboolean _glewInit_GLX_MESA_release_buffers (GLXEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GLX_MESA_release_buffers ()
 {
   GLboolean r = GL_FALSE;
 
@@ -13662,7 +20176,7 @@ static GLboolean _glewInit_GLX_MESA_release_buffers (GLXEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GLX_MESA_set_3dfx_mode
 
-static GLboolean _glewInit_GLX_MESA_set_3dfx_mode (GLXEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GLX_MESA_set_3dfx_mode ()
 {
   GLboolean r = GL_FALSE;
 
@@ -13675,7 +20189,7 @@ static GLboolean _glewInit_GLX_MESA_set_3dfx_mode (GLXEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GLX_MESA_swap_control
 
-static GLboolean _glewInit_GLX_MESA_swap_control (GLXEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GLX_MESA_swap_control ()
 {
   GLboolean r = GL_FALSE;
 
@@ -13689,7 +20203,7 @@ static GLboolean _glewInit_GLX_MESA_swap_control (GLXEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GLX_NV_copy_buffer
 
-static GLboolean _glewInit_GLX_NV_copy_buffer (GLXEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GLX_NV_copy_buffer ()
 {
   GLboolean r = GL_FALSE;
 
@@ -13703,7 +20217,7 @@ static GLboolean _glewInit_GLX_NV_copy_buffer (GLXEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GLX_NV_copy_image
 
-static GLboolean _glewInit_GLX_NV_copy_image (GLXEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GLX_NV_copy_image ()
 {
   GLboolean r = GL_FALSE;
 
@@ -13716,7 +20230,7 @@ static GLboolean _glewInit_GLX_NV_copy_image (GLXEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GLX_NV_delay_before_swap
 
-static GLboolean _glewInit_GLX_NV_delay_before_swap (GLXEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GLX_NV_delay_before_swap ()
 {
   GLboolean r = GL_FALSE;
 
@@ -13727,17 +20241,9 @@ static GLboolean _glewInit_GLX_NV_delay_before_swap (GLXEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GLX_NV_delay_before_swap */
 
-#ifdef GLX_NV_float_buffer
-
-#endif /* GLX_NV_float_buffer */
-
-#ifdef GLX_NV_multisample_coverage
-
-#endif /* GLX_NV_multisample_coverage */
-
 #ifdef GLX_NV_present_video
 
-static GLboolean _glewInit_GLX_NV_present_video (GLXEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GLX_NV_present_video ()
 {
   GLboolean r = GL_FALSE;
 
@@ -13751,7 +20257,7 @@ static GLboolean _glewInit_GLX_NV_present_video (GLXEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GLX_NV_swap_group
 
-static GLboolean _glewInit_GLX_NV_swap_group (GLXEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GLX_NV_swap_group ()
 {
   GLboolean r = GL_FALSE;
 
@@ -13769,7 +20275,7 @@ static GLboolean _glewInit_GLX_NV_swap_group (GLXEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GLX_NV_vertex_array_range
 
-static GLboolean _glewInit_GLX_NV_vertex_array_range (GLXEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GLX_NV_vertex_array_range ()
 {
   GLboolean r = GL_FALSE;
 
@@ -13783,7 +20289,7 @@ static GLboolean _glewInit_GLX_NV_vertex_array_range (GLXEW_CONTEXT_ARG_DEF_INIT
 
 #ifdef GLX_NV_video_capture
 
-static GLboolean _glewInit_GLX_NV_video_capture (GLXEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GLX_NV_video_capture ()
 {
   GLboolean r = GL_FALSE;
 
@@ -13800,7 +20306,7 @@ static GLboolean _glewInit_GLX_NV_video_capture (GLXEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GLX_NV_video_out
 
-static GLboolean _glewInit_GLX_NV_video_out (GLXEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GLX_NV_video_out ()
 {
   GLboolean r = GL_FALSE;
 
@@ -13816,13 +20322,9 @@ static GLboolean _glewInit_GLX_NV_video_out (GLXEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GLX_NV_video_out */
 
-#ifdef GLX_OML_swap_method
-
-#endif /* GLX_OML_swap_method */
-
 #ifdef GLX_OML_sync_control
 
-static GLboolean _glewInit_GLX_OML_sync_control (GLXEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GLX_OML_sync_control ()
 {
   GLboolean r = GL_FALSE;
 
@@ -13837,25 +20339,9 @@ static GLboolean _glewInit_GLX_OML_sync_control (GLXEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GLX_OML_sync_control */
 
-#ifdef GLX_SGIS_blended_overlay
-
-#endif /* GLX_SGIS_blended_overlay */
-
-#ifdef GLX_SGIS_color_range
-
-#endif /* GLX_SGIS_color_range */
-
-#ifdef GLX_SGIS_multisample
-
-#endif /* GLX_SGIS_multisample */
-
-#ifdef GLX_SGIS_shared_multisample
-
-#endif /* GLX_SGIS_shared_multisample */
-
 #ifdef GLX_SGIX_fbconfig
 
-static GLboolean _glewInit_GLX_SGIX_fbconfig (GLXEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GLX_SGIX_fbconfig ()
 {
   GLboolean r = GL_FALSE;
 
@@ -13873,7 +20359,7 @@ static GLboolean _glewInit_GLX_SGIX_fbconfig (GLXEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GLX_SGIX_hyperpipe
 
-static GLboolean _glewInit_GLX_SGIX_hyperpipe (GLXEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GLX_SGIX_hyperpipe ()
 {
   GLboolean r = GL_FALSE;
 
@@ -13893,7 +20379,7 @@ static GLboolean _glewInit_GLX_SGIX_hyperpipe (GLXEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GLX_SGIX_pbuffer
 
-static GLboolean _glewInit_GLX_SGIX_pbuffer (GLXEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GLX_SGIX_pbuffer ()
 {
   GLboolean r = GL_FALSE;
 
@@ -13910,7 +20396,7 @@ static GLboolean _glewInit_GLX_SGIX_pbuffer (GLXEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GLX_SGIX_swap_barrier
 
-static GLboolean _glewInit_GLX_SGIX_swap_barrier (GLXEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GLX_SGIX_swap_barrier ()
 {
   GLboolean r = GL_FALSE;
 
@@ -13924,7 +20410,7 @@ static GLboolean _glewInit_GLX_SGIX_swap_barrier (GLXEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GLX_SGIX_swap_group
 
-static GLboolean _glewInit_GLX_SGIX_swap_group (GLXEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GLX_SGIX_swap_group ()
 {
   GLboolean r = GL_FALSE;
 
@@ -13937,7 +20423,7 @@ static GLboolean _glewInit_GLX_SGIX_swap_group (GLXEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GLX_SGIX_video_resize
 
-static GLboolean _glewInit_GLX_SGIX_video_resize (GLXEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GLX_SGIX_video_resize ()
 {
   GLboolean r = GL_FALSE;
 
@@ -13952,13 +20438,9 @@ static GLboolean _glewInit_GLX_SGIX_video_resize (GLXEW_CONTEXT_ARG_DEF_INIT)
 
 #endif /* GLX_SGIX_video_resize */
 
-#ifdef GLX_SGIX_visual_select_group
-
-#endif /* GLX_SGIX_visual_select_group */
-
 #ifdef GLX_SGI_cushion
 
-static GLboolean _glewInit_GLX_SGI_cushion (GLXEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GLX_SGI_cushion ()
 {
   GLboolean r = GL_FALSE;
 
@@ -13971,7 +20453,7 @@ static GLboolean _glewInit_GLX_SGI_cushion (GLXEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GLX_SGI_make_current_read
 
-static GLboolean _glewInit_GLX_SGI_make_current_read (GLXEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GLX_SGI_make_current_read ()
 {
   GLboolean r = GL_FALSE;
 
@@ -13985,7 +20467,7 @@ static GLboolean _glewInit_GLX_SGI_make_current_read (GLXEW_CONTEXT_ARG_DEF_INIT
 
 #ifdef GLX_SGI_swap_control
 
-static GLboolean _glewInit_GLX_SGI_swap_control (GLXEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GLX_SGI_swap_control ()
 {
   GLboolean r = GL_FALSE;
 
@@ -13998,7 +20480,7 @@ static GLboolean _glewInit_GLX_SGI_swap_control (GLXEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GLX_SGI_video_sync
 
-static GLboolean _glewInit_GLX_SGI_video_sync (GLXEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GLX_SGI_video_sync ()
 {
   GLboolean r = GL_FALSE;
 
@@ -14012,7 +20494,7 @@ static GLboolean _glewInit_GLX_SGI_video_sync (GLXEW_CONTEXT_ARG_DEF_INIT)
 
 #ifdef GLX_SUN_get_transparent_index
 
-static GLboolean _glewInit_GLX_SUN_get_transparent_index (GLXEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GLX_SUN_get_transparent_index ()
 {
   GLboolean r = GL_FALSE;
 
@@ -14025,7 +20507,7 @@ static GLboolean _glewInit_GLX_SUN_get_transparent_index (GLXEW_CONTEXT_ARG_DEF_
 
 #ifdef GLX_SUN_video_resize
 
-static GLboolean _glewInit_GLX_SUN_video_resize (GLXEW_CONTEXT_ARG_DEF_INIT)
+static GLboolean _glewInit_GLX_SUN_video_resize ()
 {
   GLboolean r = GL_FALSE;
 
@@ -14051,24 +20533,25 @@ GLboolean glxewGetExtension (const char* name)
   return _glewSearchExtension(name, start, end);
 }
 
-GLenum glxewContextInit (GLXEW_CONTEXT_ARG_DEF_LIST)
+GLenum glxewInit ()
 {
+  Display* display;
   int major, minor;
   const GLubyte* extStart;
   const GLubyte* extEnd;
   /* initialize core GLX 1.2 */
-  if (_glewInit_GLX_VERSION_1_2(GLEW_CONTEXT_ARG_VAR_INIT)) return GLEW_ERROR_GLX_VERSION_11_ONLY;
+  if (_glewInit_GLX_VERSION_1_2()) return GLEW_ERROR_GLX_VERSION_11_ONLY;
+  /* check for a display */
+  display = glXGetCurrentDisplay();
+  if (display == NULL) return GLEW_ERROR_NO_GLX_DISPLAY;
   /* initialize flags */
   GLXEW_VERSION_1_0 = GL_TRUE;
   GLXEW_VERSION_1_1 = GL_TRUE;
   GLXEW_VERSION_1_2 = GL_TRUE;
   GLXEW_VERSION_1_3 = GL_TRUE;
   GLXEW_VERSION_1_4 = GL_TRUE;
-  /* Check if GLX display is available */
-  if (glXGetCurrentDisplay == NULL || glXGetCurrentDisplay() == NULL)
-    return GLEW_OK;
   /* query GLX version */
-  glXQueryVersion(glXGetCurrentDisplay(), &major, &minor);
+  glXQueryVersion(display, &major, &minor);
   if (major == 1 && minor <= 3)
   {
     switch (minor)
@@ -14088,28 +20571,31 @@ GLenum glxewContextInit (GLXEW_CONTEXT_ARG_DEF_LIST)
   /* query GLX extension string */
   extStart = 0;
   if (glXGetCurrentDisplay != NULL)
-    extStart = (const GLubyte*)glXGetClientString(glXGetCurrentDisplay(), GLX_EXTENSIONS);
+    extStart = (const GLubyte*)glXGetClientString(display, GLX_EXTENSIONS);
   if (extStart == 0)
     extStart = (const GLubyte *)"";
   extEnd = extStart + _glewStrLen(extStart);
   /* initialize extensions */
 #ifdef GLX_VERSION_1_3
-  if (glewExperimental || GLXEW_VERSION_1_3) GLXEW_VERSION_1_3 = !_glewInit_GLX_VERSION_1_3(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLXEW_VERSION_1_3) GLXEW_VERSION_1_3 = !_glewInit_GLX_VERSION_1_3();
 #endif /* GLX_VERSION_1_3 */
 #ifdef GLX_3DFX_multisample
   GLXEW_3DFX_multisample = _glewSearchExtension("GLX_3DFX_multisample", extStart, extEnd);
 #endif /* GLX_3DFX_multisample */
 #ifdef GLX_AMD_gpu_association
   GLXEW_AMD_gpu_association = _glewSearchExtension("GLX_AMD_gpu_association", extStart, extEnd);
-  if (glewExperimental || GLXEW_AMD_gpu_association) GLXEW_AMD_gpu_association = !_glewInit_GLX_AMD_gpu_association(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLXEW_AMD_gpu_association) GLXEW_AMD_gpu_association = !_glewInit_GLX_AMD_gpu_association();
 #endif /* GLX_AMD_gpu_association */
 #ifdef GLX_ARB_context_flush_control
   GLXEW_ARB_context_flush_control = _glewSearchExtension("GLX_ARB_context_flush_control", extStart, extEnd);
 #endif /* GLX_ARB_context_flush_control */
 #ifdef GLX_ARB_create_context
   GLXEW_ARB_create_context = _glewSearchExtension("GLX_ARB_create_context", extStart, extEnd);
-  if (glewExperimental || GLXEW_ARB_create_context) GLXEW_ARB_create_context = !_glewInit_GLX_ARB_create_context(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLXEW_ARB_create_context) GLXEW_ARB_create_context = !_glewInit_GLX_ARB_create_context();
 #endif /* GLX_ARB_create_context */
+#ifdef GLX_ARB_create_context_no_error
+  GLXEW_ARB_create_context_no_error = _glewSearchExtension("GLX_ARB_create_context_no_error", extStart, extEnd);
+#endif /* GLX_ARB_create_context_no_error */
 #ifdef GLX_ARB_create_context_profile
   GLXEW_ARB_create_context_profile = _glewSearchExtension("GLX_ARB_create_context_profile", extStart, extEnd);
 #endif /* GLX_ARB_create_context_profile */
@@ -14142,7 +20628,7 @@ GLenum glxewContextInit (GLXEW_CONTEXT_ARG_DEF_LIST)
 #endif /* GLX_ATI_pixel_format_float */
 #ifdef GLX_ATI_render_texture
   GLXEW_ATI_render_texture = _glewSearchExtension("GLX_ATI_render_texture", extStart, extEnd);
-  if (glewExperimental || GLXEW_ATI_render_texture) GLXEW_ATI_render_texture = !_glewInit_GLX_ATI_render_texture(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLXEW_ATI_render_texture) GLXEW_ATI_render_texture = !_glewInit_GLX_ATI_render_texture();
 #endif /* GLX_ATI_render_texture */
 #ifdef GLX_EXT_buffer_age
   GLXEW_EXT_buffer_age = _glewSearchExtension("GLX_EXT_buffer_age", extStart, extEnd);
@@ -14161,8 +20647,11 @@ GLenum glxewContextInit (GLXEW_CONTEXT_ARG_DEF_LIST)
 #endif /* GLX_EXT_framebuffer_sRGB */
 #ifdef GLX_EXT_import_context
   GLXEW_EXT_import_context = _glewSearchExtension("GLX_EXT_import_context", extStart, extEnd);
-  if (glewExperimental || GLXEW_EXT_import_context) GLXEW_EXT_import_context = !_glewInit_GLX_EXT_import_context(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLXEW_EXT_import_context) GLXEW_EXT_import_context = !_glewInit_GLX_EXT_import_context();
 #endif /* GLX_EXT_import_context */
+#ifdef GLX_EXT_libglvnd
+  GLXEW_EXT_libglvnd = _glewSearchExtension("GLX_EXT_libglvnd", extStart, extEnd);
+#endif /* GLX_EXT_libglvnd */
 #ifdef GLX_EXT_scene_marker
   GLXEW_EXT_scene_marker = _glewSearchExtension("GLX_EXT_scene_marker", extStart, extEnd);
 #endif /* GLX_EXT_scene_marker */
@@ -14171,14 +20660,14 @@ GLenum glxewContextInit (GLXEW_CONTEXT_ARG_DEF_LIST)
 #endif /* GLX_EXT_stereo_tree */
 #ifdef GLX_EXT_swap_control
   GLXEW_EXT_swap_control = _glewSearchExtension("GLX_EXT_swap_control", extStart, extEnd);
-  if (glewExperimental || GLXEW_EXT_swap_control) GLXEW_EXT_swap_control = !_glewInit_GLX_EXT_swap_control(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLXEW_EXT_swap_control) GLXEW_EXT_swap_control = !_glewInit_GLX_EXT_swap_control();
 #endif /* GLX_EXT_swap_control */
 #ifdef GLX_EXT_swap_control_tear
   GLXEW_EXT_swap_control_tear = _glewSearchExtension("GLX_EXT_swap_control_tear", extStart, extEnd);
 #endif /* GLX_EXT_swap_control_tear */
 #ifdef GLX_EXT_texture_from_pixmap
   GLXEW_EXT_texture_from_pixmap = _glewSearchExtension("GLX_EXT_texture_from_pixmap", extStart, extEnd);
-  if (glewExperimental || GLXEW_EXT_texture_from_pixmap) GLXEW_EXT_texture_from_pixmap = !_glewInit_GLX_EXT_texture_from_pixmap(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLXEW_EXT_texture_from_pixmap) GLXEW_EXT_texture_from_pixmap = !_glewInit_GLX_EXT_texture_from_pixmap();
 #endif /* GLX_EXT_texture_from_pixmap */
 #ifdef GLX_EXT_visual_info
   GLXEW_EXT_visual_info = _glewSearchExtension("GLX_EXT_visual_info", extStart, extEnd);
@@ -14191,43 +20680,43 @@ GLenum glxewContextInit (GLXEW_CONTEXT_ARG_DEF_LIST)
 #endif /* GLX_INTEL_swap_event */
 #ifdef GLX_MESA_agp_offset
   GLXEW_MESA_agp_offset = _glewSearchExtension("GLX_MESA_agp_offset", extStart, extEnd);
-  if (glewExperimental || GLXEW_MESA_agp_offset) GLXEW_MESA_agp_offset = !_glewInit_GLX_MESA_agp_offset(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLXEW_MESA_agp_offset) GLXEW_MESA_agp_offset = !_glewInit_GLX_MESA_agp_offset();
 #endif /* GLX_MESA_agp_offset */
 #ifdef GLX_MESA_copy_sub_buffer
   GLXEW_MESA_copy_sub_buffer = _glewSearchExtension("GLX_MESA_copy_sub_buffer", extStart, extEnd);
-  if (glewExperimental || GLXEW_MESA_copy_sub_buffer) GLXEW_MESA_copy_sub_buffer = !_glewInit_GLX_MESA_copy_sub_buffer(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLXEW_MESA_copy_sub_buffer) GLXEW_MESA_copy_sub_buffer = !_glewInit_GLX_MESA_copy_sub_buffer();
 #endif /* GLX_MESA_copy_sub_buffer */
 #ifdef GLX_MESA_pixmap_colormap
   GLXEW_MESA_pixmap_colormap = _glewSearchExtension("GLX_MESA_pixmap_colormap", extStart, extEnd);
-  if (glewExperimental || GLXEW_MESA_pixmap_colormap) GLXEW_MESA_pixmap_colormap = !_glewInit_GLX_MESA_pixmap_colormap(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLXEW_MESA_pixmap_colormap) GLXEW_MESA_pixmap_colormap = !_glewInit_GLX_MESA_pixmap_colormap();
 #endif /* GLX_MESA_pixmap_colormap */
 #ifdef GLX_MESA_query_renderer
   GLXEW_MESA_query_renderer = _glewSearchExtension("GLX_MESA_query_renderer", extStart, extEnd);
-  if (glewExperimental || GLXEW_MESA_query_renderer) GLXEW_MESA_query_renderer = !_glewInit_GLX_MESA_query_renderer(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLXEW_MESA_query_renderer) GLXEW_MESA_query_renderer = !_glewInit_GLX_MESA_query_renderer();
 #endif /* GLX_MESA_query_renderer */
 #ifdef GLX_MESA_release_buffers
   GLXEW_MESA_release_buffers = _glewSearchExtension("GLX_MESA_release_buffers", extStart, extEnd);
-  if (glewExperimental || GLXEW_MESA_release_buffers) GLXEW_MESA_release_buffers = !_glewInit_GLX_MESA_release_buffers(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLXEW_MESA_release_buffers) GLXEW_MESA_release_buffers = !_glewInit_GLX_MESA_release_buffers();
 #endif /* GLX_MESA_release_buffers */
 #ifdef GLX_MESA_set_3dfx_mode
   GLXEW_MESA_set_3dfx_mode = _glewSearchExtension("GLX_MESA_set_3dfx_mode", extStart, extEnd);
-  if (glewExperimental || GLXEW_MESA_set_3dfx_mode) GLXEW_MESA_set_3dfx_mode = !_glewInit_GLX_MESA_set_3dfx_mode(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLXEW_MESA_set_3dfx_mode) GLXEW_MESA_set_3dfx_mode = !_glewInit_GLX_MESA_set_3dfx_mode();
 #endif /* GLX_MESA_set_3dfx_mode */
 #ifdef GLX_MESA_swap_control
   GLXEW_MESA_swap_control = _glewSearchExtension("GLX_MESA_swap_control", extStart, extEnd);
-  if (glewExperimental || GLXEW_MESA_swap_control) GLXEW_MESA_swap_control = !_glewInit_GLX_MESA_swap_control(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLXEW_MESA_swap_control) GLXEW_MESA_swap_control = !_glewInit_GLX_MESA_swap_control();
 #endif /* GLX_MESA_swap_control */
 #ifdef GLX_NV_copy_buffer
   GLXEW_NV_copy_buffer = _glewSearchExtension("GLX_NV_copy_buffer", extStart, extEnd);
-  if (glewExperimental || GLXEW_NV_copy_buffer) GLXEW_NV_copy_buffer = !_glewInit_GLX_NV_copy_buffer(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLXEW_NV_copy_buffer) GLXEW_NV_copy_buffer = !_glewInit_GLX_NV_copy_buffer();
 #endif /* GLX_NV_copy_buffer */
 #ifdef GLX_NV_copy_image
   GLXEW_NV_copy_image = _glewSearchExtension("GLX_NV_copy_image", extStart, extEnd);
-  if (glewExperimental || GLXEW_NV_copy_image) GLXEW_NV_copy_image = !_glewInit_GLX_NV_copy_image(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLXEW_NV_copy_image) GLXEW_NV_copy_image = !_glewInit_GLX_NV_copy_image();
 #endif /* GLX_NV_copy_image */
 #ifdef GLX_NV_delay_before_swap
   GLXEW_NV_delay_before_swap = _glewSearchExtension("GLX_NV_delay_before_swap", extStart, extEnd);
-  if (glewExperimental || GLXEW_NV_delay_before_swap) GLXEW_NV_delay_before_swap = !_glewInit_GLX_NV_delay_before_swap(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLXEW_NV_delay_before_swap) GLXEW_NV_delay_before_swap = !_glewInit_GLX_NV_delay_before_swap();
 #endif /* GLX_NV_delay_before_swap */
 #ifdef GLX_NV_float_buffer
   GLXEW_NV_float_buffer = _glewSearchExtension("GLX_NV_float_buffer", extStart, extEnd);
@@ -14237,30 +20726,33 @@ GLenum glxewContextInit (GLXEW_CONTEXT_ARG_DEF_LIST)
 #endif /* GLX_NV_multisample_coverage */
 #ifdef GLX_NV_present_video
   GLXEW_NV_present_video = _glewSearchExtension("GLX_NV_present_video", extStart, extEnd);
-  if (glewExperimental || GLXEW_NV_present_video) GLXEW_NV_present_video = !_glewInit_GLX_NV_present_video(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLXEW_NV_present_video) GLXEW_NV_present_video = !_glewInit_GLX_NV_present_video();
 #endif /* GLX_NV_present_video */
+#ifdef GLX_NV_robustness_video_memory_purge
+  GLXEW_NV_robustness_video_memory_purge = _glewSearchExtension("GLX_NV_robustness_video_memory_purge", extStart, extEnd);
+#endif /* GLX_NV_robustness_video_memory_purge */
 #ifdef GLX_NV_swap_group
   GLXEW_NV_swap_group = _glewSearchExtension("GLX_NV_swap_group", extStart, extEnd);
-  if (glewExperimental || GLXEW_NV_swap_group) GLXEW_NV_swap_group = !_glewInit_GLX_NV_swap_group(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLXEW_NV_swap_group) GLXEW_NV_swap_group = !_glewInit_GLX_NV_swap_group();
 #endif /* GLX_NV_swap_group */
 #ifdef GLX_NV_vertex_array_range
   GLXEW_NV_vertex_array_range = _glewSearchExtension("GLX_NV_vertex_array_range", extStart, extEnd);
-  if (glewExperimental || GLXEW_NV_vertex_array_range) GLXEW_NV_vertex_array_range = !_glewInit_GLX_NV_vertex_array_range(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLXEW_NV_vertex_array_range) GLXEW_NV_vertex_array_range = !_glewInit_GLX_NV_vertex_array_range();
 #endif /* GLX_NV_vertex_array_range */
 #ifdef GLX_NV_video_capture
   GLXEW_NV_video_capture = _glewSearchExtension("GLX_NV_video_capture", extStart, extEnd);
-  if (glewExperimental || GLXEW_NV_video_capture) GLXEW_NV_video_capture = !_glewInit_GLX_NV_video_capture(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLXEW_NV_video_capture) GLXEW_NV_video_capture = !_glewInit_GLX_NV_video_capture();
 #endif /* GLX_NV_video_capture */
 #ifdef GLX_NV_video_out
   GLXEW_NV_video_out = _glewSearchExtension("GLX_NV_video_out", extStart, extEnd);
-  if (glewExperimental || GLXEW_NV_video_out) GLXEW_NV_video_out = !_glewInit_GLX_NV_video_out(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLXEW_NV_video_out) GLXEW_NV_video_out = !_glewInit_GLX_NV_video_out();
 #endif /* GLX_NV_video_out */
 #ifdef GLX_OML_swap_method
   GLXEW_OML_swap_method = _glewSearchExtension("GLX_OML_swap_method", extStart, extEnd);
 #endif /* GLX_OML_swap_method */
 #ifdef GLX_OML_sync_control
   GLXEW_OML_sync_control = _glewSearchExtension("GLX_OML_sync_control", extStart, extEnd);
-  if (glewExperimental || GLXEW_OML_sync_control) GLXEW_OML_sync_control = !_glewInit_GLX_OML_sync_control(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLXEW_OML_sync_control) GLXEW_OML_sync_control = !_glewInit_GLX_OML_sync_control();
 #endif /* GLX_OML_sync_control */
 #ifdef GLX_SGIS_blended_overlay
   GLXEW_SGIS_blended_overlay = _glewSearchExtension("GLX_SGIS_blended_overlay", extStart, extEnd);
@@ -14276,54 +20768,54 @@ GLenum glxewContextInit (GLXEW_CONTEXT_ARG_DEF_LIST)
 #endif /* GLX_SGIS_shared_multisample */
 #ifdef GLX_SGIX_fbconfig
   GLXEW_SGIX_fbconfig = _glewSearchExtension("GLX_SGIX_fbconfig", extStart, extEnd);
-  if (glewExperimental || GLXEW_SGIX_fbconfig) GLXEW_SGIX_fbconfig = !_glewInit_GLX_SGIX_fbconfig(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLXEW_SGIX_fbconfig) GLXEW_SGIX_fbconfig = !_glewInit_GLX_SGIX_fbconfig();
 #endif /* GLX_SGIX_fbconfig */
 #ifdef GLX_SGIX_hyperpipe
   GLXEW_SGIX_hyperpipe = _glewSearchExtension("GLX_SGIX_hyperpipe", extStart, extEnd);
-  if (glewExperimental || GLXEW_SGIX_hyperpipe) GLXEW_SGIX_hyperpipe = !_glewInit_GLX_SGIX_hyperpipe(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLXEW_SGIX_hyperpipe) GLXEW_SGIX_hyperpipe = !_glewInit_GLX_SGIX_hyperpipe();
 #endif /* GLX_SGIX_hyperpipe */
 #ifdef GLX_SGIX_pbuffer
   GLXEW_SGIX_pbuffer = _glewSearchExtension("GLX_SGIX_pbuffer", extStart, extEnd);
-  if (glewExperimental || GLXEW_SGIX_pbuffer) GLXEW_SGIX_pbuffer = !_glewInit_GLX_SGIX_pbuffer(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLXEW_SGIX_pbuffer) GLXEW_SGIX_pbuffer = !_glewInit_GLX_SGIX_pbuffer();
 #endif /* GLX_SGIX_pbuffer */
 #ifdef GLX_SGIX_swap_barrier
   GLXEW_SGIX_swap_barrier = _glewSearchExtension("GLX_SGIX_swap_barrier", extStart, extEnd);
-  if (glewExperimental || GLXEW_SGIX_swap_barrier) GLXEW_SGIX_swap_barrier = !_glewInit_GLX_SGIX_swap_barrier(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLXEW_SGIX_swap_barrier) GLXEW_SGIX_swap_barrier = !_glewInit_GLX_SGIX_swap_barrier();
 #endif /* GLX_SGIX_swap_barrier */
 #ifdef GLX_SGIX_swap_group
   GLXEW_SGIX_swap_group = _glewSearchExtension("GLX_SGIX_swap_group", extStart, extEnd);
-  if (glewExperimental || GLXEW_SGIX_swap_group) GLXEW_SGIX_swap_group = !_glewInit_GLX_SGIX_swap_group(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLXEW_SGIX_swap_group) GLXEW_SGIX_swap_group = !_glewInit_GLX_SGIX_swap_group();
 #endif /* GLX_SGIX_swap_group */
 #ifdef GLX_SGIX_video_resize
   GLXEW_SGIX_video_resize = _glewSearchExtension("GLX_SGIX_video_resize", extStart, extEnd);
-  if (glewExperimental || GLXEW_SGIX_video_resize) GLXEW_SGIX_video_resize = !_glewInit_GLX_SGIX_video_resize(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLXEW_SGIX_video_resize) GLXEW_SGIX_video_resize = !_glewInit_GLX_SGIX_video_resize();
 #endif /* GLX_SGIX_video_resize */
 #ifdef GLX_SGIX_visual_select_group
   GLXEW_SGIX_visual_select_group = _glewSearchExtension("GLX_SGIX_visual_select_group", extStart, extEnd);
 #endif /* GLX_SGIX_visual_select_group */
 #ifdef GLX_SGI_cushion
   GLXEW_SGI_cushion = _glewSearchExtension("GLX_SGI_cushion", extStart, extEnd);
-  if (glewExperimental || GLXEW_SGI_cushion) GLXEW_SGI_cushion = !_glewInit_GLX_SGI_cushion(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLXEW_SGI_cushion) GLXEW_SGI_cushion = !_glewInit_GLX_SGI_cushion();
 #endif /* GLX_SGI_cushion */
 #ifdef GLX_SGI_make_current_read
   GLXEW_SGI_make_current_read = _glewSearchExtension("GLX_SGI_make_current_read", extStart, extEnd);
-  if (glewExperimental || GLXEW_SGI_make_current_read) GLXEW_SGI_make_current_read = !_glewInit_GLX_SGI_make_current_read(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLXEW_SGI_make_current_read) GLXEW_SGI_make_current_read = !_glewInit_GLX_SGI_make_current_read();
 #endif /* GLX_SGI_make_current_read */
 #ifdef GLX_SGI_swap_control
   GLXEW_SGI_swap_control = _glewSearchExtension("GLX_SGI_swap_control", extStart, extEnd);
-  if (glewExperimental || GLXEW_SGI_swap_control) GLXEW_SGI_swap_control = !_glewInit_GLX_SGI_swap_control(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLXEW_SGI_swap_control) GLXEW_SGI_swap_control = !_glewInit_GLX_SGI_swap_control();
 #endif /* GLX_SGI_swap_control */
 #ifdef GLX_SGI_video_sync
   GLXEW_SGI_video_sync = _glewSearchExtension("GLX_SGI_video_sync", extStart, extEnd);
-  if (glewExperimental || GLXEW_SGI_video_sync) GLXEW_SGI_video_sync = !_glewInit_GLX_SGI_video_sync(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLXEW_SGI_video_sync) GLXEW_SGI_video_sync = !_glewInit_GLX_SGI_video_sync();
 #endif /* GLX_SGI_video_sync */
 #ifdef GLX_SUN_get_transparent_index
   GLXEW_SUN_get_transparent_index = _glewSearchExtension("GLX_SUN_get_transparent_index", extStart, extEnd);
-  if (glewExperimental || GLXEW_SUN_get_transparent_index) GLXEW_SUN_get_transparent_index = !_glewInit_GLX_SUN_get_transparent_index(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLXEW_SUN_get_transparent_index) GLXEW_SUN_get_transparent_index = !_glewInit_GLX_SUN_get_transparent_index();
 #endif /* GLX_SUN_get_transparent_index */
 #ifdef GLX_SUN_video_resize
   GLXEW_SUN_video_resize = _glewSearchExtension("GLX_SUN_video_resize", extStart, extEnd);
-  if (glewExperimental || GLXEW_SUN_video_resize) GLXEW_SUN_video_resize = !_glewInit_GLX_SUN_video_resize(GLEW_CONTEXT_ARG_VAR_INIT);
+  if (glewExperimental || GLXEW_SUN_video_resize) GLXEW_SUN_video_resize = !_glewInit_GLX_SUN_video_resize();
 #endif /* GLX_SUN_video_resize */
 
   return GLEW_OK;
@@ -14352,9 +20844,9 @@ const GLubyte * GLEWAPIENTRY glewGetString (GLenum name)
   static const GLubyte* _glewString[] =
   {
     (const GLubyte*)NULL,
-    (const GLubyte*)"1.11.0",
+    (const GLubyte*)"2.1.0",
+    (const GLubyte*)"2",
     (const GLubyte*)"1",
-    (const GLubyte*)"11",
     (const GLubyte*)"0"
   };
   const size_t max_string = sizeof(_glewString)/sizeof(*_glewString) - 1;
@@ -14365,36 +20857,42 @@ const GLubyte * GLEWAPIENTRY glewGetString (GLenum name)
 
 GLboolean glewExperimental = GL_FALSE;
 
-#if !defined(GLEW_MX)
-
-#if defined(_WIN32)
-extern GLenum GLEWAPIENTRY wglewContextInit (void);
-#elif !defined(__ANDROID__) && !defined(__native_client__) && !defined(__HAIKU__) && (!defined(__APPLE__) || defined(GLEW_APPLE_GLX))
-extern GLenum GLEWAPIENTRY glxewContextInit (void);
-#endif /* _WIN32 */
-
 GLenum GLEWAPIENTRY glewInit (void)
 {
   GLenum r;
+#if defined(GLEW_EGL)
+  PFNEGLGETCURRENTDISPLAYPROC getCurrentDisplay = NULL;
+#endif
   r = glewContextInit();
   if ( r != 0 ) return r;
-#if defined(_WIN32)
-  return wglewContextInit();
-#elif !defined(__ANDROID__) && !defined(__native_client__) && !defined(__HAIKU__) && (!defined(__APPLE__) || defined(GLEW_APPLE_GLX)) /* _UNIX */
-  return glxewContextInit();
+#if defined(GLEW_EGL)
+  getCurrentDisplay = (PFNEGLGETCURRENTDISPLAYPROC) glewGetProcAddress("eglGetCurrentDisplay");
+  return eglewInit(getCurrentDisplay());
+#elif defined(GLEW_OSMESA) || defined(__ANDROID__) || defined(__native_client__) || defined(__HAIKU__)
+  return r;
+#elif defined(_WIN32)
+  return wglewInit();
+#elif !defined(__APPLE__) || defined(GLEW_APPLE_GLX) /* _UNIX */
+  return glxewInit();
 #else
   return r;
 #endif /* _WIN32 */
 }
 
-#endif /* !GLEW_MX */
-#ifdef GLEW_MX
-GLboolean GLEWAPIENTRY glewContextIsSupported (const GLEWContext* ctx, const char* name)
-#else
-GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
-#endif
+#if defined(_WIN32) && defined(GLEW_BUILD) && defined(__GNUC__)
+/* GCC requires a DLL entry point even without any standard library included. */
+/* Types extracted from windows.h to avoid polluting the rest of the file. */
+int __stdcall DllMainCRTStartup(void* instance, unsigned reason, void* reserved)
 {
-  GLubyte* pos = (GLubyte*)name;
+  (void) instance;
+  (void) reason;
+  (void) reserved;
+  return 1;
+}
+#endif
+GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
+{
+  const GLubyte* pos = (const GLubyte*)name;
   GLuint len = _glewStrLen(pos);
   GLboolean ret = GL_TRUE;
   while (ret && len > 0)
@@ -14522,6 +21020,13 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_VERSION_4_6
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"4_6", 3))
+        {
+          ret = GLEW_VERSION_4_6;
+          continue;
+        }
+#endif
       }
       if (_glewStrSame2(&pos, &len, (const GLubyte*)"3DFX_", 5))
       {
@@ -14556,6 +21061,20 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_AMD_compressed_3DC_texture
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"compressed_3DC_texture", 22))
+        {
+          ret = GLEW_AMD_compressed_3DC_texture;
+          continue;
+        }
+#endif
+#ifdef GL_AMD_compressed_ATC_texture
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"compressed_ATC_texture", 22))
+        {
+          ret = GLEW_AMD_compressed_ATC_texture;
+          continue;
+        }
+#endif
 #ifdef GL_AMD_conservative_depth
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"conservative_depth", 18))
         {
@@ -14584,10 +21103,31 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_AMD_framebuffer_sample_positions
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"framebuffer_sample_positions", 28))
+        {
+          ret = GLEW_AMD_framebuffer_sample_positions;
+          continue;
+        }
+#endif
 #ifdef GL_AMD_gcn_shader
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"gcn_shader", 10))
         {
           ret = GLEW_AMD_gcn_shader;
+          continue;
+        }
+#endif
+#ifdef GL_AMD_gpu_shader_half_float
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"gpu_shader_half_float", 21))
+        {
+          ret = GLEW_AMD_gpu_shader_half_float;
+          continue;
+        }
+#endif
+#ifdef GL_AMD_gpu_shader_int16
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"gpu_shader_int16", 16))
+        {
+          ret = GLEW_AMD_gpu_shader_int16;
           continue;
         }
 #endif
@@ -14640,6 +21180,13 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_AMD_program_binary_Z400
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"program_binary_Z400", 19))
+        {
+          ret = GLEW_AMD_program_binary_Z400;
+          continue;
+        }
+#endif
 #ifdef GL_AMD_query_buffer_object
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"query_buffer_object", 19))
         {
@@ -14665,6 +21212,20 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"shader_atomic_counter_ops", 25))
         {
           ret = GLEW_AMD_shader_atomic_counter_ops;
+          continue;
+        }
+#endif
+#ifdef GL_AMD_shader_ballot
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"shader_ballot", 13))
+        {
+          ret = GLEW_AMD_shader_ballot;
+          continue;
+        }
+#endif
+#ifdef GL_AMD_shader_explicit_vertex_parameter
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"shader_explicit_vertex_parameter", 32))
+        {
+          ret = GLEW_AMD_shader_explicit_vertex_parameter;
           continue;
         }
 #endif
@@ -14700,6 +21261,13 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"stencil_operation_extended", 26))
         {
           ret = GLEW_AMD_stencil_operation_extended;
+          continue;
+        }
+#endif
+#ifdef GL_AMD_texture_gather_bias_lod
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"texture_gather_bias_lod", 23))
+        {
+          ret = GLEW_AMD_texture_gather_bias_lod;
           continue;
         }
 #endif
@@ -14742,6 +21310,16 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"vertex_shader_viewport_index", 28))
         {
           ret = GLEW_AMD_vertex_shader_viewport_index;
+          continue;
+        }
+#endif
+      }
+      if (_glewStrSame2(&pos, &len, (const GLubyte*)"ANDROID_", 8))
+      {
+#ifdef GL_ANDROID_extension_pack_es31a
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"extension_pack_es31a", 20))
+        {
+          ret = GLEW_ANDROID_extension_pack_es31a;
           continue;
         }
 #endif
@@ -14849,6 +21427,27 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_APPLE_clip_distance
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"clip_distance", 13))
+        {
+          ret = GLEW_APPLE_clip_distance;
+          continue;
+        }
+#endif
+#ifdef GL_APPLE_color_buffer_packed_float
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"color_buffer_packed_float", 25))
+        {
+          ret = GLEW_APPLE_color_buffer_packed_float;
+          continue;
+        }
+#endif
+#ifdef GL_APPLE_copy_texture_levels
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"copy_texture_levels", 19))
+        {
+          ret = GLEW_APPLE_copy_texture_levels;
+          continue;
+        }
+#endif
 #ifdef GL_APPLE_element_array
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"element_array", 13))
         {
@@ -14874,6 +21473,13 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"flush_buffer_range", 18))
         {
           ret = GLEW_APPLE_flush_buffer_range;
+          continue;
+        }
+#endif
+#ifdef GL_APPLE_framebuffer_multisample
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"framebuffer_multisample", 23))
+        {
+          ret = GLEW_APPLE_framebuffer_multisample;
           continue;
         }
 #endif
@@ -14909,6 +21515,41 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"specular_vector", 15))
         {
           ret = GLEW_APPLE_specular_vector;
+          continue;
+        }
+#endif
+#ifdef GL_APPLE_sync
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"sync", 4))
+        {
+          ret = GLEW_APPLE_sync;
+          continue;
+        }
+#endif
+#ifdef GL_APPLE_texture_2D_limited_npot
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"texture_2D_limited_npot", 23))
+        {
+          ret = GLEW_APPLE_texture_2D_limited_npot;
+          continue;
+        }
+#endif
+#ifdef GL_APPLE_texture_format_BGRA8888
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"texture_format_BGRA8888", 23))
+        {
+          ret = GLEW_APPLE_texture_format_BGRA8888;
+          continue;
+        }
+#endif
+#ifdef GL_APPLE_texture_max_level
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"texture_max_level", 17))
+        {
+          ret = GLEW_APPLE_texture_max_level;
+          continue;
+        }
+#endif
+#ifdef GL_APPLE_texture_packed_float
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"texture_packed_float", 20))
+        {
+          ret = GLEW_APPLE_texture_packed_float;
           continue;
         }
 #endif
@@ -14968,6 +21609,13 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"ES3_1_compatibility", 19))
         {
           ret = GLEW_ARB_ES3_1_compatibility;
+          continue;
+        }
+#endif
+#ifdef GL_ARB_ES3_2_compatibility
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"ES3_2_compatibility", 19))
+        {
+          ret = GLEW_ARB_ES3_2_compatibility;
           continue;
         }
 #endif
@@ -15244,6 +21892,13 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_ARB_fragment_shader_interlock
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"fragment_shader_interlock", 25))
+        {
+          ret = GLEW_ARB_fragment_shader_interlock;
+          continue;
+        }
+#endif
 #ifdef GL_ARB_framebuffer_no_attachments
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"framebuffer_no_attachments", 26))
         {
@@ -15286,6 +21941,13 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_ARB_gl_spirv
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"gl_spirv", 8))
+        {
+          ret = GLEW_ARB_gl_spirv;
+          continue;
+        }
+#endif
 #ifdef GL_ARB_gpu_shader5
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"gpu_shader5", 11))
         {
@@ -15297,6 +21959,13 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"gpu_shader_fp64", 15))
         {
           ret = GLEW_ARB_gpu_shader_fp64;
+          continue;
+        }
+#endif
+#ifdef GL_ARB_gpu_shader_int64
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"gpu_shader_int64", 16))
+        {
+          ret = GLEW_ARB_gpu_shader_int64;
           continue;
         }
 #endif
@@ -15419,6 +22088,13 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_ARB_parallel_shader_compile
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"parallel_shader_compile", 23))
+        {
+          ret = GLEW_ARB_parallel_shader_compile;
+          continue;
+        }
+#endif
 #ifdef GL_ARB_pipeline_statistics_query
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"pipeline_statistics_query", 25))
         {
@@ -15444,6 +22120,20 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"point_sprite", 12))
         {
           ret = GLEW_ARB_point_sprite;
+          continue;
+        }
+#endif
+#ifdef GL_ARB_polygon_offset_clamp
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"polygon_offset_clamp", 20))
+        {
+          ret = GLEW_ARB_polygon_offset_clamp;
+          continue;
+        }
+#endif
+#ifdef GL_ARB_post_depth_coverage
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"post_depth_coverage", 19))
+        {
+          ret = GLEW_ARB_post_depth_coverage;
           continue;
         }
 #endif
@@ -15496,6 +22186,13 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_ARB_sample_locations
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"sample_locations", 16))
+        {
+          ret = GLEW_ARB_sample_locations;
+          continue;
+        }
+#endif
 #ifdef GL_ARB_sample_shading
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"sample_shading", 14))
         {
@@ -15531,6 +22228,13 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_ARB_shader_atomic_counter_ops
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"shader_atomic_counter_ops", 25))
+        {
+          ret = GLEW_ARB_shader_atomic_counter_ops;
+          continue;
+        }
+#endif
 #ifdef GL_ARB_shader_atomic_counters
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"shader_atomic_counters", 22))
         {
@@ -15538,10 +22242,24 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_ARB_shader_ballot
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"shader_ballot", 13))
+        {
+          ret = GLEW_ARB_shader_ballot;
+          continue;
+        }
+#endif
 #ifdef GL_ARB_shader_bit_encoding
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"shader_bit_encoding", 19))
         {
           ret = GLEW_ARB_shader_bit_encoding;
+          continue;
+        }
+#endif
+#ifdef GL_ARB_shader_clock
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"shader_clock", 12))
+        {
+          ret = GLEW_ARB_shader_clock;
           continue;
         }
 #endif
@@ -15622,6 +22340,13 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_ARB_shader_viewport_layer_array
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"shader_viewport_layer_array", 27))
+        {
+          ret = GLEW_ARB_shader_viewport_layer_array;
+          continue;
+        }
+#endif
 #ifdef GL_ARB_shading_language_100
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"shading_language_100", 20))
         {
@@ -15675,6 +22400,27 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"sparse_texture", 14))
         {
           ret = GLEW_ARB_sparse_texture;
+          continue;
+        }
+#endif
+#ifdef GL_ARB_sparse_texture2
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"sparse_texture2", 15))
+        {
+          ret = GLEW_ARB_sparse_texture2;
+          continue;
+        }
+#endif
+#ifdef GL_ARB_sparse_texture_clamp
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"sparse_texture_clamp", 20))
+        {
+          ret = GLEW_ARB_sparse_texture_clamp;
+          continue;
+        }
+#endif
+#ifdef GL_ARB_spirv_extensions
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"spirv_extensions", 16))
+        {
+          ret = GLEW_ARB_spirv_extensions;
           continue;
         }
 #endif
@@ -15794,6 +22540,20 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"texture_env_dot3", 16))
         {
           ret = GLEW_ARB_texture_env_dot3;
+          continue;
+        }
+#endif
+#ifdef GL_ARB_texture_filter_anisotropic
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"texture_filter_anisotropic", 26))
+        {
+          ret = GLEW_ARB_texture_filter_anisotropic;
+          continue;
+        }
+#endif
+#ifdef GL_ARB_texture_filter_minmax
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"texture_filter_minmax", 21))
+        {
+          ret = GLEW_ARB_texture_filter_minmax;
           continue;
         }
 #endif
@@ -16043,6 +22803,44 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
         }
 #endif
       }
+      if (_glewStrSame2(&pos, &len, (const GLubyte*)"ARM_", 4))
+      {
+#ifdef GL_ARM_mali_program_binary
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"mali_program_binary", 19))
+        {
+          ret = GLEW_ARM_mali_program_binary;
+          continue;
+        }
+#endif
+#ifdef GL_ARM_mali_shader_binary
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"mali_shader_binary", 18))
+        {
+          ret = GLEW_ARM_mali_shader_binary;
+          continue;
+        }
+#endif
+#ifdef GL_ARM_rgba8
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"rgba8", 5))
+        {
+          ret = GLEW_ARM_rgba8;
+          continue;
+        }
+#endif
+#ifdef GL_ARM_shader_framebuffer_fetch
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"shader_framebuffer_fetch", 24))
+        {
+          ret = GLEW_ARM_shader_framebuffer_fetch;
+          continue;
+        }
+#endif
+#ifdef GL_ARM_shader_framebuffer_fetch_depth_stencil
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"shader_framebuffer_fetch_depth_stencil", 38))
+        {
+          ret = GLEW_ARM_shader_framebuffer_fetch_depth_stencil;
+          continue;
+        }
+#endif
+      }
       if (_glewStrSame2(&pos, &len, (const GLubyte*)"ATIX_", 5))
       {
 #ifdef GL_ATIX_point_sprites
@@ -16196,6 +22994,23 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
         }
 #endif
       }
+      if (_glewStrSame2(&pos, &len, (const GLubyte*)"EGL_", 4))
+      {
+#ifdef GL_EGL_KHR_context_flush_control
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"KHR_context_flush_control", 25))
+        {
+          ret = GLEW_EGL_KHR_context_flush_control;
+          continue;
+        }
+#endif
+#ifdef GL_EGL_NV_robustness_video_memory_purge
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"NV_robustness_video_memory_purge", 32))
+        {
+          ret = GLEW_EGL_NV_robustness_video_memory_purge;
+          continue;
+        }
+#endif
+      }
       if (_glewStrSame2(&pos, &len, (const GLubyte*)"EXT_", 4))
       {
 #ifdef GL_EXT_422_pixels
@@ -16212,10 +23027,31 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_EXT_EGL_image_array
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"EGL_image_array", 15))
+        {
+          ret = GLEW_EXT_EGL_image_array;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_YUV_target
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"YUV_target", 10))
+        {
+          ret = GLEW_EXT_YUV_target;
+          continue;
+        }
+#endif
 #ifdef GL_EXT_abgr
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"abgr", 4))
         {
           ret = GLEW_EXT_abgr;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_base_instance
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"base_instance", 13))
+        {
+          ret = GLEW_EXT_base_instance;
           continue;
         }
 #endif
@@ -16247,6 +23083,13 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_EXT_blend_func_extended
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"blend_func_extended", 19))
+        {
+          ret = GLEW_EXT_blend_func_extended;
+          continue;
+        }
+#endif
 #ifdef GL_EXT_blend_func_separate
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"blend_func_separate", 19))
         {
@@ -16275,6 +23118,27 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_EXT_buffer_storage
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"buffer_storage", 14))
+        {
+          ret = GLEW_EXT_buffer_storage;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_clear_texture
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"clear_texture", 13))
+        {
+          ret = GLEW_EXT_clear_texture;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_clip_cull_distance
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"clip_cull_distance", 18))
+        {
+          ret = GLEW_EXT_clip_cull_distance;
+          continue;
+        }
+#endif
 #ifdef GL_EXT_clip_volume_hint
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"clip_volume_hint", 16))
         {
@@ -16286,6 +23150,20 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"cmyka", 5))
         {
           ret = GLEW_EXT_cmyka;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_color_buffer_float
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"color_buffer_float", 18))
+        {
+          ret = GLEW_EXT_color_buffer_float;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_color_buffer_half_float
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"color_buffer_half_float", 23))
+        {
+          ret = GLEW_EXT_color_buffer_half_float;
           continue;
         }
 #endif
@@ -16303,6 +23181,20 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_EXT_compressed_ETC1_RGB8_sub_texture
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"compressed_ETC1_RGB8_sub_texture", 32))
+        {
+          ret = GLEW_EXT_compressed_ETC1_RGB8_sub_texture;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_conservative_depth
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"conservative_depth", 18))
+        {
+          ret = GLEW_EXT_conservative_depth;
+          continue;
+        }
+#endif
 #ifdef GL_EXT_convolution
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"convolution", 11))
         {
@@ -16314,6 +23206,13 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"coordinate_frame", 16))
         {
           ret = GLEW_EXT_coordinate_frame;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_copy_image
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"copy_image", 10))
+        {
+          ret = GLEW_EXT_copy_image;
           continue;
         }
 #endif
@@ -16359,10 +23258,38 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_EXT_discard_framebuffer
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"discard_framebuffer", 19))
+        {
+          ret = GLEW_EXT_discard_framebuffer;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_draw_buffers
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"draw_buffers", 12))
+        {
+          ret = GLEW_EXT_draw_buffers;
+          continue;
+        }
+#endif
 #ifdef GL_EXT_draw_buffers2
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"draw_buffers2", 13))
         {
           ret = GLEW_EXT_draw_buffers2;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_draw_buffers_indexed
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"draw_buffers_indexed", 20))
+        {
+          ret = GLEW_EXT_draw_buffers_indexed;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_draw_elements_base_vertex
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"draw_elements_base_vertex", 25))
+        {
+          ret = GLEW_EXT_draw_elements_base_vertex;
           continue;
         }
 #endif
@@ -16380,10 +23307,31 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_EXT_external_buffer
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"external_buffer", 15))
+        {
+          ret = GLEW_EXT_external_buffer;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_float_blend
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"float_blend", 11))
+        {
+          ret = GLEW_EXT_float_blend;
+          continue;
+        }
+#endif
 #ifdef GL_EXT_fog_coord
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"fog_coord", 9))
         {
           ret = GLEW_EXT_fog_coord;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_frag_depth
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"frag_depth", 10))
+        {
+          ret = GLEW_EXT_frag_depth;
           continue;
         }
 #endif
@@ -16429,6 +23377,20 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_EXT_geometry_point_size
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"geometry_point_size", 19))
+        {
+          ret = GLEW_EXT_geometry_point_size;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_geometry_shader
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"geometry_shader", 15))
+        {
+          ret = GLEW_EXT_geometry_shader;
+          continue;
+        }
+#endif
 #ifdef GL_EXT_geometry_shader4
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"geometry_shader4", 16))
         {
@@ -16447,6 +23409,13 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"gpu_shader4", 11))
         {
           ret = GLEW_EXT_gpu_shader4;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_gpu_shader5
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"gpu_shader5", 11))
+        {
+          ret = GLEW_EXT_gpu_shader5;
           continue;
         }
 #endif
@@ -16485,10 +23454,45 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_EXT_instanced_arrays
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"instanced_arrays", 16))
+        {
+          ret = GLEW_EXT_instanced_arrays;
+          continue;
+        }
+#endif
 #ifdef GL_EXT_light_texture
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"light_texture", 13))
         {
           ret = GLEW_EXT_light_texture;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_map_buffer_range
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"map_buffer_range", 16))
+        {
+          ret = GLEW_EXT_map_buffer_range;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_memory_object
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"memory_object", 13))
+        {
+          ret = GLEW_EXT_memory_object;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_memory_object_fd
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"memory_object_fd", 16))
+        {
+          ret = GLEW_EXT_memory_object_fd;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_memory_object_win32
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"memory_object_win32", 19))
+        {
+          ret = GLEW_EXT_memory_object_win32;
           continue;
         }
 #endif
@@ -16506,10 +23510,52 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_EXT_multi_draw_indirect
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"multi_draw_indirect", 19))
+        {
+          ret = GLEW_EXT_multi_draw_indirect;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_multiple_textures
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"multiple_textures", 17))
+        {
+          ret = GLEW_EXT_multiple_textures;
+          continue;
+        }
+#endif
 #ifdef GL_EXT_multisample
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"multisample", 11))
         {
           ret = GLEW_EXT_multisample;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_multisample_compatibility
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"multisample_compatibility", 25))
+        {
+          ret = GLEW_EXT_multisample_compatibility;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_multisampled_render_to_texture
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"multisampled_render_to_texture", 30))
+        {
+          ret = GLEW_EXT_multisampled_render_to_texture;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_multisampled_render_to_texture2
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"multisampled_render_to_texture2", 31))
+        {
+          ret = GLEW_EXT_multisampled_render_to_texture2;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_multiview_draw_buffers
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"multiview_draw_buffers", 22))
+        {
+          ret = GLEW_EXT_multiview_draw_buffers;
           continue;
         }
 #endif
@@ -16576,6 +23622,20 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_EXT_polygon_offset_clamp
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"polygon_offset_clamp", 20))
+        {
+          ret = GLEW_EXT_polygon_offset_clamp;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_post_depth_coverage
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"post_depth_coverage", 19))
+        {
+          ret = GLEW_EXT_post_depth_coverage;
+          continue;
+        }
+#endif
 #ifdef GL_EXT_provoking_vertex
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"provoking_vertex", 16))
         {
@@ -16583,10 +23643,52 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_EXT_pvrtc_sRGB
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"pvrtc_sRGB", 10))
+        {
+          ret = GLEW_EXT_pvrtc_sRGB;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_raster_multisample
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"raster_multisample", 18))
+        {
+          ret = GLEW_EXT_raster_multisample;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_read_format_bgra
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"read_format_bgra", 16))
+        {
+          ret = GLEW_EXT_read_format_bgra;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_render_snorm
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"render_snorm", 12))
+        {
+          ret = GLEW_EXT_render_snorm;
+          continue;
+        }
+#endif
 #ifdef GL_EXT_rescale_normal
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"rescale_normal", 14))
         {
           ret = GLEW_EXT_rescale_normal;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_sRGB
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"sRGB", 4))
+        {
+          ret = GLEW_EXT_sRGB;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_sRGB_write_control
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"sRGB_write_control", 18))
+        {
+          ret = GLEW_EXT_sRGB_write_control;
           continue;
         }
 #endif
@@ -16604,6 +23706,27 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_EXT_semaphore
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"semaphore", 9))
+        {
+          ret = GLEW_EXT_semaphore;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_semaphore_fd
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"semaphore_fd", 12))
+        {
+          ret = GLEW_EXT_semaphore_fd;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_semaphore_win32
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"semaphore_win32", 15))
+        {
+          ret = GLEW_EXT_semaphore_win32;
+          continue;
+        }
+#endif
 #ifdef GL_EXT_separate_shader_objects
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"separate_shader_objects", 23))
         {
@@ -16615,6 +23738,20 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"separate_specular_color", 23))
         {
           ret = GLEW_EXT_separate_specular_color;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_shader_framebuffer_fetch
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"shader_framebuffer_fetch", 24))
+        {
+          ret = GLEW_EXT_shader_framebuffer_fetch;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_shader_group_vote
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"shader_group_vote", 17))
+        {
+          ret = GLEW_EXT_shader_group_vote;
           continue;
         }
 #endif
@@ -16632,10 +23769,52 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_EXT_shader_implicit_conversions
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"shader_implicit_conversions", 27))
+        {
+          ret = GLEW_EXT_shader_implicit_conversions;
+          continue;
+        }
+#endif
 #ifdef GL_EXT_shader_integer_mix
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"shader_integer_mix", 18))
         {
           ret = GLEW_EXT_shader_integer_mix;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_shader_io_blocks
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"shader_io_blocks", 16))
+        {
+          ret = GLEW_EXT_shader_io_blocks;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_shader_non_constant_global_initializers
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"shader_non_constant_global_initializers", 39))
+        {
+          ret = GLEW_EXT_shader_non_constant_global_initializers;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_shader_pixel_local_storage
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"shader_pixel_local_storage", 26))
+        {
+          ret = GLEW_EXT_shader_pixel_local_storage;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_shader_pixel_local_storage2
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"shader_pixel_local_storage2", 27))
+        {
+          ret = GLEW_EXT_shader_pixel_local_storage2;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_shader_texture_lod
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"shader_texture_lod", 18))
+        {
+          ret = GLEW_EXT_shader_texture_lod;
           continue;
         }
 #endif
@@ -16646,10 +23825,31 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_EXT_shadow_samplers
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"shadow_samplers", 15))
+        {
+          ret = GLEW_EXT_shadow_samplers;
+          continue;
+        }
+#endif
 #ifdef GL_EXT_shared_texture_palette
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"shared_texture_palette", 22))
         {
           ret = GLEW_EXT_shared_texture_palette;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_sparse_texture
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"sparse_texture", 14))
+        {
+          ret = GLEW_EXT_sparse_texture;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_sparse_texture2
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"sparse_texture2", 15))
+        {
+          ret = GLEW_EXT_sparse_texture2;
           continue;
         }
 #endif
@@ -16709,6 +23909,27 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_EXT_texture_compression_astc_decode_mode
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"texture_compression_astc_decode_mode", 36))
+        {
+          ret = GLEW_EXT_texture_compression_astc_decode_mode;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_texture_compression_astc_decode_mode_rgb9e5
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"texture_compression_astc_decode_mode_rgb9e5", 43))
+        {
+          ret = GLEW_EXT_texture_compression_astc_decode_mode_rgb9e5;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_texture_compression_bptc
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"texture_compression_bptc", 24))
+        {
+          ret = GLEW_EXT_texture_compression_bptc;
+          continue;
+        }
+#endif
 #ifdef GL_EXT_texture_compression_dxt1
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"texture_compression_dxt1", 24))
         {
@@ -16741,6 +23962,13 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"texture_cube_map", 16))
         {
           ret = GLEW_EXT_texture_cube_map;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_texture_cube_map_array
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"texture_cube_map_array", 22))
+        {
+          ret = GLEW_EXT_texture_cube_map_array;
           continue;
         }
 #endif
@@ -16786,6 +24014,20 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_EXT_texture_filter_minmax
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"texture_filter_minmax", 21))
+        {
+          ret = GLEW_EXT_texture_filter_minmax;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_texture_format_BGRA8888
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"texture_format_BGRA8888", 23))
+        {
+          ret = GLEW_EXT_texture_format_BGRA8888;
+          continue;
+        }
+#endif
 #ifdef GL_EXT_texture_integer
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"texture_integer", 15))
         {
@@ -16804,6 +24046,13 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"texture_mirror_clamp", 20))
         {
           ret = GLEW_EXT_texture_mirror_clamp;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_texture_norm16
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"texture_norm16", 14))
+        {
+          ret = GLEW_EXT_texture_norm16;
           continue;
         }
 #endif
@@ -16828,10 +24077,31 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_EXT_texture_rg
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"texture_rg", 10))
+        {
+          ret = GLEW_EXT_texture_rg;
+          continue;
+        }
+#endif
 #ifdef GL_EXT_texture_sRGB
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"texture_sRGB", 12))
         {
           ret = GLEW_EXT_texture_sRGB;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_texture_sRGB_R8
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"texture_sRGB_R8", 15))
+        {
+          ret = GLEW_EXT_texture_sRGB_R8;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_texture_sRGB_RG8
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"texture_sRGB_RG8", 16))
+        {
+          ret = GLEW_EXT_texture_sRGB_RG8;
           continue;
         }
 #endif
@@ -16856,10 +24126,31 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_EXT_texture_storage
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"texture_storage", 15))
+        {
+          ret = GLEW_EXT_texture_storage;
+          continue;
+        }
+#endif
 #ifdef GL_EXT_texture_swizzle
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"texture_swizzle", 15))
         {
           ret = GLEW_EXT_texture_swizzle;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_texture_type_2_10_10_10_REV
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"texture_type_2_10_10_10_REV", 27))
+        {
+          ret = GLEW_EXT_texture_type_2_10_10_10_REV;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_texture_view
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"texture_view", 12))
+        {
+          ret = GLEW_EXT_texture_view;
           continue;
         }
 #endif
@@ -16877,6 +24168,13 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_EXT_unpack_subimage
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"unpack_subimage", 15))
+        {
+          ret = GLEW_EXT_unpack_subimage;
+          continue;
+        }
+#endif
 #ifdef GL_EXT_vertex_array
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"vertex_array", 12))
         {
@@ -16888,6 +24186,13 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"vertex_array_bgra", 17))
         {
           ret = GLEW_EXT_vertex_array_bgra;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_vertex_array_setXXX
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"vertex_array_setXXX", 19))
+        {
+          ret = GLEW_EXT_vertex_array_setXXX;
           continue;
         }
 #endif
@@ -16909,6 +24214,20 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"vertex_weighting", 16))
         {
           ret = GLEW_EXT_vertex_weighting;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_win32_keyed_mutex
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"win32_keyed_mutex", 17))
+        {
+          ret = GLEW_EXT_win32_keyed_mutex;
+          continue;
+        }
+#endif
+#ifdef GL_EXT_window_rectangles
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"window_rectangles", 17))
+        {
+          ret = GLEW_EXT_window_rectangles;
           continue;
         }
 #endif
@@ -17032,10 +24351,24 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
       }
       if (_glewStrSame2(&pos, &len, (const GLubyte*)"INTEL_", 6))
       {
+#ifdef GL_INTEL_conservative_rasterization
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"conservative_rasterization", 26))
+        {
+          ret = GLEW_INTEL_conservative_rasterization;
+          continue;
+        }
+#endif
 #ifdef GL_INTEL_fragment_shader_ordering
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"fragment_shader_ordering", 24))
         {
           ret = GLEW_INTEL_fragment_shader_ordering;
+          continue;
+        }
+#endif
+#ifdef GL_INTEL_framebuffer_CMAA
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"framebuffer_CMAA", 16))
+        {
+          ret = GLEW_INTEL_framebuffer_CMAA;
           continue;
         }
 #endif
@@ -17098,6 +24431,20 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_KHR_no_error
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"no_error", 8))
+        {
+          ret = GLEW_KHR_no_error;
+          continue;
+        }
+#endif
+#ifdef GL_KHR_parallel_shader_compile
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"parallel_shader_compile", 23))
+        {
+          ret = GLEW_KHR_parallel_shader_compile;
+          continue;
+        }
+#endif
 #ifdef GL_KHR_robust_buffer_access_behavior
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"robust_buffer_access_behavior", 29))
         {
@@ -17123,6 +24470,13 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"texture_compression_astc_ldr", 28))
         {
           ret = GLEW_KHR_texture_compression_astc_ldr;
+          continue;
+        }
+#endif
+#ifdef GL_KHR_texture_compression_astc_sliced_3d
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"texture_compression_astc_sliced_3d", 34))
+        {
+          ret = GLEW_KHR_texture_compression_astc_sliced_3d;
           continue;
         }
 #endif
@@ -17163,6 +24517,13 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_MESA_shader_integer_functions
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"shader_integer_functions", 24))
+        {
+          ret = GLEW_MESA_shader_integer_functions;
+          continue;
+        }
+#endif
 #ifdef GL_MESA_window_pos
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"window_pos", 10))
         {
@@ -17180,6 +24541,13 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
       }
       if (_glewStrSame2(&pos, &len, (const GLubyte*)"NVX_", 4))
       {
+#ifdef GL_NVX_blend_equation_advanced_multi_draw_buffers
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"blend_equation_advanced_multi_draw_buffers", 42))
+        {
+          ret = GLEW_NVX_blend_equation_advanced_multi_draw_buffers;
+          continue;
+        }
+#endif
 #ifdef GL_NVX_conditional_render
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"conditional_render", 18))
         {
@@ -17194,9 +24562,44 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_NVX_linked_gpu_multicast
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"linked_gpu_multicast", 20))
+        {
+          ret = GLEW_NVX_linked_gpu_multicast;
+          continue;
+        }
+#endif
       }
       if (_glewStrSame2(&pos, &len, (const GLubyte*)"NV_", 3))
       {
+#ifdef GL_NV_3dvision_settings
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"3dvision_settings", 17))
+        {
+          ret = GLEW_NV_3dvision_settings;
+          continue;
+        }
+#endif
+#ifdef GL_NV_EGL_stream_consumer_external
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"EGL_stream_consumer_external", 28))
+        {
+          ret = GLEW_NV_EGL_stream_consumer_external;
+          continue;
+        }
+#endif
+#ifdef GL_NV_alpha_to_coverage_dither_control
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"alpha_to_coverage_dither_control", 32))
+        {
+          ret = GLEW_NV_alpha_to_coverage_dither_control;
+          continue;
+        }
+#endif
+#ifdef GL_NV_bgr
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"bgr", 3))
+        {
+          ret = GLEW_NV_bgr;
+          continue;
+        }
+#endif
 #ifdef GL_NV_bindless_multi_draw_indirect
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"bindless_multi_draw_indirect", 28))
         {
@@ -17232,10 +24635,31 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_NV_blend_minmax_factor
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"blend_minmax_factor", 19))
+        {
+          ret = GLEW_NV_blend_minmax_factor;
+          continue;
+        }
+#endif
 #ifdef GL_NV_blend_square
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"blend_square", 12))
         {
           ret = GLEW_NV_blend_square;
+          continue;
+        }
+#endif
+#ifdef GL_NV_clip_space_w_scaling
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"clip_space_w_scaling", 20))
+        {
+          ret = GLEW_NV_clip_space_w_scaling;
+          continue;
+        }
+#endif
+#ifdef GL_NV_command_list
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"command_list", 12))
+        {
+          ret = GLEW_NV_command_list;
           continue;
         }
 #endif
@@ -17250,6 +24674,34 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"conditional_render", 18))
         {
           ret = GLEW_NV_conditional_render;
+          continue;
+        }
+#endif
+#ifdef GL_NV_conservative_raster
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"conservative_raster", 19))
+        {
+          ret = GLEW_NV_conservative_raster;
+          continue;
+        }
+#endif
+#ifdef GL_NV_conservative_raster_dilate
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"conservative_raster_dilate", 26))
+        {
+          ret = GLEW_NV_conservative_raster_dilate;
+          continue;
+        }
+#endif
+#ifdef GL_NV_conservative_raster_pre_snap_triangles
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"conservative_raster_pre_snap_triangles", 38))
+        {
+          ret = GLEW_NV_conservative_raster_pre_snap_triangles;
+          continue;
+        }
+#endif
+#ifdef GL_NV_copy_buffer
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"copy_buffer", 11))
+        {
+          ret = GLEW_NV_copy_buffer;
           continue;
         }
 #endif
@@ -17295,10 +24747,31 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_NV_draw_buffers
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"draw_buffers", 12))
+        {
+          ret = GLEW_NV_draw_buffers;
+          continue;
+        }
+#endif
+#ifdef GL_NV_draw_instanced
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"draw_instanced", 14))
+        {
+          ret = GLEW_NV_draw_instanced;
+          continue;
+        }
+#endif
 #ifdef GL_NV_draw_texture
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"draw_texture", 12))
         {
           ret = GLEW_NV_draw_texture;
+          continue;
+        }
+#endif
+#ifdef GL_NV_draw_vulkan_image
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"draw_vulkan_image", 17))
+        {
+          ret = GLEW_NV_draw_vulkan_image;
           continue;
         }
 #endif
@@ -17309,6 +24782,13 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_NV_explicit_attrib_location
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"explicit_attrib_location", 24))
+        {
+          ret = GLEW_NV_explicit_attrib_location;
+          continue;
+        }
+#endif
 #ifdef GL_NV_explicit_multisample
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"explicit_multisample", 20))
         {
@@ -17316,10 +24796,24 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_NV_fbo_color_attachments
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"fbo_color_attachments", 21))
+        {
+          ret = GLEW_NV_fbo_color_attachments;
+          continue;
+        }
+#endif
 #ifdef GL_NV_fence
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"fence", 5))
         {
           ret = GLEW_NV_fence;
+          continue;
+        }
+#endif
+#ifdef GL_NV_fill_rectangle
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"fill_rectangle", 14))
+        {
+          ret = GLEW_NV_fill_rectangle;
           continue;
         }
 #endif
@@ -17334,6 +24828,13 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"fog_distance", 12))
         {
           ret = GLEW_NV_fog_distance;
+          continue;
+        }
+#endif
+#ifdef GL_NV_fragment_coverage_to_color
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"fragment_coverage_to_color", 26))
+        {
+          ret = GLEW_NV_fragment_coverage_to_color;
           continue;
         }
 #endif
@@ -17365,10 +24866,45 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_NV_fragment_shader_interlock
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"fragment_shader_interlock", 25))
+        {
+          ret = GLEW_NV_fragment_shader_interlock;
+          continue;
+        }
+#endif
+#ifdef GL_NV_framebuffer_blit
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"framebuffer_blit", 16))
+        {
+          ret = GLEW_NV_framebuffer_blit;
+          continue;
+        }
+#endif
+#ifdef GL_NV_framebuffer_mixed_samples
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"framebuffer_mixed_samples", 25))
+        {
+          ret = GLEW_NV_framebuffer_mixed_samples;
+          continue;
+        }
+#endif
+#ifdef GL_NV_framebuffer_multisample
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"framebuffer_multisample", 23))
+        {
+          ret = GLEW_NV_framebuffer_multisample;
+          continue;
+        }
+#endif
 #ifdef GL_NV_framebuffer_multisample_coverage
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"framebuffer_multisample_coverage", 32))
         {
           ret = GLEW_NV_framebuffer_multisample_coverage;
+          continue;
+        }
+#endif
+#ifdef GL_NV_generate_mipmap_sRGB
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"generate_mipmap_sRGB", 20))
+        {
+          ret = GLEW_NV_generate_mipmap_sRGB;
           continue;
         }
 #endif
@@ -17383,6 +24919,20 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"geometry_shader4", 16))
         {
           ret = GLEW_NV_geometry_shader4;
+          continue;
+        }
+#endif
+#ifdef GL_NV_geometry_shader_passthrough
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"geometry_shader_passthrough", 27))
+        {
+          ret = GLEW_NV_geometry_shader_passthrough;
+          continue;
+        }
+#endif
+#ifdef GL_NV_gpu_multicast
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"gpu_multicast", 13))
+        {
+          ret = GLEW_NV_gpu_multicast;
           continue;
         }
 #endif
@@ -17428,6 +24978,27 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_NV_image_formats
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"image_formats", 13))
+        {
+          ret = GLEW_NV_image_formats;
+          continue;
+        }
+#endif
+#ifdef GL_NV_instanced_arrays
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"instanced_arrays", 16))
+        {
+          ret = GLEW_NV_instanced_arrays;
+          continue;
+        }
+#endif
+#ifdef GL_NV_internalformat_sample_query
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"internalformat_sample_query", 27))
+        {
+          ret = GLEW_NV_internalformat_sample_query;
+          continue;
+        }
+#endif
 #ifdef GL_NV_light_max_exponent
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"light_max_exponent", 18))
         {
@@ -17449,6 +25020,13 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_NV_non_square_matrices
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"non_square_matrices", 19))
+        {
+          ret = GLEW_NV_non_square_matrices;
+          continue;
+        }
+#endif
 #ifdef GL_NV_occlusion_query
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"occlusion_query", 15))
         {
@@ -17456,10 +25034,31 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_NV_pack_subimage
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"pack_subimage", 13))
+        {
+          ret = GLEW_NV_pack_subimage;
+          continue;
+        }
+#endif
 #ifdef GL_NV_packed_depth_stencil
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"packed_depth_stencil", 20))
         {
           ret = GLEW_NV_packed_depth_stencil;
+          continue;
+        }
+#endif
+#ifdef GL_NV_packed_float
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"packed_float", 12))
+        {
+          ret = GLEW_NV_packed_float;
+          continue;
+        }
+#endif
+#ifdef GL_NV_packed_float_linear
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"packed_float_linear", 19))
+        {
+          ret = GLEW_NV_packed_float_linear;
           continue;
         }
 #endif
@@ -17484,6 +25083,20 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_NV_path_rendering_shared_edge
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"path_rendering_shared_edge", 26))
+        {
+          ret = GLEW_NV_path_rendering_shared_edge;
+          continue;
+        }
+#endif
+#ifdef GL_NV_pixel_buffer_object
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"pixel_buffer_object", 19))
+        {
+          ret = GLEW_NV_pixel_buffer_object;
+          continue;
+        }
+#endif
 #ifdef GL_NV_pixel_data_range
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"pixel_data_range", 16))
         {
@@ -17491,10 +25104,24 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_NV_platform_binary
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"platform_binary", 15))
+        {
+          ret = GLEW_NV_platform_binary;
+          continue;
+        }
+#endif
 #ifdef GL_NV_point_sprite
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"point_sprite", 12))
         {
           ret = GLEW_NV_point_sprite;
+          continue;
+        }
+#endif
+#ifdef GL_NV_polygon_mode
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"polygon_mode", 12))
+        {
+          ret = GLEW_NV_polygon_mode;
           continue;
         }
 #endif
@@ -17512,6 +25139,27 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_NV_read_depth
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"read_depth", 10))
+        {
+          ret = GLEW_NV_read_depth;
+          continue;
+        }
+#endif
+#ifdef GL_NV_read_depth_stencil
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"read_depth_stencil", 18))
+        {
+          ret = GLEW_NV_read_depth_stencil;
+          continue;
+        }
+#endif
+#ifdef GL_NV_read_stencil
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"read_stencil", 12))
+        {
+          ret = GLEW_NV_read_stencil;
+          continue;
+        }
+#endif
 #ifdef GL_NV_register_combiners
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"register_combiners", 18))
         {
@@ -17523,6 +25171,34 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"register_combiners2", 19))
         {
           ret = GLEW_NV_register_combiners2;
+          continue;
+        }
+#endif
+#ifdef GL_NV_robustness_video_memory_purge
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"robustness_video_memory_purge", 29))
+        {
+          ret = GLEW_NV_robustness_video_memory_purge;
+          continue;
+        }
+#endif
+#ifdef GL_NV_sRGB_formats
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"sRGB_formats", 12))
+        {
+          ret = GLEW_NV_sRGB_formats;
+          continue;
+        }
+#endif
+#ifdef GL_NV_sample_locations
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"sample_locations", 16))
+        {
+          ret = GLEW_NV_sample_locations;
+          continue;
+        }
+#endif
+#ifdef GL_NV_sample_mask_override_coverage
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"sample_mask_override_coverage", 29))
+        {
+          ret = GLEW_NV_sample_mask_override_coverage;
           continue;
         }
 #endif
@@ -17540,6 +25216,20 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_NV_shader_atomic_float64
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"shader_atomic_float64", 21))
+        {
+          ret = GLEW_NV_shader_atomic_float64;
+          continue;
+        }
+#endif
+#ifdef GL_NV_shader_atomic_fp16_vector
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"shader_atomic_fp16_vector", 25))
+        {
+          ret = GLEW_NV_shader_atomic_fp16_vector;
+          continue;
+        }
+#endif
 #ifdef GL_NV_shader_atomic_int64
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"shader_atomic_int64", 19))
         {
@@ -17551,6 +25241,13 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"shader_buffer_load", 18))
         {
           ret = GLEW_NV_shader_buffer_load;
+          continue;
+        }
+#endif
+#ifdef GL_NV_shader_noperspective_interpolation
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"shader_noperspective_interpolation", 34))
+        {
+          ret = GLEW_NV_shader_noperspective_interpolation;
           continue;
         }
 #endif
@@ -17575,6 +25272,27 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_NV_shadow_samplers_array
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"shadow_samplers_array", 21))
+        {
+          ret = GLEW_NV_shadow_samplers_array;
+          continue;
+        }
+#endif
+#ifdef GL_NV_shadow_samplers_cube
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"shadow_samplers_cube", 20))
+        {
+          ret = GLEW_NV_shadow_samplers_cube;
+          continue;
+        }
+#endif
+#ifdef GL_NV_stereo_view_rendering
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"stereo_view_rendering", 21))
+        {
+          ret = GLEW_NV_stereo_view_rendering;
+          continue;
+        }
+#endif
 #ifdef GL_NV_tessellation_program5
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"tessellation_program5", 21))
         {
@@ -17596,10 +25314,45 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_NV_texture_array
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"texture_array", 13))
+        {
+          ret = GLEW_NV_texture_array;
+          continue;
+        }
+#endif
 #ifdef GL_NV_texture_barrier
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"texture_barrier", 15))
         {
           ret = GLEW_NV_texture_barrier;
+          continue;
+        }
+#endif
+#ifdef GL_NV_texture_border_clamp
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"texture_border_clamp", 20))
+        {
+          ret = GLEW_NV_texture_border_clamp;
+          continue;
+        }
+#endif
+#ifdef GL_NV_texture_compression_latc
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"texture_compression_latc", 24))
+        {
+          ret = GLEW_NV_texture_compression_latc;
+          continue;
+        }
+#endif
+#ifdef GL_NV_texture_compression_s3tc
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"texture_compression_s3tc", 24))
+        {
+          ret = GLEW_NV_texture_compression_s3tc;
+          continue;
+        }
+#endif
+#ifdef GL_NV_texture_compression_s3tc_update
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"texture_compression_s3tc_update", 31))
+        {
+          ret = GLEW_NV_texture_compression_s3tc_update;
           continue;
         }
 #endif
@@ -17631,10 +25384,24 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_NV_texture_npot_2D_mipmap
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"texture_npot_2D_mipmap", 22))
+        {
+          ret = GLEW_NV_texture_npot_2D_mipmap;
+          continue;
+        }
+#endif
 #ifdef GL_NV_texture_rectangle
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"texture_rectangle", 17))
         {
           ret = GLEW_NV_texture_rectangle;
+          continue;
+        }
+#endif
+#ifdef GL_NV_texture_rectangle_compressed
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"texture_rectangle_compressed", 28))
+        {
+          ret = GLEW_NV_texture_rectangle_compressed;
           continue;
         }
 #endif
@@ -17670,6 +25437,13 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"transform_feedback2", 19))
         {
           ret = GLEW_NV_transform_feedback2;
+          continue;
+        }
+#endif
+#ifdef GL_NV_uniform_buffer_unified_memory
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"uniform_buffer_unified_memory", 29))
+        {
+          ret = GLEW_NV_uniform_buffer_unified_memory;
           continue;
         }
 #endif
@@ -17757,6 +25531,27 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_NV_viewport_array
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"viewport_array", 14))
+        {
+          ret = GLEW_NV_viewport_array;
+          continue;
+        }
+#endif
+#ifdef GL_NV_viewport_array2
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"viewport_array2", 15))
+        {
+          ret = GLEW_NV_viewport_array2;
+          continue;
+        }
+#endif
+#ifdef GL_NV_viewport_swizzle
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"viewport_swizzle", 16))
+        {
+          ret = GLEW_NV_viewport_swizzle;
+          continue;
+        }
+#endif
       }
       if (_glewStrSame2(&pos, &len, (const GLubyte*)"OES_", 4))
       {
@@ -17764,27 +25559,6 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"byte_coordinates", 16))
         {
           ret = GLEW_OES_byte_coordinates;
-          continue;
-        }
-#endif
-#ifdef GL_OES_compressed_paletted_texture
-        if (_glewStrSame3(&pos, &len, (const GLubyte*)"compressed_paletted_texture", 27))
-        {
-          ret = GLEW_OES_compressed_paletted_texture;
-          continue;
-        }
-#endif
-#ifdef GL_OES_read_format
-        if (_glewStrSame3(&pos, &len, (const GLubyte*)"read_format", 11))
-        {
-          ret = GLEW_OES_read_format;
-          continue;
-        }
-#endif
-#ifdef GL_OES_single_precision
-        if (_glewStrSame3(&pos, &len, (const GLubyte*)"single_precision", 16))
-        {
-          ret = GLEW_OES_single_precision;
           continue;
         }
 #endif
@@ -17813,6 +25587,30 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
         }
 #endif
       }
+      if (_glewStrSame2(&pos, &len, (const GLubyte*)"OVR_", 4))
+      {
+#ifdef GL_OVR_multiview
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"multiview", 9))
+        {
+          ret = GLEW_OVR_multiview;
+          continue;
+        }
+#endif
+#ifdef GL_OVR_multiview2
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"multiview2", 10))
+        {
+          ret = GLEW_OVR_multiview2;
+          continue;
+        }
+#endif
+#ifdef GL_OVR_multiview_multisampled_render_to_texture
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"multiview_multisampled_render_to_texture", 40))
+        {
+          ret = GLEW_OVR_multiview_multisampled_render_to_texture;
+          continue;
+        }
+#endif
+      }
       if (_glewStrSame2(&pos, &len, (const GLubyte*)"PGI_", 4))
       {
 #ifdef GL_PGI_misc_hints
@@ -17826,6 +25624,79 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"vertex_hints", 12))
         {
           ret = GLEW_PGI_vertex_hints;
+          continue;
+        }
+#endif
+      }
+      if (_glewStrSame2(&pos, &len, (const GLubyte*)"QCOM_", 5))
+      {
+#ifdef GL_QCOM_alpha_test
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"alpha_test", 10))
+        {
+          ret = GLEW_QCOM_alpha_test;
+          continue;
+        }
+#endif
+#ifdef GL_QCOM_binning_control
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"binning_control", 15))
+        {
+          ret = GLEW_QCOM_binning_control;
+          continue;
+        }
+#endif
+#ifdef GL_QCOM_driver_control
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"driver_control", 14))
+        {
+          ret = GLEW_QCOM_driver_control;
+          continue;
+        }
+#endif
+#ifdef GL_QCOM_extended_get
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"extended_get", 12))
+        {
+          ret = GLEW_QCOM_extended_get;
+          continue;
+        }
+#endif
+#ifdef GL_QCOM_extended_get2
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"extended_get2", 13))
+        {
+          ret = GLEW_QCOM_extended_get2;
+          continue;
+        }
+#endif
+#ifdef GL_QCOM_framebuffer_foveated
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"framebuffer_foveated", 20))
+        {
+          ret = GLEW_QCOM_framebuffer_foveated;
+          continue;
+        }
+#endif
+#ifdef GL_QCOM_perfmon_global_mode
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"perfmon_global_mode", 19))
+        {
+          ret = GLEW_QCOM_perfmon_global_mode;
+          continue;
+        }
+#endif
+#ifdef GL_QCOM_shader_framebuffer_fetch_noncoherent
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"shader_framebuffer_fetch_noncoherent", 36))
+        {
+          ret = GLEW_QCOM_shader_framebuffer_fetch_noncoherent;
+          continue;
+        }
+#endif
+#ifdef GL_QCOM_tiled_rendering
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"tiled_rendering", 15))
+        {
+          ret = GLEW_QCOM_tiled_rendering;
+          continue;
+        }
+#endif
+#ifdef GL_QCOM_writeonly_rendering
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"writeonly_rendering", 19))
+        {
+          ret = GLEW_QCOM_writeonly_rendering;
           continue;
         }
 #endif
@@ -17904,6 +25775,13 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
       }
       if (_glewStrSame2(&pos, &len, (const GLubyte*)"SGIS_", 5))
       {
+#ifdef GL_SGIS_clip_band_hint
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"clip_band_hint", 14))
+        {
+          ret = GLEW_SGIS_clip_band_hint;
+          continue;
+        }
+#endif
 #ifdef GL_SGIS_color_range
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"color_range", 11))
         {
@@ -17932,10 +25810,24 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_SGIS_line_texgen
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"line_texgen", 11))
+        {
+          ret = GLEW_SGIS_line_texgen;
+          continue;
+        }
+#endif
 #ifdef GL_SGIS_multisample
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"multisample", 11))
         {
           ret = GLEW_SGIS_multisample;
+          continue;
+        }
+#endif
+#ifdef GL_SGIS_multitexture
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"multitexture", 12))
+        {
+          ret = GLEW_SGIS_multitexture;
           continue;
         }
 #endif
@@ -17950,6 +25842,13 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"point_line_texgen", 17))
         {
           ret = GLEW_SGIS_point_line_texgen;
+          continue;
+        }
+#endif
+#ifdef GL_SGIS_shared_multisample
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"shared_multisample", 18))
+        {
+          ret = GLEW_SGIS_shared_multisample;
           continue;
         }
 #endif
@@ -18026,10 +25925,52 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_SGIX_bali_g_instruments
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"bali_g_instruments", 18))
+        {
+          ret = GLEW_SGIX_bali_g_instruments;
+          continue;
+        }
+#endif
+#ifdef GL_SGIX_bali_r_instruments
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"bali_r_instruments", 18))
+        {
+          ret = GLEW_SGIX_bali_r_instruments;
+          continue;
+        }
+#endif
+#ifdef GL_SGIX_bali_timer_instruments
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"bali_timer_instruments", 22))
+        {
+          ret = GLEW_SGIX_bali_timer_instruments;
+          continue;
+        }
+#endif
 #ifdef GL_SGIX_blend_alpha_minmax
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"blend_alpha_minmax", 18))
         {
           ret = GLEW_SGIX_blend_alpha_minmax;
+          continue;
+        }
+#endif
+#ifdef GL_SGIX_blend_cadd
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"blend_cadd", 10))
+        {
+          ret = GLEW_SGIX_blend_cadd;
+          continue;
+        }
+#endif
+#ifdef GL_SGIX_blend_cmultiply
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"blend_cmultiply", 15))
+        {
+          ret = GLEW_SGIX_blend_cmultiply;
+          continue;
+        }
+#endif
+#ifdef GL_SGIX_calligraphic_fragment
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"calligraphic_fragment", 21))
+        {
+          ret = GLEW_SGIX_calligraphic_fragment;
           continue;
         }
 #endif
@@ -18040,10 +25981,66 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_SGIX_color_matrix_accuracy
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"color_matrix_accuracy", 21))
+        {
+          ret = GLEW_SGIX_color_matrix_accuracy;
+          continue;
+        }
+#endif
+#ifdef GL_SGIX_color_table_index_mode
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"color_table_index_mode", 22))
+        {
+          ret = GLEW_SGIX_color_table_index_mode;
+          continue;
+        }
+#endif
+#ifdef GL_SGIX_complex_polar
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"complex_polar", 13))
+        {
+          ret = GLEW_SGIX_complex_polar;
+          continue;
+        }
+#endif
 #ifdef GL_SGIX_convolution_accuracy
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"convolution_accuracy", 20))
         {
           ret = GLEW_SGIX_convolution_accuracy;
+          continue;
+        }
+#endif
+#ifdef GL_SGIX_cube_map
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"cube_map", 8))
+        {
+          ret = GLEW_SGIX_cube_map;
+          continue;
+        }
+#endif
+#ifdef GL_SGIX_cylinder_texgen
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"cylinder_texgen", 15))
+        {
+          ret = GLEW_SGIX_cylinder_texgen;
+          continue;
+        }
+#endif
+#ifdef GL_SGIX_datapipe
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"datapipe", 8))
+        {
+          ret = GLEW_SGIX_datapipe;
+          continue;
+        }
+#endif
+#ifdef GL_SGIX_decimation
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"decimation", 10))
+        {
+          ret = GLEW_SGIX_decimation;
+          continue;
+        }
+#endif
+#ifdef GL_SGIX_depth_pass_instrument
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"depth_pass_instrument", 21))
+        {
+          ret = GLEW_SGIX_depth_pass_instrument;
           continue;
         }
 #endif
@@ -18054,10 +26051,38 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_SGIX_dvc
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"dvc", 3))
+        {
+          ret = GLEW_SGIX_dvc;
+          continue;
+        }
+#endif
 #ifdef GL_SGIX_flush_raster
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"flush_raster", 12))
         {
           ret = GLEW_SGIX_flush_raster;
+          continue;
+        }
+#endif
+#ifdef GL_SGIX_fog_blend
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"fog_blend", 9))
+        {
+          ret = GLEW_SGIX_fog_blend;
+          continue;
+        }
+#endif
+#ifdef GL_SGIX_fog_factor_to_alpha
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"fog_factor_to_alpha", 19))
+        {
+          ret = GLEW_SGIX_fog_factor_to_alpha;
+          continue;
+        }
+#endif
+#ifdef GL_SGIX_fog_layers
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"fog_layers", 10))
+        {
+          ret = GLEW_SGIX_fog_layers;
           continue;
         }
 #endif
@@ -18068,10 +26093,31 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_SGIX_fog_patchy
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"fog_patchy", 10))
+        {
+          ret = GLEW_SGIX_fog_patchy;
+          continue;
+        }
+#endif
+#ifdef GL_SGIX_fog_scale
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"fog_scale", 9))
+        {
+          ret = GLEW_SGIX_fog_scale;
+          continue;
+        }
+#endif
 #ifdef GL_SGIX_fog_texture
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"fog_texture", 11))
         {
           ret = GLEW_SGIX_fog_texture;
+          continue;
+        }
+#endif
+#ifdef GL_SGIX_fragment_lighting_space
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"fragment_lighting_space", 23))
+        {
+          ret = GLEW_SGIX_fragment_lighting_space;
           continue;
         }
 #endif
@@ -18082,10 +26128,52 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_SGIX_fragments_instrument
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"fragments_instrument", 20))
+        {
+          ret = GLEW_SGIX_fragments_instrument;
+          continue;
+        }
+#endif
 #ifdef GL_SGIX_framezoom
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"framezoom", 9))
         {
           ret = GLEW_SGIX_framezoom;
+          continue;
+        }
+#endif
+#ifdef GL_SGIX_icc_texture
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"icc_texture", 11))
+        {
+          ret = GLEW_SGIX_icc_texture;
+          continue;
+        }
+#endif
+#ifdef GL_SGIX_igloo_interface
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"igloo_interface", 15))
+        {
+          ret = GLEW_SGIX_igloo_interface;
+          continue;
+        }
+#endif
+#ifdef GL_SGIX_image_compression
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"image_compression", 17))
+        {
+          ret = GLEW_SGIX_image_compression;
+          continue;
+        }
+#endif
+#ifdef GL_SGIX_impact_pixel_texture
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"impact_pixel_texture", 20))
+        {
+          ret = GLEW_SGIX_impact_pixel_texture;
+          continue;
+        }
+#endif
+#ifdef GL_SGIX_instrument_error
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"instrument_error", 16))
+        {
+          ret = GLEW_SGIX_instrument_error;
           continue;
         }
 #endif
@@ -18103,10 +26191,59 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_SGIX_line_quality_hint
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"line_quality_hint", 17))
+        {
+          ret = GLEW_SGIX_line_quality_hint;
+          continue;
+        }
+#endif
 #ifdef GL_SGIX_list_priority
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"list_priority", 13))
         {
           ret = GLEW_SGIX_list_priority;
+          continue;
+        }
+#endif
+#ifdef GL_SGIX_mpeg1
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"mpeg1", 5))
+        {
+          ret = GLEW_SGIX_mpeg1;
+          continue;
+        }
+#endif
+#ifdef GL_SGIX_mpeg2
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"mpeg2", 5))
+        {
+          ret = GLEW_SGIX_mpeg2;
+          continue;
+        }
+#endif
+#ifdef GL_SGIX_nonlinear_lighting_pervertex
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"nonlinear_lighting_pervertex", 28))
+        {
+          ret = GLEW_SGIX_nonlinear_lighting_pervertex;
+          continue;
+        }
+#endif
+#ifdef GL_SGIX_nurbs_eval
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"nurbs_eval", 10))
+        {
+          ret = GLEW_SGIX_nurbs_eval;
+          continue;
+        }
+#endif
+#ifdef GL_SGIX_occlusion_instrument
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"occlusion_instrument", 20))
+        {
+          ret = GLEW_SGIX_occlusion_instrument;
+          continue;
+        }
+#endif
+#ifdef GL_SGIX_packed_6bytes
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"packed_6bytes", 13))
+        {
+          ret = GLEW_SGIX_packed_6bytes;
           continue;
         }
 #endif
@@ -18124,6 +26261,34 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_SGIX_pixel_texture_lod
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"pixel_texture_lod", 17))
+        {
+          ret = GLEW_SGIX_pixel_texture_lod;
+          continue;
+        }
+#endif
+#ifdef GL_SGIX_pixel_tiles
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"pixel_tiles", 11))
+        {
+          ret = GLEW_SGIX_pixel_tiles;
+          continue;
+        }
+#endif
+#ifdef GL_SGIX_polynomial_ffd
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"polynomial_ffd", 14))
+        {
+          ret = GLEW_SGIX_polynomial_ffd;
+          continue;
+        }
+#endif
+#ifdef GL_SGIX_quad_mesh
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"quad_mesh", 9))
+        {
+          ret = GLEW_SGIX_quad_mesh;
+          continue;
+        }
+#endif
 #ifdef GL_SGIX_reference_plane
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"reference_plane", 15))
         {
@@ -18135,6 +26300,13 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"resample", 8))
         {
           ret = GLEW_SGIX_resample;
+          continue;
+        }
+#endif
+#ifdef GL_SGIX_scalebias_hint
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"scalebias_hint", 14))
+        {
+          ret = GLEW_SGIX_scalebias_hint;
           continue;
         }
 #endif
@@ -18152,10 +26324,38 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_SGIX_slim
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"slim", 4))
+        {
+          ret = GLEW_SGIX_slim;
+          continue;
+        }
+#endif
+#ifdef GL_SGIX_spotlight_cutoff
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"spotlight_cutoff", 16))
+        {
+          ret = GLEW_SGIX_spotlight_cutoff;
+          continue;
+        }
+#endif
 #ifdef GL_SGIX_sprite
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"sprite", 6))
         {
           ret = GLEW_SGIX_sprite;
+          continue;
+        }
+#endif
+#ifdef GL_SGIX_subdiv_patch
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"subdiv_patch", 12))
+        {
+          ret = GLEW_SGIX_subdiv_patch;
+          continue;
+        }
+#endif
+#ifdef GL_SGIX_subsample
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"subsample", 9))
+        {
+          ret = GLEW_SGIX_subsample;
           continue;
         }
 #endif
@@ -18187,10 +26387,24 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_SGIX_texture_mipmap_anisotropic
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"texture_mipmap_anisotropic", 26))
+        {
+          ret = GLEW_SGIX_texture_mipmap_anisotropic;
+          continue;
+        }
+#endif
 #ifdef GL_SGIX_texture_multi_buffer
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"texture_multi_buffer", 20))
         {
           ret = GLEW_SGIX_texture_multi_buffer;
+          continue;
+        }
+#endif
+#ifdef GL_SGIX_texture_phase
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"texture_phase", 13))
+        {
+          ret = GLEW_SGIX_texture_phase;
           continue;
         }
 #endif
@@ -18205,6 +26419,27 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"texture_scale_bias", 18))
         {
           ret = GLEW_SGIX_texture_scale_bias;
+          continue;
+        }
+#endif
+#ifdef GL_SGIX_texture_supersample
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"texture_supersample", 19))
+        {
+          ret = GLEW_SGIX_texture_supersample;
+          continue;
+        }
+#endif
+#ifdef GL_SGIX_vector_ops
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"vector_ops", 10))
+        {
+          ret = GLEW_SGIX_vector_ops;
+          continue;
+        }
+#endif
+#ifdef GL_SGIX_vertex_array_object
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"vertex_array_object", 19))
+        {
+          ret = GLEW_SGIX_vertex_array_object;
           continue;
         }
 #endif
@@ -18229,6 +26464,20 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_SGIX_ycrcb_subsample
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"ycrcb_subsample", 15))
+        {
+          ret = GLEW_SGIX_ycrcb_subsample;
+          continue;
+        }
+#endif
+#ifdef GL_SGIX_ycrcba
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"ycrcba", 6))
+        {
+          ret = GLEW_SGIX_ycrcba;
+          continue;
+        }
+#endif
       }
       if (_glewStrSame2(&pos, &len, (const GLubyte*)"SGI_", 4))
       {
@@ -18243,6 +26492,27 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"color_table", 11))
         {
           ret = GLEW_SGI_color_table;
+          continue;
+        }
+#endif
+#ifdef GL_SGI_complex
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"complex", 7))
+        {
+          ret = GLEW_SGI_complex;
+          continue;
+        }
+#endif
+#ifdef GL_SGI_complex_type
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"complex_type", 12))
+        {
+          ret = GLEW_SGI_complex_type;
+          continue;
+        }
+#endif
+#ifdef GL_SGI_fft
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"fft", 3))
+        {
+          ret = GLEW_SGI_fft;
           continue;
         }
 #endif
@@ -18325,6 +26595,13 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
           continue;
         }
 #endif
+#ifdef GL_WIN_scene_markerXXX
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"scene_markerXXX", 15))
+        {
+          ret = GLEW_WIN_scene_markerXXX;
+          continue;
+        }
+#endif
 #ifdef GL_WIN_specular_fog
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"specular_fog", 12))
         {
@@ -18346,15 +26623,11 @@ GLboolean GLEWAPIENTRY glewIsSupported (const char* name)
   return ret;
 }
 
-#if defined(_WIN32)
+#if defined(_WIN32) && !defined(GLEW_EGL) && !defined(GLEW_OSMESA)
 
-#if defined(GLEW_MX)
-GLboolean GLEWAPIENTRY wglewContextIsSupported (const WGLEWContext* ctx, const char* name)
-#else
 GLboolean GLEWAPIENTRY wglewIsSupported (const char* name)
-#endif
 {
-  GLubyte* pos = (GLubyte*)name;
+  const GLubyte* pos = (const GLubyte*)name;
   GLuint len = _glewStrLen(pos);
   GLboolean ret = GL_TRUE;
   while (ret && len > 0)
@@ -18411,6 +26684,13 @@ GLboolean GLEWAPIENTRY wglewIsSupported (const char* name)
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"create_context", 14))
         {
           ret = WGLEW_ARB_create_context;
+          continue;
+        }
+#endif
+#ifdef WGL_ARB_create_context_no_error
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"create_context_no_error", 23))
+        {
+          ret = WGLEW_ARB_create_context_no_error;
           continue;
         }
 #endif
@@ -18518,6 +26798,13 @@ GLboolean GLEWAPIENTRY wglewIsSupported (const char* name)
       }
       if (_glewStrSame2(&pos, &len, (const GLubyte*)"EXT_", 4))
       {
+#ifdef WGL_EXT_colorspace
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"colorspace", 10))
+        {
+          ret = WGLEW_EXT_colorspace;
+          continue;
+        }
+#endif
 #ifdef WGL_EXT_create_context_es2_profile
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"create_context_es2_profile", 26))
         {
@@ -18772,15 +27059,11 @@ GLboolean GLEWAPIENTRY wglewIsSupported (const char* name)
   return ret;
 }
 
-#elif !defined(__ANDROID__) && !defined(__native_client__) && !defined(__HAIKU__) && !defined(__APPLE__) || defined(GLEW_APPLE_GLX)
+#elif !defined(GLEW_OSMESA) && !defined(GLEW_EGL) && !defined(__ANDROID__) && !defined(__native_client__) && !defined(__HAIKU__) && !defined(__APPLE__) || defined(GLEW_APPLE_GLX)
 
-#if defined(GLEW_MX)
-GLboolean glxewContextIsSupported (const GLXEWContext* ctx, const char* name)
-#else
 GLboolean glxewIsSupported (const char* name)
-#endif
 {
-  GLubyte* pos = (GLubyte*)name;
+  const GLubyte* pos = (const GLubyte*)name;
   GLuint len = _glewStrLen(pos);
   GLboolean ret = GL_TRUE;
   while (ret && len > 0)
@@ -18844,6 +27127,13 @@ GLboolean glxewIsSupported (const char* name)
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"create_context", 14))
         {
           ret = GLXEW_ARB_create_context;
+          continue;
+        }
+#endif
+#ifdef GLX_ARB_create_context_no_error
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"create_context_no_error", 23))
+        {
+          ret = GLXEW_ARB_create_context_no_error;
           continue;
         }
 #endif
@@ -18969,6 +27259,13 @@ GLboolean glxewIsSupported (const char* name)
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"import_context", 14))
         {
           ret = GLXEW_EXT_import_context;
+          continue;
+        }
+#endif
+#ifdef GLX_EXT_libglvnd
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"libglvnd", 8))
+        {
+          ret = GLXEW_EXT_libglvnd;
           continue;
         }
 #endif
@@ -19125,6 +27422,13 @@ GLboolean glxewIsSupported (const char* name)
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"present_video", 13))
         {
           ret = GLXEW_NV_present_video;
+          continue;
+        }
+#endif
+#ifdef GLX_NV_robustness_video_memory_purge
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"robustness_video_memory_purge", 29))
+        {
+          ret = GLXEW_NV_robustness_video_memory_purge;
           continue;
         }
 #endif
@@ -19301,6 +27605,969 @@ GLboolean glxewIsSupported (const char* name)
         if (_glewStrSame3(&pos, &len, (const GLubyte*)"video_resize", 12))
         {
           ret = GLXEW_SUN_video_resize;
+          continue;
+        }
+#endif
+      }
+    }
+    ret = (len == 0);
+  }
+  return ret;
+}
+
+#elif defined(GLEW_EGL)
+
+GLboolean eglewIsSupported (const char* name)
+{
+  const GLubyte* pos = (const GLubyte*)name;
+  GLuint len = _glewStrLen(pos);
+  GLboolean ret = GL_TRUE;
+  while (ret && len > 0)
+  {
+    if(_glewStrSame1(&pos, &len, (const GLubyte*)"EGL_", 4))
+    {
+      if (_glewStrSame2(&pos, &len, (const GLubyte*)"VERSION_", 8))
+      {
+#ifdef EGL_VERSION_1_0
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"1_0", 3))
+        {
+          ret = EGLEW_VERSION_1_0;
+          continue;
+        }
+#endif
+#ifdef EGL_VERSION_1_1
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"1_1", 3))
+        {
+          ret = EGLEW_VERSION_1_1;
+          continue;
+        }
+#endif
+#ifdef EGL_VERSION_1_2
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"1_2", 3))
+        {
+          ret = EGLEW_VERSION_1_2;
+          continue;
+        }
+#endif
+#ifdef EGL_VERSION_1_3
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"1_3", 3))
+        {
+          ret = EGLEW_VERSION_1_3;
+          continue;
+        }
+#endif
+#ifdef EGL_VERSION_1_4
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"1_4", 3))
+        {
+          ret = EGLEW_VERSION_1_4;
+          continue;
+        }
+#endif
+#ifdef EGL_VERSION_1_5
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"1_5", 3))
+        {
+          ret = EGLEW_VERSION_1_5;
+          continue;
+        }
+#endif
+      }
+      if (_glewStrSame2(&pos, &len, (const GLubyte*)"ANDROID_", 8))
+      {
+#ifdef EGL_ANDROID_blob_cache
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"blob_cache", 10))
+        {
+          ret = EGLEW_ANDROID_blob_cache;
+          continue;
+        }
+#endif
+#ifdef EGL_ANDROID_create_native_client_buffer
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"create_native_client_buffer", 27))
+        {
+          ret = EGLEW_ANDROID_create_native_client_buffer;
+          continue;
+        }
+#endif
+#ifdef EGL_ANDROID_framebuffer_target
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"framebuffer_target", 18))
+        {
+          ret = EGLEW_ANDROID_framebuffer_target;
+          continue;
+        }
+#endif
+#ifdef EGL_ANDROID_front_buffer_auto_refresh
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"front_buffer_auto_refresh", 25))
+        {
+          ret = EGLEW_ANDROID_front_buffer_auto_refresh;
+          continue;
+        }
+#endif
+#ifdef EGL_ANDROID_image_native_buffer
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"image_native_buffer", 19))
+        {
+          ret = EGLEW_ANDROID_image_native_buffer;
+          continue;
+        }
+#endif
+#ifdef EGL_ANDROID_native_fence_sync
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"native_fence_sync", 17))
+        {
+          ret = EGLEW_ANDROID_native_fence_sync;
+          continue;
+        }
+#endif
+#ifdef EGL_ANDROID_presentation_time
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"presentation_time", 17))
+        {
+          ret = EGLEW_ANDROID_presentation_time;
+          continue;
+        }
+#endif
+#ifdef EGL_ANDROID_recordable
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"recordable", 10))
+        {
+          ret = EGLEW_ANDROID_recordable;
+          continue;
+        }
+#endif
+      }
+      if (_glewStrSame2(&pos, &len, (const GLubyte*)"ANGLE_", 6))
+      {
+#ifdef EGL_ANGLE_d3d_share_handle_client_buffer
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"d3d_share_handle_client_buffer", 30))
+        {
+          ret = EGLEW_ANGLE_d3d_share_handle_client_buffer;
+          continue;
+        }
+#endif
+#ifdef EGL_ANGLE_device_d3d
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"device_d3d", 10))
+        {
+          ret = EGLEW_ANGLE_device_d3d;
+          continue;
+        }
+#endif
+#ifdef EGL_ANGLE_query_surface_pointer
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"query_surface_pointer", 21))
+        {
+          ret = EGLEW_ANGLE_query_surface_pointer;
+          continue;
+        }
+#endif
+#ifdef EGL_ANGLE_surface_d3d_texture_2d_share_handle
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"surface_d3d_texture_2d_share_handle", 35))
+        {
+          ret = EGLEW_ANGLE_surface_d3d_texture_2d_share_handle;
+          continue;
+        }
+#endif
+#ifdef EGL_ANGLE_window_fixed_size
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"window_fixed_size", 17))
+        {
+          ret = EGLEW_ANGLE_window_fixed_size;
+          continue;
+        }
+#endif
+      }
+      if (_glewStrSame2(&pos, &len, (const GLubyte*)"ARM_", 4))
+      {
+#ifdef EGL_ARM_implicit_external_sync
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"implicit_external_sync", 22))
+        {
+          ret = EGLEW_ARM_implicit_external_sync;
+          continue;
+        }
+#endif
+#ifdef EGL_ARM_pixmap_multisample_discard
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"pixmap_multisample_discard", 26))
+        {
+          ret = EGLEW_ARM_pixmap_multisample_discard;
+          continue;
+        }
+#endif
+      }
+      if (_glewStrSame2(&pos, &len, (const GLubyte*)"EXT_", 4))
+      {
+#ifdef EGL_EXT_buffer_age
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"buffer_age", 10))
+        {
+          ret = EGLEW_EXT_buffer_age;
+          continue;
+        }
+#endif
+#ifdef EGL_EXT_client_extensions
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"client_extensions", 17))
+        {
+          ret = EGLEW_EXT_client_extensions;
+          continue;
+        }
+#endif
+#ifdef EGL_EXT_create_context_robustness
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"create_context_robustness", 25))
+        {
+          ret = EGLEW_EXT_create_context_robustness;
+          continue;
+        }
+#endif
+#ifdef EGL_EXT_device_base
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"device_base", 11))
+        {
+          ret = EGLEW_EXT_device_base;
+          continue;
+        }
+#endif
+#ifdef EGL_EXT_device_drm
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"device_drm", 10))
+        {
+          ret = EGLEW_EXT_device_drm;
+          continue;
+        }
+#endif
+#ifdef EGL_EXT_device_enumeration
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"device_enumeration", 18))
+        {
+          ret = EGLEW_EXT_device_enumeration;
+          continue;
+        }
+#endif
+#ifdef EGL_EXT_device_openwf
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"device_openwf", 13))
+        {
+          ret = EGLEW_EXT_device_openwf;
+          continue;
+        }
+#endif
+#ifdef EGL_EXT_device_query
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"device_query", 12))
+        {
+          ret = EGLEW_EXT_device_query;
+          continue;
+        }
+#endif
+#ifdef EGL_EXT_gl_colorspace_bt2020_linear
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"gl_colorspace_bt2020_linear", 27))
+        {
+          ret = EGLEW_EXT_gl_colorspace_bt2020_linear;
+          continue;
+        }
+#endif
+#ifdef EGL_EXT_gl_colorspace_bt2020_pq
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"gl_colorspace_bt2020_pq", 23))
+        {
+          ret = EGLEW_EXT_gl_colorspace_bt2020_pq;
+          continue;
+        }
+#endif
+#ifdef EGL_EXT_gl_colorspace_scrgb_linear
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"gl_colorspace_scrgb_linear", 26))
+        {
+          ret = EGLEW_EXT_gl_colorspace_scrgb_linear;
+          continue;
+        }
+#endif
+#ifdef EGL_EXT_image_dma_buf_import
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"image_dma_buf_import", 20))
+        {
+          ret = EGLEW_EXT_image_dma_buf_import;
+          continue;
+        }
+#endif
+#ifdef EGL_EXT_image_dma_buf_import_modifiers
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"image_dma_buf_import_modifiers", 30))
+        {
+          ret = EGLEW_EXT_image_dma_buf_import_modifiers;
+          continue;
+        }
+#endif
+#ifdef EGL_EXT_multiview_window
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"multiview_window", 16))
+        {
+          ret = EGLEW_EXT_multiview_window;
+          continue;
+        }
+#endif
+#ifdef EGL_EXT_output_base
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"output_base", 11))
+        {
+          ret = EGLEW_EXT_output_base;
+          continue;
+        }
+#endif
+#ifdef EGL_EXT_output_drm
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"output_drm", 10))
+        {
+          ret = EGLEW_EXT_output_drm;
+          continue;
+        }
+#endif
+#ifdef EGL_EXT_output_openwf
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"output_openwf", 13))
+        {
+          ret = EGLEW_EXT_output_openwf;
+          continue;
+        }
+#endif
+#ifdef EGL_EXT_pixel_format_float
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"pixel_format_float", 18))
+        {
+          ret = EGLEW_EXT_pixel_format_float;
+          continue;
+        }
+#endif
+#ifdef EGL_EXT_platform_base
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"platform_base", 13))
+        {
+          ret = EGLEW_EXT_platform_base;
+          continue;
+        }
+#endif
+#ifdef EGL_EXT_platform_device
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"platform_device", 15))
+        {
+          ret = EGLEW_EXT_platform_device;
+          continue;
+        }
+#endif
+#ifdef EGL_EXT_platform_wayland
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"platform_wayland", 16))
+        {
+          ret = EGLEW_EXT_platform_wayland;
+          continue;
+        }
+#endif
+#ifdef EGL_EXT_platform_x11
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"platform_x11", 12))
+        {
+          ret = EGLEW_EXT_platform_x11;
+          continue;
+        }
+#endif
+#ifdef EGL_EXT_protected_content
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"protected_content", 17))
+        {
+          ret = EGLEW_EXT_protected_content;
+          continue;
+        }
+#endif
+#ifdef EGL_EXT_protected_surface
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"protected_surface", 17))
+        {
+          ret = EGLEW_EXT_protected_surface;
+          continue;
+        }
+#endif
+#ifdef EGL_EXT_stream_consumer_egloutput
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"stream_consumer_egloutput", 25))
+        {
+          ret = EGLEW_EXT_stream_consumer_egloutput;
+          continue;
+        }
+#endif
+#ifdef EGL_EXT_surface_SMPTE2086_metadata
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"surface_SMPTE2086_metadata", 26))
+        {
+          ret = EGLEW_EXT_surface_SMPTE2086_metadata;
+          continue;
+        }
+#endif
+#ifdef EGL_EXT_swap_buffers_with_damage
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"swap_buffers_with_damage", 24))
+        {
+          ret = EGLEW_EXT_swap_buffers_with_damage;
+          continue;
+        }
+#endif
+#ifdef EGL_EXT_yuv_surface
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"yuv_surface", 11))
+        {
+          ret = EGLEW_EXT_yuv_surface;
+          continue;
+        }
+#endif
+      }
+      if (_glewStrSame2(&pos, &len, (const GLubyte*)"HI_", 3))
+      {
+#ifdef EGL_HI_clientpixmap
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"clientpixmap", 12))
+        {
+          ret = EGLEW_HI_clientpixmap;
+          continue;
+        }
+#endif
+#ifdef EGL_HI_colorformats
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"colorformats", 12))
+        {
+          ret = EGLEW_HI_colorformats;
+          continue;
+        }
+#endif
+      }
+      if (_glewStrSame2(&pos, &len, (const GLubyte*)"IMG_", 4))
+      {
+#ifdef EGL_IMG_context_priority
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"context_priority", 16))
+        {
+          ret = EGLEW_IMG_context_priority;
+          continue;
+        }
+#endif
+#ifdef EGL_IMG_image_plane_attribs
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"image_plane_attribs", 19))
+        {
+          ret = EGLEW_IMG_image_plane_attribs;
+          continue;
+        }
+#endif
+      }
+      if (_glewStrSame2(&pos, &len, (const GLubyte*)"KHR_", 4))
+      {
+#ifdef EGL_KHR_cl_event
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"cl_event", 8))
+        {
+          ret = EGLEW_KHR_cl_event;
+          continue;
+        }
+#endif
+#ifdef EGL_KHR_cl_event2
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"cl_event2", 9))
+        {
+          ret = EGLEW_KHR_cl_event2;
+          continue;
+        }
+#endif
+#ifdef EGL_KHR_client_get_all_proc_addresses
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"client_get_all_proc_addresses", 29))
+        {
+          ret = EGLEW_KHR_client_get_all_proc_addresses;
+          continue;
+        }
+#endif
+#ifdef EGL_KHR_config_attribs
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"config_attribs", 14))
+        {
+          ret = EGLEW_KHR_config_attribs;
+          continue;
+        }
+#endif
+#ifdef EGL_KHR_context_flush_control
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"context_flush_control", 21))
+        {
+          ret = EGLEW_KHR_context_flush_control;
+          continue;
+        }
+#endif
+#ifdef EGL_KHR_create_context
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"create_context", 14))
+        {
+          ret = EGLEW_KHR_create_context;
+          continue;
+        }
+#endif
+#ifdef EGL_KHR_create_context_no_error
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"create_context_no_error", 23))
+        {
+          ret = EGLEW_KHR_create_context_no_error;
+          continue;
+        }
+#endif
+#ifdef EGL_KHR_debug
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"debug", 5))
+        {
+          ret = EGLEW_KHR_debug;
+          continue;
+        }
+#endif
+#ifdef EGL_KHR_fence_sync
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"fence_sync", 10))
+        {
+          ret = EGLEW_KHR_fence_sync;
+          continue;
+        }
+#endif
+#ifdef EGL_KHR_get_all_proc_addresses
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"get_all_proc_addresses", 22))
+        {
+          ret = EGLEW_KHR_get_all_proc_addresses;
+          continue;
+        }
+#endif
+#ifdef EGL_KHR_gl_colorspace
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"gl_colorspace", 13))
+        {
+          ret = EGLEW_KHR_gl_colorspace;
+          continue;
+        }
+#endif
+#ifdef EGL_KHR_gl_renderbuffer_image
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"gl_renderbuffer_image", 21))
+        {
+          ret = EGLEW_KHR_gl_renderbuffer_image;
+          continue;
+        }
+#endif
+#ifdef EGL_KHR_gl_texture_2D_image
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"gl_texture_2D_image", 19))
+        {
+          ret = EGLEW_KHR_gl_texture_2D_image;
+          continue;
+        }
+#endif
+#ifdef EGL_KHR_gl_texture_3D_image
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"gl_texture_3D_image", 19))
+        {
+          ret = EGLEW_KHR_gl_texture_3D_image;
+          continue;
+        }
+#endif
+#ifdef EGL_KHR_gl_texture_cubemap_image
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"gl_texture_cubemap_image", 24))
+        {
+          ret = EGLEW_KHR_gl_texture_cubemap_image;
+          continue;
+        }
+#endif
+#ifdef EGL_KHR_image
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"image", 5))
+        {
+          ret = EGLEW_KHR_image;
+          continue;
+        }
+#endif
+#ifdef EGL_KHR_image_base
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"image_base", 10))
+        {
+          ret = EGLEW_KHR_image_base;
+          continue;
+        }
+#endif
+#ifdef EGL_KHR_image_pixmap
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"image_pixmap", 12))
+        {
+          ret = EGLEW_KHR_image_pixmap;
+          continue;
+        }
+#endif
+#ifdef EGL_KHR_lock_surface
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"lock_surface", 12))
+        {
+          ret = EGLEW_KHR_lock_surface;
+          continue;
+        }
+#endif
+#ifdef EGL_KHR_lock_surface2
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"lock_surface2", 13))
+        {
+          ret = EGLEW_KHR_lock_surface2;
+          continue;
+        }
+#endif
+#ifdef EGL_KHR_lock_surface3
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"lock_surface3", 13))
+        {
+          ret = EGLEW_KHR_lock_surface3;
+          continue;
+        }
+#endif
+#ifdef EGL_KHR_mutable_render_buffer
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"mutable_render_buffer", 21))
+        {
+          ret = EGLEW_KHR_mutable_render_buffer;
+          continue;
+        }
+#endif
+#ifdef EGL_KHR_no_config_context
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"no_config_context", 17))
+        {
+          ret = EGLEW_KHR_no_config_context;
+          continue;
+        }
+#endif
+#ifdef EGL_KHR_partial_update
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"partial_update", 14))
+        {
+          ret = EGLEW_KHR_partial_update;
+          continue;
+        }
+#endif
+#ifdef EGL_KHR_platform_android
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"platform_android", 16))
+        {
+          ret = EGLEW_KHR_platform_android;
+          continue;
+        }
+#endif
+#ifdef EGL_KHR_platform_gbm
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"platform_gbm", 12))
+        {
+          ret = EGLEW_KHR_platform_gbm;
+          continue;
+        }
+#endif
+#ifdef EGL_KHR_platform_wayland
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"platform_wayland", 16))
+        {
+          ret = EGLEW_KHR_platform_wayland;
+          continue;
+        }
+#endif
+#ifdef EGL_KHR_platform_x11
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"platform_x11", 12))
+        {
+          ret = EGLEW_KHR_platform_x11;
+          continue;
+        }
+#endif
+#ifdef EGL_KHR_reusable_sync
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"reusable_sync", 13))
+        {
+          ret = EGLEW_KHR_reusable_sync;
+          continue;
+        }
+#endif
+#ifdef EGL_KHR_stream
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"stream", 6))
+        {
+          ret = EGLEW_KHR_stream;
+          continue;
+        }
+#endif
+#ifdef EGL_KHR_stream_attrib
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"stream_attrib", 13))
+        {
+          ret = EGLEW_KHR_stream_attrib;
+          continue;
+        }
+#endif
+#ifdef EGL_KHR_stream_consumer_gltexture
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"stream_consumer_gltexture", 25))
+        {
+          ret = EGLEW_KHR_stream_consumer_gltexture;
+          continue;
+        }
+#endif
+#ifdef EGL_KHR_stream_cross_process_fd
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"stream_cross_process_fd", 23))
+        {
+          ret = EGLEW_KHR_stream_cross_process_fd;
+          continue;
+        }
+#endif
+#ifdef EGL_KHR_stream_fifo
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"stream_fifo", 11))
+        {
+          ret = EGLEW_KHR_stream_fifo;
+          continue;
+        }
+#endif
+#ifdef EGL_KHR_stream_producer_aldatalocator
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"stream_producer_aldatalocator", 29))
+        {
+          ret = EGLEW_KHR_stream_producer_aldatalocator;
+          continue;
+        }
+#endif
+#ifdef EGL_KHR_stream_producer_eglsurface
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"stream_producer_eglsurface", 26))
+        {
+          ret = EGLEW_KHR_stream_producer_eglsurface;
+          continue;
+        }
+#endif
+#ifdef EGL_KHR_surfaceless_context
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"surfaceless_context", 19))
+        {
+          ret = EGLEW_KHR_surfaceless_context;
+          continue;
+        }
+#endif
+#ifdef EGL_KHR_swap_buffers_with_damage
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"swap_buffers_with_damage", 24))
+        {
+          ret = EGLEW_KHR_swap_buffers_with_damage;
+          continue;
+        }
+#endif
+#ifdef EGL_KHR_vg_parent_image
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"vg_parent_image", 15))
+        {
+          ret = EGLEW_KHR_vg_parent_image;
+          continue;
+        }
+#endif
+#ifdef EGL_KHR_wait_sync
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"wait_sync", 9))
+        {
+          ret = EGLEW_KHR_wait_sync;
+          continue;
+        }
+#endif
+      }
+      if (_glewStrSame2(&pos, &len, (const GLubyte*)"MESA_", 5))
+      {
+#ifdef EGL_MESA_drm_image
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"drm_image", 9))
+        {
+          ret = EGLEW_MESA_drm_image;
+          continue;
+        }
+#endif
+#ifdef EGL_MESA_image_dma_buf_export
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"image_dma_buf_export", 20))
+        {
+          ret = EGLEW_MESA_image_dma_buf_export;
+          continue;
+        }
+#endif
+#ifdef EGL_MESA_platform_gbm
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"platform_gbm", 12))
+        {
+          ret = EGLEW_MESA_platform_gbm;
+          continue;
+        }
+#endif
+#ifdef EGL_MESA_platform_surfaceless
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"platform_surfaceless", 20))
+        {
+          ret = EGLEW_MESA_platform_surfaceless;
+          continue;
+        }
+#endif
+      }
+      if (_glewStrSame2(&pos, &len, (const GLubyte*)"NOK_", 4))
+      {
+#ifdef EGL_NOK_swap_region
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"swap_region", 11))
+        {
+          ret = EGLEW_NOK_swap_region;
+          continue;
+        }
+#endif
+#ifdef EGL_NOK_swap_region2
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"swap_region2", 12))
+        {
+          ret = EGLEW_NOK_swap_region2;
+          continue;
+        }
+#endif
+#ifdef EGL_NOK_texture_from_pixmap
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"texture_from_pixmap", 19))
+        {
+          ret = EGLEW_NOK_texture_from_pixmap;
+          continue;
+        }
+#endif
+      }
+      if (_glewStrSame2(&pos, &len, (const GLubyte*)"NV_", 3))
+      {
+#ifdef EGL_NV_3dvision_surface
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"3dvision_surface", 16))
+        {
+          ret = EGLEW_NV_3dvision_surface;
+          continue;
+        }
+#endif
+#ifdef EGL_NV_coverage_sample
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"coverage_sample", 15))
+        {
+          ret = EGLEW_NV_coverage_sample;
+          continue;
+        }
+#endif
+#ifdef EGL_NV_coverage_sample_resolve
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"coverage_sample_resolve", 23))
+        {
+          ret = EGLEW_NV_coverage_sample_resolve;
+          continue;
+        }
+#endif
+#ifdef EGL_NV_cuda_event
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"cuda_event", 10))
+        {
+          ret = EGLEW_NV_cuda_event;
+          continue;
+        }
+#endif
+#ifdef EGL_NV_depth_nonlinear
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"depth_nonlinear", 15))
+        {
+          ret = EGLEW_NV_depth_nonlinear;
+          continue;
+        }
+#endif
+#ifdef EGL_NV_device_cuda
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"device_cuda", 11))
+        {
+          ret = EGLEW_NV_device_cuda;
+          continue;
+        }
+#endif
+#ifdef EGL_NV_native_query
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"native_query", 12))
+        {
+          ret = EGLEW_NV_native_query;
+          continue;
+        }
+#endif
+#ifdef EGL_NV_post_convert_rounding
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"post_convert_rounding", 21))
+        {
+          ret = EGLEW_NV_post_convert_rounding;
+          continue;
+        }
+#endif
+#ifdef EGL_NV_post_sub_buffer
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"post_sub_buffer", 15))
+        {
+          ret = EGLEW_NV_post_sub_buffer;
+          continue;
+        }
+#endif
+#ifdef EGL_NV_robustness_video_memory_purge
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"robustness_video_memory_purge", 29))
+        {
+          ret = EGLEW_NV_robustness_video_memory_purge;
+          continue;
+        }
+#endif
+#ifdef EGL_NV_stream_consumer_gltexture_yuv
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"stream_consumer_gltexture_yuv", 29))
+        {
+          ret = EGLEW_NV_stream_consumer_gltexture_yuv;
+          continue;
+        }
+#endif
+#ifdef EGL_NV_stream_cross_display
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"stream_cross_display", 20))
+        {
+          ret = EGLEW_NV_stream_cross_display;
+          continue;
+        }
+#endif
+#ifdef EGL_NV_stream_cross_object
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"stream_cross_object", 19))
+        {
+          ret = EGLEW_NV_stream_cross_object;
+          continue;
+        }
+#endif
+#ifdef EGL_NV_stream_cross_partition
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"stream_cross_partition", 22))
+        {
+          ret = EGLEW_NV_stream_cross_partition;
+          continue;
+        }
+#endif
+#ifdef EGL_NV_stream_cross_process
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"stream_cross_process", 20))
+        {
+          ret = EGLEW_NV_stream_cross_process;
+          continue;
+        }
+#endif
+#ifdef EGL_NV_stream_cross_system
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"stream_cross_system", 19))
+        {
+          ret = EGLEW_NV_stream_cross_system;
+          continue;
+        }
+#endif
+#ifdef EGL_NV_stream_fifo_next
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"stream_fifo_next", 16))
+        {
+          ret = EGLEW_NV_stream_fifo_next;
+          continue;
+        }
+#endif
+#ifdef EGL_NV_stream_fifo_synchronous
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"stream_fifo_synchronous", 23))
+        {
+          ret = EGLEW_NV_stream_fifo_synchronous;
+          continue;
+        }
+#endif
+#ifdef EGL_NV_stream_frame_limits
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"stream_frame_limits", 19))
+        {
+          ret = EGLEW_NV_stream_frame_limits;
+          continue;
+        }
+#endif
+#ifdef EGL_NV_stream_metadata
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"stream_metadata", 15))
+        {
+          ret = EGLEW_NV_stream_metadata;
+          continue;
+        }
+#endif
+#ifdef EGL_NV_stream_remote
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"stream_remote", 13))
+        {
+          ret = EGLEW_NV_stream_remote;
+          continue;
+        }
+#endif
+#ifdef EGL_NV_stream_reset
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"stream_reset", 12))
+        {
+          ret = EGLEW_NV_stream_reset;
+          continue;
+        }
+#endif
+#ifdef EGL_NV_stream_socket
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"stream_socket", 13))
+        {
+          ret = EGLEW_NV_stream_socket;
+          continue;
+        }
+#endif
+#ifdef EGL_NV_stream_socket_inet
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"stream_socket_inet", 18))
+        {
+          ret = EGLEW_NV_stream_socket_inet;
+          continue;
+        }
+#endif
+#ifdef EGL_NV_stream_socket_unix
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"stream_socket_unix", 18))
+        {
+          ret = EGLEW_NV_stream_socket_unix;
+          continue;
+        }
+#endif
+#ifdef EGL_NV_stream_sync
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"stream_sync", 11))
+        {
+          ret = EGLEW_NV_stream_sync;
+          continue;
+        }
+#endif
+#ifdef EGL_NV_sync
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"sync", 4))
+        {
+          ret = EGLEW_NV_sync;
+          continue;
+        }
+#endif
+#ifdef EGL_NV_system_time
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"system_time", 11))
+        {
+          ret = EGLEW_NV_system_time;
+          continue;
+        }
+#endif
+      }
+      if (_glewStrSame2(&pos, &len, (const GLubyte*)"TIZEN_", 6))
+      {
+#ifdef EGL_TIZEN_image_native_buffer
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"image_native_buffer", 19))
+        {
+          ret = EGLEW_TIZEN_image_native_buffer;
+          continue;
+        }
+#endif
+#ifdef EGL_TIZEN_image_native_surface
+        if (_glewStrSame3(&pos, &len, (const GLubyte*)"image_native_surface", 20))
+        {
+          ret = EGLEW_TIZEN_image_native_surface;
           continue;
         }
 #endif

--- a/lib/glew/src/glewinfo.c
+++ b/lib/glew/src/glewinfo.c
@@ -1,6 +1,6 @@
 /*
 ** The OpenGL Extension Wrangler Library
-** Copyright (C) 2008-2014, Nigel Stewart <nigels[]users sourceforge net>
+** Copyright (C) 2008-2017, Nigel Stewart <nigels[]users sourceforge net>
 ** Copyright (C) 2002-2008, Milan Ikits <milan ikits[]ieee org>
 ** Copyright (C) 2002-2008, Marcelo E. Magallon <mmagallo[]debian org>
 ** Copyright (C) 2002, Lev Povalahev
@@ -34,10 +34,19 @@
 #include <stdlib.h>
 #include <string.h>
 #include <GL/glew.h>
-#if defined(_WIN32)
+#if defined(GLEW_EGL)
+#include <GL/eglew.h>
+#elif defined(GLEW_OSMESA)
+#define GLAPI extern
+#include <GL/osmesa.h>
+#elif defined(_WIN32)
 #include <GL/wglew.h>
 #elif !defined(__APPLE__) && !defined(__HAIKU__) || defined(GLEW_APPLE_GLX)
 #include <GL/glxew.h>
+#endif
+
+#if defined(__APPLE__)
+#include <AvailabilityMacros.h>
 #endif
 
 #ifdef GLEW_REGAL
@@ -46,29 +55,28 @@
 
 static FILE* f;
 
-#ifdef GLEW_MX
-GLEWContext _glewctx;
-#define glewGetContext() (&_glewctx)
-#ifdef _WIN32
-WGLEWContext _wglewctx;
-#define wglewGetContext() (&_wglewctx)
-#elif !defined(__APPLE__) && !defined(__HAIKU__) || defined(GLEW_APPLE_GLX)
-GLXEWContext _glxewctx;
-#define glxewGetContext() (&_glxewctx)
-#endif
-#endif
+/* Command-line parameters for GL context creation */
 
-#if defined(_WIN32)
-GLboolean glewCreateContext (int* pixelformat);
+struct createParams
+{
+#if defined(GLEW_OSMESA)
+#elif defined(GLEW_EGL)
+#elif defined(_WIN32)
+  int         pixelformat;
 #elif !defined(__APPLE__) && !defined(__HAIKU__) || defined(GLEW_APPLE_GLX)
-GLboolean glewCreateContext (const char* display, int* visual);
-#else
-GLboolean glewCreateContext ();
+  const char* display;
+  int         visual;
 #endif
+  int         major, minor;  /* GL context version number */
 
-#if defined(_WIN32) || !defined(__APPLE__) || defined(GLEW_APPLE_GLX)
-GLboolean glewParseArgs (int argc, char** argv, char** display, int* visual);
-#endif
+  /* https://www.opengl.org/registry/specs/ARB/glx_create_context.txt */
+  int         profile;       /* core = 1, compatibility = 2 */
+  int         flags;         /* debug = 1, forward compatible = 2 */
+};
+
+GLboolean glewCreateContext (struct createParams *params);
+
+GLboolean glewParseArgs (int argc, char** argv, struct createParams *);
 
 void glewDestroyContext ();
 
@@ -554,9 +562,27 @@ static void _glewInfo_GL_VERSION_4_4 (void)
 static void _glewInfo_GL_VERSION_4_5 (void)
 {
   glewPrintExt("GL_VERSION_4_5", GLEW_VERSION_4_5, GLEW_VERSION_4_5, GLEW_VERSION_4_5);
+
+  glewInfoFunc("glGetGraphicsResetStatus", glGetGraphicsResetStatus == NULL);
+  glewInfoFunc("glGetnCompressedTexImage", glGetnCompressedTexImage == NULL);
+  glewInfoFunc("glGetnTexImage", glGetnTexImage == NULL);
+  glewInfoFunc("glGetnUniformdv", glGetnUniformdv == NULL);
 }
 
 #endif /* GL_VERSION_4_5 */
+
+#ifdef GL_VERSION_4_6
+
+static void _glewInfo_GL_VERSION_4_6 (void)
+{
+  glewPrintExt("GL_VERSION_4_6", GLEW_VERSION_4_6, GLEW_VERSION_4_6, GLEW_VERSION_4_6);
+
+  glewInfoFunc("glMultiDrawArraysIndirectCount", glMultiDrawArraysIndirectCount == NULL);
+  glewInfoFunc("glMultiDrawElementsIndirectCount", glMultiDrawElementsIndirectCount == NULL);
+  glewInfoFunc("glSpecializeShader", glSpecializeShader == NULL);
+}
+
+#endif /* GL_VERSION_4_6 */
 
 #ifdef GL_3DFX_multisample
 
@@ -595,6 +621,24 @@ static void _glewInfo_GL_AMD_blend_minmax_factor (void)
 }
 
 #endif /* GL_AMD_blend_minmax_factor */
+
+#ifdef GL_AMD_compressed_3DC_texture
+
+static void _glewInfo_GL_AMD_compressed_3DC_texture (void)
+{
+  glewPrintExt("GL_AMD_compressed_3DC_texture", GLEW_AMD_compressed_3DC_texture, glewIsSupported("GL_AMD_compressed_3DC_texture"), glewGetExtension("GL_AMD_compressed_3DC_texture"));
+}
+
+#endif /* GL_AMD_compressed_3DC_texture */
+
+#ifdef GL_AMD_compressed_ATC_texture
+
+static void _glewInfo_GL_AMD_compressed_ATC_texture (void)
+{
+  glewPrintExt("GL_AMD_compressed_ATC_texture", GLEW_AMD_compressed_ATC_texture, glewIsSupported("GL_AMD_compressed_ATC_texture"), glewGetExtension("GL_AMD_compressed_ATC_texture"));
+}
+
+#endif /* GL_AMD_compressed_ATC_texture */
 
 #ifdef GL_AMD_conservative_depth
 
@@ -642,6 +686,20 @@ static void _glewInfo_GL_AMD_draw_buffers_blend (void)
 
 #endif /* GL_AMD_draw_buffers_blend */
 
+#ifdef GL_AMD_framebuffer_sample_positions
+
+static void _glewInfo_GL_AMD_framebuffer_sample_positions (void)
+{
+  glewPrintExt("GL_AMD_framebuffer_sample_positions", GLEW_AMD_framebuffer_sample_positions, glewIsSupported("GL_AMD_framebuffer_sample_positions"), glewGetExtension("GL_AMD_framebuffer_sample_positions"));
+
+  glewInfoFunc("glFramebufferSamplePositionsfvAMD", glFramebufferSamplePositionsfvAMD == NULL);
+  glewInfoFunc("glGetFramebufferParameterfvAMD", glGetFramebufferParameterfvAMD == NULL);
+  glewInfoFunc("glGetNamedFramebufferParameterfvAMD", glGetNamedFramebufferParameterfvAMD == NULL);
+  glewInfoFunc("glNamedFramebufferSamplePositionsfvAMD", glNamedFramebufferSamplePositionsfvAMD == NULL);
+}
+
+#endif /* GL_AMD_framebuffer_sample_positions */
+
 #ifdef GL_AMD_gcn_shader
 
 static void _glewInfo_GL_AMD_gcn_shader (void)
@@ -650,6 +708,24 @@ static void _glewInfo_GL_AMD_gcn_shader (void)
 }
 
 #endif /* GL_AMD_gcn_shader */
+
+#ifdef GL_AMD_gpu_shader_half_float
+
+static void _glewInfo_GL_AMD_gpu_shader_half_float (void)
+{
+  glewPrintExt("GL_AMD_gpu_shader_half_float", GLEW_AMD_gpu_shader_half_float, glewIsSupported("GL_AMD_gpu_shader_half_float"), glewGetExtension("GL_AMD_gpu_shader_half_float"));
+}
+
+#endif /* GL_AMD_gpu_shader_half_float */
+
+#ifdef GL_AMD_gpu_shader_int16
+
+static void _glewInfo_GL_AMD_gpu_shader_int16 (void)
+{
+  glewPrintExt("GL_AMD_gpu_shader_int16", GLEW_AMD_gpu_shader_int16, glewIsSupported("GL_AMD_gpu_shader_int16"), glewGetExtension("GL_AMD_gpu_shader_int16"));
+}
+
+#endif /* GL_AMD_gpu_shader_int16 */
 
 #ifdef GL_AMD_gpu_shader_int64
 
@@ -737,6 +813,15 @@ static void _glewInfo_GL_AMD_pinned_memory (void)
 
 #endif /* GL_AMD_pinned_memory */
 
+#ifdef GL_AMD_program_binary_Z400
+
+static void _glewInfo_GL_AMD_program_binary_Z400 (void)
+{
+  glewPrintExt("GL_AMD_program_binary_Z400", GLEW_AMD_program_binary_Z400, glewIsSupported("GL_AMD_program_binary_Z400"), glewGetExtension("GL_AMD_program_binary_Z400"));
+}
+
+#endif /* GL_AMD_program_binary_Z400 */
+
 #ifdef GL_AMD_query_buffer_object
 
 static void _glewInfo_GL_AMD_query_buffer_object (void)
@@ -774,6 +859,24 @@ static void _glewInfo_GL_AMD_shader_atomic_counter_ops (void)
 }
 
 #endif /* GL_AMD_shader_atomic_counter_ops */
+
+#ifdef GL_AMD_shader_ballot
+
+static void _glewInfo_GL_AMD_shader_ballot (void)
+{
+  glewPrintExt("GL_AMD_shader_ballot", GLEW_AMD_shader_ballot, glewIsSupported("GL_AMD_shader_ballot"), glewGetExtension("GL_AMD_shader_ballot"));
+}
+
+#endif /* GL_AMD_shader_ballot */
+
+#ifdef GL_AMD_shader_explicit_vertex_parameter
+
+static void _glewInfo_GL_AMD_shader_explicit_vertex_parameter (void)
+{
+  glewPrintExt("GL_AMD_shader_explicit_vertex_parameter", GLEW_AMD_shader_explicit_vertex_parameter, glewIsSupported("GL_AMD_shader_explicit_vertex_parameter"), glewGetExtension("GL_AMD_shader_explicit_vertex_parameter"));
+}
+
+#endif /* GL_AMD_shader_explicit_vertex_parameter */
 
 #ifdef GL_AMD_shader_stencil_export
 
@@ -824,6 +927,15 @@ static void _glewInfo_GL_AMD_stencil_operation_extended (void)
 }
 
 #endif /* GL_AMD_stencil_operation_extended */
+
+#ifdef GL_AMD_texture_gather_bias_lod
+
+static void _glewInfo_GL_AMD_texture_gather_bias_lod (void)
+{
+  glewPrintExt("GL_AMD_texture_gather_bias_lod", GLEW_AMD_texture_gather_bias_lod, glewIsSupported("GL_AMD_texture_gather_bias_lod"), glewGetExtension("GL_AMD_texture_gather_bias_lod"));
+}
+
+#endif /* GL_AMD_texture_gather_bias_lod */
 
 #ifdef GL_AMD_texture_texture4
 
@@ -881,6 +993,15 @@ static void _glewInfo_GL_AMD_vertex_shader_viewport_index (void)
 }
 
 #endif /* GL_AMD_vertex_shader_viewport_index */
+
+#ifdef GL_ANDROID_extension_pack_es31a
+
+static void _glewInfo_GL_ANDROID_extension_pack_es31a (void)
+{
+  glewPrintExt("GL_ANDROID_extension_pack_es31a", GLEW_ANDROID_extension_pack_es31a, glewIsSupported("GL_ANDROID_extension_pack_es31a"), glewGetExtension("GL_ANDROID_extension_pack_es31a"));
+}
+
+#endif /* GL_ANDROID_extension_pack_es31a */
 
 #ifdef GL_ANGLE_depth_texture
 
@@ -1030,6 +1151,35 @@ static void _glewInfo_GL_APPLE_client_storage (void)
 
 #endif /* GL_APPLE_client_storage */
 
+#ifdef GL_APPLE_clip_distance
+
+static void _glewInfo_GL_APPLE_clip_distance (void)
+{
+  glewPrintExt("GL_APPLE_clip_distance", GLEW_APPLE_clip_distance, glewIsSupported("GL_APPLE_clip_distance"), glewGetExtension("GL_APPLE_clip_distance"));
+}
+
+#endif /* GL_APPLE_clip_distance */
+
+#ifdef GL_APPLE_color_buffer_packed_float
+
+static void _glewInfo_GL_APPLE_color_buffer_packed_float (void)
+{
+  glewPrintExt("GL_APPLE_color_buffer_packed_float", GLEW_APPLE_color_buffer_packed_float, glewIsSupported("GL_APPLE_color_buffer_packed_float"), glewGetExtension("GL_APPLE_color_buffer_packed_float"));
+}
+
+#endif /* GL_APPLE_color_buffer_packed_float */
+
+#ifdef GL_APPLE_copy_texture_levels
+
+static void _glewInfo_GL_APPLE_copy_texture_levels (void)
+{
+  glewPrintExt("GL_APPLE_copy_texture_levels", GLEW_APPLE_copy_texture_levels, glewIsSupported("GL_APPLE_copy_texture_levels"), glewGetExtension("GL_APPLE_copy_texture_levels"));
+
+  glewInfoFunc("glCopyTextureLevelsAPPLE", glCopyTextureLevelsAPPLE == NULL);
+}
+
+#endif /* GL_APPLE_copy_texture_levels */
+
 #ifdef GL_APPLE_element_array
 
 static void _glewInfo_GL_APPLE_element_array (void)
@@ -1084,6 +1234,18 @@ static void _glewInfo_GL_APPLE_flush_buffer_range (void)
 
 #endif /* GL_APPLE_flush_buffer_range */
 
+#ifdef GL_APPLE_framebuffer_multisample
+
+static void _glewInfo_GL_APPLE_framebuffer_multisample (void)
+{
+  glewPrintExt("GL_APPLE_framebuffer_multisample", GLEW_APPLE_framebuffer_multisample, glewIsSupported("GL_APPLE_framebuffer_multisample"), glewGetExtension("GL_APPLE_framebuffer_multisample"));
+
+  glewInfoFunc("glRenderbufferStorageMultisampleAPPLE", glRenderbufferStorageMultisampleAPPLE == NULL);
+  glewInfoFunc("glResolveMultisampleFramebufferAPPLE", glResolveMultisampleFramebufferAPPLE == NULL);
+}
+
+#endif /* GL_APPLE_framebuffer_multisample */
+
 #ifdef GL_APPLE_object_purgeable
 
 static void _glewInfo_GL_APPLE_object_purgeable (void)
@@ -1132,6 +1294,59 @@ static void _glewInfo_GL_APPLE_specular_vector (void)
 }
 
 #endif /* GL_APPLE_specular_vector */
+
+#ifdef GL_APPLE_sync
+
+static void _glewInfo_GL_APPLE_sync (void)
+{
+  glewPrintExt("GL_APPLE_sync", GLEW_APPLE_sync, glewIsSupported("GL_APPLE_sync"), glewGetExtension("GL_APPLE_sync"));
+
+  glewInfoFunc("glClientWaitSyncAPPLE", glClientWaitSyncAPPLE == NULL);
+  glewInfoFunc("glDeleteSyncAPPLE", glDeleteSyncAPPLE == NULL);
+  glewInfoFunc("glFenceSyncAPPLE", glFenceSyncAPPLE == NULL);
+  glewInfoFunc("glGetInteger64vAPPLE", glGetInteger64vAPPLE == NULL);
+  glewInfoFunc("glGetSyncivAPPLE", glGetSyncivAPPLE == NULL);
+  glewInfoFunc("glIsSyncAPPLE", glIsSyncAPPLE == NULL);
+  glewInfoFunc("glWaitSyncAPPLE", glWaitSyncAPPLE == NULL);
+}
+
+#endif /* GL_APPLE_sync */
+
+#ifdef GL_APPLE_texture_2D_limited_npot
+
+static void _glewInfo_GL_APPLE_texture_2D_limited_npot (void)
+{
+  glewPrintExt("GL_APPLE_texture_2D_limited_npot", GLEW_APPLE_texture_2D_limited_npot, glewIsSupported("GL_APPLE_texture_2D_limited_npot"), glewGetExtension("GL_APPLE_texture_2D_limited_npot"));
+}
+
+#endif /* GL_APPLE_texture_2D_limited_npot */
+
+#ifdef GL_APPLE_texture_format_BGRA8888
+
+static void _glewInfo_GL_APPLE_texture_format_BGRA8888 (void)
+{
+  glewPrintExt("GL_APPLE_texture_format_BGRA8888", GLEW_APPLE_texture_format_BGRA8888, glewIsSupported("GL_APPLE_texture_format_BGRA8888"), glewGetExtension("GL_APPLE_texture_format_BGRA8888"));
+}
+
+#endif /* GL_APPLE_texture_format_BGRA8888 */
+
+#ifdef GL_APPLE_texture_max_level
+
+static void _glewInfo_GL_APPLE_texture_max_level (void)
+{
+  glewPrintExt("GL_APPLE_texture_max_level", GLEW_APPLE_texture_max_level, glewIsSupported("GL_APPLE_texture_max_level"), glewGetExtension("GL_APPLE_texture_max_level"));
+}
+
+#endif /* GL_APPLE_texture_max_level */
+
+#ifdef GL_APPLE_texture_packed_float
+
+static void _glewInfo_GL_APPLE_texture_packed_float (void)
+{
+  glewPrintExt("GL_APPLE_texture_packed_float", GLEW_APPLE_texture_packed_float, glewIsSupported("GL_APPLE_texture_packed_float"), glewGetExtension("GL_APPLE_texture_packed_float"));
+}
+
+#endif /* GL_APPLE_texture_packed_float */
 
 #ifdef GL_APPLE_texture_range
 
@@ -1233,6 +1448,17 @@ static void _glewInfo_GL_ARB_ES3_1_compatibility (void)
 
 #endif /* GL_ARB_ES3_1_compatibility */
 
+#ifdef GL_ARB_ES3_2_compatibility
+
+static void _glewInfo_GL_ARB_ES3_2_compatibility (void)
+{
+  glewPrintExt("GL_ARB_ES3_2_compatibility", GLEW_ARB_ES3_2_compatibility, glewIsSupported("GL_ARB_ES3_2_compatibility"), glewGetExtension("GL_ARB_ES3_2_compatibility"));
+
+  glewInfoFunc("glPrimitiveBoundingBoxARB", glPrimitiveBoundingBoxARB == NULL);
+}
+
+#endif /* GL_ARB_ES3_2_compatibility */
+
 #ifdef GL_ARB_ES3_compatibility
 
 static void _glewInfo_GL_ARB_ES3_compatibility (void)
@@ -1309,7 +1535,6 @@ static void _glewInfo_GL_ARB_buffer_storage (void)
   glewPrintExt("GL_ARB_buffer_storage", GLEW_ARB_buffer_storage, glewIsSupported("GL_ARB_buffer_storage"), glewGetExtension("GL_ARB_buffer_storage"));
 
   glewInfoFunc("glBufferStorage", glBufferStorage == NULL);
-  glewInfoFunc("glNamedBufferStorageEXT", glNamedBufferStorageEXT == NULL);
 }
 
 #endif /* GL_ARB_buffer_storage */
@@ -1556,6 +1781,10 @@ static void _glewInfo_GL_ARB_direct_state_access (void)
   glewInfoFunc("glGetNamedFramebufferAttachmentParameteriv", glGetNamedFramebufferAttachmentParameteriv == NULL);
   glewInfoFunc("glGetNamedFramebufferParameteriv", glGetNamedFramebufferParameteriv == NULL);
   glewInfoFunc("glGetNamedRenderbufferParameteriv", glGetNamedRenderbufferParameteriv == NULL);
+  glewInfoFunc("glGetQueryBufferObjecti64v", glGetQueryBufferObjecti64v == NULL);
+  glewInfoFunc("glGetQueryBufferObjectiv", glGetQueryBufferObjectiv == NULL);
+  glewInfoFunc("glGetQueryBufferObjectui64v", glGetQueryBufferObjectui64v == NULL);
+  glewInfoFunc("glGetQueryBufferObjectuiv", glGetQueryBufferObjectuiv == NULL);
   glewInfoFunc("glGetTextureImage", glGetTextureImage == NULL);
   glewInfoFunc("glGetTextureLevelParameterfv", glGetTextureLevelParameterfv == NULL);
   glewInfoFunc("glGetTextureLevelParameteriv", glGetTextureLevelParameteriv == NULL);
@@ -1748,6 +1977,15 @@ static void _glewInfo_GL_ARB_fragment_shader (void)
 
 #endif /* GL_ARB_fragment_shader */
 
+#ifdef GL_ARB_fragment_shader_interlock
+
+static void _glewInfo_GL_ARB_fragment_shader_interlock (void)
+{
+  glewPrintExt("GL_ARB_fragment_shader_interlock", GLEW_ARB_fragment_shader_interlock, glewIsSupported("GL_ARB_fragment_shader_interlock"), glewGetExtension("GL_ARB_fragment_shader_interlock"));
+}
+
+#endif /* GL_ARB_fragment_shader_interlock */
+
 #ifdef GL_ARB_framebuffer_no_attachments
 
 static void _glewInfo_GL_ARB_framebuffer_no_attachments (void)
@@ -1840,6 +2078,17 @@ static void _glewInfo_GL_ARB_get_texture_sub_image (void)
 
 #endif /* GL_ARB_get_texture_sub_image */
 
+#ifdef GL_ARB_gl_spirv
+
+static void _glewInfo_GL_ARB_gl_spirv (void)
+{
+  glewPrintExt("GL_ARB_gl_spirv", GLEW_ARB_gl_spirv, glewIsSupported("GL_ARB_gl_spirv"), glewGetExtension("GL_ARB_gl_spirv"));
+
+  glewInfoFunc("glSpecializeShaderARB", glSpecializeShaderARB == NULL);
+}
+
+#endif /* GL_ARB_gl_spirv */
+
 #ifdef GL_ARB_gpu_shader5
 
 static void _glewInfo_GL_ARB_gpu_shader5 (void)
@@ -1876,6 +2125,52 @@ static void _glewInfo_GL_ARB_gpu_shader_fp64 (void)
 }
 
 #endif /* GL_ARB_gpu_shader_fp64 */
+
+#ifdef GL_ARB_gpu_shader_int64
+
+static void _glewInfo_GL_ARB_gpu_shader_int64 (void)
+{
+  glewPrintExt("GL_ARB_gpu_shader_int64", GLEW_ARB_gpu_shader_int64, glewIsSupported("GL_ARB_gpu_shader_int64"), glewGetExtension("GL_ARB_gpu_shader_int64"));
+
+  glewInfoFunc("glGetUniformi64vARB", glGetUniformi64vARB == NULL);
+  glewInfoFunc("glGetUniformui64vARB", glGetUniformui64vARB == NULL);
+  glewInfoFunc("glGetnUniformi64vARB", glGetnUniformi64vARB == NULL);
+  glewInfoFunc("glGetnUniformui64vARB", glGetnUniformui64vARB == NULL);
+  glewInfoFunc("glProgramUniform1i64ARB", glProgramUniform1i64ARB == NULL);
+  glewInfoFunc("glProgramUniform1i64vARB", glProgramUniform1i64vARB == NULL);
+  glewInfoFunc("glProgramUniform1ui64ARB", glProgramUniform1ui64ARB == NULL);
+  glewInfoFunc("glProgramUniform1ui64vARB", glProgramUniform1ui64vARB == NULL);
+  glewInfoFunc("glProgramUniform2i64ARB", glProgramUniform2i64ARB == NULL);
+  glewInfoFunc("glProgramUniform2i64vARB", glProgramUniform2i64vARB == NULL);
+  glewInfoFunc("glProgramUniform2ui64ARB", glProgramUniform2ui64ARB == NULL);
+  glewInfoFunc("glProgramUniform2ui64vARB", glProgramUniform2ui64vARB == NULL);
+  glewInfoFunc("glProgramUniform3i64ARB", glProgramUniform3i64ARB == NULL);
+  glewInfoFunc("glProgramUniform3i64vARB", glProgramUniform3i64vARB == NULL);
+  glewInfoFunc("glProgramUniform3ui64ARB", glProgramUniform3ui64ARB == NULL);
+  glewInfoFunc("glProgramUniform3ui64vARB", glProgramUniform3ui64vARB == NULL);
+  glewInfoFunc("glProgramUniform4i64ARB", glProgramUniform4i64ARB == NULL);
+  glewInfoFunc("glProgramUniform4i64vARB", glProgramUniform4i64vARB == NULL);
+  glewInfoFunc("glProgramUniform4ui64ARB", glProgramUniform4ui64ARB == NULL);
+  glewInfoFunc("glProgramUniform4ui64vARB", glProgramUniform4ui64vARB == NULL);
+  glewInfoFunc("glUniform1i64ARB", glUniform1i64ARB == NULL);
+  glewInfoFunc("glUniform1i64vARB", glUniform1i64vARB == NULL);
+  glewInfoFunc("glUniform1ui64ARB", glUniform1ui64ARB == NULL);
+  glewInfoFunc("glUniform1ui64vARB", glUniform1ui64vARB == NULL);
+  glewInfoFunc("glUniform2i64ARB", glUniform2i64ARB == NULL);
+  glewInfoFunc("glUniform2i64vARB", glUniform2i64vARB == NULL);
+  glewInfoFunc("glUniform2ui64ARB", glUniform2ui64ARB == NULL);
+  glewInfoFunc("glUniform2ui64vARB", glUniform2ui64vARB == NULL);
+  glewInfoFunc("glUniform3i64ARB", glUniform3i64ARB == NULL);
+  glewInfoFunc("glUniform3i64vARB", glUniform3i64vARB == NULL);
+  glewInfoFunc("glUniform3ui64ARB", glUniform3ui64ARB == NULL);
+  glewInfoFunc("glUniform3ui64vARB", glUniform3ui64vARB == NULL);
+  glewInfoFunc("glUniform4i64ARB", glUniform4i64ARB == NULL);
+  glewInfoFunc("glUniform4i64vARB", glUniform4i64vARB == NULL);
+  glewInfoFunc("glUniform4ui64ARB", glUniform4ui64ARB == NULL);
+  glewInfoFunc("glUniform4ui64vARB", glUniform4ui64vARB == NULL);
+}
+
+#endif /* GL_ARB_gpu_shader_int64 */
 
 #ifdef GL_ARB_half_float_pixel
 
@@ -2147,6 +2442,17 @@ static void _glewInfo_GL_ARB_occlusion_query2 (void)
 
 #endif /* GL_ARB_occlusion_query2 */
 
+#ifdef GL_ARB_parallel_shader_compile
+
+static void _glewInfo_GL_ARB_parallel_shader_compile (void)
+{
+  glewPrintExt("GL_ARB_parallel_shader_compile", GLEW_ARB_parallel_shader_compile, glewIsSupported("GL_ARB_parallel_shader_compile"), glewGetExtension("GL_ARB_parallel_shader_compile"));
+
+  glewInfoFunc("glMaxShaderCompilerThreadsARB", glMaxShaderCompilerThreadsARB == NULL);
+}
+
+#endif /* GL_ARB_parallel_shader_compile */
+
 #ifdef GL_ARB_pipeline_statistics_query
 
 static void _glewInfo_GL_ARB_pipeline_statistics_query (void)
@@ -2185,6 +2491,26 @@ static void _glewInfo_GL_ARB_point_sprite (void)
 }
 
 #endif /* GL_ARB_point_sprite */
+
+#ifdef GL_ARB_polygon_offset_clamp
+
+static void _glewInfo_GL_ARB_polygon_offset_clamp (void)
+{
+  glewPrintExt("GL_ARB_polygon_offset_clamp", GLEW_ARB_polygon_offset_clamp, glewIsSupported("GL_ARB_polygon_offset_clamp"), glewGetExtension("GL_ARB_polygon_offset_clamp"));
+
+  glewInfoFunc("glPolygonOffsetClamp", glPolygonOffsetClamp == NULL);
+}
+
+#endif /* GL_ARB_polygon_offset_clamp */
+
+#ifdef GL_ARB_post_depth_coverage
+
+static void _glewInfo_GL_ARB_post_depth_coverage (void)
+{
+  glewPrintExt("GL_ARB_post_depth_coverage", GLEW_ARB_post_depth_coverage, glewIsSupported("GL_ARB_post_depth_coverage"), glewGetExtension("GL_ARB_post_depth_coverage"));
+}
+
+#endif /* GL_ARB_post_depth_coverage */
 
 #ifdef GL_ARB_program_interface_query
 
@@ -2278,6 +2604,18 @@ static void _glewInfo_GL_ARB_robustness_share_group_isolation (void)
 }
 
 #endif /* GL_ARB_robustness_share_group_isolation */
+
+#ifdef GL_ARB_sample_locations
+
+static void _glewInfo_GL_ARB_sample_locations (void)
+{
+  glewPrintExt("GL_ARB_sample_locations", GLEW_ARB_sample_locations, glewIsSupported("GL_ARB_sample_locations"), glewGetExtension("GL_ARB_sample_locations"));
+
+  glewInfoFunc("glFramebufferSampleLocationsfvARB", glFramebufferSampleLocationsfvARB == NULL);
+  glewInfoFunc("glNamedFramebufferSampleLocationsfvARB", glNamedFramebufferSampleLocationsfvARB == NULL);
+}
+
+#endif /* GL_ARB_sample_locations */
 
 #ifdef GL_ARB_sample_shading
 
@@ -2402,6 +2740,15 @@ static void _glewInfo_GL_ARB_separate_shader_objects (void)
 
 #endif /* GL_ARB_separate_shader_objects */
 
+#ifdef GL_ARB_shader_atomic_counter_ops
+
+static void _glewInfo_GL_ARB_shader_atomic_counter_ops (void)
+{
+  glewPrintExt("GL_ARB_shader_atomic_counter_ops", GLEW_ARB_shader_atomic_counter_ops, glewIsSupported("GL_ARB_shader_atomic_counter_ops"), glewGetExtension("GL_ARB_shader_atomic_counter_ops"));
+}
+
+#endif /* GL_ARB_shader_atomic_counter_ops */
+
 #ifdef GL_ARB_shader_atomic_counters
 
 static void _glewInfo_GL_ARB_shader_atomic_counters (void)
@@ -2413,6 +2760,15 @@ static void _glewInfo_GL_ARB_shader_atomic_counters (void)
 
 #endif /* GL_ARB_shader_atomic_counters */
 
+#ifdef GL_ARB_shader_ballot
+
+static void _glewInfo_GL_ARB_shader_ballot (void)
+{
+  glewPrintExt("GL_ARB_shader_ballot", GLEW_ARB_shader_ballot, glewIsSupported("GL_ARB_shader_ballot"), glewGetExtension("GL_ARB_shader_ballot"));
+}
+
+#endif /* GL_ARB_shader_ballot */
+
 #ifdef GL_ARB_shader_bit_encoding
 
 static void _glewInfo_GL_ARB_shader_bit_encoding (void)
@@ -2421,6 +2777,15 @@ static void _glewInfo_GL_ARB_shader_bit_encoding (void)
 }
 
 #endif /* GL_ARB_shader_bit_encoding */
+
+#ifdef GL_ARB_shader_clock
+
+static void _glewInfo_GL_ARB_shader_clock (void)
+{
+  glewPrintExt("GL_ARB_shader_clock", GLEW_ARB_shader_clock, glewIsSupported("GL_ARB_shader_clock"), glewGetExtension("GL_ARB_shader_clock"));
+}
+
+#endif /* GL_ARB_shader_clock */
 
 #ifdef GL_ARB_shader_draw_parameters
 
@@ -2575,6 +2940,15 @@ static void _glewInfo_GL_ARB_shader_texture_lod (void)
 
 #endif /* GL_ARB_shader_texture_lod */
 
+#ifdef GL_ARB_shader_viewport_layer_array
+
+static void _glewInfo_GL_ARB_shader_viewport_layer_array (void)
+{
+  glewPrintExt("GL_ARB_shader_viewport_layer_array", GLEW_ARB_shader_viewport_layer_array, glewIsSupported("GL_ARB_shader_viewport_layer_array"), glewGetExtension("GL_ARB_shader_viewport_layer_array"));
+}
+
+#endif /* GL_ARB_shader_viewport_layer_array */
+
 #ifdef GL_ARB_shading_language_100
 
 static void _glewInfo_GL_ARB_shading_language_100 (void)
@@ -2654,10 +3028,36 @@ static void _glewInfo_GL_ARB_sparse_texture (void)
   glewPrintExt("GL_ARB_sparse_texture", GLEW_ARB_sparse_texture, glewIsSupported("GL_ARB_sparse_texture"), glewGetExtension("GL_ARB_sparse_texture"));
 
   glewInfoFunc("glTexPageCommitmentARB", glTexPageCommitmentARB == NULL);
-  glewInfoFunc("glTexturePageCommitmentEXT", glTexturePageCommitmentEXT == NULL);
 }
 
 #endif /* GL_ARB_sparse_texture */
+
+#ifdef GL_ARB_sparse_texture2
+
+static void _glewInfo_GL_ARB_sparse_texture2 (void)
+{
+  glewPrintExt("GL_ARB_sparse_texture2", GLEW_ARB_sparse_texture2, glewIsSupported("GL_ARB_sparse_texture2"), glewGetExtension("GL_ARB_sparse_texture2"));
+}
+
+#endif /* GL_ARB_sparse_texture2 */
+
+#ifdef GL_ARB_sparse_texture_clamp
+
+static void _glewInfo_GL_ARB_sparse_texture_clamp (void)
+{
+  glewPrintExt("GL_ARB_sparse_texture_clamp", GLEW_ARB_sparse_texture_clamp, glewIsSupported("GL_ARB_sparse_texture_clamp"), glewGetExtension("GL_ARB_sparse_texture_clamp"));
+}
+
+#endif /* GL_ARB_sparse_texture_clamp */
+
+#ifdef GL_ARB_spirv_extensions
+
+static void _glewInfo_GL_ARB_spirv_extensions (void)
+{
+  glewPrintExt("GL_ARB_spirv_extensions", GLEW_ARB_spirv_extensions, glewIsSupported("GL_ARB_spirv_extensions"), glewGetExtension("GL_ARB_spirv_extensions"));
+}
+
+#endif /* GL_ARB_spirv_extensions */
 
 #ifdef GL_ARB_stencil_texturing
 
@@ -2838,6 +3238,24 @@ static void _glewInfo_GL_ARB_texture_env_dot3 (void)
 
 #endif /* GL_ARB_texture_env_dot3 */
 
+#ifdef GL_ARB_texture_filter_anisotropic
+
+static void _glewInfo_GL_ARB_texture_filter_anisotropic (void)
+{
+  glewPrintExt("GL_ARB_texture_filter_anisotropic", GLEW_ARB_texture_filter_anisotropic, glewIsSupported("GL_ARB_texture_filter_anisotropic"), glewGetExtension("GL_ARB_texture_filter_anisotropic"));
+}
+
+#endif /* GL_ARB_texture_filter_anisotropic */
+
+#ifdef GL_ARB_texture_filter_minmax
+
+static void _glewInfo_GL_ARB_texture_filter_minmax (void)
+{
+  glewPrintExt("GL_ARB_texture_filter_minmax", GLEW_ARB_texture_filter_minmax, glewIsSupported("GL_ARB_texture_filter_minmax"), glewGetExtension("GL_ARB_texture_filter_minmax"));
+}
+
+#endif /* GL_ARB_texture_filter_minmax */
+
 #ifdef GL_ARB_texture_float
 
 static void _glewInfo_GL_ARB_texture_float (void)
@@ -2960,9 +3378,6 @@ static void _glewInfo_GL_ARB_texture_storage (void)
   glewInfoFunc("glTexStorage1D", glTexStorage1D == NULL);
   glewInfoFunc("glTexStorage2D", glTexStorage2D == NULL);
   glewInfoFunc("glTexStorage3D", glTexStorage3D == NULL);
-  glewInfoFunc("glTextureStorage1DEXT", glTextureStorage1DEXT == NULL);
-  glewInfoFunc("glTextureStorage2DEXT", glTextureStorage2DEXT == NULL);
-  glewInfoFunc("glTextureStorage3DEXT", glTextureStorage3DEXT == NULL);
 }
 
 #endif /* GL_ARB_texture_storage */
@@ -3394,6 +3809,51 @@ static void _glewInfo_GL_ARB_window_pos (void)
 
 #endif /* GL_ARB_window_pos */
 
+#ifdef GL_ARM_mali_program_binary
+
+static void _glewInfo_GL_ARM_mali_program_binary (void)
+{
+  glewPrintExt("GL_ARM_mali_program_binary", GLEW_ARM_mali_program_binary, glewIsSupported("GL_ARM_mali_program_binary"), glewGetExtension("GL_ARM_mali_program_binary"));
+}
+
+#endif /* GL_ARM_mali_program_binary */
+
+#ifdef GL_ARM_mali_shader_binary
+
+static void _glewInfo_GL_ARM_mali_shader_binary (void)
+{
+  glewPrintExt("GL_ARM_mali_shader_binary", GLEW_ARM_mali_shader_binary, glewIsSupported("GL_ARM_mali_shader_binary"), glewGetExtension("GL_ARM_mali_shader_binary"));
+}
+
+#endif /* GL_ARM_mali_shader_binary */
+
+#ifdef GL_ARM_rgba8
+
+static void _glewInfo_GL_ARM_rgba8 (void)
+{
+  glewPrintExt("GL_ARM_rgba8", GLEW_ARM_rgba8, glewIsSupported("GL_ARM_rgba8"), glewGetExtension("GL_ARM_rgba8"));
+}
+
+#endif /* GL_ARM_rgba8 */
+
+#ifdef GL_ARM_shader_framebuffer_fetch
+
+static void _glewInfo_GL_ARM_shader_framebuffer_fetch (void)
+{
+  glewPrintExt("GL_ARM_shader_framebuffer_fetch", GLEW_ARM_shader_framebuffer_fetch, glewIsSupported("GL_ARM_shader_framebuffer_fetch"), glewGetExtension("GL_ARM_shader_framebuffer_fetch"));
+}
+
+#endif /* GL_ARM_shader_framebuffer_fetch */
+
+#ifdef GL_ARM_shader_framebuffer_fetch_depth_stencil
+
+static void _glewInfo_GL_ARM_shader_framebuffer_fetch_depth_stencil (void)
+{
+  glewPrintExt("GL_ARM_shader_framebuffer_fetch_depth_stencil", GLEW_ARM_shader_framebuffer_fetch_depth_stencil, glewIsSupported("GL_ARM_shader_framebuffer_fetch_depth_stencil"), glewGetExtension("GL_ARM_shader_framebuffer_fetch_depth_stencil"));
+}
+
+#endif /* GL_ARM_shader_framebuffer_fetch_depth_stencil */
+
 #ifdef GL_ATIX_point_sprites
 
 static void _glewInfo_GL_ATIX_point_sprites (void)
@@ -3681,6 +4141,24 @@ static void _glewInfo_GL_ATI_vertex_streams (void)
 
 #endif /* GL_ATI_vertex_streams */
 
+#ifdef GL_EGL_KHR_context_flush_control
+
+static void _glewInfo_GL_EGL_KHR_context_flush_control (void)
+{
+  glewPrintExt("GL_EGL_KHR_context_flush_control", GLEW_EGL_KHR_context_flush_control, glewIsSupported("GL_EGL_KHR_context_flush_control"), glewGetExtension("GL_EGL_KHR_context_flush_control"));
+}
+
+#endif /* GL_EGL_KHR_context_flush_control */
+
+#ifdef GL_EGL_NV_robustness_video_memory_purge
+
+static void _glewInfo_GL_EGL_NV_robustness_video_memory_purge (void)
+{
+  glewPrintExt("GL_EGL_NV_robustness_video_memory_purge", GLEW_EGL_NV_robustness_video_memory_purge, glewIsSupported("GL_EGL_NV_robustness_video_memory_purge"), glewGetExtension("GL_EGL_NV_robustness_video_memory_purge"));
+}
+
+#endif /* GL_EGL_NV_robustness_video_memory_purge */
+
 #ifdef GL_EXT_422_pixels
 
 static void _glewInfo_GL_EXT_422_pixels (void)
@@ -3699,6 +4177,24 @@ static void _glewInfo_GL_EXT_Cg_shader (void)
 
 #endif /* GL_EXT_Cg_shader */
 
+#ifdef GL_EXT_EGL_image_array
+
+static void _glewInfo_GL_EXT_EGL_image_array (void)
+{
+  glewPrintExt("GL_EXT_EGL_image_array", GLEW_EXT_EGL_image_array, glewIsSupported("GL_EXT_EGL_image_array"), glewGetExtension("GL_EXT_EGL_image_array"));
+}
+
+#endif /* GL_EXT_EGL_image_array */
+
+#ifdef GL_EXT_YUV_target
+
+static void _glewInfo_GL_EXT_YUV_target (void)
+{
+  glewPrintExt("GL_EXT_YUV_target", GLEW_EXT_YUV_target, glewIsSupported("GL_EXT_YUV_target"), glewGetExtension("GL_EXT_YUV_target"));
+}
+
+#endif /* GL_EXT_YUV_target */
+
 #ifdef GL_EXT_abgr
 
 static void _glewInfo_GL_EXT_abgr (void)
@@ -3707,6 +4203,19 @@ static void _glewInfo_GL_EXT_abgr (void)
 }
 
 #endif /* GL_EXT_abgr */
+
+#ifdef GL_EXT_base_instance
+
+static void _glewInfo_GL_EXT_base_instance (void)
+{
+  glewPrintExt("GL_EXT_base_instance", GLEW_EXT_base_instance, glewIsSupported("GL_EXT_base_instance"), glewGetExtension("GL_EXT_base_instance"));
+
+  glewInfoFunc("glDrawArraysInstancedBaseInstanceEXT", glDrawArraysInstancedBaseInstanceEXT == NULL);
+  glewInfoFunc("glDrawElementsInstancedBaseInstanceEXT", glDrawElementsInstancedBaseInstanceEXT == NULL);
+  glewInfoFunc("glDrawElementsInstancedBaseVertexBaseInstanceEXT", glDrawElementsInstancedBaseVertexBaseInstanceEXT == NULL);
+}
+
+#endif /* GL_EXT_base_instance */
 
 #ifdef GL_EXT_bgra
 
@@ -3752,6 +4261,19 @@ static void _glewInfo_GL_EXT_blend_equation_separate (void)
 
 #endif /* GL_EXT_blend_equation_separate */
 
+#ifdef GL_EXT_blend_func_extended
+
+static void _glewInfo_GL_EXT_blend_func_extended (void)
+{
+  glewPrintExt("GL_EXT_blend_func_extended", GLEW_EXT_blend_func_extended, glewIsSupported("GL_EXT_blend_func_extended"), glewGetExtension("GL_EXT_blend_func_extended"));
+
+  glewInfoFunc("glBindFragDataLocationIndexedEXT", glBindFragDataLocationIndexedEXT == NULL);
+  glewInfoFunc("glGetFragDataIndexEXT", glGetFragDataIndexEXT == NULL);
+  glewInfoFunc("glGetProgramResourceLocationIndexEXT", glGetProgramResourceLocationIndexEXT == NULL);
+}
+
+#endif /* GL_EXT_blend_func_extended */
+
 #ifdef GL_EXT_blend_func_separate
 
 static void _glewInfo_GL_EXT_blend_func_separate (void)
@@ -3792,6 +4314,39 @@ static void _glewInfo_GL_EXT_blend_subtract (void)
 
 #endif /* GL_EXT_blend_subtract */
 
+#ifdef GL_EXT_buffer_storage
+
+static void _glewInfo_GL_EXT_buffer_storage (void)
+{
+  glewPrintExt("GL_EXT_buffer_storage", GLEW_EXT_buffer_storage, glewIsSupported("GL_EXT_buffer_storage"), glewGetExtension("GL_EXT_buffer_storage"));
+
+  glewInfoFunc("glBufferStorageEXT", glBufferStorageEXT == NULL);
+  glewInfoFunc("glNamedBufferStorageEXT", glNamedBufferStorageEXT == NULL);
+}
+
+#endif /* GL_EXT_buffer_storage */
+
+#ifdef GL_EXT_clear_texture
+
+static void _glewInfo_GL_EXT_clear_texture (void)
+{
+  glewPrintExt("GL_EXT_clear_texture", GLEW_EXT_clear_texture, glewIsSupported("GL_EXT_clear_texture"), glewGetExtension("GL_EXT_clear_texture"));
+
+  glewInfoFunc("glClearTexImageEXT", glClearTexImageEXT == NULL);
+  glewInfoFunc("glClearTexSubImageEXT", glClearTexSubImageEXT == NULL);
+}
+
+#endif /* GL_EXT_clear_texture */
+
+#ifdef GL_EXT_clip_cull_distance
+
+static void _glewInfo_GL_EXT_clip_cull_distance (void)
+{
+  glewPrintExt("GL_EXT_clip_cull_distance", GLEW_EXT_clip_cull_distance, glewIsSupported("GL_EXT_clip_cull_distance"), glewGetExtension("GL_EXT_clip_cull_distance"));
+}
+
+#endif /* GL_EXT_clip_cull_distance */
+
 #ifdef GL_EXT_clip_volume_hint
 
 static void _glewInfo_GL_EXT_clip_volume_hint (void)
@@ -3809,6 +4364,24 @@ static void _glewInfo_GL_EXT_cmyka (void)
 }
 
 #endif /* GL_EXT_cmyka */
+
+#ifdef GL_EXT_color_buffer_float
+
+static void _glewInfo_GL_EXT_color_buffer_float (void)
+{
+  glewPrintExt("GL_EXT_color_buffer_float", GLEW_EXT_color_buffer_float, glewIsSupported("GL_EXT_color_buffer_float"), glewGetExtension("GL_EXT_color_buffer_float"));
+}
+
+#endif /* GL_EXT_color_buffer_float */
+
+#ifdef GL_EXT_color_buffer_half_float
+
+static void _glewInfo_GL_EXT_color_buffer_half_float (void)
+{
+  glewPrintExt("GL_EXT_color_buffer_half_float", GLEW_EXT_color_buffer_half_float, glewIsSupported("GL_EXT_color_buffer_half_float"), glewGetExtension("GL_EXT_color_buffer_half_float"));
+}
+
+#endif /* GL_EXT_color_buffer_half_float */
 
 #ifdef GL_EXT_color_subtable
 
@@ -3833,6 +4406,24 @@ static void _glewInfo_GL_EXT_compiled_vertex_array (void)
 }
 
 #endif /* GL_EXT_compiled_vertex_array */
+
+#ifdef GL_EXT_compressed_ETC1_RGB8_sub_texture
+
+static void _glewInfo_GL_EXT_compressed_ETC1_RGB8_sub_texture (void)
+{
+  glewPrintExt("GL_EXT_compressed_ETC1_RGB8_sub_texture", GLEW_EXT_compressed_ETC1_RGB8_sub_texture, glewIsSupported("GL_EXT_compressed_ETC1_RGB8_sub_texture"), glewGetExtension("GL_EXT_compressed_ETC1_RGB8_sub_texture"));
+}
+
+#endif /* GL_EXT_compressed_ETC1_RGB8_sub_texture */
+
+#ifdef GL_EXT_conservative_depth
+
+static void _glewInfo_GL_EXT_conservative_depth (void)
+{
+  glewPrintExt("GL_EXT_conservative_depth", GLEW_EXT_conservative_depth, glewIsSupported("GL_EXT_conservative_depth"), glewGetExtension("GL_EXT_conservative_depth"));
+}
+
+#endif /* GL_EXT_conservative_depth */
 
 #ifdef GL_EXT_convolution
 
@@ -3868,6 +4459,17 @@ static void _glewInfo_GL_EXT_coordinate_frame (void)
 }
 
 #endif /* GL_EXT_coordinate_frame */
+
+#ifdef GL_EXT_copy_image
+
+static void _glewInfo_GL_EXT_copy_image (void)
+{
+  glewPrintExt("GL_EXT_copy_image", GLEW_EXT_copy_image, glewIsSupported("GL_EXT_copy_image"), glewGetExtension("GL_EXT_copy_image"));
+
+  glewInfoFunc("glCopyImageSubDataEXT", glCopyImageSubDataEXT == NULL);
+}
+
+#endif /* GL_EXT_copy_image */
 
 #ifdef GL_EXT_copy_texture
 
@@ -4156,6 +4758,28 @@ static void _glewInfo_GL_EXT_direct_state_access (void)
 
 #endif /* GL_EXT_direct_state_access */
 
+#ifdef GL_EXT_discard_framebuffer
+
+static void _glewInfo_GL_EXT_discard_framebuffer (void)
+{
+  glewPrintExt("GL_EXT_discard_framebuffer", GLEW_EXT_discard_framebuffer, glewIsSupported("GL_EXT_discard_framebuffer"), glewGetExtension("GL_EXT_discard_framebuffer"));
+
+  glewInfoFunc("glDiscardFramebufferEXT", glDiscardFramebufferEXT == NULL);
+}
+
+#endif /* GL_EXT_discard_framebuffer */
+
+#ifdef GL_EXT_draw_buffers
+
+static void _glewInfo_GL_EXT_draw_buffers (void)
+{
+  glewPrintExt("GL_EXT_draw_buffers", GLEW_EXT_draw_buffers, glewIsSupported("GL_EXT_draw_buffers"), glewGetExtension("GL_EXT_draw_buffers"));
+
+  glewInfoFunc("glDrawBuffersEXT", glDrawBuffersEXT == NULL);
+}
+
+#endif /* GL_EXT_draw_buffers */
+
 #ifdef GL_EXT_draw_buffers2
 
 static void _glewInfo_GL_EXT_draw_buffers2 (void)
@@ -4171,6 +4795,38 @@ static void _glewInfo_GL_EXT_draw_buffers2 (void)
 }
 
 #endif /* GL_EXT_draw_buffers2 */
+
+#ifdef GL_EXT_draw_buffers_indexed
+
+static void _glewInfo_GL_EXT_draw_buffers_indexed (void)
+{
+  glewPrintExt("GL_EXT_draw_buffers_indexed", GLEW_EXT_draw_buffers_indexed, glewIsSupported("GL_EXT_draw_buffers_indexed"), glewGetExtension("GL_EXT_draw_buffers_indexed"));
+
+  glewInfoFunc("glBlendEquationSeparateiEXT", glBlendEquationSeparateiEXT == NULL);
+  glewInfoFunc("glBlendEquationiEXT", glBlendEquationiEXT == NULL);
+  glewInfoFunc("glBlendFuncSeparateiEXT", glBlendFuncSeparateiEXT == NULL);
+  glewInfoFunc("glBlendFunciEXT", glBlendFunciEXT == NULL);
+  glewInfoFunc("glColorMaskiEXT", glColorMaskiEXT == NULL);
+  glewInfoFunc("glDisableiEXT", glDisableiEXT == NULL);
+  glewInfoFunc("glEnableiEXT", glEnableiEXT == NULL);
+  glewInfoFunc("glIsEnablediEXT", glIsEnablediEXT == NULL);
+}
+
+#endif /* GL_EXT_draw_buffers_indexed */
+
+#ifdef GL_EXT_draw_elements_base_vertex
+
+static void _glewInfo_GL_EXT_draw_elements_base_vertex (void)
+{
+  glewPrintExt("GL_EXT_draw_elements_base_vertex", GLEW_EXT_draw_elements_base_vertex, glewIsSupported("GL_EXT_draw_elements_base_vertex"), glewGetExtension("GL_EXT_draw_elements_base_vertex"));
+
+  glewInfoFunc("glDrawElementsBaseVertexEXT", glDrawElementsBaseVertexEXT == NULL);
+  glewInfoFunc("glDrawElementsInstancedBaseVertexEXT", glDrawElementsInstancedBaseVertexEXT == NULL);
+  glewInfoFunc("glDrawRangeElementsBaseVertexEXT", glDrawRangeElementsBaseVertexEXT == NULL);
+  glewInfoFunc("glMultiDrawElementsBaseVertexEXT", glMultiDrawElementsBaseVertexEXT == NULL);
+}
+
+#endif /* GL_EXT_draw_elements_base_vertex */
 
 #ifdef GL_EXT_draw_instanced
 
@@ -4195,6 +4851,27 @@ static void _glewInfo_GL_EXT_draw_range_elements (void)
 
 #endif /* GL_EXT_draw_range_elements */
 
+#ifdef GL_EXT_external_buffer
+
+static void _glewInfo_GL_EXT_external_buffer (void)
+{
+  glewPrintExt("GL_EXT_external_buffer", GLEW_EXT_external_buffer, glewIsSupported("GL_EXT_external_buffer"), glewGetExtension("GL_EXT_external_buffer"));
+
+  glewInfoFunc("glBufferStorageExternalEXT", glBufferStorageExternalEXT == NULL);
+  glewInfoFunc("glNamedBufferStorageExternalEXT", glNamedBufferStorageExternalEXT == NULL);
+}
+
+#endif /* GL_EXT_external_buffer */
+
+#ifdef GL_EXT_float_blend
+
+static void _glewInfo_GL_EXT_float_blend (void)
+{
+  glewPrintExt("GL_EXT_float_blend", GLEW_EXT_float_blend, glewIsSupported("GL_EXT_float_blend"), glewGetExtension("GL_EXT_float_blend"));
+}
+
+#endif /* GL_EXT_float_blend */
+
 #ifdef GL_EXT_fog_coord
 
 static void _glewInfo_GL_EXT_fog_coord (void)
@@ -4209,6 +4886,15 @@ static void _glewInfo_GL_EXT_fog_coord (void)
 }
 
 #endif /* GL_EXT_fog_coord */
+
+#ifdef GL_EXT_frag_depth
+
+static void _glewInfo_GL_EXT_frag_depth (void)
+{
+  glewPrintExt("GL_EXT_frag_depth", GLEW_EXT_frag_depth, glewIsSupported("GL_EXT_frag_depth"), glewGetExtension("GL_EXT_frag_depth"));
+}
+
+#endif /* GL_EXT_frag_depth */
 
 #ifdef GL_EXT_fragment_lighting
 
@@ -4305,6 +4991,24 @@ static void _glewInfo_GL_EXT_framebuffer_sRGB (void)
 
 #endif /* GL_EXT_framebuffer_sRGB */
 
+#ifdef GL_EXT_geometry_point_size
+
+static void _glewInfo_GL_EXT_geometry_point_size (void)
+{
+  glewPrintExt("GL_EXT_geometry_point_size", GLEW_EXT_geometry_point_size, glewIsSupported("GL_EXT_geometry_point_size"), glewGetExtension("GL_EXT_geometry_point_size"));
+}
+
+#endif /* GL_EXT_geometry_point_size */
+
+#ifdef GL_EXT_geometry_shader
+
+static void _glewInfo_GL_EXT_geometry_shader (void)
+{
+  glewPrintExt("GL_EXT_geometry_shader", GLEW_EXT_geometry_shader, glewIsSupported("GL_EXT_geometry_shader"), glewGetExtension("GL_EXT_geometry_shader"));
+}
+
+#endif /* GL_EXT_geometry_shader */
+
 #ifdef GL_EXT_geometry_shader4
 
 static void _glewInfo_GL_EXT_geometry_shader4 (void)
@@ -4374,6 +5078,15 @@ static void _glewInfo_GL_EXT_gpu_shader4 (void)
 
 #endif /* GL_EXT_gpu_shader4 */
 
+#ifdef GL_EXT_gpu_shader5
+
+static void _glewInfo_GL_EXT_gpu_shader5 (void)
+{
+  glewPrintExt("GL_EXT_gpu_shader5", GLEW_EXT_gpu_shader5, glewIsSupported("GL_EXT_gpu_shader5"), glewGetExtension("GL_EXT_gpu_shader5"));
+}
+
+#endif /* GL_EXT_gpu_shader5 */
+
 #ifdef GL_EXT_histogram
 
 static void _glewInfo_GL_EXT_histogram (void)
@@ -4434,6 +5147,17 @@ static void _glewInfo_GL_EXT_index_texture (void)
 
 #endif /* GL_EXT_index_texture */
 
+#ifdef GL_EXT_instanced_arrays
+
+static void _glewInfo_GL_EXT_instanced_arrays (void)
+{
+  glewPrintExt("GL_EXT_instanced_arrays", GLEW_EXT_instanced_arrays, glewIsSupported("GL_EXT_instanced_arrays"), glewGetExtension("GL_EXT_instanced_arrays"));
+
+  glewInfoFunc("glVertexAttribDivisorEXT", glVertexAttribDivisorEXT == NULL);
+}
+
+#endif /* GL_EXT_instanced_arrays */
+
 #ifdef GL_EXT_light_texture
 
 static void _glewInfo_GL_EXT_light_texture (void)
@@ -4446,6 +5170,70 @@ static void _glewInfo_GL_EXT_light_texture (void)
 }
 
 #endif /* GL_EXT_light_texture */
+
+#ifdef GL_EXT_map_buffer_range
+
+static void _glewInfo_GL_EXT_map_buffer_range (void)
+{
+  glewPrintExt("GL_EXT_map_buffer_range", GLEW_EXT_map_buffer_range, glewIsSupported("GL_EXT_map_buffer_range"), glewGetExtension("GL_EXT_map_buffer_range"));
+
+  glewInfoFunc("glFlushMappedBufferRangeEXT", glFlushMappedBufferRangeEXT == NULL);
+  glewInfoFunc("glMapBufferRangeEXT", glMapBufferRangeEXT == NULL);
+}
+
+#endif /* GL_EXT_map_buffer_range */
+
+#ifdef GL_EXT_memory_object
+
+static void _glewInfo_GL_EXT_memory_object (void)
+{
+  glewPrintExt("GL_EXT_memory_object", GLEW_EXT_memory_object, glewIsSupported("GL_EXT_memory_object"), glewGetExtension("GL_EXT_memory_object"));
+
+  glewInfoFunc("glBufferStorageMemEXT", glBufferStorageMemEXT == NULL);
+  glewInfoFunc("glCreateMemoryObjectsEXT", glCreateMemoryObjectsEXT == NULL);
+  glewInfoFunc("glDeleteMemoryObjectsEXT", glDeleteMemoryObjectsEXT == NULL);
+  glewInfoFunc("glGetMemoryObjectParameterivEXT", glGetMemoryObjectParameterivEXT == NULL);
+  glewInfoFunc("glGetUnsignedBytei_vEXT", glGetUnsignedBytei_vEXT == NULL);
+  glewInfoFunc("glGetUnsignedBytevEXT", glGetUnsignedBytevEXT == NULL);
+  glewInfoFunc("glIsMemoryObjectEXT", glIsMemoryObjectEXT == NULL);
+  glewInfoFunc("glMemoryObjectParameterivEXT", glMemoryObjectParameterivEXT == NULL);
+  glewInfoFunc("glNamedBufferStorageMemEXT", glNamedBufferStorageMemEXT == NULL);
+  glewInfoFunc("glTexStorageMem1DEXT", glTexStorageMem1DEXT == NULL);
+  glewInfoFunc("glTexStorageMem2DEXT", glTexStorageMem2DEXT == NULL);
+  glewInfoFunc("glTexStorageMem2DMultisampleEXT", glTexStorageMem2DMultisampleEXT == NULL);
+  glewInfoFunc("glTexStorageMem3DEXT", glTexStorageMem3DEXT == NULL);
+  glewInfoFunc("glTexStorageMem3DMultisampleEXT", glTexStorageMem3DMultisampleEXT == NULL);
+  glewInfoFunc("glTextureStorageMem1DEXT", glTextureStorageMem1DEXT == NULL);
+  glewInfoFunc("glTextureStorageMem2DEXT", glTextureStorageMem2DEXT == NULL);
+  glewInfoFunc("glTextureStorageMem2DMultisampleEXT", glTextureStorageMem2DMultisampleEXT == NULL);
+  glewInfoFunc("glTextureStorageMem3DEXT", glTextureStorageMem3DEXT == NULL);
+  glewInfoFunc("glTextureStorageMem3DMultisampleEXT", glTextureStorageMem3DMultisampleEXT == NULL);
+}
+
+#endif /* GL_EXT_memory_object */
+
+#ifdef GL_EXT_memory_object_fd
+
+static void _glewInfo_GL_EXT_memory_object_fd (void)
+{
+  glewPrintExt("GL_EXT_memory_object_fd", GLEW_EXT_memory_object_fd, glewIsSupported("GL_EXT_memory_object_fd"), glewGetExtension("GL_EXT_memory_object_fd"));
+
+  glewInfoFunc("glImportMemoryFdEXT", glImportMemoryFdEXT == NULL);
+}
+
+#endif /* GL_EXT_memory_object_fd */
+
+#ifdef GL_EXT_memory_object_win32
+
+static void _glewInfo_GL_EXT_memory_object_win32 (void)
+{
+  glewPrintExt("GL_EXT_memory_object_win32", GLEW_EXT_memory_object_win32, glewIsSupported("GL_EXT_memory_object_win32"), glewGetExtension("GL_EXT_memory_object_win32"));
+
+  glewInfoFunc("glImportMemoryWin32HandleEXT", glImportMemoryWin32HandleEXT == NULL);
+  glewInfoFunc("glImportMemoryWin32NameEXT", glImportMemoryWin32NameEXT == NULL);
+}
+
+#endif /* GL_EXT_memory_object_win32 */
 
 #ifdef GL_EXT_misc_attribute
 
@@ -4468,6 +5256,27 @@ static void _glewInfo_GL_EXT_multi_draw_arrays (void)
 
 #endif /* GL_EXT_multi_draw_arrays */
 
+#ifdef GL_EXT_multi_draw_indirect
+
+static void _glewInfo_GL_EXT_multi_draw_indirect (void)
+{
+  glewPrintExt("GL_EXT_multi_draw_indirect", GLEW_EXT_multi_draw_indirect, glewIsSupported("GL_EXT_multi_draw_indirect"), glewGetExtension("GL_EXT_multi_draw_indirect"));
+
+  glewInfoFunc("glMultiDrawArraysIndirectEXT", glMultiDrawArraysIndirectEXT == NULL);
+  glewInfoFunc("glMultiDrawElementsIndirectEXT", glMultiDrawElementsIndirectEXT == NULL);
+}
+
+#endif /* GL_EXT_multi_draw_indirect */
+
+#ifdef GL_EXT_multiple_textures
+
+static void _glewInfo_GL_EXT_multiple_textures (void)
+{
+  glewPrintExt("GL_EXT_multiple_textures", GLEW_EXT_multiple_textures, glewIsSupported("GL_EXT_multiple_textures"), glewGetExtension("GL_EXT_multiple_textures"));
+}
+
+#endif /* GL_EXT_multiple_textures */
+
 #ifdef GL_EXT_multisample
 
 static void _glewInfo_GL_EXT_multisample (void)
@@ -4479,6 +5288,48 @@ static void _glewInfo_GL_EXT_multisample (void)
 }
 
 #endif /* GL_EXT_multisample */
+
+#ifdef GL_EXT_multisample_compatibility
+
+static void _glewInfo_GL_EXT_multisample_compatibility (void)
+{
+  glewPrintExt("GL_EXT_multisample_compatibility", GLEW_EXT_multisample_compatibility, glewIsSupported("GL_EXT_multisample_compatibility"), glewGetExtension("GL_EXT_multisample_compatibility"));
+}
+
+#endif /* GL_EXT_multisample_compatibility */
+
+#ifdef GL_EXT_multisampled_render_to_texture
+
+static void _glewInfo_GL_EXT_multisampled_render_to_texture (void)
+{
+  glewPrintExt("GL_EXT_multisampled_render_to_texture", GLEW_EXT_multisampled_render_to_texture, glewIsSupported("GL_EXT_multisampled_render_to_texture"), glewGetExtension("GL_EXT_multisampled_render_to_texture"));
+
+  glewInfoFunc("glFramebufferTexture2DMultisampleEXT", glFramebufferTexture2DMultisampleEXT == NULL);
+}
+
+#endif /* GL_EXT_multisampled_render_to_texture */
+
+#ifdef GL_EXT_multisampled_render_to_texture2
+
+static void _glewInfo_GL_EXT_multisampled_render_to_texture2 (void)
+{
+  glewPrintExt("GL_EXT_multisampled_render_to_texture2", GLEW_EXT_multisampled_render_to_texture2, glewIsSupported("GL_EXT_multisampled_render_to_texture2"), glewGetExtension("GL_EXT_multisampled_render_to_texture2"));
+}
+
+#endif /* GL_EXT_multisampled_render_to_texture2 */
+
+#ifdef GL_EXT_multiview_draw_buffers
+
+static void _glewInfo_GL_EXT_multiview_draw_buffers (void)
+{
+  glewPrintExt("GL_EXT_multiview_draw_buffers", GLEW_EXT_multiview_draw_buffers, glewIsSupported("GL_EXT_multiview_draw_buffers"), glewGetExtension("GL_EXT_multiview_draw_buffers"));
+
+  glewInfoFunc("glDrawBuffersIndexedEXT", glDrawBuffersIndexedEXT == NULL);
+  glewInfoFunc("glGetIntegeri_vEXT", glGetIntegeri_vEXT == NULL);
+  glewInfoFunc("glReadBufferIndexedEXT", glReadBufferIndexedEXT == NULL);
+}
+
+#endif /* GL_EXT_multiview_draw_buffers */
 
 #ifdef GL_EXT_packed_depth_stencil
 
@@ -4578,6 +5429,26 @@ static void _glewInfo_GL_EXT_polygon_offset (void)
 
 #endif /* GL_EXT_polygon_offset */
 
+#ifdef GL_EXT_polygon_offset_clamp
+
+static void _glewInfo_GL_EXT_polygon_offset_clamp (void)
+{
+  glewPrintExt("GL_EXT_polygon_offset_clamp", GLEW_EXT_polygon_offset_clamp, glewIsSupported("GL_EXT_polygon_offset_clamp"), glewGetExtension("GL_EXT_polygon_offset_clamp"));
+
+  glewInfoFunc("glPolygonOffsetClampEXT", glPolygonOffsetClampEXT == NULL);
+}
+
+#endif /* GL_EXT_polygon_offset_clamp */
+
+#ifdef GL_EXT_post_depth_coverage
+
+static void _glewInfo_GL_EXT_post_depth_coverage (void)
+{
+  glewPrintExt("GL_EXT_post_depth_coverage", GLEW_EXT_post_depth_coverage, glewIsSupported("GL_EXT_post_depth_coverage"), glewGetExtension("GL_EXT_post_depth_coverage"));
+}
+
+#endif /* GL_EXT_post_depth_coverage */
+
 #ifdef GL_EXT_provoking_vertex
 
 static void _glewInfo_GL_EXT_provoking_vertex (void)
@@ -4589,6 +5460,47 @@ static void _glewInfo_GL_EXT_provoking_vertex (void)
 
 #endif /* GL_EXT_provoking_vertex */
 
+#ifdef GL_EXT_pvrtc_sRGB
+
+static void _glewInfo_GL_EXT_pvrtc_sRGB (void)
+{
+  glewPrintExt("GL_EXT_pvrtc_sRGB", GLEW_EXT_pvrtc_sRGB, glewIsSupported("GL_EXT_pvrtc_sRGB"), glewGetExtension("GL_EXT_pvrtc_sRGB"));
+}
+
+#endif /* GL_EXT_pvrtc_sRGB */
+
+#ifdef GL_EXT_raster_multisample
+
+static void _glewInfo_GL_EXT_raster_multisample (void)
+{
+  glewPrintExt("GL_EXT_raster_multisample", GLEW_EXT_raster_multisample, glewIsSupported("GL_EXT_raster_multisample"), glewGetExtension("GL_EXT_raster_multisample"));
+
+  glewInfoFunc("glCoverageModulationNV", glCoverageModulationNV == NULL);
+  glewInfoFunc("glCoverageModulationTableNV", glCoverageModulationTableNV == NULL);
+  glewInfoFunc("glGetCoverageModulationTableNV", glGetCoverageModulationTableNV == NULL);
+  glewInfoFunc("glRasterSamplesEXT", glRasterSamplesEXT == NULL);
+}
+
+#endif /* GL_EXT_raster_multisample */
+
+#ifdef GL_EXT_read_format_bgra
+
+static void _glewInfo_GL_EXT_read_format_bgra (void)
+{
+  glewPrintExt("GL_EXT_read_format_bgra", GLEW_EXT_read_format_bgra, glewIsSupported("GL_EXT_read_format_bgra"), glewGetExtension("GL_EXT_read_format_bgra"));
+}
+
+#endif /* GL_EXT_read_format_bgra */
+
+#ifdef GL_EXT_render_snorm
+
+static void _glewInfo_GL_EXT_render_snorm (void)
+{
+  glewPrintExt("GL_EXT_render_snorm", GLEW_EXT_render_snorm, glewIsSupported("GL_EXT_render_snorm"), glewGetExtension("GL_EXT_render_snorm"));
+}
+
+#endif /* GL_EXT_render_snorm */
+
 #ifdef GL_EXT_rescale_normal
 
 static void _glewInfo_GL_EXT_rescale_normal (void)
@@ -4597,6 +5509,24 @@ static void _glewInfo_GL_EXT_rescale_normal (void)
 }
 
 #endif /* GL_EXT_rescale_normal */
+
+#ifdef GL_EXT_sRGB
+
+static void _glewInfo_GL_EXT_sRGB (void)
+{
+  glewPrintExt("GL_EXT_sRGB", GLEW_EXT_sRGB, glewIsSupported("GL_EXT_sRGB"), glewGetExtension("GL_EXT_sRGB"));
+}
+
+#endif /* GL_EXT_sRGB */
+
+#ifdef GL_EXT_sRGB_write_control
+
+static void _glewInfo_GL_EXT_sRGB_write_control (void)
+{
+  glewPrintExt("GL_EXT_sRGB_write_control", GLEW_EXT_sRGB_write_control, glewIsSupported("GL_EXT_sRGB_write_control"), glewGetExtension("GL_EXT_sRGB_write_control"));
+}
+
+#endif /* GL_EXT_sRGB_write_control */
 
 #ifdef GL_EXT_scene_marker
 
@@ -4637,6 +5567,46 @@ static void _glewInfo_GL_EXT_secondary_color (void)
 
 #endif /* GL_EXT_secondary_color */
 
+#ifdef GL_EXT_semaphore
+
+static void _glewInfo_GL_EXT_semaphore (void)
+{
+  glewPrintExt("GL_EXT_semaphore", GLEW_EXT_semaphore, glewIsSupported("GL_EXT_semaphore"), glewGetExtension("GL_EXT_semaphore"));
+
+  glewInfoFunc("glDeleteSemaphoresEXT", glDeleteSemaphoresEXT == NULL);
+  glewInfoFunc("glGenSemaphoresEXT", glGenSemaphoresEXT == NULL);
+  glewInfoFunc("glGetSemaphoreParameterui64vEXT", glGetSemaphoreParameterui64vEXT == NULL);
+  glewInfoFunc("glIsSemaphoreEXT", glIsSemaphoreEXT == NULL);
+  glewInfoFunc("glSemaphoreParameterui64vEXT", glSemaphoreParameterui64vEXT == NULL);
+  glewInfoFunc("glSignalSemaphoreEXT", glSignalSemaphoreEXT == NULL);
+  glewInfoFunc("glWaitSemaphoreEXT", glWaitSemaphoreEXT == NULL);
+}
+
+#endif /* GL_EXT_semaphore */
+
+#ifdef GL_EXT_semaphore_fd
+
+static void _glewInfo_GL_EXT_semaphore_fd (void)
+{
+  glewPrintExt("GL_EXT_semaphore_fd", GLEW_EXT_semaphore_fd, glewIsSupported("GL_EXT_semaphore_fd"), glewGetExtension("GL_EXT_semaphore_fd"));
+
+  glewInfoFunc("glImportSemaphoreFdEXT", glImportSemaphoreFdEXT == NULL);
+}
+
+#endif /* GL_EXT_semaphore_fd */
+
+#ifdef GL_EXT_semaphore_win32
+
+static void _glewInfo_GL_EXT_semaphore_win32 (void)
+{
+  glewPrintExt("GL_EXT_semaphore_win32", GLEW_EXT_semaphore_win32, glewIsSupported("GL_EXT_semaphore_win32"), glewGetExtension("GL_EXT_semaphore_win32"));
+
+  glewInfoFunc("glImportSemaphoreWin32HandleEXT", glImportSemaphoreWin32HandleEXT == NULL);
+  glewInfoFunc("glImportSemaphoreWin32NameEXT", glImportSemaphoreWin32NameEXT == NULL);
+}
+
+#endif /* GL_EXT_semaphore_win32 */
+
 #ifdef GL_EXT_separate_shader_objects
 
 static void _glewInfo_GL_EXT_separate_shader_objects (void)
@@ -4659,6 +5629,24 @@ static void _glewInfo_GL_EXT_separate_specular_color (void)
 
 #endif /* GL_EXT_separate_specular_color */
 
+#ifdef GL_EXT_shader_framebuffer_fetch
+
+static void _glewInfo_GL_EXT_shader_framebuffer_fetch (void)
+{
+  glewPrintExt("GL_EXT_shader_framebuffer_fetch", GLEW_EXT_shader_framebuffer_fetch, glewIsSupported("GL_EXT_shader_framebuffer_fetch"), glewGetExtension("GL_EXT_shader_framebuffer_fetch"));
+}
+
+#endif /* GL_EXT_shader_framebuffer_fetch */
+
+#ifdef GL_EXT_shader_group_vote
+
+static void _glewInfo_GL_EXT_shader_group_vote (void)
+{
+  glewPrintExt("GL_EXT_shader_group_vote", GLEW_EXT_shader_group_vote, glewIsSupported("GL_EXT_shader_group_vote"), glewGetExtension("GL_EXT_shader_group_vote"));
+}
+
+#endif /* GL_EXT_shader_group_vote */
+
 #ifdef GL_EXT_shader_image_load_formatted
 
 static void _glewInfo_GL_EXT_shader_image_load_formatted (void)
@@ -4680,6 +5668,15 @@ static void _glewInfo_GL_EXT_shader_image_load_store (void)
 
 #endif /* GL_EXT_shader_image_load_store */
 
+#ifdef GL_EXT_shader_implicit_conversions
+
+static void _glewInfo_GL_EXT_shader_implicit_conversions (void)
+{
+  glewPrintExt("GL_EXT_shader_implicit_conversions", GLEW_EXT_shader_implicit_conversions, glewIsSupported("GL_EXT_shader_implicit_conversions"), glewGetExtension("GL_EXT_shader_implicit_conversions"));
+}
+
+#endif /* GL_EXT_shader_implicit_conversions */
+
 #ifdef GL_EXT_shader_integer_mix
 
 static void _glewInfo_GL_EXT_shader_integer_mix (void)
@@ -4688,6 +5685,55 @@ static void _glewInfo_GL_EXT_shader_integer_mix (void)
 }
 
 #endif /* GL_EXT_shader_integer_mix */
+
+#ifdef GL_EXT_shader_io_blocks
+
+static void _glewInfo_GL_EXT_shader_io_blocks (void)
+{
+  glewPrintExt("GL_EXT_shader_io_blocks", GLEW_EXT_shader_io_blocks, glewIsSupported("GL_EXT_shader_io_blocks"), glewGetExtension("GL_EXT_shader_io_blocks"));
+}
+
+#endif /* GL_EXT_shader_io_blocks */
+
+#ifdef GL_EXT_shader_non_constant_global_initializers
+
+static void _glewInfo_GL_EXT_shader_non_constant_global_initializers (void)
+{
+  glewPrintExt("GL_EXT_shader_non_constant_global_initializers", GLEW_EXT_shader_non_constant_global_initializers, glewIsSupported("GL_EXT_shader_non_constant_global_initializers"), glewGetExtension("GL_EXT_shader_non_constant_global_initializers"));
+}
+
+#endif /* GL_EXT_shader_non_constant_global_initializers */
+
+#ifdef GL_EXT_shader_pixel_local_storage
+
+static void _glewInfo_GL_EXT_shader_pixel_local_storage (void)
+{
+  glewPrintExt("GL_EXT_shader_pixel_local_storage", GLEW_EXT_shader_pixel_local_storage, glewIsSupported("GL_EXT_shader_pixel_local_storage"), glewGetExtension("GL_EXT_shader_pixel_local_storage"));
+}
+
+#endif /* GL_EXT_shader_pixel_local_storage */
+
+#ifdef GL_EXT_shader_pixel_local_storage2
+
+static void _glewInfo_GL_EXT_shader_pixel_local_storage2 (void)
+{
+  glewPrintExt("GL_EXT_shader_pixel_local_storage2", GLEW_EXT_shader_pixel_local_storage2, glewIsSupported("GL_EXT_shader_pixel_local_storage2"), glewGetExtension("GL_EXT_shader_pixel_local_storage2"));
+
+  glewInfoFunc("glClearPixelLocalStorageuiEXT", glClearPixelLocalStorageuiEXT == NULL);
+  glewInfoFunc("glFramebufferPixelLocalStorageSizeEXT", glFramebufferPixelLocalStorageSizeEXT == NULL);
+  glewInfoFunc("glGetFramebufferPixelLocalStorageSizeEXT", glGetFramebufferPixelLocalStorageSizeEXT == NULL);
+}
+
+#endif /* GL_EXT_shader_pixel_local_storage2 */
+
+#ifdef GL_EXT_shader_texture_lod
+
+static void _glewInfo_GL_EXT_shader_texture_lod (void)
+{
+  glewPrintExt("GL_EXT_shader_texture_lod", GLEW_EXT_shader_texture_lod, glewIsSupported("GL_EXT_shader_texture_lod"), glewGetExtension("GL_EXT_shader_texture_lod"));
+}
+
+#endif /* GL_EXT_shader_texture_lod */
 
 #ifdef GL_EXT_shadow_funcs
 
@@ -4698,6 +5744,15 @@ static void _glewInfo_GL_EXT_shadow_funcs (void)
 
 #endif /* GL_EXT_shadow_funcs */
 
+#ifdef GL_EXT_shadow_samplers
+
+static void _glewInfo_GL_EXT_shadow_samplers (void)
+{
+  glewPrintExt("GL_EXT_shadow_samplers", GLEW_EXT_shadow_samplers, glewIsSupported("GL_EXT_shadow_samplers"), glewGetExtension("GL_EXT_shadow_samplers"));
+}
+
+#endif /* GL_EXT_shadow_samplers */
+
 #ifdef GL_EXT_shared_texture_palette
 
 static void _glewInfo_GL_EXT_shared_texture_palette (void)
@@ -4706,6 +5761,27 @@ static void _glewInfo_GL_EXT_shared_texture_palette (void)
 }
 
 #endif /* GL_EXT_shared_texture_palette */
+
+#ifdef GL_EXT_sparse_texture
+
+static void _glewInfo_GL_EXT_sparse_texture (void)
+{
+  glewPrintExt("GL_EXT_sparse_texture", GLEW_EXT_sparse_texture, glewIsSupported("GL_EXT_sparse_texture"), glewGetExtension("GL_EXT_sparse_texture"));
+
+  glewInfoFunc("glTexPageCommitmentEXT", glTexPageCommitmentEXT == NULL);
+  glewInfoFunc("glTexturePageCommitmentEXT", glTexturePageCommitmentEXT == NULL);
+}
+
+#endif /* GL_EXT_sparse_texture */
+
+#ifdef GL_EXT_sparse_texture2
+
+static void _glewInfo_GL_EXT_sparse_texture2 (void)
+{
+  glewPrintExt("GL_EXT_sparse_texture2", GLEW_EXT_sparse_texture2, glewIsSupported("GL_EXT_sparse_texture2"), glewGetExtension("GL_EXT_sparse_texture2"));
+}
+
+#endif /* GL_EXT_sparse_texture2 */
 
 #ifdef GL_EXT_stencil_clear_tag
 
@@ -4791,6 +5867,33 @@ static void _glewInfo_GL_EXT_texture_buffer_object (void)
 
 #endif /* GL_EXT_texture_buffer_object */
 
+#ifdef GL_EXT_texture_compression_astc_decode_mode
+
+static void _glewInfo_GL_EXT_texture_compression_astc_decode_mode (void)
+{
+  glewPrintExt("GL_EXT_texture_compression_astc_decode_mode", GLEW_EXT_texture_compression_astc_decode_mode, glewIsSupported("GL_EXT_texture_compression_astc_decode_mode"), glewGetExtension("GL_EXT_texture_compression_astc_decode_mode"));
+}
+
+#endif /* GL_EXT_texture_compression_astc_decode_mode */
+
+#ifdef GL_EXT_texture_compression_astc_decode_mode_rgb9e5
+
+static void _glewInfo_GL_EXT_texture_compression_astc_decode_mode_rgb9e5 (void)
+{
+  glewPrintExt("GL_EXT_texture_compression_astc_decode_mode_rgb9e5", GLEW_EXT_texture_compression_astc_decode_mode_rgb9e5, glewIsSupported("GL_EXT_texture_compression_astc_decode_mode_rgb9e5"), glewGetExtension("GL_EXT_texture_compression_astc_decode_mode_rgb9e5"));
+}
+
+#endif /* GL_EXT_texture_compression_astc_decode_mode_rgb9e5 */
+
+#ifdef GL_EXT_texture_compression_bptc
+
+static void _glewInfo_GL_EXT_texture_compression_bptc (void)
+{
+  glewPrintExt("GL_EXT_texture_compression_bptc", GLEW_EXT_texture_compression_bptc, glewIsSupported("GL_EXT_texture_compression_bptc"), glewGetExtension("GL_EXT_texture_compression_bptc"));
+}
+
+#endif /* GL_EXT_texture_compression_bptc */
+
 #ifdef GL_EXT_texture_compression_dxt1
 
 static void _glewInfo_GL_EXT_texture_compression_dxt1 (void)
@@ -4835,6 +5938,15 @@ static void _glewInfo_GL_EXT_texture_cube_map (void)
 }
 
 #endif /* GL_EXT_texture_cube_map */
+
+#ifdef GL_EXT_texture_cube_map_array
+
+static void _glewInfo_GL_EXT_texture_cube_map_array (void)
+{
+  glewPrintExt("GL_EXT_texture_cube_map_array", GLEW_EXT_texture_cube_map_array, glewIsSupported("GL_EXT_texture_cube_map_array"), glewGetExtension("GL_EXT_texture_cube_map_array"));
+}
+
+#endif /* GL_EXT_texture_cube_map_array */
 
 #ifdef GL_EXT_texture_edge_clamp
 
@@ -4890,6 +6002,24 @@ static void _glewInfo_GL_EXT_texture_filter_anisotropic (void)
 
 #endif /* GL_EXT_texture_filter_anisotropic */
 
+#ifdef GL_EXT_texture_filter_minmax
+
+static void _glewInfo_GL_EXT_texture_filter_minmax (void)
+{
+  glewPrintExt("GL_EXT_texture_filter_minmax", GLEW_EXT_texture_filter_minmax, glewIsSupported("GL_EXT_texture_filter_minmax"), glewGetExtension("GL_EXT_texture_filter_minmax"));
+}
+
+#endif /* GL_EXT_texture_filter_minmax */
+
+#ifdef GL_EXT_texture_format_BGRA8888
+
+static void _glewInfo_GL_EXT_texture_format_BGRA8888 (void)
+{
+  glewPrintExt("GL_EXT_texture_format_BGRA8888", GLEW_EXT_texture_format_BGRA8888, glewIsSupported("GL_EXT_texture_format_BGRA8888"), glewGetExtension("GL_EXT_texture_format_BGRA8888"));
+}
+
+#endif /* GL_EXT_texture_format_BGRA8888 */
+
 #ifdef GL_EXT_texture_integer
 
 static void _glewInfo_GL_EXT_texture_integer (void)
@@ -4923,6 +6053,15 @@ static void _glewInfo_GL_EXT_texture_mirror_clamp (void)
 }
 
 #endif /* GL_EXT_texture_mirror_clamp */
+
+#ifdef GL_EXT_texture_norm16
+
+static void _glewInfo_GL_EXT_texture_norm16 (void)
+{
+  glewPrintExt("GL_EXT_texture_norm16", GLEW_EXT_texture_norm16, glewIsSupported("GL_EXT_texture_norm16"), glewGetExtension("GL_EXT_texture_norm16"));
+}
+
+#endif /* GL_EXT_texture_norm16 */
 
 #ifdef GL_EXT_texture_object
 
@@ -4960,6 +6099,15 @@ static void _glewInfo_GL_EXT_texture_rectangle (void)
 
 #endif /* GL_EXT_texture_rectangle */
 
+#ifdef GL_EXT_texture_rg
+
+static void _glewInfo_GL_EXT_texture_rg (void)
+{
+  glewPrintExt("GL_EXT_texture_rg", GLEW_EXT_texture_rg, glewIsSupported("GL_EXT_texture_rg"), glewGetExtension("GL_EXT_texture_rg"));
+}
+
+#endif /* GL_EXT_texture_rg */
+
 #ifdef GL_EXT_texture_sRGB
 
 static void _glewInfo_GL_EXT_texture_sRGB (void)
@@ -4968,6 +6116,24 @@ static void _glewInfo_GL_EXT_texture_sRGB (void)
 }
 
 #endif /* GL_EXT_texture_sRGB */
+
+#ifdef GL_EXT_texture_sRGB_R8
+
+static void _glewInfo_GL_EXT_texture_sRGB_R8 (void)
+{
+  glewPrintExt("GL_EXT_texture_sRGB_R8", GLEW_EXT_texture_sRGB_R8, glewIsSupported("GL_EXT_texture_sRGB_R8"), glewGetExtension("GL_EXT_texture_sRGB_R8"));
+}
+
+#endif /* GL_EXT_texture_sRGB_R8 */
+
+#ifdef GL_EXT_texture_sRGB_RG8
+
+static void _glewInfo_GL_EXT_texture_sRGB_RG8 (void)
+{
+  glewPrintExt("GL_EXT_texture_sRGB_RG8", GLEW_EXT_texture_sRGB_RG8, glewIsSupported("GL_EXT_texture_sRGB_RG8"), glewGetExtension("GL_EXT_texture_sRGB_RG8"));
+}
+
+#endif /* GL_EXT_texture_sRGB_RG8 */
 
 #ifdef GL_EXT_texture_sRGB_decode
 
@@ -4996,6 +6162,22 @@ static void _glewInfo_GL_EXT_texture_snorm (void)
 
 #endif /* GL_EXT_texture_snorm */
 
+#ifdef GL_EXT_texture_storage
+
+static void _glewInfo_GL_EXT_texture_storage (void)
+{
+  glewPrintExt("GL_EXT_texture_storage", GLEW_EXT_texture_storage, glewIsSupported("GL_EXT_texture_storage"), glewGetExtension("GL_EXT_texture_storage"));
+
+  glewInfoFunc("glTexStorage1DEXT", glTexStorage1DEXT == NULL);
+  glewInfoFunc("glTexStorage2DEXT", glTexStorage2DEXT == NULL);
+  glewInfoFunc("glTexStorage3DEXT", glTexStorage3DEXT == NULL);
+  glewInfoFunc("glTextureStorage1DEXT", glTextureStorage1DEXT == NULL);
+  glewInfoFunc("glTextureStorage2DEXT", glTextureStorage2DEXT == NULL);
+  glewInfoFunc("glTextureStorage3DEXT", glTextureStorage3DEXT == NULL);
+}
+
+#endif /* GL_EXT_texture_storage */
+
 #ifdef GL_EXT_texture_swizzle
 
 static void _glewInfo_GL_EXT_texture_swizzle (void)
@@ -5004,6 +6186,26 @@ static void _glewInfo_GL_EXT_texture_swizzle (void)
 }
 
 #endif /* GL_EXT_texture_swizzle */
+
+#ifdef GL_EXT_texture_type_2_10_10_10_REV
+
+static void _glewInfo_GL_EXT_texture_type_2_10_10_10_REV (void)
+{
+  glewPrintExt("GL_EXT_texture_type_2_10_10_10_REV", GLEW_EXT_texture_type_2_10_10_10_REV, glewIsSupported("GL_EXT_texture_type_2_10_10_10_REV"), glewGetExtension("GL_EXT_texture_type_2_10_10_10_REV"));
+}
+
+#endif /* GL_EXT_texture_type_2_10_10_10_REV */
+
+#ifdef GL_EXT_texture_view
+
+static void _glewInfo_GL_EXT_texture_view (void)
+{
+  glewPrintExt("GL_EXT_texture_view", GLEW_EXT_texture_view, glewIsSupported("GL_EXT_texture_view"), glewGetExtension("GL_EXT_texture_view"));
+
+  glewInfoFunc("glTextureViewEXT", glTextureViewEXT == NULL);
+}
+
+#endif /* GL_EXT_texture_view */
 
 #ifdef GL_EXT_timer_query
 
@@ -5034,6 +6236,15 @@ static void _glewInfo_GL_EXT_transform_feedback (void)
 
 #endif /* GL_EXT_transform_feedback */
 
+#ifdef GL_EXT_unpack_subimage
+
+static void _glewInfo_GL_EXT_unpack_subimage (void)
+{
+  glewPrintExt("GL_EXT_unpack_subimage", GLEW_EXT_unpack_subimage, glewIsSupported("GL_EXT_unpack_subimage"), glewGetExtension("GL_EXT_unpack_subimage"));
+}
+
+#endif /* GL_EXT_unpack_subimage */
+
 #ifdef GL_EXT_vertex_array
 
 static void _glewInfo_GL_EXT_vertex_array (void)
@@ -5060,6 +6271,19 @@ static void _glewInfo_GL_EXT_vertex_array_bgra (void)
 }
 
 #endif /* GL_EXT_vertex_array_bgra */
+
+#ifdef GL_EXT_vertex_array_setXXX
+
+static void _glewInfo_GL_EXT_vertex_array_setXXX (void)
+{
+  glewPrintExt("GL_EXT_vertex_array_setXXX", GLEW_EXT_vertex_array_setXXX, glewIsSupported("GL_EXT_vertex_array_setXXX"), glewGetExtension("GL_EXT_vertex_array_setXXX"));
+
+  glewInfoFunc("glBindArraySetEXT", glBindArraySetEXT == NULL);
+  glewInfoFunc("glCreateArraySetExt", glCreateArraySetExt == NULL);
+  glewInfoFunc("glDeleteArraySetsEXT", glDeleteArraySetsEXT == NULL);
+}
+
+#endif /* GL_EXT_vertex_array_setXXX */
 
 #ifdef GL_EXT_vertex_attrib_64bit
 
@@ -5146,6 +6370,29 @@ static void _glewInfo_GL_EXT_vertex_weighting (void)
 }
 
 #endif /* GL_EXT_vertex_weighting */
+
+#ifdef GL_EXT_win32_keyed_mutex
+
+static void _glewInfo_GL_EXT_win32_keyed_mutex (void)
+{
+  glewPrintExt("GL_EXT_win32_keyed_mutex", GLEW_EXT_win32_keyed_mutex, glewIsSupported("GL_EXT_win32_keyed_mutex"), glewGetExtension("GL_EXT_win32_keyed_mutex"));
+
+  glewInfoFunc("glAcquireKeyedMutexWin32EXT", glAcquireKeyedMutexWin32EXT == NULL);
+  glewInfoFunc("glReleaseKeyedMutexWin32EXT", glReleaseKeyedMutexWin32EXT == NULL);
+}
+
+#endif /* GL_EXT_win32_keyed_mutex */
+
+#ifdef GL_EXT_window_rectangles
+
+static void _glewInfo_GL_EXT_window_rectangles (void)
+{
+  glewPrintExt("GL_EXT_window_rectangles", GLEW_EXT_window_rectangles, glewIsSupported("GL_EXT_window_rectangles"), glewGetExtension("GL_EXT_window_rectangles"));
+
+  glewInfoFunc("glWindowRectanglesEXT", glWindowRectanglesEXT == NULL);
+}
+
+#endif /* GL_EXT_window_rectangles */
 
 #ifdef GL_EXT_x11_sync_object
 
@@ -5307,6 +6554,15 @@ static void _glewInfo_GL_INGR_interlace_read (void)
 
 #endif /* GL_INGR_interlace_read */
 
+#ifdef GL_INTEL_conservative_rasterization
+
+static void _glewInfo_GL_INTEL_conservative_rasterization (void)
+{
+  glewPrintExt("GL_INTEL_conservative_rasterization", GLEW_INTEL_conservative_rasterization, glewIsSupported("GL_INTEL_conservative_rasterization"), glewGetExtension("GL_INTEL_conservative_rasterization"));
+}
+
+#endif /* GL_INTEL_conservative_rasterization */
+
 #ifdef GL_INTEL_fragment_shader_ordering
 
 static void _glewInfo_GL_INTEL_fragment_shader_ordering (void)
@@ -5315,6 +6571,15 @@ static void _glewInfo_GL_INTEL_fragment_shader_ordering (void)
 }
 
 #endif /* GL_INTEL_fragment_shader_ordering */
+
+#ifdef GL_INTEL_framebuffer_CMAA
+
+static void _glewInfo_GL_INTEL_framebuffer_CMAA (void)
+{
+  glewPrintExt("GL_INTEL_framebuffer_CMAA", GLEW_INTEL_framebuffer_CMAA, glewIsSupported("GL_INTEL_framebuffer_CMAA"), glewGetExtension("GL_INTEL_framebuffer_CMAA"));
+}
+
+#endif /* GL_INTEL_framebuffer_CMAA */
 
 #ifdef GL_INTEL_map_texture
 
@@ -5424,6 +6689,26 @@ static void _glewInfo_GL_KHR_debug (void)
 
 #endif /* GL_KHR_debug */
 
+#ifdef GL_KHR_no_error
+
+static void _glewInfo_GL_KHR_no_error (void)
+{
+  glewPrintExt("GL_KHR_no_error", GLEW_KHR_no_error, glewIsSupported("GL_KHR_no_error"), glewGetExtension("GL_KHR_no_error"));
+}
+
+#endif /* GL_KHR_no_error */
+
+#ifdef GL_KHR_parallel_shader_compile
+
+static void _glewInfo_GL_KHR_parallel_shader_compile (void)
+{
+  glewPrintExt("GL_KHR_parallel_shader_compile", GLEW_KHR_parallel_shader_compile, glewIsSupported("GL_KHR_parallel_shader_compile"), glewGetExtension("GL_KHR_parallel_shader_compile"));
+
+  glewInfoFunc("glMaxShaderCompilerThreadsKHR", glMaxShaderCompilerThreadsKHR == NULL);
+}
+
+#endif /* GL_KHR_parallel_shader_compile */
+
 #ifdef GL_KHR_robust_buffer_access_behavior
 
 static void _glewInfo_GL_KHR_robust_buffer_access_behavior (void)
@@ -5464,6 +6749,15 @@ static void _glewInfo_GL_KHR_texture_compression_astc_ldr (void)
 }
 
 #endif /* GL_KHR_texture_compression_astc_ldr */
+
+#ifdef GL_KHR_texture_compression_astc_sliced_3d
+
+static void _glewInfo_GL_KHR_texture_compression_astc_sliced_3d (void)
+{
+  glewPrintExt("GL_KHR_texture_compression_astc_sliced_3d", GLEW_KHR_texture_compression_astc_sliced_3d, glewIsSupported("GL_KHR_texture_compression_astc_sliced_3d"), glewGetExtension("GL_KHR_texture_compression_astc_sliced_3d"));
+}
+
+#endif /* GL_KHR_texture_compression_astc_sliced_3d */
 
 #ifdef GL_KTX_buffer_region
 
@@ -5509,6 +6803,15 @@ static void _glewInfo_GL_MESA_resize_buffers (void)
 
 #endif /* GL_MESA_resize_buffers */
 
+#ifdef GL_MESA_shader_integer_functions
+
+static void _glewInfo_GL_MESA_shader_integer_functions (void)
+{
+  glewPrintExt("GL_MESA_shader_integer_functions", GLEW_MESA_shader_integer_functions, glewIsSupported("GL_MESA_shader_integer_functions"), glewGetExtension("GL_MESA_shader_integer_functions"));
+}
+
+#endif /* GL_MESA_shader_integer_functions */
+
 #ifdef GL_MESA_window_pos
 
 static void _glewInfo_GL_MESA_window_pos (void)
@@ -5552,6 +6855,15 @@ static void _glewInfo_GL_MESA_ycbcr_texture (void)
 
 #endif /* GL_MESA_ycbcr_texture */
 
+#ifdef GL_NVX_blend_equation_advanced_multi_draw_buffers
+
+static void _glewInfo_GL_NVX_blend_equation_advanced_multi_draw_buffers (void)
+{
+  glewPrintExt("GL_NVX_blend_equation_advanced_multi_draw_buffers", GLEW_NVX_blend_equation_advanced_multi_draw_buffers, glewIsSupported("GL_NVX_blend_equation_advanced_multi_draw_buffers"), glewGetExtension("GL_NVX_blend_equation_advanced_multi_draw_buffers"));
+}
+
+#endif /* GL_NVX_blend_equation_advanced_multi_draw_buffers */
+
 #ifdef GL_NVX_conditional_render
 
 static void _glewInfo_GL_NVX_conditional_render (void)
@@ -5572,6 +6884,58 @@ static void _glewInfo_GL_NVX_gpu_memory_info (void)
 }
 
 #endif /* GL_NVX_gpu_memory_info */
+
+#ifdef GL_NVX_linked_gpu_multicast
+
+static void _glewInfo_GL_NVX_linked_gpu_multicast (void)
+{
+  glewPrintExt("GL_NVX_linked_gpu_multicast", GLEW_NVX_linked_gpu_multicast, glewIsSupported("GL_NVX_linked_gpu_multicast"), glewGetExtension("GL_NVX_linked_gpu_multicast"));
+
+  glewInfoFunc("glLGPUCopyImageSubDataNVX", glLGPUCopyImageSubDataNVX == NULL);
+  glewInfoFunc("glLGPUInterlockNVX", glLGPUInterlockNVX == NULL);
+  glewInfoFunc("glLGPUNamedBufferSubDataNVX", glLGPUNamedBufferSubDataNVX == NULL);
+}
+
+#endif /* GL_NVX_linked_gpu_multicast */
+
+#ifdef GL_NV_3dvision_settings
+
+static void _glewInfo_GL_NV_3dvision_settings (void)
+{
+  glewPrintExt("GL_NV_3dvision_settings", GLEW_NV_3dvision_settings, glewIsSupported("GL_NV_3dvision_settings"), glewGetExtension("GL_NV_3dvision_settings"));
+
+  glewInfoFunc("glStereoParameterfNV", glStereoParameterfNV == NULL);
+  glewInfoFunc("glStereoParameteriNV", glStereoParameteriNV == NULL);
+}
+
+#endif /* GL_NV_3dvision_settings */
+
+#ifdef GL_NV_EGL_stream_consumer_external
+
+static void _glewInfo_GL_NV_EGL_stream_consumer_external (void)
+{
+  glewPrintExt("GL_NV_EGL_stream_consumer_external", GLEW_NV_EGL_stream_consumer_external, glewIsSupported("GL_NV_EGL_stream_consumer_external"), glewGetExtension("GL_NV_EGL_stream_consumer_external"));
+}
+
+#endif /* GL_NV_EGL_stream_consumer_external */
+
+#ifdef GL_NV_alpha_to_coverage_dither_control
+
+static void _glewInfo_GL_NV_alpha_to_coverage_dither_control (void)
+{
+  glewPrintExt("GL_NV_alpha_to_coverage_dither_control", GLEW_NV_alpha_to_coverage_dither_control, glewIsSupported("GL_NV_alpha_to_coverage_dither_control"), glewGetExtension("GL_NV_alpha_to_coverage_dither_control"));
+}
+
+#endif /* GL_NV_alpha_to_coverage_dither_control */
+
+#ifdef GL_NV_bgr
+
+static void _glewInfo_GL_NV_bgr (void)
+{
+  glewPrintExt("GL_NV_bgr", GLEW_NV_bgr, glewIsSupported("GL_NV_bgr"), glewGetExtension("GL_NV_bgr"));
+}
+
+#endif /* GL_NV_bgr */
 
 #ifdef GL_NV_bindless_multi_draw_indirect
 
@@ -5641,6 +7005,15 @@ static void _glewInfo_GL_NV_blend_equation_advanced_coherent (void)
 
 #endif /* GL_NV_blend_equation_advanced_coherent */
 
+#ifdef GL_NV_blend_minmax_factor
+
+static void _glewInfo_GL_NV_blend_minmax_factor (void)
+{
+  glewPrintExt("GL_NV_blend_minmax_factor", GLEW_NV_blend_minmax_factor, glewIsSupported("GL_NV_blend_minmax_factor"), glewGetExtension("GL_NV_blend_minmax_factor"));
+}
+
+#endif /* GL_NV_blend_minmax_factor */
+
 #ifdef GL_NV_blend_square
 
 static void _glewInfo_GL_NV_blend_square (void)
@@ -5649,6 +7022,44 @@ static void _glewInfo_GL_NV_blend_square (void)
 }
 
 #endif /* GL_NV_blend_square */
+
+#ifdef GL_NV_clip_space_w_scaling
+
+static void _glewInfo_GL_NV_clip_space_w_scaling (void)
+{
+  glewPrintExt("GL_NV_clip_space_w_scaling", GLEW_NV_clip_space_w_scaling, glewIsSupported("GL_NV_clip_space_w_scaling"), glewGetExtension("GL_NV_clip_space_w_scaling"));
+
+  glewInfoFunc("glViewportPositionWScaleNV", glViewportPositionWScaleNV == NULL);
+}
+
+#endif /* GL_NV_clip_space_w_scaling */
+
+#ifdef GL_NV_command_list
+
+static void _glewInfo_GL_NV_command_list (void)
+{
+  glewPrintExt("GL_NV_command_list", GLEW_NV_command_list, glewIsSupported("GL_NV_command_list"), glewGetExtension("GL_NV_command_list"));
+
+  glewInfoFunc("glCallCommandListNV", glCallCommandListNV == NULL);
+  glewInfoFunc("glCommandListSegmentsNV", glCommandListSegmentsNV == NULL);
+  glewInfoFunc("glCompileCommandListNV", glCompileCommandListNV == NULL);
+  glewInfoFunc("glCreateCommandListsNV", glCreateCommandListsNV == NULL);
+  glewInfoFunc("glCreateStatesNV", glCreateStatesNV == NULL);
+  glewInfoFunc("glDeleteCommandListsNV", glDeleteCommandListsNV == NULL);
+  glewInfoFunc("glDeleteStatesNV", glDeleteStatesNV == NULL);
+  glewInfoFunc("glDrawCommandsAddressNV", glDrawCommandsAddressNV == NULL);
+  glewInfoFunc("glDrawCommandsNV", glDrawCommandsNV == NULL);
+  glewInfoFunc("glDrawCommandsStatesAddressNV", glDrawCommandsStatesAddressNV == NULL);
+  glewInfoFunc("glDrawCommandsStatesNV", glDrawCommandsStatesNV == NULL);
+  glewInfoFunc("glGetCommandHeaderNV", glGetCommandHeaderNV == NULL);
+  glewInfoFunc("glGetStageIndexNV", glGetStageIndexNV == NULL);
+  glewInfoFunc("glIsCommandListNV", glIsCommandListNV == NULL);
+  glewInfoFunc("glIsStateNV", glIsStateNV == NULL);
+  glewInfoFunc("glListDrawCommandsStatesClientNV", glListDrawCommandsStatesClientNV == NULL);
+  glewInfoFunc("glStateCaptureNV", glStateCaptureNV == NULL);
+}
+
+#endif /* GL_NV_command_list */
 
 #ifdef GL_NV_compute_program5
 
@@ -5670,6 +7081,50 @@ static void _glewInfo_GL_NV_conditional_render (void)
 }
 
 #endif /* GL_NV_conditional_render */
+
+#ifdef GL_NV_conservative_raster
+
+static void _glewInfo_GL_NV_conservative_raster (void)
+{
+  glewPrintExt("GL_NV_conservative_raster", GLEW_NV_conservative_raster, glewIsSupported("GL_NV_conservative_raster"), glewGetExtension("GL_NV_conservative_raster"));
+
+  glewInfoFunc("glSubpixelPrecisionBiasNV", glSubpixelPrecisionBiasNV == NULL);
+}
+
+#endif /* GL_NV_conservative_raster */
+
+#ifdef GL_NV_conservative_raster_dilate
+
+static void _glewInfo_GL_NV_conservative_raster_dilate (void)
+{
+  glewPrintExt("GL_NV_conservative_raster_dilate", GLEW_NV_conservative_raster_dilate, glewIsSupported("GL_NV_conservative_raster_dilate"), glewGetExtension("GL_NV_conservative_raster_dilate"));
+
+  glewInfoFunc("glConservativeRasterParameterfNV", glConservativeRasterParameterfNV == NULL);
+}
+
+#endif /* GL_NV_conservative_raster_dilate */
+
+#ifdef GL_NV_conservative_raster_pre_snap_triangles
+
+static void _glewInfo_GL_NV_conservative_raster_pre_snap_triangles (void)
+{
+  glewPrintExt("GL_NV_conservative_raster_pre_snap_triangles", GLEW_NV_conservative_raster_pre_snap_triangles, glewIsSupported("GL_NV_conservative_raster_pre_snap_triangles"), glewGetExtension("GL_NV_conservative_raster_pre_snap_triangles"));
+
+  glewInfoFunc("glConservativeRasterParameteriNV", glConservativeRasterParameteriNV == NULL);
+}
+
+#endif /* GL_NV_conservative_raster_pre_snap_triangles */
+
+#ifdef GL_NV_copy_buffer
+
+static void _glewInfo_GL_NV_copy_buffer (void)
+{
+  glewPrintExt("GL_NV_copy_buffer", GLEW_NV_copy_buffer, glewIsSupported("GL_NV_copy_buffer"), glewGetExtension("GL_NV_copy_buffer"));
+
+  glewInfoFunc("glCopyBufferSubDataNV", glCopyBufferSubDataNV == NULL);
+}
+
+#endif /* GL_NV_copy_buffer */
 
 #ifdef GL_NV_copy_depth_to_color
 
@@ -5731,6 +7186,29 @@ static void _glewInfo_GL_NV_depth_range_unclamped (void)
 
 #endif /* GL_NV_depth_range_unclamped */
 
+#ifdef GL_NV_draw_buffers
+
+static void _glewInfo_GL_NV_draw_buffers (void)
+{
+  glewPrintExt("GL_NV_draw_buffers", GLEW_NV_draw_buffers, glewIsSupported("GL_NV_draw_buffers"), glewGetExtension("GL_NV_draw_buffers"));
+
+  glewInfoFunc("glDrawBuffersNV", glDrawBuffersNV == NULL);
+}
+
+#endif /* GL_NV_draw_buffers */
+
+#ifdef GL_NV_draw_instanced
+
+static void _glewInfo_GL_NV_draw_instanced (void)
+{
+  glewPrintExt("GL_NV_draw_instanced", GLEW_NV_draw_instanced, glewIsSupported("GL_NV_draw_instanced"), glewGetExtension("GL_NV_draw_instanced"));
+
+  glewInfoFunc("glDrawArraysInstancedNV", glDrawArraysInstancedNV == NULL);
+  glewInfoFunc("glDrawElementsInstancedNV", glDrawElementsInstancedNV == NULL);
+}
+
+#endif /* GL_NV_draw_instanced */
+
 #ifdef GL_NV_draw_texture
 
 static void _glewInfo_GL_NV_draw_texture (void)
@@ -5741,6 +7219,21 @@ static void _glewInfo_GL_NV_draw_texture (void)
 }
 
 #endif /* GL_NV_draw_texture */
+
+#ifdef GL_NV_draw_vulkan_image
+
+static void _glewInfo_GL_NV_draw_vulkan_image (void)
+{
+  glewPrintExt("GL_NV_draw_vulkan_image", GLEW_NV_draw_vulkan_image, glewIsSupported("GL_NV_draw_vulkan_image"), glewGetExtension("GL_NV_draw_vulkan_image"));
+
+  glewInfoFunc("glDrawVkImageNV", glDrawVkImageNV == NULL);
+  glewInfoFunc("glGetVkProcAddrNV", glGetVkProcAddrNV == NULL);
+  glewInfoFunc("glSignalVkFenceNV", glSignalVkFenceNV == NULL);
+  glewInfoFunc("glSignalVkSemaphoreNV", glSignalVkSemaphoreNV == NULL);
+  glewInfoFunc("glWaitVkSemaphoreNV", glWaitVkSemaphoreNV == NULL);
+}
+
+#endif /* GL_NV_draw_vulkan_image */
 
 #ifdef GL_NV_evaluators
 
@@ -5761,6 +7254,15 @@ static void _glewInfo_GL_NV_evaluators (void)
 
 #endif /* GL_NV_evaluators */
 
+#ifdef GL_NV_explicit_attrib_location
+
+static void _glewInfo_GL_NV_explicit_attrib_location (void)
+{
+  glewPrintExt("GL_NV_explicit_attrib_location", GLEW_NV_explicit_attrib_location, glewIsSupported("GL_NV_explicit_attrib_location"), glewGetExtension("GL_NV_explicit_attrib_location"));
+}
+
+#endif /* GL_NV_explicit_attrib_location */
+
 #ifdef GL_NV_explicit_multisample
 
 static void _glewInfo_GL_NV_explicit_multisample (void)
@@ -5773,6 +7275,15 @@ static void _glewInfo_GL_NV_explicit_multisample (void)
 }
 
 #endif /* GL_NV_explicit_multisample */
+
+#ifdef GL_NV_fbo_color_attachments
+
+static void _glewInfo_GL_NV_fbo_color_attachments (void)
+{
+  glewPrintExt("GL_NV_fbo_color_attachments", GLEW_NV_fbo_color_attachments, glewIsSupported("GL_NV_fbo_color_attachments"), glewGetExtension("GL_NV_fbo_color_attachments"));
+}
+
+#endif /* GL_NV_fbo_color_attachments */
 
 #ifdef GL_NV_fence
 
@@ -5791,6 +7302,15 @@ static void _glewInfo_GL_NV_fence (void)
 
 #endif /* GL_NV_fence */
 
+#ifdef GL_NV_fill_rectangle
+
+static void _glewInfo_GL_NV_fill_rectangle (void)
+{
+  glewPrintExt("GL_NV_fill_rectangle", GLEW_NV_fill_rectangle, glewIsSupported("GL_NV_fill_rectangle"), glewGetExtension("GL_NV_fill_rectangle"));
+}
+
+#endif /* GL_NV_fill_rectangle */
+
 #ifdef GL_NV_float_buffer
 
 static void _glewInfo_GL_NV_float_buffer (void)
@@ -5808,6 +7328,17 @@ static void _glewInfo_GL_NV_fog_distance (void)
 }
 
 #endif /* GL_NV_fog_distance */
+
+#ifdef GL_NV_fragment_coverage_to_color
+
+static void _glewInfo_GL_NV_fragment_coverage_to_color (void)
+{
+  glewPrintExt("GL_NV_fragment_coverage_to_color", GLEW_NV_fragment_coverage_to_color, glewIsSupported("GL_NV_fragment_coverage_to_color"), glewGetExtension("GL_NV_fragment_coverage_to_color"));
+
+  glewInfoFunc("glFragmentCoverageColorNV", glFragmentCoverageColorNV == NULL);
+}
+
+#endif /* GL_NV_fragment_coverage_to_color */
 
 #ifdef GL_NV_fragment_program
 
@@ -5852,6 +7383,46 @@ static void _glewInfo_GL_NV_fragment_program_option (void)
 
 #endif /* GL_NV_fragment_program_option */
 
+#ifdef GL_NV_fragment_shader_interlock
+
+static void _glewInfo_GL_NV_fragment_shader_interlock (void)
+{
+  glewPrintExt("GL_NV_fragment_shader_interlock", GLEW_NV_fragment_shader_interlock, glewIsSupported("GL_NV_fragment_shader_interlock"), glewGetExtension("GL_NV_fragment_shader_interlock"));
+}
+
+#endif /* GL_NV_fragment_shader_interlock */
+
+#ifdef GL_NV_framebuffer_blit
+
+static void _glewInfo_GL_NV_framebuffer_blit (void)
+{
+  glewPrintExt("GL_NV_framebuffer_blit", GLEW_NV_framebuffer_blit, glewIsSupported("GL_NV_framebuffer_blit"), glewGetExtension("GL_NV_framebuffer_blit"));
+
+  glewInfoFunc("glBlitFramebufferNV", glBlitFramebufferNV == NULL);
+}
+
+#endif /* GL_NV_framebuffer_blit */
+
+#ifdef GL_NV_framebuffer_mixed_samples
+
+static void _glewInfo_GL_NV_framebuffer_mixed_samples (void)
+{
+  glewPrintExt("GL_NV_framebuffer_mixed_samples", GLEW_NV_framebuffer_mixed_samples, glewIsSupported("GL_NV_framebuffer_mixed_samples"), glewGetExtension("GL_NV_framebuffer_mixed_samples"));
+}
+
+#endif /* GL_NV_framebuffer_mixed_samples */
+
+#ifdef GL_NV_framebuffer_multisample
+
+static void _glewInfo_GL_NV_framebuffer_multisample (void)
+{
+  glewPrintExt("GL_NV_framebuffer_multisample", GLEW_NV_framebuffer_multisample, glewIsSupported("GL_NV_framebuffer_multisample"), glewGetExtension("GL_NV_framebuffer_multisample"));
+
+  glewInfoFunc("glRenderbufferStorageMultisampleNV", glRenderbufferStorageMultisampleNV == NULL);
+}
+
+#endif /* GL_NV_framebuffer_multisample */
+
 #ifdef GL_NV_framebuffer_multisample_coverage
 
 static void _glewInfo_GL_NV_framebuffer_multisample_coverage (void)
@@ -5862,6 +7433,15 @@ static void _glewInfo_GL_NV_framebuffer_multisample_coverage (void)
 }
 
 #endif /* GL_NV_framebuffer_multisample_coverage */
+
+#ifdef GL_NV_generate_mipmap_sRGB
+
+static void _glewInfo_GL_NV_generate_mipmap_sRGB (void)
+{
+  glewPrintExt("GL_NV_generate_mipmap_sRGB", GLEW_NV_generate_mipmap_sRGB, glewIsSupported("GL_NV_generate_mipmap_sRGB"), glewGetExtension("GL_NV_generate_mipmap_sRGB"));
+}
+
+#endif /* GL_NV_generate_mipmap_sRGB */
 
 #ifdef GL_NV_geometry_program4
 
@@ -5882,6 +7462,37 @@ static void _glewInfo_GL_NV_geometry_shader4 (void)
 }
 
 #endif /* GL_NV_geometry_shader4 */
+
+#ifdef GL_NV_geometry_shader_passthrough
+
+static void _glewInfo_GL_NV_geometry_shader_passthrough (void)
+{
+  glewPrintExt("GL_NV_geometry_shader_passthrough", GLEW_NV_geometry_shader_passthrough, glewIsSupported("GL_NV_geometry_shader_passthrough"), glewGetExtension("GL_NV_geometry_shader_passthrough"));
+}
+
+#endif /* GL_NV_geometry_shader_passthrough */
+
+#ifdef GL_NV_gpu_multicast
+
+static void _glewInfo_GL_NV_gpu_multicast (void)
+{
+  glewPrintExt("GL_NV_gpu_multicast", GLEW_NV_gpu_multicast, glewIsSupported("GL_NV_gpu_multicast"), glewGetExtension("GL_NV_gpu_multicast"));
+
+  glewInfoFunc("glMulticastBarrierNV", glMulticastBarrierNV == NULL);
+  glewInfoFunc("glMulticastBlitFramebufferNV", glMulticastBlitFramebufferNV == NULL);
+  glewInfoFunc("glMulticastBufferSubDataNV", glMulticastBufferSubDataNV == NULL);
+  glewInfoFunc("glMulticastCopyBufferSubDataNV", glMulticastCopyBufferSubDataNV == NULL);
+  glewInfoFunc("glMulticastCopyImageSubDataNV", glMulticastCopyImageSubDataNV == NULL);
+  glewInfoFunc("glMulticastFramebufferSampleLocationsfvNV", glMulticastFramebufferSampleLocationsfvNV == NULL);
+  glewInfoFunc("glMulticastGetQueryObjecti64vNV", glMulticastGetQueryObjecti64vNV == NULL);
+  glewInfoFunc("glMulticastGetQueryObjectivNV", glMulticastGetQueryObjectivNV == NULL);
+  glewInfoFunc("glMulticastGetQueryObjectui64vNV", glMulticastGetQueryObjectui64vNV == NULL);
+  glewInfoFunc("glMulticastGetQueryObjectuivNV", glMulticastGetQueryObjectuivNV == NULL);
+  glewInfoFunc("glMulticastWaitSyncNV", glMulticastWaitSyncNV == NULL);
+  glewInfoFunc("glRenderGpuMaskNV", glRenderGpuMaskNV == NULL);
+}
+
+#endif /* GL_NV_gpu_multicast */
 
 #ifdef GL_NV_gpu_program4
 
@@ -6032,6 +7643,37 @@ static void _glewInfo_GL_NV_half_float (void)
 
 #endif /* GL_NV_half_float */
 
+#ifdef GL_NV_image_formats
+
+static void _glewInfo_GL_NV_image_formats (void)
+{
+  glewPrintExt("GL_NV_image_formats", GLEW_NV_image_formats, glewIsSupported("GL_NV_image_formats"), glewGetExtension("GL_NV_image_formats"));
+}
+
+#endif /* GL_NV_image_formats */
+
+#ifdef GL_NV_instanced_arrays
+
+static void _glewInfo_GL_NV_instanced_arrays (void)
+{
+  glewPrintExt("GL_NV_instanced_arrays", GLEW_NV_instanced_arrays, glewIsSupported("GL_NV_instanced_arrays"), glewGetExtension("GL_NV_instanced_arrays"));
+
+  glewInfoFunc("glVertexAttribDivisorNV", glVertexAttribDivisorNV == NULL);
+}
+
+#endif /* GL_NV_instanced_arrays */
+
+#ifdef GL_NV_internalformat_sample_query
+
+static void _glewInfo_GL_NV_internalformat_sample_query (void)
+{
+  glewPrintExt("GL_NV_internalformat_sample_query", GLEW_NV_internalformat_sample_query, glewIsSupported("GL_NV_internalformat_sample_query"), glewGetExtension("GL_NV_internalformat_sample_query"));
+
+  glewInfoFunc("glGetInternalformatSampleivNV", glGetInternalformatSampleivNV == NULL);
+}
+
+#endif /* GL_NV_internalformat_sample_query */
+
 #ifdef GL_NV_light_max_exponent
 
 static void _glewInfo_GL_NV_light_max_exponent (void)
@@ -6059,6 +7701,22 @@ static void _glewInfo_GL_NV_multisample_filter_hint (void)
 
 #endif /* GL_NV_multisample_filter_hint */
 
+#ifdef GL_NV_non_square_matrices
+
+static void _glewInfo_GL_NV_non_square_matrices (void)
+{
+  glewPrintExt("GL_NV_non_square_matrices", GLEW_NV_non_square_matrices, glewIsSupported("GL_NV_non_square_matrices"), glewGetExtension("GL_NV_non_square_matrices"));
+
+  glewInfoFunc("glUniformMatrix2x3fvNV", glUniformMatrix2x3fvNV == NULL);
+  glewInfoFunc("glUniformMatrix2x4fvNV", glUniformMatrix2x4fvNV == NULL);
+  glewInfoFunc("glUniformMatrix3x2fvNV", glUniformMatrix3x2fvNV == NULL);
+  glewInfoFunc("glUniformMatrix3x4fvNV", glUniformMatrix3x4fvNV == NULL);
+  glewInfoFunc("glUniformMatrix4x2fvNV", glUniformMatrix4x2fvNV == NULL);
+  glewInfoFunc("glUniformMatrix4x3fvNV", glUniformMatrix4x3fvNV == NULL);
+}
+
+#endif /* GL_NV_non_square_matrices */
+
 #ifdef GL_NV_occlusion_query
 
 static void _glewInfo_GL_NV_occlusion_query (void)
@@ -6076,6 +7734,15 @@ static void _glewInfo_GL_NV_occlusion_query (void)
 
 #endif /* GL_NV_occlusion_query */
 
+#ifdef GL_NV_pack_subimage
+
+static void _glewInfo_GL_NV_pack_subimage (void)
+{
+  glewPrintExt("GL_NV_pack_subimage", GLEW_NV_pack_subimage, glewIsSupported("GL_NV_pack_subimage"), glewGetExtension("GL_NV_pack_subimage"));
+}
+
+#endif /* GL_NV_pack_subimage */
+
 #ifdef GL_NV_packed_depth_stencil
 
 static void _glewInfo_GL_NV_packed_depth_stencil (void)
@@ -6084,6 +7751,24 @@ static void _glewInfo_GL_NV_packed_depth_stencil (void)
 }
 
 #endif /* GL_NV_packed_depth_stencil */
+
+#ifdef GL_NV_packed_float
+
+static void _glewInfo_GL_NV_packed_float (void)
+{
+  glewPrintExt("GL_NV_packed_float", GLEW_NV_packed_float, glewIsSupported("GL_NV_packed_float"), glewGetExtension("GL_NV_packed_float"));
+}
+
+#endif /* GL_NV_packed_float */
+
+#ifdef GL_NV_packed_float_linear
+
+static void _glewInfo_GL_NV_packed_float_linear (void)
+{
+  glewPrintExt("GL_NV_packed_float_linear", GLEW_NV_packed_float_linear, glewIsSupported("GL_NV_packed_float_linear"), glewGetExtension("GL_NV_packed_float_linear"));
+}
+
+#endif /* GL_NV_packed_float_linear */
 
 #ifdef GL_NV_parameter_buffer_object
 
@@ -6133,18 +7818,28 @@ static void _glewInfo_GL_NV_path_rendering (void)
   glewInfoFunc("glGetPathSpacingNV", glGetPathSpacingNV == NULL);
   glewInfoFunc("glGetPathTexGenfvNV", glGetPathTexGenfvNV == NULL);
   glewInfoFunc("glGetPathTexGenivNV", glGetPathTexGenivNV == NULL);
+  glewInfoFunc("glGetProgramResourcefvNV", glGetProgramResourcefvNV == NULL);
   glewInfoFunc("glInterpolatePathsNV", glInterpolatePathsNV == NULL);
   glewInfoFunc("glIsPathNV", glIsPathNV == NULL);
   glewInfoFunc("glIsPointInFillPathNV", glIsPointInFillPathNV == NULL);
   glewInfoFunc("glIsPointInStrokePathNV", glIsPointInStrokePathNV == NULL);
+  glewInfoFunc("glMatrixLoad3x2fNV", glMatrixLoad3x2fNV == NULL);
+  glewInfoFunc("glMatrixLoad3x3fNV", glMatrixLoad3x3fNV == NULL);
+  glewInfoFunc("glMatrixLoadTranspose3x3fNV", glMatrixLoadTranspose3x3fNV == NULL);
+  glewInfoFunc("glMatrixMult3x2fNV", glMatrixMult3x2fNV == NULL);
+  glewInfoFunc("glMatrixMult3x3fNV", glMatrixMult3x3fNV == NULL);
+  glewInfoFunc("glMatrixMultTranspose3x3fNV", glMatrixMultTranspose3x3fNV == NULL);
   glewInfoFunc("glPathColorGenNV", glPathColorGenNV == NULL);
   glewInfoFunc("glPathCommandsNV", glPathCommandsNV == NULL);
   glewInfoFunc("glPathCoordsNV", glPathCoordsNV == NULL);
   glewInfoFunc("glPathCoverDepthFuncNV", glPathCoverDepthFuncNV == NULL);
   glewInfoFunc("glPathDashArrayNV", glPathDashArrayNV == NULL);
   glewInfoFunc("glPathFogGenNV", glPathFogGenNV == NULL);
+  glewInfoFunc("glPathGlyphIndexArrayNV", glPathGlyphIndexArrayNV == NULL);
+  glewInfoFunc("glPathGlyphIndexRangeNV", glPathGlyphIndexRangeNV == NULL);
   glewInfoFunc("glPathGlyphRangeNV", glPathGlyphRangeNV == NULL);
   glewInfoFunc("glPathGlyphsNV", glPathGlyphsNV == NULL);
+  glewInfoFunc("glPathMemoryGlyphIndexArrayNV", glPathMemoryGlyphIndexArrayNV == NULL);
   glewInfoFunc("glPathParameterfNV", glPathParameterfNV == NULL);
   glewInfoFunc("glPathParameterfvNV", glPathParameterfvNV == NULL);
   glewInfoFunc("glPathParameteriNV", glPathParameteriNV == NULL);
@@ -6156,15 +7851,38 @@ static void _glewInfo_GL_NV_path_rendering (void)
   glewInfoFunc("glPathSubCoordsNV", glPathSubCoordsNV == NULL);
   glewInfoFunc("glPathTexGenNV", glPathTexGenNV == NULL);
   glewInfoFunc("glPointAlongPathNV", glPointAlongPathNV == NULL);
+  glewInfoFunc("glProgramPathFragmentInputGenNV", glProgramPathFragmentInputGenNV == NULL);
   glewInfoFunc("glStencilFillPathInstancedNV", glStencilFillPathInstancedNV == NULL);
   glewInfoFunc("glStencilFillPathNV", glStencilFillPathNV == NULL);
   glewInfoFunc("glStencilStrokePathInstancedNV", glStencilStrokePathInstancedNV == NULL);
   glewInfoFunc("glStencilStrokePathNV", glStencilStrokePathNV == NULL);
+  glewInfoFunc("glStencilThenCoverFillPathInstancedNV", glStencilThenCoverFillPathInstancedNV == NULL);
+  glewInfoFunc("glStencilThenCoverFillPathNV", glStencilThenCoverFillPathNV == NULL);
+  glewInfoFunc("glStencilThenCoverStrokePathInstancedNV", glStencilThenCoverStrokePathInstancedNV == NULL);
+  glewInfoFunc("glStencilThenCoverStrokePathNV", glStencilThenCoverStrokePathNV == NULL);
   glewInfoFunc("glTransformPathNV", glTransformPathNV == NULL);
   glewInfoFunc("glWeightPathsNV", glWeightPathsNV == NULL);
 }
 
 #endif /* GL_NV_path_rendering */
+
+#ifdef GL_NV_path_rendering_shared_edge
+
+static void _glewInfo_GL_NV_path_rendering_shared_edge (void)
+{
+  glewPrintExt("GL_NV_path_rendering_shared_edge", GLEW_NV_path_rendering_shared_edge, glewIsSupported("GL_NV_path_rendering_shared_edge"), glewGetExtension("GL_NV_path_rendering_shared_edge"));
+}
+
+#endif /* GL_NV_path_rendering_shared_edge */
+
+#ifdef GL_NV_pixel_buffer_object
+
+static void _glewInfo_GL_NV_pixel_buffer_object (void)
+{
+  glewPrintExt("GL_NV_pixel_buffer_object", GLEW_NV_pixel_buffer_object, glewIsSupported("GL_NV_pixel_buffer_object"), glewGetExtension("GL_NV_pixel_buffer_object"));
+}
+
+#endif /* GL_NV_pixel_buffer_object */
 
 #ifdef GL_NV_pixel_data_range
 
@@ -6178,6 +7896,15 @@ static void _glewInfo_GL_NV_pixel_data_range (void)
 
 #endif /* GL_NV_pixel_data_range */
 
+#ifdef GL_NV_platform_binary
+
+static void _glewInfo_GL_NV_platform_binary (void)
+{
+  glewPrintExt("GL_NV_platform_binary", GLEW_NV_platform_binary, glewIsSupported("GL_NV_platform_binary"), glewGetExtension("GL_NV_platform_binary"));
+}
+
+#endif /* GL_NV_platform_binary */
+
 #ifdef GL_NV_point_sprite
 
 static void _glewInfo_GL_NV_point_sprite (void)
@@ -6189,6 +7916,17 @@ static void _glewInfo_GL_NV_point_sprite (void)
 }
 
 #endif /* GL_NV_point_sprite */
+
+#ifdef GL_NV_polygon_mode
+
+static void _glewInfo_GL_NV_polygon_mode (void)
+{
+  glewPrintExt("GL_NV_polygon_mode", GLEW_NV_polygon_mode, glewIsSupported("GL_NV_polygon_mode"), glewGetExtension("GL_NV_polygon_mode"));
+
+  glewInfoFunc("glPolygonModeNV", glPolygonModeNV == NULL);
+}
+
+#endif /* GL_NV_polygon_mode */
 
 #ifdef GL_NV_present_video
 
@@ -6217,6 +7955,33 @@ static void _glewInfo_GL_NV_primitive_restart (void)
 }
 
 #endif /* GL_NV_primitive_restart */
+
+#ifdef GL_NV_read_depth
+
+static void _glewInfo_GL_NV_read_depth (void)
+{
+  glewPrintExt("GL_NV_read_depth", GLEW_NV_read_depth, glewIsSupported("GL_NV_read_depth"), glewGetExtension("GL_NV_read_depth"));
+}
+
+#endif /* GL_NV_read_depth */
+
+#ifdef GL_NV_read_depth_stencil
+
+static void _glewInfo_GL_NV_read_depth_stencil (void)
+{
+  glewPrintExt("GL_NV_read_depth_stencil", GLEW_NV_read_depth_stencil, glewIsSupported("GL_NV_read_depth_stencil"), glewGetExtension("GL_NV_read_depth_stencil"));
+}
+
+#endif /* GL_NV_read_depth_stencil */
+
+#ifdef GL_NV_read_stencil
+
+static void _glewInfo_GL_NV_read_stencil (void)
+{
+  glewPrintExt("GL_NV_read_stencil", GLEW_NV_read_stencil, glewIsSupported("GL_NV_read_stencil"), glewGetExtension("GL_NV_read_stencil"));
+}
+
+#endif /* GL_NV_read_stencil */
 
 #ifdef GL_NV_register_combiners
 
@@ -6253,6 +8018,45 @@ static void _glewInfo_GL_NV_register_combiners2 (void)
 
 #endif /* GL_NV_register_combiners2 */
 
+#ifdef GL_NV_robustness_video_memory_purge
+
+static void _glewInfo_GL_NV_robustness_video_memory_purge (void)
+{
+  glewPrintExt("GL_NV_robustness_video_memory_purge", GLEW_NV_robustness_video_memory_purge, glewIsSupported("GL_NV_robustness_video_memory_purge"), glewGetExtension("GL_NV_robustness_video_memory_purge"));
+}
+
+#endif /* GL_NV_robustness_video_memory_purge */
+
+#ifdef GL_NV_sRGB_formats
+
+static void _glewInfo_GL_NV_sRGB_formats (void)
+{
+  glewPrintExt("GL_NV_sRGB_formats", GLEW_NV_sRGB_formats, glewIsSupported("GL_NV_sRGB_formats"), glewGetExtension("GL_NV_sRGB_formats"));
+}
+
+#endif /* GL_NV_sRGB_formats */
+
+#ifdef GL_NV_sample_locations
+
+static void _glewInfo_GL_NV_sample_locations (void)
+{
+  glewPrintExt("GL_NV_sample_locations", GLEW_NV_sample_locations, glewIsSupported("GL_NV_sample_locations"), glewGetExtension("GL_NV_sample_locations"));
+
+  glewInfoFunc("glFramebufferSampleLocationsfvNV", glFramebufferSampleLocationsfvNV == NULL);
+  glewInfoFunc("glNamedFramebufferSampleLocationsfvNV", glNamedFramebufferSampleLocationsfvNV == NULL);
+}
+
+#endif /* GL_NV_sample_locations */
+
+#ifdef GL_NV_sample_mask_override_coverage
+
+static void _glewInfo_GL_NV_sample_mask_override_coverage (void)
+{
+  glewPrintExt("GL_NV_sample_mask_override_coverage", GLEW_NV_sample_mask_override_coverage, glewIsSupported("GL_NV_sample_mask_override_coverage"), glewGetExtension("GL_NV_sample_mask_override_coverage"));
+}
+
+#endif /* GL_NV_sample_mask_override_coverage */
+
 #ifdef GL_NV_shader_atomic_counters
 
 static void _glewInfo_GL_NV_shader_atomic_counters (void)
@@ -6270,6 +8074,24 @@ static void _glewInfo_GL_NV_shader_atomic_float (void)
 }
 
 #endif /* GL_NV_shader_atomic_float */
+
+#ifdef GL_NV_shader_atomic_float64
+
+static void _glewInfo_GL_NV_shader_atomic_float64 (void)
+{
+  glewPrintExt("GL_NV_shader_atomic_float64", GLEW_NV_shader_atomic_float64, glewIsSupported("GL_NV_shader_atomic_float64"), glewGetExtension("GL_NV_shader_atomic_float64"));
+}
+
+#endif /* GL_NV_shader_atomic_float64 */
+
+#ifdef GL_NV_shader_atomic_fp16_vector
+
+static void _glewInfo_GL_NV_shader_atomic_fp16_vector (void)
+{
+  glewPrintExt("GL_NV_shader_atomic_fp16_vector", GLEW_NV_shader_atomic_fp16_vector, glewIsSupported("GL_NV_shader_atomic_fp16_vector"), glewGetExtension("GL_NV_shader_atomic_fp16_vector"));
+}
+
+#endif /* GL_NV_shader_atomic_fp16_vector */
 
 #ifdef GL_NV_shader_atomic_int64
 
@@ -6303,6 +8125,15 @@ static void _glewInfo_GL_NV_shader_buffer_load (void)
 
 #endif /* GL_NV_shader_buffer_load */
 
+#ifdef GL_NV_shader_noperspective_interpolation
+
+static void _glewInfo_GL_NV_shader_noperspective_interpolation (void)
+{
+  glewPrintExt("GL_NV_shader_noperspective_interpolation", GLEW_NV_shader_noperspective_interpolation, glewIsSupported("GL_NV_shader_noperspective_interpolation"), glewGetExtension("GL_NV_shader_noperspective_interpolation"));
+}
+
+#endif /* GL_NV_shader_noperspective_interpolation */
+
 #ifdef GL_NV_shader_storage_buffer_object
 
 static void _glewInfo_GL_NV_shader_storage_buffer_object (void)
@@ -6329,6 +8160,33 @@ static void _glewInfo_GL_NV_shader_thread_shuffle (void)
 }
 
 #endif /* GL_NV_shader_thread_shuffle */
+
+#ifdef GL_NV_shadow_samplers_array
+
+static void _glewInfo_GL_NV_shadow_samplers_array (void)
+{
+  glewPrintExt("GL_NV_shadow_samplers_array", GLEW_NV_shadow_samplers_array, glewIsSupported("GL_NV_shadow_samplers_array"), glewGetExtension("GL_NV_shadow_samplers_array"));
+}
+
+#endif /* GL_NV_shadow_samplers_array */
+
+#ifdef GL_NV_shadow_samplers_cube
+
+static void _glewInfo_GL_NV_shadow_samplers_cube (void)
+{
+  glewPrintExt("GL_NV_shadow_samplers_cube", GLEW_NV_shadow_samplers_cube, glewIsSupported("GL_NV_shadow_samplers_cube"), glewGetExtension("GL_NV_shadow_samplers_cube"));
+}
+
+#endif /* GL_NV_shadow_samplers_cube */
+
+#ifdef GL_NV_stereo_view_rendering
+
+static void _glewInfo_GL_NV_stereo_view_rendering (void)
+{
+  glewPrintExt("GL_NV_stereo_view_rendering", GLEW_NV_stereo_view_rendering, glewIsSupported("GL_NV_stereo_view_rendering"), glewGetExtension("GL_NV_stereo_view_rendering"));
+}
+
+#endif /* GL_NV_stereo_view_rendering */
 
 #ifdef GL_NV_tessellation_program5
 
@@ -6357,6 +8215,22 @@ static void _glewInfo_GL_NV_texgen_reflection (void)
 
 #endif /* GL_NV_texgen_reflection */
 
+#ifdef GL_NV_texture_array
+
+static void _glewInfo_GL_NV_texture_array (void)
+{
+  glewPrintExt("GL_NV_texture_array", GLEW_NV_texture_array, glewIsSupported("GL_NV_texture_array"), glewGetExtension("GL_NV_texture_array"));
+
+  glewInfoFunc("glCompressedTexImage3DNV", glCompressedTexImage3DNV == NULL);
+  glewInfoFunc("glCompressedTexSubImage3DNV", glCompressedTexSubImage3DNV == NULL);
+  glewInfoFunc("glCopyTexSubImage3DNV", glCopyTexSubImage3DNV == NULL);
+  glewInfoFunc("glFramebufferTextureLayerNV", glFramebufferTextureLayerNV == NULL);
+  glewInfoFunc("glTexImage3DNV", glTexImage3DNV == NULL);
+  glewInfoFunc("glTexSubImage3DNV", glTexSubImage3DNV == NULL);
+}
+
+#endif /* GL_NV_texture_array */
+
 #ifdef GL_NV_texture_barrier
 
 static void _glewInfo_GL_NV_texture_barrier (void)
@@ -6367,6 +8241,42 @@ static void _glewInfo_GL_NV_texture_barrier (void)
 }
 
 #endif /* GL_NV_texture_barrier */
+
+#ifdef GL_NV_texture_border_clamp
+
+static void _glewInfo_GL_NV_texture_border_clamp (void)
+{
+  glewPrintExt("GL_NV_texture_border_clamp", GLEW_NV_texture_border_clamp, glewIsSupported("GL_NV_texture_border_clamp"), glewGetExtension("GL_NV_texture_border_clamp"));
+}
+
+#endif /* GL_NV_texture_border_clamp */
+
+#ifdef GL_NV_texture_compression_latc
+
+static void _glewInfo_GL_NV_texture_compression_latc (void)
+{
+  glewPrintExt("GL_NV_texture_compression_latc", GLEW_NV_texture_compression_latc, glewIsSupported("GL_NV_texture_compression_latc"), glewGetExtension("GL_NV_texture_compression_latc"));
+}
+
+#endif /* GL_NV_texture_compression_latc */
+
+#ifdef GL_NV_texture_compression_s3tc
+
+static void _glewInfo_GL_NV_texture_compression_s3tc (void)
+{
+  glewPrintExt("GL_NV_texture_compression_s3tc", GLEW_NV_texture_compression_s3tc, glewIsSupported("GL_NV_texture_compression_s3tc"), glewGetExtension("GL_NV_texture_compression_s3tc"));
+}
+
+#endif /* GL_NV_texture_compression_s3tc */
+
+#ifdef GL_NV_texture_compression_s3tc_update
+
+static void _glewInfo_GL_NV_texture_compression_s3tc_update (void)
+{
+  glewPrintExt("GL_NV_texture_compression_s3tc_update", GLEW_NV_texture_compression_s3tc_update, glewIsSupported("GL_NV_texture_compression_s3tc_update"), glewGetExtension("GL_NV_texture_compression_s3tc_update"));
+}
+
+#endif /* GL_NV_texture_compression_s3tc_update */
 
 #ifdef GL_NV_texture_compression_vtc
 
@@ -6411,6 +8321,15 @@ static void _glewInfo_GL_NV_texture_multisample (void)
 
 #endif /* GL_NV_texture_multisample */
 
+#ifdef GL_NV_texture_npot_2D_mipmap
+
+static void _glewInfo_GL_NV_texture_npot_2D_mipmap (void)
+{
+  glewPrintExt("GL_NV_texture_npot_2D_mipmap", GLEW_NV_texture_npot_2D_mipmap, glewIsSupported("GL_NV_texture_npot_2D_mipmap"), glewGetExtension("GL_NV_texture_npot_2D_mipmap"));
+}
+
+#endif /* GL_NV_texture_npot_2D_mipmap */
+
 #ifdef GL_NV_texture_rectangle
 
 static void _glewInfo_GL_NV_texture_rectangle (void)
@@ -6419,6 +8338,15 @@ static void _glewInfo_GL_NV_texture_rectangle (void)
 }
 
 #endif /* GL_NV_texture_rectangle */
+
+#ifdef GL_NV_texture_rectangle_compressed
+
+static void _glewInfo_GL_NV_texture_rectangle_compressed (void)
+{
+  glewPrintExt("GL_NV_texture_rectangle_compressed", GLEW_NV_texture_rectangle_compressed, glewIsSupported("GL_NV_texture_rectangle_compressed"), glewGetExtension("GL_NV_texture_rectangle_compressed"));
+}
+
+#endif /* GL_NV_texture_rectangle_compressed */
 
 #ifdef GL_NV_texture_shader
 
@@ -6484,6 +8412,15 @@ static void _glewInfo_GL_NV_transform_feedback2 (void)
 }
 
 #endif /* GL_NV_transform_feedback2 */
+
+#ifdef GL_NV_uniform_buffer_unified_memory
+
+static void _glewInfo_GL_NV_uniform_buffer_unified_memory (void)
+{
+  glewPrintExt("GL_NV_uniform_buffer_unified_memory", GLEW_NV_uniform_buffer_unified_memory, glewIsSupported("GL_NV_uniform_buffer_unified_memory"), glewGetExtension("GL_NV_uniform_buffer_unified_memory"));
+}
+
+#endif /* GL_NV_uniform_buffer_unified_memory */
 
 #ifdef GL_NV_vdpau_interop
 
@@ -6718,6 +8655,48 @@ static void _glewInfo_GL_NV_video_capture (void)
 
 #endif /* GL_NV_video_capture */
 
+#ifdef GL_NV_viewport_array
+
+static void _glewInfo_GL_NV_viewport_array (void)
+{
+  glewPrintExt("GL_NV_viewport_array", GLEW_NV_viewport_array, glewIsSupported("GL_NV_viewport_array"), glewGetExtension("GL_NV_viewport_array"));
+
+  glewInfoFunc("glDepthRangeArrayfvNV", glDepthRangeArrayfvNV == NULL);
+  glewInfoFunc("glDepthRangeIndexedfNV", glDepthRangeIndexedfNV == NULL);
+  glewInfoFunc("glDisableiNV", glDisableiNV == NULL);
+  glewInfoFunc("glEnableiNV", glEnableiNV == NULL);
+  glewInfoFunc("glGetFloati_vNV", glGetFloati_vNV == NULL);
+  glewInfoFunc("glIsEnablediNV", glIsEnablediNV == NULL);
+  glewInfoFunc("glScissorArrayvNV", glScissorArrayvNV == NULL);
+  glewInfoFunc("glScissorIndexedNV", glScissorIndexedNV == NULL);
+  glewInfoFunc("glScissorIndexedvNV", glScissorIndexedvNV == NULL);
+  glewInfoFunc("glViewportArrayvNV", glViewportArrayvNV == NULL);
+  glewInfoFunc("glViewportIndexedfNV", glViewportIndexedfNV == NULL);
+  glewInfoFunc("glViewportIndexedfvNV", glViewportIndexedfvNV == NULL);
+}
+
+#endif /* GL_NV_viewport_array */
+
+#ifdef GL_NV_viewport_array2
+
+static void _glewInfo_GL_NV_viewport_array2 (void)
+{
+  glewPrintExt("GL_NV_viewport_array2", GLEW_NV_viewport_array2, glewIsSupported("GL_NV_viewport_array2"), glewGetExtension("GL_NV_viewport_array2"));
+}
+
+#endif /* GL_NV_viewport_array2 */
+
+#ifdef GL_NV_viewport_swizzle
+
+static void _glewInfo_GL_NV_viewport_swizzle (void)
+{
+  glewPrintExt("GL_NV_viewport_swizzle", GLEW_NV_viewport_swizzle, glewIsSupported("GL_NV_viewport_swizzle"), glewGetExtension("GL_NV_viewport_swizzle"));
+
+  glewInfoFunc("glViewportSwizzleNV", glViewportSwizzleNV == NULL);
+}
+
+#endif /* GL_NV_viewport_swizzle */
+
 #ifdef GL_OES_byte_coordinates
 
 static void _glewInfo_GL_OES_byte_coordinates (void)
@@ -6726,40 +8705,6 @@ static void _glewInfo_GL_OES_byte_coordinates (void)
 }
 
 #endif /* GL_OES_byte_coordinates */
-
-#ifdef GL_OES_compressed_paletted_texture
-
-static void _glewInfo_GL_OES_compressed_paletted_texture (void)
-{
-  glewPrintExt("GL_OES_compressed_paletted_texture", GLEW_OES_compressed_paletted_texture, glewIsSupported("GL_OES_compressed_paletted_texture"), glewGetExtension("GL_OES_compressed_paletted_texture"));
-}
-
-#endif /* GL_OES_compressed_paletted_texture */
-
-#ifdef GL_OES_read_format
-
-static void _glewInfo_GL_OES_read_format (void)
-{
-  glewPrintExt("GL_OES_read_format", GLEW_OES_read_format, glewIsSupported("GL_OES_read_format"), glewGetExtension("GL_OES_read_format"));
-}
-
-#endif /* GL_OES_read_format */
-
-#ifdef GL_OES_single_precision
-
-static void _glewInfo_GL_OES_single_precision (void)
-{
-  glewPrintExt("GL_OES_single_precision", GLEW_OES_single_precision, glewIsSupported("GL_OES_single_precision"), glewGetExtension("GL_OES_single_precision"));
-
-  glewInfoFunc("glClearDepthfOES", glClearDepthfOES == NULL);
-  glewInfoFunc("glClipPlanefOES", glClipPlanefOES == NULL);
-  glewInfoFunc("glDepthRangefOES", glDepthRangefOES == NULL);
-  glewInfoFunc("glFrustumfOES", glFrustumfOES == NULL);
-  glewInfoFunc("glGetClipPlanefOES", glGetClipPlanefOES == NULL);
-  glewInfoFunc("glOrthofOES", glOrthofOES == NULL);
-}
-
-#endif /* GL_OES_single_precision */
 
 #ifdef GL_OML_interlace
 
@@ -6788,6 +8733,37 @@ static void _glewInfo_GL_OML_subsample (void)
 
 #endif /* GL_OML_subsample */
 
+#ifdef GL_OVR_multiview
+
+static void _glewInfo_GL_OVR_multiview (void)
+{
+  glewPrintExt("GL_OVR_multiview", GLEW_OVR_multiview, glewIsSupported("GL_OVR_multiview"), glewGetExtension("GL_OVR_multiview"));
+
+  glewInfoFunc("glFramebufferTextureMultiviewOVR", glFramebufferTextureMultiviewOVR == NULL);
+}
+
+#endif /* GL_OVR_multiview */
+
+#ifdef GL_OVR_multiview2
+
+static void _glewInfo_GL_OVR_multiview2 (void)
+{
+  glewPrintExt("GL_OVR_multiview2", GLEW_OVR_multiview2, glewIsSupported("GL_OVR_multiview2"), glewGetExtension("GL_OVR_multiview2"));
+}
+
+#endif /* GL_OVR_multiview2 */
+
+#ifdef GL_OVR_multiview_multisampled_render_to_texture
+
+static void _glewInfo_GL_OVR_multiview_multisampled_render_to_texture (void)
+{
+  glewPrintExt("GL_OVR_multiview_multisampled_render_to_texture", GLEW_OVR_multiview_multisampled_render_to_texture, glewIsSupported("GL_OVR_multiview_multisampled_render_to_texture"), glewGetExtension("GL_OVR_multiview_multisampled_render_to_texture"));
+
+  glewInfoFunc("glFramebufferTextureMultisampleMultiviewOVR", glFramebufferTextureMultisampleMultiviewOVR == NULL);
+}
+
+#endif /* GL_OVR_multiview_multisampled_render_to_texture */
+
 #ifdef GL_PGI_misc_hints
 
 static void _glewInfo_GL_PGI_misc_hints (void)
@@ -6805,6 +8781,125 @@ static void _glewInfo_GL_PGI_vertex_hints (void)
 }
 
 #endif /* GL_PGI_vertex_hints */
+
+#ifdef GL_QCOM_alpha_test
+
+static void _glewInfo_GL_QCOM_alpha_test (void)
+{
+  glewPrintExt("GL_QCOM_alpha_test", GLEW_QCOM_alpha_test, glewIsSupported("GL_QCOM_alpha_test"), glewGetExtension("GL_QCOM_alpha_test"));
+
+  glewInfoFunc("glAlphaFuncQCOM", glAlphaFuncQCOM == NULL);
+}
+
+#endif /* GL_QCOM_alpha_test */
+
+#ifdef GL_QCOM_binning_control
+
+static void _glewInfo_GL_QCOM_binning_control (void)
+{
+  glewPrintExt("GL_QCOM_binning_control", GLEW_QCOM_binning_control, glewIsSupported("GL_QCOM_binning_control"), glewGetExtension("GL_QCOM_binning_control"));
+}
+
+#endif /* GL_QCOM_binning_control */
+
+#ifdef GL_QCOM_driver_control
+
+static void _glewInfo_GL_QCOM_driver_control (void)
+{
+  glewPrintExt("GL_QCOM_driver_control", GLEW_QCOM_driver_control, glewIsSupported("GL_QCOM_driver_control"), glewGetExtension("GL_QCOM_driver_control"));
+
+  glewInfoFunc("glDisableDriverControlQCOM", glDisableDriverControlQCOM == NULL);
+  glewInfoFunc("glEnableDriverControlQCOM", glEnableDriverControlQCOM == NULL);
+  glewInfoFunc("glGetDriverControlStringQCOM", glGetDriverControlStringQCOM == NULL);
+  glewInfoFunc("glGetDriverControlsQCOM", glGetDriverControlsQCOM == NULL);
+}
+
+#endif /* GL_QCOM_driver_control */
+
+#ifdef GL_QCOM_extended_get
+
+static void _glewInfo_GL_QCOM_extended_get (void)
+{
+  glewPrintExt("GL_QCOM_extended_get", GLEW_QCOM_extended_get, glewIsSupported("GL_QCOM_extended_get"), glewGetExtension("GL_QCOM_extended_get"));
+
+  glewInfoFunc("glExtGetBufferPointervQCOM", glExtGetBufferPointervQCOM == NULL);
+  glewInfoFunc("glExtGetBuffersQCOM", glExtGetBuffersQCOM == NULL);
+  glewInfoFunc("glExtGetFramebuffersQCOM", glExtGetFramebuffersQCOM == NULL);
+  glewInfoFunc("glExtGetRenderbuffersQCOM", glExtGetRenderbuffersQCOM == NULL);
+  glewInfoFunc("glExtGetTexLevelParameterivQCOM", glExtGetTexLevelParameterivQCOM == NULL);
+  glewInfoFunc("glExtGetTexSubImageQCOM", glExtGetTexSubImageQCOM == NULL);
+  glewInfoFunc("glExtGetTexturesQCOM", glExtGetTexturesQCOM == NULL);
+  glewInfoFunc("glExtTexObjectStateOverrideiQCOM", glExtTexObjectStateOverrideiQCOM == NULL);
+}
+
+#endif /* GL_QCOM_extended_get */
+
+#ifdef GL_QCOM_extended_get2
+
+static void _glewInfo_GL_QCOM_extended_get2 (void)
+{
+  glewPrintExt("GL_QCOM_extended_get2", GLEW_QCOM_extended_get2, glewIsSupported("GL_QCOM_extended_get2"), glewGetExtension("GL_QCOM_extended_get2"));
+
+  glewInfoFunc("glExtGetProgramBinarySourceQCOM", glExtGetProgramBinarySourceQCOM == NULL);
+  glewInfoFunc("glExtGetProgramsQCOM", glExtGetProgramsQCOM == NULL);
+  glewInfoFunc("glExtGetShadersQCOM", glExtGetShadersQCOM == NULL);
+  glewInfoFunc("glExtIsProgramBinaryQCOM", glExtIsProgramBinaryQCOM == NULL);
+}
+
+#endif /* GL_QCOM_extended_get2 */
+
+#ifdef GL_QCOM_framebuffer_foveated
+
+static void _glewInfo_GL_QCOM_framebuffer_foveated (void)
+{
+  glewPrintExt("GL_QCOM_framebuffer_foveated", GLEW_QCOM_framebuffer_foveated, glewIsSupported("GL_QCOM_framebuffer_foveated"), glewGetExtension("GL_QCOM_framebuffer_foveated"));
+
+  glewInfoFunc("glFramebufferFoveationConfigQCOM", glFramebufferFoveationConfigQCOM == NULL);
+  glewInfoFunc("glFramebufferFoveationParametersQCOM", glFramebufferFoveationParametersQCOM == NULL);
+}
+
+#endif /* GL_QCOM_framebuffer_foveated */
+
+#ifdef GL_QCOM_perfmon_global_mode
+
+static void _glewInfo_GL_QCOM_perfmon_global_mode (void)
+{
+  glewPrintExt("GL_QCOM_perfmon_global_mode", GLEW_QCOM_perfmon_global_mode, glewIsSupported("GL_QCOM_perfmon_global_mode"), glewGetExtension("GL_QCOM_perfmon_global_mode"));
+}
+
+#endif /* GL_QCOM_perfmon_global_mode */
+
+#ifdef GL_QCOM_shader_framebuffer_fetch_noncoherent
+
+static void _glewInfo_GL_QCOM_shader_framebuffer_fetch_noncoherent (void)
+{
+  glewPrintExt("GL_QCOM_shader_framebuffer_fetch_noncoherent", GLEW_QCOM_shader_framebuffer_fetch_noncoherent, glewIsSupported("GL_QCOM_shader_framebuffer_fetch_noncoherent"), glewGetExtension("GL_QCOM_shader_framebuffer_fetch_noncoherent"));
+
+  glewInfoFunc("glFramebufferFetchBarrierQCOM", glFramebufferFetchBarrierQCOM == NULL);
+}
+
+#endif /* GL_QCOM_shader_framebuffer_fetch_noncoherent */
+
+#ifdef GL_QCOM_tiled_rendering
+
+static void _glewInfo_GL_QCOM_tiled_rendering (void)
+{
+  glewPrintExt("GL_QCOM_tiled_rendering", GLEW_QCOM_tiled_rendering, glewIsSupported("GL_QCOM_tiled_rendering"), glewGetExtension("GL_QCOM_tiled_rendering"));
+
+  glewInfoFunc("glEndTilingQCOM", glEndTilingQCOM == NULL);
+  glewInfoFunc("glStartTilingQCOM", glStartTilingQCOM == NULL);
+}
+
+#endif /* GL_QCOM_tiled_rendering */
+
+#ifdef GL_QCOM_writeonly_rendering
+
+static void _glewInfo_GL_QCOM_writeonly_rendering (void)
+{
+  glewPrintExt("GL_QCOM_writeonly_rendering", GLEW_QCOM_writeonly_rendering, glewIsSupported("GL_QCOM_writeonly_rendering"), glewGetExtension("GL_QCOM_writeonly_rendering"));
+}
+
+#endif /* GL_QCOM_writeonly_rendering */
 
 #ifdef GL_REGAL_ES1_0_compatibility
 
@@ -6942,6 +9037,15 @@ static void _glewInfo_GL_S3_s3tc (void)
 
 #endif /* GL_S3_s3tc */
 
+#ifdef GL_SGIS_clip_band_hint
+
+static void _glewInfo_GL_SGIS_clip_band_hint (void)
+{
+  glewPrintExt("GL_SGIS_clip_band_hint", GLEW_SGIS_clip_band_hint, glewIsSupported("GL_SGIS_clip_band_hint"), glewGetExtension("GL_SGIS_clip_band_hint"));
+}
+
+#endif /* GL_SGIS_clip_band_hint */
+
 #ifdef GL_SGIS_color_range
 
 static void _glewInfo_GL_SGIS_color_range (void)
@@ -6984,6 +9088,15 @@ static void _glewInfo_GL_SGIS_generate_mipmap (void)
 
 #endif /* GL_SGIS_generate_mipmap */
 
+#ifdef GL_SGIS_line_texgen
+
+static void _glewInfo_GL_SGIS_line_texgen (void)
+{
+  glewPrintExt("GL_SGIS_line_texgen", GLEW_SGIS_line_texgen, glewIsSupported("GL_SGIS_line_texgen"), glewGetExtension("GL_SGIS_line_texgen"));
+}
+
+#endif /* GL_SGIS_line_texgen */
+
 #ifdef GL_SGIS_multisample
 
 static void _glewInfo_GL_SGIS_multisample (void)
@@ -6995,6 +9108,20 @@ static void _glewInfo_GL_SGIS_multisample (void)
 }
 
 #endif /* GL_SGIS_multisample */
+
+#ifdef GL_SGIS_multitexture
+
+static void _glewInfo_GL_SGIS_multitexture (void)
+{
+  glewPrintExt("GL_SGIS_multitexture", GLEW_SGIS_multitexture, glewIsSupported("GL_SGIS_multitexture"), glewGetExtension("GL_SGIS_multitexture"));
+
+  glewInfoFunc("glInterleavedTextureCoordSetsSGIS", glInterleavedTextureCoordSetsSGIS == NULL);
+  glewInfoFunc("glSelectTextureCoordSetSGIS", glSelectTextureCoordSetSGIS == NULL);
+  glewInfoFunc("glSelectTextureSGIS", glSelectTextureSGIS == NULL);
+  glewInfoFunc("glSelectTextureTransformSGIS", glSelectTextureTransformSGIS == NULL);
+}
+
+#endif /* GL_SGIS_multitexture */
 
 #ifdef GL_SGIS_pixel_texture
 
@@ -7013,6 +9140,17 @@ static void _glewInfo_GL_SGIS_point_line_texgen (void)
 }
 
 #endif /* GL_SGIS_point_line_texgen */
+
+#ifdef GL_SGIS_shared_multisample
+
+static void _glewInfo_GL_SGIS_shared_multisample (void)
+{
+  glewPrintExt("GL_SGIS_shared_multisample", GLEW_SGIS_shared_multisample, glewIsSupported("GL_SGIS_shared_multisample"), glewGetExtension("GL_SGIS_shared_multisample"));
+
+  glewInfoFunc("glMultisampleSubRectPosSGIS", glMultisampleSubRectPosSGIS == NULL);
+}
+
+#endif /* GL_SGIS_shared_multisample */
 
 #ifdef GL_SGIS_sharpen_texture
 
@@ -7120,6 +9258,33 @@ static void _glewInfo_GL_SGIX_async_pixel (void)
 
 #endif /* GL_SGIX_async_pixel */
 
+#ifdef GL_SGIX_bali_g_instruments
+
+static void _glewInfo_GL_SGIX_bali_g_instruments (void)
+{
+  glewPrintExt("GL_SGIX_bali_g_instruments", GLEW_SGIX_bali_g_instruments, glewIsSupported("GL_SGIX_bali_g_instruments"), glewGetExtension("GL_SGIX_bali_g_instruments"));
+}
+
+#endif /* GL_SGIX_bali_g_instruments */
+
+#ifdef GL_SGIX_bali_r_instruments
+
+static void _glewInfo_GL_SGIX_bali_r_instruments (void)
+{
+  glewPrintExt("GL_SGIX_bali_r_instruments", GLEW_SGIX_bali_r_instruments, glewIsSupported("GL_SGIX_bali_r_instruments"), glewGetExtension("GL_SGIX_bali_r_instruments"));
+}
+
+#endif /* GL_SGIX_bali_r_instruments */
+
+#ifdef GL_SGIX_bali_timer_instruments
+
+static void _glewInfo_GL_SGIX_bali_timer_instruments (void)
+{
+  glewPrintExt("GL_SGIX_bali_timer_instruments", GLEW_SGIX_bali_timer_instruments, glewIsSupported("GL_SGIX_bali_timer_instruments"), glewGetExtension("GL_SGIX_bali_timer_instruments"));
+}
+
+#endif /* GL_SGIX_bali_timer_instruments */
+
 #ifdef GL_SGIX_blend_alpha_minmax
 
 static void _glewInfo_GL_SGIX_blend_alpha_minmax (void)
@@ -7128,6 +9293,33 @@ static void _glewInfo_GL_SGIX_blend_alpha_minmax (void)
 }
 
 #endif /* GL_SGIX_blend_alpha_minmax */
+
+#ifdef GL_SGIX_blend_cadd
+
+static void _glewInfo_GL_SGIX_blend_cadd (void)
+{
+  glewPrintExt("GL_SGIX_blend_cadd", GLEW_SGIX_blend_cadd, glewIsSupported("GL_SGIX_blend_cadd"), glewGetExtension("GL_SGIX_blend_cadd"));
+}
+
+#endif /* GL_SGIX_blend_cadd */
+
+#ifdef GL_SGIX_blend_cmultiply
+
+static void _glewInfo_GL_SGIX_blend_cmultiply (void)
+{
+  glewPrintExt("GL_SGIX_blend_cmultiply", GLEW_SGIX_blend_cmultiply, glewIsSupported("GL_SGIX_blend_cmultiply"), glewGetExtension("GL_SGIX_blend_cmultiply"));
+}
+
+#endif /* GL_SGIX_blend_cmultiply */
+
+#ifdef GL_SGIX_calligraphic_fragment
+
+static void _glewInfo_GL_SGIX_calligraphic_fragment (void)
+{
+  glewPrintExt("GL_SGIX_calligraphic_fragment", GLEW_SGIX_calligraphic_fragment, glewIsSupported("GL_SGIX_calligraphic_fragment"), glewGetExtension("GL_SGIX_calligraphic_fragment"));
+}
+
+#endif /* GL_SGIX_calligraphic_fragment */
 
 #ifdef GL_SGIX_clipmap
 
@@ -7138,6 +9330,33 @@ static void _glewInfo_GL_SGIX_clipmap (void)
 
 #endif /* GL_SGIX_clipmap */
 
+#ifdef GL_SGIX_color_matrix_accuracy
+
+static void _glewInfo_GL_SGIX_color_matrix_accuracy (void)
+{
+  glewPrintExt("GL_SGIX_color_matrix_accuracy", GLEW_SGIX_color_matrix_accuracy, glewIsSupported("GL_SGIX_color_matrix_accuracy"), glewGetExtension("GL_SGIX_color_matrix_accuracy"));
+}
+
+#endif /* GL_SGIX_color_matrix_accuracy */
+
+#ifdef GL_SGIX_color_table_index_mode
+
+static void _glewInfo_GL_SGIX_color_table_index_mode (void)
+{
+  glewPrintExt("GL_SGIX_color_table_index_mode", GLEW_SGIX_color_table_index_mode, glewIsSupported("GL_SGIX_color_table_index_mode"), glewGetExtension("GL_SGIX_color_table_index_mode"));
+}
+
+#endif /* GL_SGIX_color_table_index_mode */
+
+#ifdef GL_SGIX_complex_polar
+
+static void _glewInfo_GL_SGIX_complex_polar (void)
+{
+  glewPrintExt("GL_SGIX_complex_polar", GLEW_SGIX_complex_polar, glewIsSupported("GL_SGIX_complex_polar"), glewGetExtension("GL_SGIX_complex_polar"));
+}
+
+#endif /* GL_SGIX_complex_polar */
+
 #ifdef GL_SGIX_convolution_accuracy
 
 static void _glewInfo_GL_SGIX_convolution_accuracy (void)
@@ -7147,6 +9366,54 @@ static void _glewInfo_GL_SGIX_convolution_accuracy (void)
 
 #endif /* GL_SGIX_convolution_accuracy */
 
+#ifdef GL_SGIX_cube_map
+
+static void _glewInfo_GL_SGIX_cube_map (void)
+{
+  glewPrintExt("GL_SGIX_cube_map", GLEW_SGIX_cube_map, glewIsSupported("GL_SGIX_cube_map"), glewGetExtension("GL_SGIX_cube_map"));
+}
+
+#endif /* GL_SGIX_cube_map */
+
+#ifdef GL_SGIX_cylinder_texgen
+
+static void _glewInfo_GL_SGIX_cylinder_texgen (void)
+{
+  glewPrintExt("GL_SGIX_cylinder_texgen", GLEW_SGIX_cylinder_texgen, glewIsSupported("GL_SGIX_cylinder_texgen"), glewGetExtension("GL_SGIX_cylinder_texgen"));
+}
+
+#endif /* GL_SGIX_cylinder_texgen */
+
+#ifdef GL_SGIX_datapipe
+
+static void _glewInfo_GL_SGIX_datapipe (void)
+{
+  glewPrintExt("GL_SGIX_datapipe", GLEW_SGIX_datapipe, glewIsSupported("GL_SGIX_datapipe"), glewGetExtension("GL_SGIX_datapipe"));
+
+  glewInfoFunc("glAddressSpace", glAddressSpace == NULL);
+  glewInfoFunc("glDataPipe", glDataPipe == NULL);
+}
+
+#endif /* GL_SGIX_datapipe */
+
+#ifdef GL_SGIX_decimation
+
+static void _glewInfo_GL_SGIX_decimation (void)
+{
+  glewPrintExt("GL_SGIX_decimation", GLEW_SGIX_decimation, glewIsSupported("GL_SGIX_decimation"), glewGetExtension("GL_SGIX_decimation"));
+}
+
+#endif /* GL_SGIX_decimation */
+
+#ifdef GL_SGIX_depth_pass_instrument
+
+static void _glewInfo_GL_SGIX_depth_pass_instrument (void)
+{
+  glewPrintExt("GL_SGIX_depth_pass_instrument", GLEW_SGIX_depth_pass_instrument, glewIsSupported("GL_SGIX_depth_pass_instrument"), glewGetExtension("GL_SGIX_depth_pass_instrument"));
+}
+
+#endif /* GL_SGIX_depth_pass_instrument */
+
 #ifdef GL_SGIX_depth_texture
 
 static void _glewInfo_GL_SGIX_depth_texture (void)
@@ -7155,6 +9422,15 @@ static void _glewInfo_GL_SGIX_depth_texture (void)
 }
 
 #endif /* GL_SGIX_depth_texture */
+
+#ifdef GL_SGIX_dvc
+
+static void _glewInfo_GL_SGIX_dvc (void)
+{
+  glewPrintExt("GL_SGIX_dvc", GLEW_SGIX_dvc, glewIsSupported("GL_SGIX_dvc"), glewGetExtension("GL_SGIX_dvc"));
+}
+
+#endif /* GL_SGIX_dvc */
 
 #ifdef GL_SGIX_flush_raster
 
@@ -7167,6 +9443,36 @@ static void _glewInfo_GL_SGIX_flush_raster (void)
 
 #endif /* GL_SGIX_flush_raster */
 
+#ifdef GL_SGIX_fog_blend
+
+static void _glewInfo_GL_SGIX_fog_blend (void)
+{
+  glewPrintExt("GL_SGIX_fog_blend", GLEW_SGIX_fog_blend, glewIsSupported("GL_SGIX_fog_blend"), glewGetExtension("GL_SGIX_fog_blend"));
+}
+
+#endif /* GL_SGIX_fog_blend */
+
+#ifdef GL_SGIX_fog_factor_to_alpha
+
+static void _glewInfo_GL_SGIX_fog_factor_to_alpha (void)
+{
+  glewPrintExt("GL_SGIX_fog_factor_to_alpha", GLEW_SGIX_fog_factor_to_alpha, glewIsSupported("GL_SGIX_fog_factor_to_alpha"), glewGetExtension("GL_SGIX_fog_factor_to_alpha"));
+}
+
+#endif /* GL_SGIX_fog_factor_to_alpha */
+
+#ifdef GL_SGIX_fog_layers
+
+static void _glewInfo_GL_SGIX_fog_layers (void)
+{
+  glewPrintExt("GL_SGIX_fog_layers", GLEW_SGIX_fog_layers, glewIsSupported("GL_SGIX_fog_layers"), glewGetExtension("GL_SGIX_fog_layers"));
+
+  glewInfoFunc("glFogLayersSGIX", glFogLayersSGIX == NULL);
+  glewInfoFunc("glGetFogLayersSGIX", glGetFogLayersSGIX == NULL);
+}
+
+#endif /* GL_SGIX_fog_layers */
+
 #ifdef GL_SGIX_fog_offset
 
 static void _glewInfo_GL_SGIX_fog_offset (void)
@@ -7175,6 +9481,24 @@ static void _glewInfo_GL_SGIX_fog_offset (void)
 }
 
 #endif /* GL_SGIX_fog_offset */
+
+#ifdef GL_SGIX_fog_patchy
+
+static void _glewInfo_GL_SGIX_fog_patchy (void)
+{
+  glewPrintExt("GL_SGIX_fog_patchy", GLEW_SGIX_fog_patchy, glewIsSupported("GL_SGIX_fog_patchy"), glewGetExtension("GL_SGIX_fog_patchy"));
+}
+
+#endif /* GL_SGIX_fog_patchy */
+
+#ifdef GL_SGIX_fog_scale
+
+static void _glewInfo_GL_SGIX_fog_scale (void)
+{
+  glewPrintExt("GL_SGIX_fog_scale", GLEW_SGIX_fog_scale, glewIsSupported("GL_SGIX_fog_scale"), glewGetExtension("GL_SGIX_fog_scale"));
+}
+
+#endif /* GL_SGIX_fog_scale */
 
 #ifdef GL_SGIX_fog_texture
 
@@ -7186,6 +9510,15 @@ static void _glewInfo_GL_SGIX_fog_texture (void)
 }
 
 #endif /* GL_SGIX_fog_texture */
+
+#ifdef GL_SGIX_fragment_lighting_space
+
+static void _glewInfo_GL_SGIX_fragment_lighting_space (void)
+{
+  glewPrintExt("GL_SGIX_fragment_lighting_space", GLEW_SGIX_fragment_lighting_space, glewIsSupported("GL_SGIX_fragment_lighting_space"), glewGetExtension("GL_SGIX_fragment_lighting_space"));
+}
+
+#endif /* GL_SGIX_fragment_lighting_space */
 
 #ifdef GL_SGIX_fragment_specular_lighting
 
@@ -7214,6 +9547,15 @@ static void _glewInfo_GL_SGIX_fragment_specular_lighting (void)
 
 #endif /* GL_SGIX_fragment_specular_lighting */
 
+#ifdef GL_SGIX_fragments_instrument
+
+static void _glewInfo_GL_SGIX_fragments_instrument (void)
+{
+  glewPrintExt("GL_SGIX_fragments_instrument", GLEW_SGIX_fragments_instrument, glewIsSupported("GL_SGIX_fragments_instrument"), glewGetExtension("GL_SGIX_fragments_instrument"));
+}
+
+#endif /* GL_SGIX_fragments_instrument */
+
 #ifdef GL_SGIX_framezoom
 
 static void _glewInfo_GL_SGIX_framezoom (void)
@@ -7224,6 +9566,53 @@ static void _glewInfo_GL_SGIX_framezoom (void)
 }
 
 #endif /* GL_SGIX_framezoom */
+
+#ifdef GL_SGIX_icc_texture
+
+static void _glewInfo_GL_SGIX_icc_texture (void)
+{
+  glewPrintExt("GL_SGIX_icc_texture", GLEW_SGIX_icc_texture, glewIsSupported("GL_SGIX_icc_texture"), glewGetExtension("GL_SGIX_icc_texture"));
+}
+
+#endif /* GL_SGIX_icc_texture */
+
+#ifdef GL_SGIX_igloo_interface
+
+static void _glewInfo_GL_SGIX_igloo_interface (void)
+{
+  glewPrintExt("GL_SGIX_igloo_interface", GLEW_SGIX_igloo_interface, glewIsSupported("GL_SGIX_igloo_interface"), glewGetExtension("GL_SGIX_igloo_interface"));
+
+  glewInfoFunc("glIglooInterfaceSGIX", glIglooInterfaceSGIX == NULL);
+}
+
+#endif /* GL_SGIX_igloo_interface */
+
+#ifdef GL_SGIX_image_compression
+
+static void _glewInfo_GL_SGIX_image_compression (void)
+{
+  glewPrintExt("GL_SGIX_image_compression", GLEW_SGIX_image_compression, glewIsSupported("GL_SGIX_image_compression"), glewGetExtension("GL_SGIX_image_compression"));
+}
+
+#endif /* GL_SGIX_image_compression */
+
+#ifdef GL_SGIX_impact_pixel_texture
+
+static void _glewInfo_GL_SGIX_impact_pixel_texture (void)
+{
+  glewPrintExt("GL_SGIX_impact_pixel_texture", GLEW_SGIX_impact_pixel_texture, glewIsSupported("GL_SGIX_impact_pixel_texture"), glewGetExtension("GL_SGIX_impact_pixel_texture"));
+}
+
+#endif /* GL_SGIX_impact_pixel_texture */
+
+#ifdef GL_SGIX_instrument_error
+
+static void _glewInfo_GL_SGIX_instrument_error (void)
+{
+  glewPrintExt("GL_SGIX_instrument_error", GLEW_SGIX_instrument_error, glewIsSupported("GL_SGIX_instrument_error"), glewGetExtension("GL_SGIX_instrument_error"));
+}
+
+#endif /* GL_SGIX_instrument_error */
 
 #ifdef GL_SGIX_interlace
 
@@ -7243,6 +9632,15 @@ static void _glewInfo_GL_SGIX_ir_instrument1 (void)
 
 #endif /* GL_SGIX_ir_instrument1 */
 
+#ifdef GL_SGIX_line_quality_hint
+
+static void _glewInfo_GL_SGIX_line_quality_hint (void)
+{
+  glewPrintExt("GL_SGIX_line_quality_hint", GLEW_SGIX_line_quality_hint, glewIsSupported("GL_SGIX_line_quality_hint"), glewGetExtension("GL_SGIX_line_quality_hint"));
+}
+
+#endif /* GL_SGIX_line_quality_hint */
+
 #ifdef GL_SGIX_list_priority
 
 static void _glewInfo_GL_SGIX_list_priority (void)
@@ -7251,6 +9649,77 @@ static void _glewInfo_GL_SGIX_list_priority (void)
 }
 
 #endif /* GL_SGIX_list_priority */
+
+#ifdef GL_SGIX_mpeg1
+
+static void _glewInfo_GL_SGIX_mpeg1 (void)
+{
+  glewPrintExt("GL_SGIX_mpeg1", GLEW_SGIX_mpeg1, glewIsSupported("GL_SGIX_mpeg1"), glewGetExtension("GL_SGIX_mpeg1"));
+
+  glewInfoFunc("glAllocMPEGPredictorsSGIX", glAllocMPEGPredictorsSGIX == NULL);
+  glewInfoFunc("glDeleteMPEGPredictorsSGIX", glDeleteMPEGPredictorsSGIX == NULL);
+  glewInfoFunc("glGenMPEGPredictorsSGIX", glGenMPEGPredictorsSGIX == NULL);
+  glewInfoFunc("glGetMPEGParameterfvSGIX", glGetMPEGParameterfvSGIX == NULL);
+  glewInfoFunc("glGetMPEGParameterivSGIX", glGetMPEGParameterivSGIX == NULL);
+  glewInfoFunc("glGetMPEGPredictorSGIX", glGetMPEGPredictorSGIX == NULL);
+  glewInfoFunc("glGetMPEGQuantTableubv", glGetMPEGQuantTableubv == NULL);
+  glewInfoFunc("glIsMPEGPredictorSGIX", glIsMPEGPredictorSGIX == NULL);
+  glewInfoFunc("glMPEGPredictorSGIX", glMPEGPredictorSGIX == NULL);
+  glewInfoFunc("glMPEGQuantTableubv", glMPEGQuantTableubv == NULL);
+  glewInfoFunc("glSwapMPEGPredictorsSGIX", glSwapMPEGPredictorsSGIX == NULL);
+}
+
+#endif /* GL_SGIX_mpeg1 */
+
+#ifdef GL_SGIX_mpeg2
+
+static void _glewInfo_GL_SGIX_mpeg2 (void)
+{
+  glewPrintExt("GL_SGIX_mpeg2", GLEW_SGIX_mpeg2, glewIsSupported("GL_SGIX_mpeg2"), glewGetExtension("GL_SGIX_mpeg2"));
+}
+
+#endif /* GL_SGIX_mpeg2 */
+
+#ifdef GL_SGIX_nonlinear_lighting_pervertex
+
+static void _glewInfo_GL_SGIX_nonlinear_lighting_pervertex (void)
+{
+  glewPrintExt("GL_SGIX_nonlinear_lighting_pervertex", GLEW_SGIX_nonlinear_lighting_pervertex, glewIsSupported("GL_SGIX_nonlinear_lighting_pervertex"), glewGetExtension("GL_SGIX_nonlinear_lighting_pervertex"));
+
+  glewInfoFunc("glGetNonlinLightfvSGIX", glGetNonlinLightfvSGIX == NULL);
+  glewInfoFunc("glGetNonlinMaterialfvSGIX", glGetNonlinMaterialfvSGIX == NULL);
+  glewInfoFunc("glNonlinLightfvSGIX", glNonlinLightfvSGIX == NULL);
+  glewInfoFunc("glNonlinMaterialfvSGIX", glNonlinMaterialfvSGIX == NULL);
+}
+
+#endif /* GL_SGIX_nonlinear_lighting_pervertex */
+
+#ifdef GL_SGIX_nurbs_eval
+
+static void _glewInfo_GL_SGIX_nurbs_eval (void)
+{
+  glewPrintExt("GL_SGIX_nurbs_eval", GLEW_SGIX_nurbs_eval, glewIsSupported("GL_SGIX_nurbs_eval"), glewGetExtension("GL_SGIX_nurbs_eval"));
+}
+
+#endif /* GL_SGIX_nurbs_eval */
+
+#ifdef GL_SGIX_occlusion_instrument
+
+static void _glewInfo_GL_SGIX_occlusion_instrument (void)
+{
+  glewPrintExt("GL_SGIX_occlusion_instrument", GLEW_SGIX_occlusion_instrument, glewIsSupported("GL_SGIX_occlusion_instrument"), glewGetExtension("GL_SGIX_occlusion_instrument"));
+}
+
+#endif /* GL_SGIX_occlusion_instrument */
+
+#ifdef GL_SGIX_packed_6bytes
+
+static void _glewInfo_GL_SGIX_packed_6bytes (void)
+{
+  glewPrintExt("GL_SGIX_packed_6bytes", GLEW_SGIX_packed_6bytes, glewIsSupported("GL_SGIX_packed_6bytes"), glewGetExtension("GL_SGIX_packed_6bytes"));
+}
+
+#endif /* GL_SGIX_packed_6bytes */
 
 #ifdef GL_SGIX_pixel_texture
 
@@ -7272,6 +9741,48 @@ static void _glewInfo_GL_SGIX_pixel_texture_bits (void)
 
 #endif /* GL_SGIX_pixel_texture_bits */
 
+#ifdef GL_SGIX_pixel_texture_lod
+
+static void _glewInfo_GL_SGIX_pixel_texture_lod (void)
+{
+  glewPrintExt("GL_SGIX_pixel_texture_lod", GLEW_SGIX_pixel_texture_lod, glewIsSupported("GL_SGIX_pixel_texture_lod"), glewGetExtension("GL_SGIX_pixel_texture_lod"));
+}
+
+#endif /* GL_SGIX_pixel_texture_lod */
+
+#ifdef GL_SGIX_pixel_tiles
+
+static void _glewInfo_GL_SGIX_pixel_tiles (void)
+{
+  glewPrintExt("GL_SGIX_pixel_tiles", GLEW_SGIX_pixel_tiles, glewIsSupported("GL_SGIX_pixel_tiles"), glewGetExtension("GL_SGIX_pixel_tiles"));
+}
+
+#endif /* GL_SGIX_pixel_tiles */
+
+#ifdef GL_SGIX_polynomial_ffd
+
+static void _glewInfo_GL_SGIX_polynomial_ffd (void)
+{
+  glewPrintExt("GL_SGIX_polynomial_ffd", GLEW_SGIX_polynomial_ffd, glewIsSupported("GL_SGIX_polynomial_ffd"), glewGetExtension("GL_SGIX_polynomial_ffd"));
+
+  glewInfoFunc("glDeformSGIX", glDeformSGIX == NULL);
+  glewInfoFunc("glLoadIdentityDeformationMapSGIX", glLoadIdentityDeformationMapSGIX == NULL);
+}
+
+#endif /* GL_SGIX_polynomial_ffd */
+
+#ifdef GL_SGIX_quad_mesh
+
+static void _glewInfo_GL_SGIX_quad_mesh (void)
+{
+  glewPrintExt("GL_SGIX_quad_mesh", GLEW_SGIX_quad_mesh, glewIsSupported("GL_SGIX_quad_mesh"), glewGetExtension("GL_SGIX_quad_mesh"));
+
+  glewInfoFunc("glMeshBreadthSGIX", glMeshBreadthSGIX == NULL);
+  glewInfoFunc("glMeshStrideSGIX", glMeshStrideSGIX == NULL);
+}
+
+#endif /* GL_SGIX_quad_mesh */
+
 #ifdef GL_SGIX_reference_plane
 
 static void _glewInfo_GL_SGIX_reference_plane (void)
@@ -7292,6 +9803,15 @@ static void _glewInfo_GL_SGIX_resample (void)
 
 #endif /* GL_SGIX_resample */
 
+#ifdef GL_SGIX_scalebias_hint
+
+static void _glewInfo_GL_SGIX_scalebias_hint (void)
+{
+  glewPrintExt("GL_SGIX_scalebias_hint", GLEW_SGIX_scalebias_hint, glewIsSupported("GL_SGIX_scalebias_hint"), glewGetExtension("GL_SGIX_scalebias_hint"));
+}
+
+#endif /* GL_SGIX_scalebias_hint */
+
 #ifdef GL_SGIX_shadow
 
 static void _glewInfo_GL_SGIX_shadow (void)
@@ -7310,6 +9830,24 @@ static void _glewInfo_GL_SGIX_shadow_ambient (void)
 
 #endif /* GL_SGIX_shadow_ambient */
 
+#ifdef GL_SGIX_slim
+
+static void _glewInfo_GL_SGIX_slim (void)
+{
+  glewPrintExt("GL_SGIX_slim", GLEW_SGIX_slim, glewIsSupported("GL_SGIX_slim"), glewGetExtension("GL_SGIX_slim"));
+}
+
+#endif /* GL_SGIX_slim */
+
+#ifdef GL_SGIX_spotlight_cutoff
+
+static void _glewInfo_GL_SGIX_spotlight_cutoff (void)
+{
+  glewPrintExt("GL_SGIX_spotlight_cutoff", GLEW_SGIX_spotlight_cutoff, glewIsSupported("GL_SGIX_spotlight_cutoff"), glewGetExtension("GL_SGIX_spotlight_cutoff"));
+}
+
+#endif /* GL_SGIX_spotlight_cutoff */
+
 #ifdef GL_SGIX_sprite
 
 static void _glewInfo_GL_SGIX_sprite (void)
@@ -7323,6 +9861,24 @@ static void _glewInfo_GL_SGIX_sprite (void)
 }
 
 #endif /* GL_SGIX_sprite */
+
+#ifdef GL_SGIX_subdiv_patch
+
+static void _glewInfo_GL_SGIX_subdiv_patch (void)
+{
+  glewPrintExt("GL_SGIX_subdiv_patch", GLEW_SGIX_subdiv_patch, glewIsSupported("GL_SGIX_subdiv_patch"), glewGetExtension("GL_SGIX_subdiv_patch"));
+}
+
+#endif /* GL_SGIX_subdiv_patch */
+
+#ifdef GL_SGIX_subsample
+
+static void _glewInfo_GL_SGIX_subsample (void)
+{
+  glewPrintExt("GL_SGIX_subsample", GLEW_SGIX_subsample, glewIsSupported("GL_SGIX_subsample"), glewGetExtension("GL_SGIX_subsample"));
+}
+
+#endif /* GL_SGIX_subsample */
 
 #ifdef GL_SGIX_tag_sample_buffer
 
@@ -7362,6 +9918,15 @@ static void _glewInfo_GL_SGIX_texture_lod_bias (void)
 
 #endif /* GL_SGIX_texture_lod_bias */
 
+#ifdef GL_SGIX_texture_mipmap_anisotropic
+
+static void _glewInfo_GL_SGIX_texture_mipmap_anisotropic (void)
+{
+  glewPrintExt("GL_SGIX_texture_mipmap_anisotropic", GLEW_SGIX_texture_mipmap_anisotropic, glewIsSupported("GL_SGIX_texture_mipmap_anisotropic"), glewGetExtension("GL_SGIX_texture_mipmap_anisotropic"));
+}
+
+#endif /* GL_SGIX_texture_mipmap_anisotropic */
+
 #ifdef GL_SGIX_texture_multi_buffer
 
 static void _glewInfo_GL_SGIX_texture_multi_buffer (void)
@@ -7370,6 +9935,15 @@ static void _glewInfo_GL_SGIX_texture_multi_buffer (void)
 }
 
 #endif /* GL_SGIX_texture_multi_buffer */
+
+#ifdef GL_SGIX_texture_phase
+
+static void _glewInfo_GL_SGIX_texture_phase (void)
+{
+  glewPrintExt("GL_SGIX_texture_phase", GLEW_SGIX_texture_phase, glewIsSupported("GL_SGIX_texture_phase"), glewGetExtension("GL_SGIX_texture_phase"));
+}
+
+#endif /* GL_SGIX_texture_phase */
 
 #ifdef GL_SGIX_texture_range
 
@@ -7388,6 +9962,43 @@ static void _glewInfo_GL_SGIX_texture_scale_bias (void)
 }
 
 #endif /* GL_SGIX_texture_scale_bias */
+
+#ifdef GL_SGIX_texture_supersample
+
+static void _glewInfo_GL_SGIX_texture_supersample (void)
+{
+  glewPrintExt("GL_SGIX_texture_supersample", GLEW_SGIX_texture_supersample, glewIsSupported("GL_SGIX_texture_supersample"), glewGetExtension("GL_SGIX_texture_supersample"));
+}
+
+#endif /* GL_SGIX_texture_supersample */
+
+#ifdef GL_SGIX_vector_ops
+
+static void _glewInfo_GL_SGIX_vector_ops (void)
+{
+  glewPrintExt("GL_SGIX_vector_ops", GLEW_SGIX_vector_ops, glewIsSupported("GL_SGIX_vector_ops"), glewGetExtension("GL_SGIX_vector_ops"));
+
+  glewInfoFunc("glGetVectorOperationSGIX", glGetVectorOperationSGIX == NULL);
+  glewInfoFunc("glVectorOperationSGIX", glVectorOperationSGIX == NULL);
+}
+
+#endif /* GL_SGIX_vector_ops */
+
+#ifdef GL_SGIX_vertex_array_object
+
+static void _glewInfo_GL_SGIX_vertex_array_object (void)
+{
+  glewPrintExt("GL_SGIX_vertex_array_object", GLEW_SGIX_vertex_array_object, glewIsSupported("GL_SGIX_vertex_array_object"), glewGetExtension("GL_SGIX_vertex_array_object"));
+
+  glewInfoFunc("glAreVertexArraysResidentSGIX", glAreVertexArraysResidentSGIX == NULL);
+  glewInfoFunc("glBindVertexArraySGIX", glBindVertexArraySGIX == NULL);
+  glewInfoFunc("glDeleteVertexArraysSGIX", glDeleteVertexArraysSGIX == NULL);
+  glewInfoFunc("glGenVertexArraysSGIX", glGenVertexArraysSGIX == NULL);
+  glewInfoFunc("glIsVertexArraySGIX", glIsVertexArraySGIX == NULL);
+  glewInfoFunc("glPrioritizeVertexArraysSGIX", glPrioritizeVertexArraysSGIX == NULL);
+}
+
+#endif /* GL_SGIX_vertex_array_object */
 
 #ifdef GL_SGIX_vertex_preclip
 
@@ -7416,6 +10027,24 @@ static void _glewInfo_GL_SGIX_ycrcb (void)
 
 #endif /* GL_SGIX_ycrcb */
 
+#ifdef GL_SGIX_ycrcb_subsample
+
+static void _glewInfo_GL_SGIX_ycrcb_subsample (void)
+{
+  glewPrintExt("GL_SGIX_ycrcb_subsample", GLEW_SGIX_ycrcb_subsample, glewIsSupported("GL_SGIX_ycrcb_subsample"), glewGetExtension("GL_SGIX_ycrcb_subsample"));
+}
+
+#endif /* GL_SGIX_ycrcb_subsample */
+
+#ifdef GL_SGIX_ycrcba
+
+static void _glewInfo_GL_SGIX_ycrcba (void)
+{
+  glewPrintExt("GL_SGIX_ycrcba", GLEW_SGIX_ycrcba, glewIsSupported("GL_SGIX_ycrcba"), glewGetExtension("GL_SGIX_ycrcba"));
+}
+
+#endif /* GL_SGIX_ycrcba */
+
 #ifdef GL_SGI_color_matrix
 
 static void _glewInfo_GL_SGI_color_matrix (void)
@@ -7441,6 +10070,41 @@ static void _glewInfo_GL_SGI_color_table (void)
 }
 
 #endif /* GL_SGI_color_table */
+
+#ifdef GL_SGI_complex
+
+static void _glewInfo_GL_SGI_complex (void)
+{
+  glewPrintExt("GL_SGI_complex", GLEW_SGI_complex, glewIsSupported("GL_SGI_complex"), glewGetExtension("GL_SGI_complex"));
+}
+
+#endif /* GL_SGI_complex */
+
+#ifdef GL_SGI_complex_type
+
+static void _glewInfo_GL_SGI_complex_type (void)
+{
+  glewPrintExt("GL_SGI_complex_type", GLEW_SGI_complex_type, glewIsSupported("GL_SGI_complex_type"), glewGetExtension("GL_SGI_complex_type"));
+}
+
+#endif /* GL_SGI_complex_type */
+
+#ifdef GL_SGI_fft
+
+static void _glewInfo_GL_SGI_fft (void)
+{
+  glewPrintExt("GL_SGI_fft", GLEW_SGI_fft, glewIsSupported("GL_SGI_fft"), glewGetExtension("GL_SGI_fft"));
+
+  glewInfoFunc("glGetPixelTransformParameterfvSGI", glGetPixelTransformParameterfvSGI == NULL);
+  glewInfoFunc("glGetPixelTransformParameterivSGI", glGetPixelTransformParameterivSGI == NULL);
+  glewInfoFunc("glPixelTransformParameterfSGI", glPixelTransformParameterfSGI == NULL);
+  glewInfoFunc("glPixelTransformParameterfvSGI", glPixelTransformParameterfvSGI == NULL);
+  glewInfoFunc("glPixelTransformParameteriSGI", glPixelTransformParameteriSGI == NULL);
+  glewInfoFunc("glPixelTransformParameterivSGI", glPixelTransformParameterivSGI == NULL);
+  glewInfoFunc("glPixelTransformSGI", glPixelTransformSGI == NULL);
+}
+
+#endif /* GL_SGI_fft */
 
 #ifdef GL_SGI_texture_color_table
 
@@ -7594,6 +10258,15 @@ static void _glewInfo_GL_WIN_phong_shading (void)
 
 #endif /* GL_WIN_phong_shading */
 
+#ifdef GL_WIN_scene_markerXXX
+
+static void _glewInfo_GL_WIN_scene_markerXXX (void)
+{
+  glewPrintExt("GL_WIN_scene_markerXXX", GLEW_WIN_scene_markerXXX, glewIsSupported("GL_WIN_scene_markerXXX"), glewGetExtension("GL_WIN_scene_markerXXX"));
+}
+
+#endif /* GL_WIN_scene_markerXXX */
+
 #ifdef GL_WIN_specular_fog
 
 static void _glewInfo_GL_WIN_specular_fog (void)
@@ -7614,7 +10287,1350 @@ static void _glewInfo_GL_WIN_swap_hint (void)
 
 #endif /* GL_WIN_swap_hint */
 
-#ifdef _WIN32
+#if defined(GLEW_EGL)
+
+#ifdef EGL_VERSION_1_0
+
+static void _glewInfo_EGL_VERSION_1_0 (void)
+{
+  glewPrintExt("EGL_VERSION_1_0", EGLEW_VERSION_1_0, EGLEW_VERSION_1_0, EGLEW_VERSION_1_0);
+
+  glewInfoFunc("eglChooseConfig", eglChooseConfig == NULL);
+  glewInfoFunc("eglCopyBuffers", eglCopyBuffers == NULL);
+  glewInfoFunc("eglCreateContext", eglCreateContext == NULL);
+  glewInfoFunc("eglCreatePbufferSurface", eglCreatePbufferSurface == NULL);
+  glewInfoFunc("eglCreatePixmapSurface", eglCreatePixmapSurface == NULL);
+  glewInfoFunc("eglCreateWindowSurface", eglCreateWindowSurface == NULL);
+  glewInfoFunc("eglDestroyContext", eglDestroyContext == NULL);
+  glewInfoFunc("eglDestroySurface", eglDestroySurface == NULL);
+  glewInfoFunc("eglGetConfigAttrib", eglGetConfigAttrib == NULL);
+  glewInfoFunc("eglGetConfigs", eglGetConfigs == NULL);
+  glewInfoFunc("eglGetCurrentDisplay", eglGetCurrentDisplay == NULL);
+  glewInfoFunc("eglGetCurrentSurface", eglGetCurrentSurface == NULL);
+  glewInfoFunc("eglGetDisplay", eglGetDisplay == NULL);
+  glewInfoFunc("eglGetError", eglGetError == NULL);
+  glewInfoFunc("eglInitialize", eglInitialize == NULL);
+  glewInfoFunc("eglMakeCurrent", eglMakeCurrent == NULL);
+  glewInfoFunc("eglQueryContext", eglQueryContext == NULL);
+  glewInfoFunc("eglQueryString", eglQueryString == NULL);
+  glewInfoFunc("eglQuerySurface", eglQuerySurface == NULL);
+  glewInfoFunc("eglSwapBuffers", eglSwapBuffers == NULL);
+  glewInfoFunc("eglTerminate", eglTerminate == NULL);
+  glewInfoFunc("eglWaitGL", eglWaitGL == NULL);
+  glewInfoFunc("eglWaitNative", eglWaitNative == NULL);
+}
+
+#endif /* EGL_VERSION_1_0 */
+
+#ifdef EGL_VERSION_1_1
+
+static void _glewInfo_EGL_VERSION_1_1 (void)
+{
+  glewPrintExt("EGL_VERSION_1_1", EGLEW_VERSION_1_1, EGLEW_VERSION_1_1, EGLEW_VERSION_1_1);
+
+  glewInfoFunc("eglBindTexImage", eglBindTexImage == NULL);
+  glewInfoFunc("eglReleaseTexImage", eglReleaseTexImage == NULL);
+  glewInfoFunc("eglSurfaceAttrib", eglSurfaceAttrib == NULL);
+  glewInfoFunc("eglSwapInterval", eglSwapInterval == NULL);
+}
+
+#endif /* EGL_VERSION_1_1 */
+
+#ifdef EGL_VERSION_1_2
+
+static void _glewInfo_EGL_VERSION_1_2 (void)
+{
+  glewPrintExt("EGL_VERSION_1_2", EGLEW_VERSION_1_2, EGLEW_VERSION_1_2, EGLEW_VERSION_1_2);
+
+  glewInfoFunc("eglBindAPI", eglBindAPI == NULL);
+  glewInfoFunc("eglCreatePbufferFromClientBuffer", eglCreatePbufferFromClientBuffer == NULL);
+  glewInfoFunc("eglQueryAPI", eglQueryAPI == NULL);
+  glewInfoFunc("eglReleaseThread", eglReleaseThread == NULL);
+  glewInfoFunc("eglWaitClient", eglWaitClient == NULL);
+}
+
+#endif /* EGL_VERSION_1_2 */
+
+#ifdef EGL_VERSION_1_3
+
+static void _glewInfo_EGL_VERSION_1_3 (void)
+{
+  glewPrintExt("EGL_VERSION_1_3", EGLEW_VERSION_1_3, EGLEW_VERSION_1_3, EGLEW_VERSION_1_3);
+}
+
+#endif /* EGL_VERSION_1_3 */
+
+#ifdef EGL_VERSION_1_4
+
+static void _glewInfo_EGL_VERSION_1_4 (void)
+{
+  glewPrintExt("EGL_VERSION_1_4", EGLEW_VERSION_1_4, EGLEW_VERSION_1_4, EGLEW_VERSION_1_4);
+
+  glewInfoFunc("eglGetCurrentContext", eglGetCurrentContext == NULL);
+}
+
+#endif /* EGL_VERSION_1_4 */
+
+#ifdef EGL_VERSION_1_5
+
+static void _glewInfo_EGL_VERSION_1_5 (void)
+{
+  glewPrintExt("EGL_VERSION_1_5", EGLEW_VERSION_1_5, EGLEW_VERSION_1_5, EGLEW_VERSION_1_5);
+
+  glewInfoFunc("eglClientWaitSync", eglClientWaitSync == NULL);
+  glewInfoFunc("eglCreateImage", eglCreateImage == NULL);
+  glewInfoFunc("eglCreatePlatformPixmapSurface", eglCreatePlatformPixmapSurface == NULL);
+  glewInfoFunc("eglCreatePlatformWindowSurface", eglCreatePlatformWindowSurface == NULL);
+  glewInfoFunc("eglCreateSync", eglCreateSync == NULL);
+  glewInfoFunc("eglDestroyImage", eglDestroyImage == NULL);
+  glewInfoFunc("eglDestroySync", eglDestroySync == NULL);
+  glewInfoFunc("eglGetPlatformDisplay", eglGetPlatformDisplay == NULL);
+  glewInfoFunc("eglGetSyncAttrib", eglGetSyncAttrib == NULL);
+  glewInfoFunc("eglWaitSync", eglWaitSync == NULL);
+}
+
+#endif /* EGL_VERSION_1_5 */
+
+#ifdef EGL_ANDROID_blob_cache
+
+static void _glewInfo_EGL_ANDROID_blob_cache (void)
+{
+  glewPrintExt("EGL_ANDROID_blob_cache", EGLEW_ANDROID_blob_cache, eglewIsSupported("EGL_ANDROID_blob_cache"), eglewGetExtension("EGL_ANDROID_blob_cache"));
+
+  glewInfoFunc("eglSetBlobCacheFuncsANDROID", eglSetBlobCacheFuncsANDROID == NULL);
+}
+
+#endif /* EGL_ANDROID_blob_cache */
+
+#ifdef EGL_ANDROID_create_native_client_buffer
+
+static void _glewInfo_EGL_ANDROID_create_native_client_buffer (void)
+{
+  glewPrintExt("EGL_ANDROID_create_native_client_buffer", EGLEW_ANDROID_create_native_client_buffer, eglewIsSupported("EGL_ANDROID_create_native_client_buffer"), eglewGetExtension("EGL_ANDROID_create_native_client_buffer"));
+
+  glewInfoFunc("eglCreateNativeClientBufferANDROID", eglCreateNativeClientBufferANDROID == NULL);
+}
+
+#endif /* EGL_ANDROID_create_native_client_buffer */
+
+#ifdef EGL_ANDROID_framebuffer_target
+
+static void _glewInfo_EGL_ANDROID_framebuffer_target (void)
+{
+  glewPrintExt("EGL_ANDROID_framebuffer_target", EGLEW_ANDROID_framebuffer_target, eglewIsSupported("EGL_ANDROID_framebuffer_target"), eglewGetExtension("EGL_ANDROID_framebuffer_target"));
+}
+
+#endif /* EGL_ANDROID_framebuffer_target */
+
+#ifdef EGL_ANDROID_front_buffer_auto_refresh
+
+static void _glewInfo_EGL_ANDROID_front_buffer_auto_refresh (void)
+{
+  glewPrintExt("EGL_ANDROID_front_buffer_auto_refresh", EGLEW_ANDROID_front_buffer_auto_refresh, eglewIsSupported("EGL_ANDROID_front_buffer_auto_refresh"), eglewGetExtension("EGL_ANDROID_front_buffer_auto_refresh"));
+}
+
+#endif /* EGL_ANDROID_front_buffer_auto_refresh */
+
+#ifdef EGL_ANDROID_image_native_buffer
+
+static void _glewInfo_EGL_ANDROID_image_native_buffer (void)
+{
+  glewPrintExt("EGL_ANDROID_image_native_buffer", EGLEW_ANDROID_image_native_buffer, eglewIsSupported("EGL_ANDROID_image_native_buffer"), eglewGetExtension("EGL_ANDROID_image_native_buffer"));
+}
+
+#endif /* EGL_ANDROID_image_native_buffer */
+
+#ifdef EGL_ANDROID_native_fence_sync
+
+static void _glewInfo_EGL_ANDROID_native_fence_sync (void)
+{
+  glewPrintExt("EGL_ANDROID_native_fence_sync", EGLEW_ANDROID_native_fence_sync, eglewIsSupported("EGL_ANDROID_native_fence_sync"), eglewGetExtension("EGL_ANDROID_native_fence_sync"));
+
+  glewInfoFunc("eglDupNativeFenceFDANDROID", eglDupNativeFenceFDANDROID == NULL);
+}
+
+#endif /* EGL_ANDROID_native_fence_sync */
+
+#ifdef EGL_ANDROID_presentation_time
+
+static void _glewInfo_EGL_ANDROID_presentation_time (void)
+{
+  glewPrintExt("EGL_ANDROID_presentation_time", EGLEW_ANDROID_presentation_time, eglewIsSupported("EGL_ANDROID_presentation_time"), eglewGetExtension("EGL_ANDROID_presentation_time"));
+
+  glewInfoFunc("eglPresentationTimeANDROID", eglPresentationTimeANDROID == NULL);
+}
+
+#endif /* EGL_ANDROID_presentation_time */
+
+#ifdef EGL_ANDROID_recordable
+
+static void _glewInfo_EGL_ANDROID_recordable (void)
+{
+  glewPrintExt("EGL_ANDROID_recordable", EGLEW_ANDROID_recordable, eglewIsSupported("EGL_ANDROID_recordable"), eglewGetExtension("EGL_ANDROID_recordable"));
+}
+
+#endif /* EGL_ANDROID_recordable */
+
+#ifdef EGL_ANGLE_d3d_share_handle_client_buffer
+
+static void _glewInfo_EGL_ANGLE_d3d_share_handle_client_buffer (void)
+{
+  glewPrintExt("EGL_ANGLE_d3d_share_handle_client_buffer", EGLEW_ANGLE_d3d_share_handle_client_buffer, eglewIsSupported("EGL_ANGLE_d3d_share_handle_client_buffer"), eglewGetExtension("EGL_ANGLE_d3d_share_handle_client_buffer"));
+}
+
+#endif /* EGL_ANGLE_d3d_share_handle_client_buffer */
+
+#ifdef EGL_ANGLE_device_d3d
+
+static void _glewInfo_EGL_ANGLE_device_d3d (void)
+{
+  glewPrintExt("EGL_ANGLE_device_d3d", EGLEW_ANGLE_device_d3d, eglewIsSupported("EGL_ANGLE_device_d3d"), eglewGetExtension("EGL_ANGLE_device_d3d"));
+}
+
+#endif /* EGL_ANGLE_device_d3d */
+
+#ifdef EGL_ANGLE_query_surface_pointer
+
+static void _glewInfo_EGL_ANGLE_query_surface_pointer (void)
+{
+  glewPrintExt("EGL_ANGLE_query_surface_pointer", EGLEW_ANGLE_query_surface_pointer, eglewIsSupported("EGL_ANGLE_query_surface_pointer"), eglewGetExtension("EGL_ANGLE_query_surface_pointer"));
+
+  glewInfoFunc("eglQuerySurfacePointerANGLE", eglQuerySurfacePointerANGLE == NULL);
+}
+
+#endif /* EGL_ANGLE_query_surface_pointer */
+
+#ifdef EGL_ANGLE_surface_d3d_texture_2d_share_handle
+
+static void _glewInfo_EGL_ANGLE_surface_d3d_texture_2d_share_handle (void)
+{
+  glewPrintExt("EGL_ANGLE_surface_d3d_texture_2d_share_handle", EGLEW_ANGLE_surface_d3d_texture_2d_share_handle, eglewIsSupported("EGL_ANGLE_surface_d3d_texture_2d_share_handle"), eglewGetExtension("EGL_ANGLE_surface_d3d_texture_2d_share_handle"));
+}
+
+#endif /* EGL_ANGLE_surface_d3d_texture_2d_share_handle */
+
+#ifdef EGL_ANGLE_window_fixed_size
+
+static void _glewInfo_EGL_ANGLE_window_fixed_size (void)
+{
+  glewPrintExt("EGL_ANGLE_window_fixed_size", EGLEW_ANGLE_window_fixed_size, eglewIsSupported("EGL_ANGLE_window_fixed_size"), eglewGetExtension("EGL_ANGLE_window_fixed_size"));
+}
+
+#endif /* EGL_ANGLE_window_fixed_size */
+
+#ifdef EGL_ARM_implicit_external_sync
+
+static void _glewInfo_EGL_ARM_implicit_external_sync (void)
+{
+  glewPrintExt("EGL_ARM_implicit_external_sync", EGLEW_ARM_implicit_external_sync, eglewIsSupported("EGL_ARM_implicit_external_sync"), eglewGetExtension("EGL_ARM_implicit_external_sync"));
+}
+
+#endif /* EGL_ARM_implicit_external_sync */
+
+#ifdef EGL_ARM_pixmap_multisample_discard
+
+static void _glewInfo_EGL_ARM_pixmap_multisample_discard (void)
+{
+  glewPrintExt("EGL_ARM_pixmap_multisample_discard", EGLEW_ARM_pixmap_multisample_discard, eglewIsSupported("EGL_ARM_pixmap_multisample_discard"), eglewGetExtension("EGL_ARM_pixmap_multisample_discard"));
+}
+
+#endif /* EGL_ARM_pixmap_multisample_discard */
+
+#ifdef EGL_EXT_buffer_age
+
+static void _glewInfo_EGL_EXT_buffer_age (void)
+{
+  glewPrintExt("EGL_EXT_buffer_age", EGLEW_EXT_buffer_age, eglewIsSupported("EGL_EXT_buffer_age"), eglewGetExtension("EGL_EXT_buffer_age"));
+}
+
+#endif /* EGL_EXT_buffer_age */
+
+#ifdef EGL_EXT_client_extensions
+
+static void _glewInfo_EGL_EXT_client_extensions (void)
+{
+  glewPrintExt("EGL_EXT_client_extensions", EGLEW_EXT_client_extensions, eglewIsSupported("EGL_EXT_client_extensions"), eglewGetExtension("EGL_EXT_client_extensions"));
+}
+
+#endif /* EGL_EXT_client_extensions */
+
+#ifdef EGL_EXT_create_context_robustness
+
+static void _glewInfo_EGL_EXT_create_context_robustness (void)
+{
+  glewPrintExt("EGL_EXT_create_context_robustness", EGLEW_EXT_create_context_robustness, eglewIsSupported("EGL_EXT_create_context_robustness"), eglewGetExtension("EGL_EXT_create_context_robustness"));
+}
+
+#endif /* EGL_EXT_create_context_robustness */
+
+#ifdef EGL_EXT_device_base
+
+static void _glewInfo_EGL_EXT_device_base (void)
+{
+  glewPrintExt("EGL_EXT_device_base", EGLEW_EXT_device_base, eglewIsSupported("EGL_EXT_device_base"), eglewGetExtension("EGL_EXT_device_base"));
+}
+
+#endif /* EGL_EXT_device_base */
+
+#ifdef EGL_EXT_device_drm
+
+static void _glewInfo_EGL_EXT_device_drm (void)
+{
+  glewPrintExt("EGL_EXT_device_drm", EGLEW_EXT_device_drm, eglewIsSupported("EGL_EXT_device_drm"), eglewGetExtension("EGL_EXT_device_drm"));
+}
+
+#endif /* EGL_EXT_device_drm */
+
+#ifdef EGL_EXT_device_enumeration
+
+static void _glewInfo_EGL_EXT_device_enumeration (void)
+{
+  glewPrintExt("EGL_EXT_device_enumeration", EGLEW_EXT_device_enumeration, eglewIsSupported("EGL_EXT_device_enumeration"), eglewGetExtension("EGL_EXT_device_enumeration"));
+
+  glewInfoFunc("eglQueryDevicesEXT", eglQueryDevicesEXT == NULL);
+}
+
+#endif /* EGL_EXT_device_enumeration */
+
+#ifdef EGL_EXT_device_openwf
+
+static void _glewInfo_EGL_EXT_device_openwf (void)
+{
+  glewPrintExt("EGL_EXT_device_openwf", EGLEW_EXT_device_openwf, eglewIsSupported("EGL_EXT_device_openwf"), eglewGetExtension("EGL_EXT_device_openwf"));
+}
+
+#endif /* EGL_EXT_device_openwf */
+
+#ifdef EGL_EXT_device_query
+
+static void _glewInfo_EGL_EXT_device_query (void)
+{
+  glewPrintExt("EGL_EXT_device_query", EGLEW_EXT_device_query, eglewIsSupported("EGL_EXT_device_query"), eglewGetExtension("EGL_EXT_device_query"));
+
+  glewInfoFunc("eglQueryDeviceAttribEXT", eglQueryDeviceAttribEXT == NULL);
+  glewInfoFunc("eglQueryDeviceStringEXT", eglQueryDeviceStringEXT == NULL);
+  glewInfoFunc("eglQueryDisplayAttribEXT", eglQueryDisplayAttribEXT == NULL);
+}
+
+#endif /* EGL_EXT_device_query */
+
+#ifdef EGL_EXT_gl_colorspace_bt2020_linear
+
+static void _glewInfo_EGL_EXT_gl_colorspace_bt2020_linear (void)
+{
+  glewPrintExt("EGL_EXT_gl_colorspace_bt2020_linear", EGLEW_EXT_gl_colorspace_bt2020_linear, eglewIsSupported("EGL_EXT_gl_colorspace_bt2020_linear"), eglewGetExtension("EGL_EXT_gl_colorspace_bt2020_linear"));
+}
+
+#endif /* EGL_EXT_gl_colorspace_bt2020_linear */
+
+#ifdef EGL_EXT_gl_colorspace_bt2020_pq
+
+static void _glewInfo_EGL_EXT_gl_colorspace_bt2020_pq (void)
+{
+  glewPrintExt("EGL_EXT_gl_colorspace_bt2020_pq", EGLEW_EXT_gl_colorspace_bt2020_pq, eglewIsSupported("EGL_EXT_gl_colorspace_bt2020_pq"), eglewGetExtension("EGL_EXT_gl_colorspace_bt2020_pq"));
+}
+
+#endif /* EGL_EXT_gl_colorspace_bt2020_pq */
+
+#ifdef EGL_EXT_gl_colorspace_scrgb_linear
+
+static void _glewInfo_EGL_EXT_gl_colorspace_scrgb_linear (void)
+{
+  glewPrintExt("EGL_EXT_gl_colorspace_scrgb_linear", EGLEW_EXT_gl_colorspace_scrgb_linear, eglewIsSupported("EGL_EXT_gl_colorspace_scrgb_linear"), eglewGetExtension("EGL_EXT_gl_colorspace_scrgb_linear"));
+}
+
+#endif /* EGL_EXT_gl_colorspace_scrgb_linear */
+
+#ifdef EGL_EXT_image_dma_buf_import
+
+static void _glewInfo_EGL_EXT_image_dma_buf_import (void)
+{
+  glewPrintExt("EGL_EXT_image_dma_buf_import", EGLEW_EXT_image_dma_buf_import, eglewIsSupported("EGL_EXT_image_dma_buf_import"), eglewGetExtension("EGL_EXT_image_dma_buf_import"));
+}
+
+#endif /* EGL_EXT_image_dma_buf_import */
+
+#ifdef EGL_EXT_image_dma_buf_import_modifiers
+
+static void _glewInfo_EGL_EXT_image_dma_buf_import_modifiers (void)
+{
+  glewPrintExt("EGL_EXT_image_dma_buf_import_modifiers", EGLEW_EXT_image_dma_buf_import_modifiers, eglewIsSupported("EGL_EXT_image_dma_buf_import_modifiers"), eglewGetExtension("EGL_EXT_image_dma_buf_import_modifiers"));
+
+  glewInfoFunc("eglQueryDmaBufFormatsEXT", eglQueryDmaBufFormatsEXT == NULL);
+  glewInfoFunc("eglQueryDmaBufModifiersEXT", eglQueryDmaBufModifiersEXT == NULL);
+}
+
+#endif /* EGL_EXT_image_dma_buf_import_modifiers */
+
+#ifdef EGL_EXT_multiview_window
+
+static void _glewInfo_EGL_EXT_multiview_window (void)
+{
+  glewPrintExt("EGL_EXT_multiview_window", EGLEW_EXT_multiview_window, eglewIsSupported("EGL_EXT_multiview_window"), eglewGetExtension("EGL_EXT_multiview_window"));
+}
+
+#endif /* EGL_EXT_multiview_window */
+
+#ifdef EGL_EXT_output_base
+
+static void _glewInfo_EGL_EXT_output_base (void)
+{
+  glewPrintExt("EGL_EXT_output_base", EGLEW_EXT_output_base, eglewIsSupported("EGL_EXT_output_base"), eglewGetExtension("EGL_EXT_output_base"));
+
+  glewInfoFunc("eglGetOutputLayersEXT", eglGetOutputLayersEXT == NULL);
+  glewInfoFunc("eglGetOutputPortsEXT", eglGetOutputPortsEXT == NULL);
+  glewInfoFunc("eglOutputLayerAttribEXT", eglOutputLayerAttribEXT == NULL);
+  glewInfoFunc("eglOutputPortAttribEXT", eglOutputPortAttribEXT == NULL);
+  glewInfoFunc("eglQueryOutputLayerAttribEXT", eglQueryOutputLayerAttribEXT == NULL);
+  glewInfoFunc("eglQueryOutputLayerStringEXT", eglQueryOutputLayerStringEXT == NULL);
+  glewInfoFunc("eglQueryOutputPortAttribEXT", eglQueryOutputPortAttribEXT == NULL);
+  glewInfoFunc("eglQueryOutputPortStringEXT", eglQueryOutputPortStringEXT == NULL);
+}
+
+#endif /* EGL_EXT_output_base */
+
+#ifdef EGL_EXT_output_drm
+
+static void _glewInfo_EGL_EXT_output_drm (void)
+{
+  glewPrintExt("EGL_EXT_output_drm", EGLEW_EXT_output_drm, eglewIsSupported("EGL_EXT_output_drm"), eglewGetExtension("EGL_EXT_output_drm"));
+}
+
+#endif /* EGL_EXT_output_drm */
+
+#ifdef EGL_EXT_output_openwf
+
+static void _glewInfo_EGL_EXT_output_openwf (void)
+{
+  glewPrintExt("EGL_EXT_output_openwf", EGLEW_EXT_output_openwf, eglewIsSupported("EGL_EXT_output_openwf"), eglewGetExtension("EGL_EXT_output_openwf"));
+}
+
+#endif /* EGL_EXT_output_openwf */
+
+#ifdef EGL_EXT_pixel_format_float
+
+static void _glewInfo_EGL_EXT_pixel_format_float (void)
+{
+  glewPrintExt("EGL_EXT_pixel_format_float", EGLEW_EXT_pixel_format_float, eglewIsSupported("EGL_EXT_pixel_format_float"), eglewGetExtension("EGL_EXT_pixel_format_float"));
+}
+
+#endif /* EGL_EXT_pixel_format_float */
+
+#ifdef EGL_EXT_platform_base
+
+static void _glewInfo_EGL_EXT_platform_base (void)
+{
+  glewPrintExt("EGL_EXT_platform_base", EGLEW_EXT_platform_base, eglewIsSupported("EGL_EXT_platform_base"), eglewGetExtension("EGL_EXT_platform_base"));
+
+  glewInfoFunc("eglCreatePlatformPixmapSurfaceEXT", eglCreatePlatformPixmapSurfaceEXT == NULL);
+  glewInfoFunc("eglCreatePlatformWindowSurfaceEXT", eglCreatePlatformWindowSurfaceEXT == NULL);
+  glewInfoFunc("eglGetPlatformDisplayEXT", eglGetPlatformDisplayEXT == NULL);
+}
+
+#endif /* EGL_EXT_platform_base */
+
+#ifdef EGL_EXT_platform_device
+
+static void _glewInfo_EGL_EXT_platform_device (void)
+{
+  glewPrintExt("EGL_EXT_platform_device", EGLEW_EXT_platform_device, eglewIsSupported("EGL_EXT_platform_device"), eglewGetExtension("EGL_EXT_platform_device"));
+}
+
+#endif /* EGL_EXT_platform_device */
+
+#ifdef EGL_EXT_platform_wayland
+
+static void _glewInfo_EGL_EXT_platform_wayland (void)
+{
+  glewPrintExt("EGL_EXT_platform_wayland", EGLEW_EXT_platform_wayland, eglewIsSupported("EGL_EXT_platform_wayland"), eglewGetExtension("EGL_EXT_platform_wayland"));
+}
+
+#endif /* EGL_EXT_platform_wayland */
+
+#ifdef EGL_EXT_platform_x11
+
+static void _glewInfo_EGL_EXT_platform_x11 (void)
+{
+  glewPrintExt("EGL_EXT_platform_x11", EGLEW_EXT_platform_x11, eglewIsSupported("EGL_EXT_platform_x11"), eglewGetExtension("EGL_EXT_platform_x11"));
+}
+
+#endif /* EGL_EXT_platform_x11 */
+
+#ifdef EGL_EXT_protected_content
+
+static void _glewInfo_EGL_EXT_protected_content (void)
+{
+  glewPrintExt("EGL_EXT_protected_content", EGLEW_EXT_protected_content, eglewIsSupported("EGL_EXT_protected_content"), eglewGetExtension("EGL_EXT_protected_content"));
+}
+
+#endif /* EGL_EXT_protected_content */
+
+#ifdef EGL_EXT_protected_surface
+
+static void _glewInfo_EGL_EXT_protected_surface (void)
+{
+  glewPrintExt("EGL_EXT_protected_surface", EGLEW_EXT_protected_surface, eglewIsSupported("EGL_EXT_protected_surface"), eglewGetExtension("EGL_EXT_protected_surface"));
+}
+
+#endif /* EGL_EXT_protected_surface */
+
+#ifdef EGL_EXT_stream_consumer_egloutput
+
+static void _glewInfo_EGL_EXT_stream_consumer_egloutput (void)
+{
+  glewPrintExt("EGL_EXT_stream_consumer_egloutput", EGLEW_EXT_stream_consumer_egloutput, eglewIsSupported("EGL_EXT_stream_consumer_egloutput"), eglewGetExtension("EGL_EXT_stream_consumer_egloutput"));
+
+  glewInfoFunc("eglStreamConsumerOutputEXT", eglStreamConsumerOutputEXT == NULL);
+}
+
+#endif /* EGL_EXT_stream_consumer_egloutput */
+
+#ifdef EGL_EXT_surface_SMPTE2086_metadata
+
+static void _glewInfo_EGL_EXT_surface_SMPTE2086_metadata (void)
+{
+  glewPrintExt("EGL_EXT_surface_SMPTE2086_metadata", EGLEW_EXT_surface_SMPTE2086_metadata, eglewIsSupported("EGL_EXT_surface_SMPTE2086_metadata"), eglewGetExtension("EGL_EXT_surface_SMPTE2086_metadata"));
+}
+
+#endif /* EGL_EXT_surface_SMPTE2086_metadata */
+
+#ifdef EGL_EXT_swap_buffers_with_damage
+
+static void _glewInfo_EGL_EXT_swap_buffers_with_damage (void)
+{
+  glewPrintExt("EGL_EXT_swap_buffers_with_damage", EGLEW_EXT_swap_buffers_with_damage, eglewIsSupported("EGL_EXT_swap_buffers_with_damage"), eglewGetExtension("EGL_EXT_swap_buffers_with_damage"));
+
+  glewInfoFunc("eglSwapBuffersWithDamageEXT", eglSwapBuffersWithDamageEXT == NULL);
+}
+
+#endif /* EGL_EXT_swap_buffers_with_damage */
+
+#ifdef EGL_EXT_yuv_surface
+
+static void _glewInfo_EGL_EXT_yuv_surface (void)
+{
+  glewPrintExt("EGL_EXT_yuv_surface", EGLEW_EXT_yuv_surface, eglewIsSupported("EGL_EXT_yuv_surface"), eglewGetExtension("EGL_EXT_yuv_surface"));
+}
+
+#endif /* EGL_EXT_yuv_surface */
+
+#ifdef EGL_HI_clientpixmap
+
+static void _glewInfo_EGL_HI_clientpixmap (void)
+{
+  glewPrintExt("EGL_HI_clientpixmap", EGLEW_HI_clientpixmap, eglewIsSupported("EGL_HI_clientpixmap"), eglewGetExtension("EGL_HI_clientpixmap"));
+
+  glewInfoFunc("eglCreatePixmapSurfaceHI", eglCreatePixmapSurfaceHI == NULL);
+}
+
+#endif /* EGL_HI_clientpixmap */
+
+#ifdef EGL_HI_colorformats
+
+static void _glewInfo_EGL_HI_colorformats (void)
+{
+  glewPrintExt("EGL_HI_colorformats", EGLEW_HI_colorformats, eglewIsSupported("EGL_HI_colorformats"), eglewGetExtension("EGL_HI_colorformats"));
+}
+
+#endif /* EGL_HI_colorformats */
+
+#ifdef EGL_IMG_context_priority
+
+static void _glewInfo_EGL_IMG_context_priority (void)
+{
+  glewPrintExt("EGL_IMG_context_priority", EGLEW_IMG_context_priority, eglewIsSupported("EGL_IMG_context_priority"), eglewGetExtension("EGL_IMG_context_priority"));
+}
+
+#endif /* EGL_IMG_context_priority */
+
+#ifdef EGL_IMG_image_plane_attribs
+
+static void _glewInfo_EGL_IMG_image_plane_attribs (void)
+{
+  glewPrintExt("EGL_IMG_image_plane_attribs", EGLEW_IMG_image_plane_attribs, eglewIsSupported("EGL_IMG_image_plane_attribs"), eglewGetExtension("EGL_IMG_image_plane_attribs"));
+}
+
+#endif /* EGL_IMG_image_plane_attribs */
+
+#ifdef EGL_KHR_cl_event
+
+static void _glewInfo_EGL_KHR_cl_event (void)
+{
+  glewPrintExt("EGL_KHR_cl_event", EGLEW_KHR_cl_event, eglewIsSupported("EGL_KHR_cl_event"), eglewGetExtension("EGL_KHR_cl_event"));
+}
+
+#endif /* EGL_KHR_cl_event */
+
+#ifdef EGL_KHR_cl_event2
+
+static void _glewInfo_EGL_KHR_cl_event2 (void)
+{
+  glewPrintExt("EGL_KHR_cl_event2", EGLEW_KHR_cl_event2, eglewIsSupported("EGL_KHR_cl_event2"), eglewGetExtension("EGL_KHR_cl_event2"));
+
+  glewInfoFunc("eglCreateSync64KHR", eglCreateSync64KHR == NULL);
+}
+
+#endif /* EGL_KHR_cl_event2 */
+
+#ifdef EGL_KHR_client_get_all_proc_addresses
+
+static void _glewInfo_EGL_KHR_client_get_all_proc_addresses (void)
+{
+  glewPrintExt("EGL_KHR_client_get_all_proc_addresses", EGLEW_KHR_client_get_all_proc_addresses, eglewIsSupported("EGL_KHR_client_get_all_proc_addresses"), eglewGetExtension("EGL_KHR_client_get_all_proc_addresses"));
+}
+
+#endif /* EGL_KHR_client_get_all_proc_addresses */
+
+#ifdef EGL_KHR_config_attribs
+
+static void _glewInfo_EGL_KHR_config_attribs (void)
+{
+  glewPrintExt("EGL_KHR_config_attribs", EGLEW_KHR_config_attribs, eglewIsSupported("EGL_KHR_config_attribs"), eglewGetExtension("EGL_KHR_config_attribs"));
+}
+
+#endif /* EGL_KHR_config_attribs */
+
+#ifdef EGL_KHR_context_flush_control
+
+static void _glewInfo_EGL_KHR_context_flush_control (void)
+{
+  glewPrintExt("EGL_KHR_context_flush_control", EGLEW_KHR_context_flush_control, eglewIsSupported("EGL_KHR_context_flush_control"), eglewGetExtension("EGL_KHR_context_flush_control"));
+}
+
+#endif /* EGL_KHR_context_flush_control */
+
+#ifdef EGL_KHR_create_context
+
+static void _glewInfo_EGL_KHR_create_context (void)
+{
+  glewPrintExt("EGL_KHR_create_context", EGLEW_KHR_create_context, eglewIsSupported("EGL_KHR_create_context"), eglewGetExtension("EGL_KHR_create_context"));
+}
+
+#endif /* EGL_KHR_create_context */
+
+#ifdef EGL_KHR_create_context_no_error
+
+static void _glewInfo_EGL_KHR_create_context_no_error (void)
+{
+  glewPrintExt("EGL_KHR_create_context_no_error", EGLEW_KHR_create_context_no_error, eglewIsSupported("EGL_KHR_create_context_no_error"), eglewGetExtension("EGL_KHR_create_context_no_error"));
+}
+
+#endif /* EGL_KHR_create_context_no_error */
+
+#ifdef EGL_KHR_debug
+
+static void _glewInfo_EGL_KHR_debug (void)
+{
+  glewPrintExt("EGL_KHR_debug", EGLEW_KHR_debug, eglewIsSupported("EGL_KHR_debug"), eglewGetExtension("EGL_KHR_debug"));
+
+  glewInfoFunc("eglDebugMessageControlKHR", eglDebugMessageControlKHR == NULL);
+  glewInfoFunc("eglLabelObjectKHR", eglLabelObjectKHR == NULL);
+  glewInfoFunc("eglQueryDebugKHR", eglQueryDebugKHR == NULL);
+}
+
+#endif /* EGL_KHR_debug */
+
+#ifdef EGL_KHR_fence_sync
+
+static void _glewInfo_EGL_KHR_fence_sync (void)
+{
+  glewPrintExt("EGL_KHR_fence_sync", EGLEW_KHR_fence_sync, eglewIsSupported("EGL_KHR_fence_sync"), eglewGetExtension("EGL_KHR_fence_sync"));
+}
+
+#endif /* EGL_KHR_fence_sync */
+
+#ifdef EGL_KHR_get_all_proc_addresses
+
+static void _glewInfo_EGL_KHR_get_all_proc_addresses (void)
+{
+  glewPrintExt("EGL_KHR_get_all_proc_addresses", EGLEW_KHR_get_all_proc_addresses, eglewIsSupported("EGL_KHR_get_all_proc_addresses"), eglewGetExtension("EGL_KHR_get_all_proc_addresses"));
+}
+
+#endif /* EGL_KHR_get_all_proc_addresses */
+
+#ifdef EGL_KHR_gl_colorspace
+
+static void _glewInfo_EGL_KHR_gl_colorspace (void)
+{
+  glewPrintExt("EGL_KHR_gl_colorspace", EGLEW_KHR_gl_colorspace, eglewIsSupported("EGL_KHR_gl_colorspace"), eglewGetExtension("EGL_KHR_gl_colorspace"));
+}
+
+#endif /* EGL_KHR_gl_colorspace */
+
+#ifdef EGL_KHR_gl_renderbuffer_image
+
+static void _glewInfo_EGL_KHR_gl_renderbuffer_image (void)
+{
+  glewPrintExt("EGL_KHR_gl_renderbuffer_image", EGLEW_KHR_gl_renderbuffer_image, eglewIsSupported("EGL_KHR_gl_renderbuffer_image"), eglewGetExtension("EGL_KHR_gl_renderbuffer_image"));
+}
+
+#endif /* EGL_KHR_gl_renderbuffer_image */
+
+#ifdef EGL_KHR_gl_texture_2D_image
+
+static void _glewInfo_EGL_KHR_gl_texture_2D_image (void)
+{
+  glewPrintExt("EGL_KHR_gl_texture_2D_image", EGLEW_KHR_gl_texture_2D_image, eglewIsSupported("EGL_KHR_gl_texture_2D_image"), eglewGetExtension("EGL_KHR_gl_texture_2D_image"));
+}
+
+#endif /* EGL_KHR_gl_texture_2D_image */
+
+#ifdef EGL_KHR_gl_texture_3D_image
+
+static void _glewInfo_EGL_KHR_gl_texture_3D_image (void)
+{
+  glewPrintExt("EGL_KHR_gl_texture_3D_image", EGLEW_KHR_gl_texture_3D_image, eglewIsSupported("EGL_KHR_gl_texture_3D_image"), eglewGetExtension("EGL_KHR_gl_texture_3D_image"));
+}
+
+#endif /* EGL_KHR_gl_texture_3D_image */
+
+#ifdef EGL_KHR_gl_texture_cubemap_image
+
+static void _glewInfo_EGL_KHR_gl_texture_cubemap_image (void)
+{
+  glewPrintExt("EGL_KHR_gl_texture_cubemap_image", EGLEW_KHR_gl_texture_cubemap_image, eglewIsSupported("EGL_KHR_gl_texture_cubemap_image"), eglewGetExtension("EGL_KHR_gl_texture_cubemap_image"));
+}
+
+#endif /* EGL_KHR_gl_texture_cubemap_image */
+
+#ifdef EGL_KHR_image
+
+static void _glewInfo_EGL_KHR_image (void)
+{
+  glewPrintExt("EGL_KHR_image", EGLEW_KHR_image, eglewIsSupported("EGL_KHR_image"), eglewGetExtension("EGL_KHR_image"));
+
+  glewInfoFunc("eglCreateImageKHR", eglCreateImageKHR == NULL);
+  glewInfoFunc("eglDestroyImageKHR", eglDestroyImageKHR == NULL);
+}
+
+#endif /* EGL_KHR_image */
+
+#ifdef EGL_KHR_image_base
+
+static void _glewInfo_EGL_KHR_image_base (void)
+{
+  glewPrintExt("EGL_KHR_image_base", EGLEW_KHR_image_base, eglewIsSupported("EGL_KHR_image_base"), eglewGetExtension("EGL_KHR_image_base"));
+}
+
+#endif /* EGL_KHR_image_base */
+
+#ifdef EGL_KHR_image_pixmap
+
+static void _glewInfo_EGL_KHR_image_pixmap (void)
+{
+  glewPrintExt("EGL_KHR_image_pixmap", EGLEW_KHR_image_pixmap, eglewIsSupported("EGL_KHR_image_pixmap"), eglewGetExtension("EGL_KHR_image_pixmap"));
+}
+
+#endif /* EGL_KHR_image_pixmap */
+
+#ifdef EGL_KHR_lock_surface
+
+static void _glewInfo_EGL_KHR_lock_surface (void)
+{
+  glewPrintExt("EGL_KHR_lock_surface", EGLEW_KHR_lock_surface, eglewIsSupported("EGL_KHR_lock_surface"), eglewGetExtension("EGL_KHR_lock_surface"));
+
+  glewInfoFunc("eglLockSurfaceKHR", eglLockSurfaceKHR == NULL);
+  glewInfoFunc("eglUnlockSurfaceKHR", eglUnlockSurfaceKHR == NULL);
+}
+
+#endif /* EGL_KHR_lock_surface */
+
+#ifdef EGL_KHR_lock_surface2
+
+static void _glewInfo_EGL_KHR_lock_surface2 (void)
+{
+  glewPrintExt("EGL_KHR_lock_surface2", EGLEW_KHR_lock_surface2, eglewIsSupported("EGL_KHR_lock_surface2"), eglewGetExtension("EGL_KHR_lock_surface2"));
+}
+
+#endif /* EGL_KHR_lock_surface2 */
+
+#ifdef EGL_KHR_lock_surface3
+
+static void _glewInfo_EGL_KHR_lock_surface3 (void)
+{
+  glewPrintExt("EGL_KHR_lock_surface3", EGLEW_KHR_lock_surface3, eglewIsSupported("EGL_KHR_lock_surface3"), eglewGetExtension("EGL_KHR_lock_surface3"));
+
+  glewInfoFunc("eglQuerySurface64KHR", eglQuerySurface64KHR == NULL);
+}
+
+#endif /* EGL_KHR_lock_surface3 */
+
+#ifdef EGL_KHR_mutable_render_buffer
+
+static void _glewInfo_EGL_KHR_mutable_render_buffer (void)
+{
+  glewPrintExt("EGL_KHR_mutable_render_buffer", EGLEW_KHR_mutable_render_buffer, eglewIsSupported("EGL_KHR_mutable_render_buffer"), eglewGetExtension("EGL_KHR_mutable_render_buffer"));
+}
+
+#endif /* EGL_KHR_mutable_render_buffer */
+
+#ifdef EGL_KHR_no_config_context
+
+static void _glewInfo_EGL_KHR_no_config_context (void)
+{
+  glewPrintExt("EGL_KHR_no_config_context", EGLEW_KHR_no_config_context, eglewIsSupported("EGL_KHR_no_config_context"), eglewGetExtension("EGL_KHR_no_config_context"));
+}
+
+#endif /* EGL_KHR_no_config_context */
+
+#ifdef EGL_KHR_partial_update
+
+static void _glewInfo_EGL_KHR_partial_update (void)
+{
+  glewPrintExt("EGL_KHR_partial_update", EGLEW_KHR_partial_update, eglewIsSupported("EGL_KHR_partial_update"), eglewGetExtension("EGL_KHR_partial_update"));
+
+  glewInfoFunc("eglSetDamageRegionKHR", eglSetDamageRegionKHR == NULL);
+}
+
+#endif /* EGL_KHR_partial_update */
+
+#ifdef EGL_KHR_platform_android
+
+static void _glewInfo_EGL_KHR_platform_android (void)
+{
+  glewPrintExt("EGL_KHR_platform_android", EGLEW_KHR_platform_android, eglewIsSupported("EGL_KHR_platform_android"), eglewGetExtension("EGL_KHR_platform_android"));
+}
+
+#endif /* EGL_KHR_platform_android */
+
+#ifdef EGL_KHR_platform_gbm
+
+static void _glewInfo_EGL_KHR_platform_gbm (void)
+{
+  glewPrintExt("EGL_KHR_platform_gbm", EGLEW_KHR_platform_gbm, eglewIsSupported("EGL_KHR_platform_gbm"), eglewGetExtension("EGL_KHR_platform_gbm"));
+}
+
+#endif /* EGL_KHR_platform_gbm */
+
+#ifdef EGL_KHR_platform_wayland
+
+static void _glewInfo_EGL_KHR_platform_wayland (void)
+{
+  glewPrintExt("EGL_KHR_platform_wayland", EGLEW_KHR_platform_wayland, eglewIsSupported("EGL_KHR_platform_wayland"), eglewGetExtension("EGL_KHR_platform_wayland"));
+}
+
+#endif /* EGL_KHR_platform_wayland */
+
+#ifdef EGL_KHR_platform_x11
+
+static void _glewInfo_EGL_KHR_platform_x11 (void)
+{
+  glewPrintExt("EGL_KHR_platform_x11", EGLEW_KHR_platform_x11, eglewIsSupported("EGL_KHR_platform_x11"), eglewGetExtension("EGL_KHR_platform_x11"));
+}
+
+#endif /* EGL_KHR_platform_x11 */
+
+#ifdef EGL_KHR_reusable_sync
+
+static void _glewInfo_EGL_KHR_reusable_sync (void)
+{
+  glewPrintExt("EGL_KHR_reusable_sync", EGLEW_KHR_reusable_sync, eglewIsSupported("EGL_KHR_reusable_sync"), eglewGetExtension("EGL_KHR_reusable_sync"));
+
+  glewInfoFunc("eglClientWaitSyncKHR", eglClientWaitSyncKHR == NULL);
+  glewInfoFunc("eglCreateSyncKHR", eglCreateSyncKHR == NULL);
+  glewInfoFunc("eglDestroySyncKHR", eglDestroySyncKHR == NULL);
+  glewInfoFunc("eglGetSyncAttribKHR", eglGetSyncAttribKHR == NULL);
+  glewInfoFunc("eglSignalSyncKHR", eglSignalSyncKHR == NULL);
+}
+
+#endif /* EGL_KHR_reusable_sync */
+
+#ifdef EGL_KHR_stream
+
+static void _glewInfo_EGL_KHR_stream (void)
+{
+  glewPrintExt("EGL_KHR_stream", EGLEW_KHR_stream, eglewIsSupported("EGL_KHR_stream"), eglewGetExtension("EGL_KHR_stream"));
+
+  glewInfoFunc("eglCreateStreamKHR", eglCreateStreamKHR == NULL);
+  glewInfoFunc("eglDestroyStreamKHR", eglDestroyStreamKHR == NULL);
+  glewInfoFunc("eglQueryStreamKHR", eglQueryStreamKHR == NULL);
+  glewInfoFunc("eglQueryStreamu64KHR", eglQueryStreamu64KHR == NULL);
+  glewInfoFunc("eglStreamAttribKHR", eglStreamAttribKHR == NULL);
+}
+
+#endif /* EGL_KHR_stream */
+
+#ifdef EGL_KHR_stream_attrib
+
+static void _glewInfo_EGL_KHR_stream_attrib (void)
+{
+  glewPrintExt("EGL_KHR_stream_attrib", EGLEW_KHR_stream_attrib, eglewIsSupported("EGL_KHR_stream_attrib"), eglewGetExtension("EGL_KHR_stream_attrib"));
+
+  glewInfoFunc("eglCreateStreamAttribKHR", eglCreateStreamAttribKHR == NULL);
+  glewInfoFunc("eglQueryStreamAttribKHR", eglQueryStreamAttribKHR == NULL);
+  glewInfoFunc("eglSetStreamAttribKHR", eglSetStreamAttribKHR == NULL);
+  glewInfoFunc("eglStreamConsumerAcquireAttribKHR", eglStreamConsumerAcquireAttribKHR == NULL);
+  glewInfoFunc("eglStreamConsumerReleaseAttribKHR", eglStreamConsumerReleaseAttribKHR == NULL);
+}
+
+#endif /* EGL_KHR_stream_attrib */
+
+#ifdef EGL_KHR_stream_consumer_gltexture
+
+static void _glewInfo_EGL_KHR_stream_consumer_gltexture (void)
+{
+  glewPrintExt("EGL_KHR_stream_consumer_gltexture", EGLEW_KHR_stream_consumer_gltexture, eglewIsSupported("EGL_KHR_stream_consumer_gltexture"), eglewGetExtension("EGL_KHR_stream_consumer_gltexture"));
+
+  glewInfoFunc("eglStreamConsumerAcquireKHR", eglStreamConsumerAcquireKHR == NULL);
+  glewInfoFunc("eglStreamConsumerGLTextureExternalKHR", eglStreamConsumerGLTextureExternalKHR == NULL);
+  glewInfoFunc("eglStreamConsumerReleaseKHR", eglStreamConsumerReleaseKHR == NULL);
+}
+
+#endif /* EGL_KHR_stream_consumer_gltexture */
+
+#ifdef EGL_KHR_stream_cross_process_fd
+
+static void _glewInfo_EGL_KHR_stream_cross_process_fd (void)
+{
+  glewPrintExt("EGL_KHR_stream_cross_process_fd", EGLEW_KHR_stream_cross_process_fd, eglewIsSupported("EGL_KHR_stream_cross_process_fd"), eglewGetExtension("EGL_KHR_stream_cross_process_fd"));
+
+  glewInfoFunc("eglCreateStreamFromFileDescriptorKHR", eglCreateStreamFromFileDescriptorKHR == NULL);
+  glewInfoFunc("eglGetStreamFileDescriptorKHR", eglGetStreamFileDescriptorKHR == NULL);
+}
+
+#endif /* EGL_KHR_stream_cross_process_fd */
+
+#ifdef EGL_KHR_stream_fifo
+
+static void _glewInfo_EGL_KHR_stream_fifo (void)
+{
+  glewPrintExt("EGL_KHR_stream_fifo", EGLEW_KHR_stream_fifo, eglewIsSupported("EGL_KHR_stream_fifo"), eglewGetExtension("EGL_KHR_stream_fifo"));
+
+  glewInfoFunc("eglQueryStreamTimeKHR", eglQueryStreamTimeKHR == NULL);
+}
+
+#endif /* EGL_KHR_stream_fifo */
+
+#ifdef EGL_KHR_stream_producer_aldatalocator
+
+static void _glewInfo_EGL_KHR_stream_producer_aldatalocator (void)
+{
+  glewPrintExt("EGL_KHR_stream_producer_aldatalocator", EGLEW_KHR_stream_producer_aldatalocator, eglewIsSupported("EGL_KHR_stream_producer_aldatalocator"), eglewGetExtension("EGL_KHR_stream_producer_aldatalocator"));
+}
+
+#endif /* EGL_KHR_stream_producer_aldatalocator */
+
+#ifdef EGL_KHR_stream_producer_eglsurface
+
+static void _glewInfo_EGL_KHR_stream_producer_eglsurface (void)
+{
+  glewPrintExt("EGL_KHR_stream_producer_eglsurface", EGLEW_KHR_stream_producer_eglsurface, eglewIsSupported("EGL_KHR_stream_producer_eglsurface"), eglewGetExtension("EGL_KHR_stream_producer_eglsurface"));
+
+  glewInfoFunc("eglCreateStreamProducerSurfaceKHR", eglCreateStreamProducerSurfaceKHR == NULL);
+}
+
+#endif /* EGL_KHR_stream_producer_eglsurface */
+
+#ifdef EGL_KHR_surfaceless_context
+
+static void _glewInfo_EGL_KHR_surfaceless_context (void)
+{
+  glewPrintExt("EGL_KHR_surfaceless_context", EGLEW_KHR_surfaceless_context, eglewIsSupported("EGL_KHR_surfaceless_context"), eglewGetExtension("EGL_KHR_surfaceless_context"));
+}
+
+#endif /* EGL_KHR_surfaceless_context */
+
+#ifdef EGL_KHR_swap_buffers_with_damage
+
+static void _glewInfo_EGL_KHR_swap_buffers_with_damage (void)
+{
+  glewPrintExt("EGL_KHR_swap_buffers_with_damage", EGLEW_KHR_swap_buffers_with_damage, eglewIsSupported("EGL_KHR_swap_buffers_with_damage"), eglewGetExtension("EGL_KHR_swap_buffers_with_damage"));
+
+  glewInfoFunc("eglSwapBuffersWithDamageKHR", eglSwapBuffersWithDamageKHR == NULL);
+}
+
+#endif /* EGL_KHR_swap_buffers_with_damage */
+
+#ifdef EGL_KHR_vg_parent_image
+
+static void _glewInfo_EGL_KHR_vg_parent_image (void)
+{
+  glewPrintExt("EGL_KHR_vg_parent_image", EGLEW_KHR_vg_parent_image, eglewIsSupported("EGL_KHR_vg_parent_image"), eglewGetExtension("EGL_KHR_vg_parent_image"));
+}
+
+#endif /* EGL_KHR_vg_parent_image */
+
+#ifdef EGL_KHR_wait_sync
+
+static void _glewInfo_EGL_KHR_wait_sync (void)
+{
+  glewPrintExt("EGL_KHR_wait_sync", EGLEW_KHR_wait_sync, eglewIsSupported("EGL_KHR_wait_sync"), eglewGetExtension("EGL_KHR_wait_sync"));
+
+  glewInfoFunc("eglWaitSyncKHR", eglWaitSyncKHR == NULL);
+}
+
+#endif /* EGL_KHR_wait_sync */
+
+#ifdef EGL_MESA_drm_image
+
+static void _glewInfo_EGL_MESA_drm_image (void)
+{
+  glewPrintExt("EGL_MESA_drm_image", EGLEW_MESA_drm_image, eglewIsSupported("EGL_MESA_drm_image"), eglewGetExtension("EGL_MESA_drm_image"));
+
+  glewInfoFunc("eglCreateDRMImageMESA", eglCreateDRMImageMESA == NULL);
+  glewInfoFunc("eglExportDRMImageMESA", eglExportDRMImageMESA == NULL);
+}
+
+#endif /* EGL_MESA_drm_image */
+
+#ifdef EGL_MESA_image_dma_buf_export
+
+static void _glewInfo_EGL_MESA_image_dma_buf_export (void)
+{
+  glewPrintExt("EGL_MESA_image_dma_buf_export", EGLEW_MESA_image_dma_buf_export, eglewIsSupported("EGL_MESA_image_dma_buf_export"), eglewGetExtension("EGL_MESA_image_dma_buf_export"));
+
+  glewInfoFunc("eglExportDMABUFImageMESA", eglExportDMABUFImageMESA == NULL);
+  glewInfoFunc("eglExportDMABUFImageQueryMESA", eglExportDMABUFImageQueryMESA == NULL);
+}
+
+#endif /* EGL_MESA_image_dma_buf_export */
+
+#ifdef EGL_MESA_platform_gbm
+
+static void _glewInfo_EGL_MESA_platform_gbm (void)
+{
+  glewPrintExt("EGL_MESA_platform_gbm", EGLEW_MESA_platform_gbm, eglewIsSupported("EGL_MESA_platform_gbm"), eglewGetExtension("EGL_MESA_platform_gbm"));
+}
+
+#endif /* EGL_MESA_platform_gbm */
+
+#ifdef EGL_MESA_platform_surfaceless
+
+static void _glewInfo_EGL_MESA_platform_surfaceless (void)
+{
+  glewPrintExt("EGL_MESA_platform_surfaceless", EGLEW_MESA_platform_surfaceless, eglewIsSupported("EGL_MESA_platform_surfaceless"), eglewGetExtension("EGL_MESA_platform_surfaceless"));
+}
+
+#endif /* EGL_MESA_platform_surfaceless */
+
+#ifdef EGL_NOK_swap_region
+
+static void _glewInfo_EGL_NOK_swap_region (void)
+{
+  glewPrintExt("EGL_NOK_swap_region", EGLEW_NOK_swap_region, eglewIsSupported("EGL_NOK_swap_region"), eglewGetExtension("EGL_NOK_swap_region"));
+
+  glewInfoFunc("eglSwapBuffersRegionNOK", eglSwapBuffersRegionNOK == NULL);
+}
+
+#endif /* EGL_NOK_swap_region */
+
+#ifdef EGL_NOK_swap_region2
+
+static void _glewInfo_EGL_NOK_swap_region2 (void)
+{
+  glewPrintExt("EGL_NOK_swap_region2", EGLEW_NOK_swap_region2, eglewIsSupported("EGL_NOK_swap_region2"), eglewGetExtension("EGL_NOK_swap_region2"));
+
+  glewInfoFunc("eglSwapBuffersRegion2NOK", eglSwapBuffersRegion2NOK == NULL);
+}
+
+#endif /* EGL_NOK_swap_region2 */
+
+#ifdef EGL_NOK_texture_from_pixmap
+
+static void _glewInfo_EGL_NOK_texture_from_pixmap (void)
+{
+  glewPrintExt("EGL_NOK_texture_from_pixmap", EGLEW_NOK_texture_from_pixmap, eglewIsSupported("EGL_NOK_texture_from_pixmap"), eglewGetExtension("EGL_NOK_texture_from_pixmap"));
+}
+
+#endif /* EGL_NOK_texture_from_pixmap */
+
+#ifdef EGL_NV_3dvision_surface
+
+static void _glewInfo_EGL_NV_3dvision_surface (void)
+{
+  glewPrintExt("EGL_NV_3dvision_surface", EGLEW_NV_3dvision_surface, eglewIsSupported("EGL_NV_3dvision_surface"), eglewGetExtension("EGL_NV_3dvision_surface"));
+}
+
+#endif /* EGL_NV_3dvision_surface */
+
+#ifdef EGL_NV_coverage_sample
+
+static void _glewInfo_EGL_NV_coverage_sample (void)
+{
+  glewPrintExt("EGL_NV_coverage_sample", EGLEW_NV_coverage_sample, eglewIsSupported("EGL_NV_coverage_sample"), eglewGetExtension("EGL_NV_coverage_sample"));
+}
+
+#endif /* EGL_NV_coverage_sample */
+
+#ifdef EGL_NV_coverage_sample_resolve
+
+static void _glewInfo_EGL_NV_coverage_sample_resolve (void)
+{
+  glewPrintExt("EGL_NV_coverage_sample_resolve", EGLEW_NV_coverage_sample_resolve, eglewIsSupported("EGL_NV_coverage_sample_resolve"), eglewGetExtension("EGL_NV_coverage_sample_resolve"));
+}
+
+#endif /* EGL_NV_coverage_sample_resolve */
+
+#ifdef EGL_NV_cuda_event
+
+static void _glewInfo_EGL_NV_cuda_event (void)
+{
+  glewPrintExt("EGL_NV_cuda_event", EGLEW_NV_cuda_event, eglewIsSupported("EGL_NV_cuda_event"), eglewGetExtension("EGL_NV_cuda_event"));
+}
+
+#endif /* EGL_NV_cuda_event */
+
+#ifdef EGL_NV_depth_nonlinear
+
+static void _glewInfo_EGL_NV_depth_nonlinear (void)
+{
+  glewPrintExt("EGL_NV_depth_nonlinear", EGLEW_NV_depth_nonlinear, eglewIsSupported("EGL_NV_depth_nonlinear"), eglewGetExtension("EGL_NV_depth_nonlinear"));
+}
+
+#endif /* EGL_NV_depth_nonlinear */
+
+#ifdef EGL_NV_device_cuda
+
+static void _glewInfo_EGL_NV_device_cuda (void)
+{
+  glewPrintExt("EGL_NV_device_cuda", EGLEW_NV_device_cuda, eglewIsSupported("EGL_NV_device_cuda"), eglewGetExtension("EGL_NV_device_cuda"));
+}
+
+#endif /* EGL_NV_device_cuda */
+
+#ifdef EGL_NV_native_query
+
+static void _glewInfo_EGL_NV_native_query (void)
+{
+  glewPrintExt("EGL_NV_native_query", EGLEW_NV_native_query, eglewIsSupported("EGL_NV_native_query"), eglewGetExtension("EGL_NV_native_query"));
+
+  glewInfoFunc("eglQueryNativeDisplayNV", eglQueryNativeDisplayNV == NULL);
+  glewInfoFunc("eglQueryNativePixmapNV", eglQueryNativePixmapNV == NULL);
+  glewInfoFunc("eglQueryNativeWindowNV", eglQueryNativeWindowNV == NULL);
+}
+
+#endif /* EGL_NV_native_query */
+
+#ifdef EGL_NV_post_convert_rounding
+
+static void _glewInfo_EGL_NV_post_convert_rounding (void)
+{
+  glewPrintExt("EGL_NV_post_convert_rounding", EGLEW_NV_post_convert_rounding, eglewIsSupported("EGL_NV_post_convert_rounding"), eglewGetExtension("EGL_NV_post_convert_rounding"));
+}
+
+#endif /* EGL_NV_post_convert_rounding */
+
+#ifdef EGL_NV_post_sub_buffer
+
+static void _glewInfo_EGL_NV_post_sub_buffer (void)
+{
+  glewPrintExt("EGL_NV_post_sub_buffer", EGLEW_NV_post_sub_buffer, eglewIsSupported("EGL_NV_post_sub_buffer"), eglewGetExtension("EGL_NV_post_sub_buffer"));
+
+  glewInfoFunc("eglPostSubBufferNV", eglPostSubBufferNV == NULL);
+}
+
+#endif /* EGL_NV_post_sub_buffer */
+
+#ifdef EGL_NV_robustness_video_memory_purge
+
+static void _glewInfo_EGL_NV_robustness_video_memory_purge (void)
+{
+  glewPrintExt("EGL_NV_robustness_video_memory_purge", EGLEW_NV_robustness_video_memory_purge, eglewIsSupported("EGL_NV_robustness_video_memory_purge"), eglewGetExtension("EGL_NV_robustness_video_memory_purge"));
+}
+
+#endif /* EGL_NV_robustness_video_memory_purge */
+
+#ifdef EGL_NV_stream_consumer_gltexture_yuv
+
+static void _glewInfo_EGL_NV_stream_consumer_gltexture_yuv (void)
+{
+  glewPrintExt("EGL_NV_stream_consumer_gltexture_yuv", EGLEW_NV_stream_consumer_gltexture_yuv, eglewIsSupported("EGL_NV_stream_consumer_gltexture_yuv"), eglewGetExtension("EGL_NV_stream_consumer_gltexture_yuv"));
+
+  glewInfoFunc("eglStreamConsumerGLTextureExternalAttribsNV", eglStreamConsumerGLTextureExternalAttribsNV == NULL);
+}
+
+#endif /* EGL_NV_stream_consumer_gltexture_yuv */
+
+#ifdef EGL_NV_stream_cross_display
+
+static void _glewInfo_EGL_NV_stream_cross_display (void)
+{
+  glewPrintExt("EGL_NV_stream_cross_display", EGLEW_NV_stream_cross_display, eglewIsSupported("EGL_NV_stream_cross_display"), eglewGetExtension("EGL_NV_stream_cross_display"));
+}
+
+#endif /* EGL_NV_stream_cross_display */
+
+#ifdef EGL_NV_stream_cross_object
+
+static void _glewInfo_EGL_NV_stream_cross_object (void)
+{
+  glewPrintExt("EGL_NV_stream_cross_object", EGLEW_NV_stream_cross_object, eglewIsSupported("EGL_NV_stream_cross_object"), eglewGetExtension("EGL_NV_stream_cross_object"));
+}
+
+#endif /* EGL_NV_stream_cross_object */
+
+#ifdef EGL_NV_stream_cross_partition
+
+static void _glewInfo_EGL_NV_stream_cross_partition (void)
+{
+  glewPrintExt("EGL_NV_stream_cross_partition", EGLEW_NV_stream_cross_partition, eglewIsSupported("EGL_NV_stream_cross_partition"), eglewGetExtension("EGL_NV_stream_cross_partition"));
+}
+
+#endif /* EGL_NV_stream_cross_partition */
+
+#ifdef EGL_NV_stream_cross_process
+
+static void _glewInfo_EGL_NV_stream_cross_process (void)
+{
+  glewPrintExt("EGL_NV_stream_cross_process", EGLEW_NV_stream_cross_process, eglewIsSupported("EGL_NV_stream_cross_process"), eglewGetExtension("EGL_NV_stream_cross_process"));
+}
+
+#endif /* EGL_NV_stream_cross_process */
+
+#ifdef EGL_NV_stream_cross_system
+
+static void _glewInfo_EGL_NV_stream_cross_system (void)
+{
+  glewPrintExt("EGL_NV_stream_cross_system", EGLEW_NV_stream_cross_system, eglewIsSupported("EGL_NV_stream_cross_system"), eglewGetExtension("EGL_NV_stream_cross_system"));
+}
+
+#endif /* EGL_NV_stream_cross_system */
+
+#ifdef EGL_NV_stream_fifo_next
+
+static void _glewInfo_EGL_NV_stream_fifo_next (void)
+{
+  glewPrintExt("EGL_NV_stream_fifo_next", EGLEW_NV_stream_fifo_next, eglewIsSupported("EGL_NV_stream_fifo_next"), eglewGetExtension("EGL_NV_stream_fifo_next"));
+}
+
+#endif /* EGL_NV_stream_fifo_next */
+
+#ifdef EGL_NV_stream_fifo_synchronous
+
+static void _glewInfo_EGL_NV_stream_fifo_synchronous (void)
+{
+  glewPrintExt("EGL_NV_stream_fifo_synchronous", EGLEW_NV_stream_fifo_synchronous, eglewIsSupported("EGL_NV_stream_fifo_synchronous"), eglewGetExtension("EGL_NV_stream_fifo_synchronous"));
+}
+
+#endif /* EGL_NV_stream_fifo_synchronous */
+
+#ifdef EGL_NV_stream_frame_limits
+
+static void _glewInfo_EGL_NV_stream_frame_limits (void)
+{
+  glewPrintExt("EGL_NV_stream_frame_limits", EGLEW_NV_stream_frame_limits, eglewIsSupported("EGL_NV_stream_frame_limits"), eglewGetExtension("EGL_NV_stream_frame_limits"));
+}
+
+#endif /* EGL_NV_stream_frame_limits */
+
+#ifdef EGL_NV_stream_metadata
+
+static void _glewInfo_EGL_NV_stream_metadata (void)
+{
+  glewPrintExt("EGL_NV_stream_metadata", EGLEW_NV_stream_metadata, eglewIsSupported("EGL_NV_stream_metadata"), eglewGetExtension("EGL_NV_stream_metadata"));
+
+  glewInfoFunc("eglQueryDisplayAttribNV", eglQueryDisplayAttribNV == NULL);
+  glewInfoFunc("eglQueryStreamMetadataNV", eglQueryStreamMetadataNV == NULL);
+  glewInfoFunc("eglSetStreamMetadataNV", eglSetStreamMetadataNV == NULL);
+}
+
+#endif /* EGL_NV_stream_metadata */
+
+#ifdef EGL_NV_stream_remote
+
+static void _glewInfo_EGL_NV_stream_remote (void)
+{
+  glewPrintExt("EGL_NV_stream_remote", EGLEW_NV_stream_remote, eglewIsSupported("EGL_NV_stream_remote"), eglewGetExtension("EGL_NV_stream_remote"));
+}
+
+#endif /* EGL_NV_stream_remote */
+
+#ifdef EGL_NV_stream_reset
+
+static void _glewInfo_EGL_NV_stream_reset (void)
+{
+  glewPrintExt("EGL_NV_stream_reset", EGLEW_NV_stream_reset, eglewIsSupported("EGL_NV_stream_reset"), eglewGetExtension("EGL_NV_stream_reset"));
+
+  glewInfoFunc("eglResetStreamNV", eglResetStreamNV == NULL);
+}
+
+#endif /* EGL_NV_stream_reset */
+
+#ifdef EGL_NV_stream_socket
+
+static void _glewInfo_EGL_NV_stream_socket (void)
+{
+  glewPrintExt("EGL_NV_stream_socket", EGLEW_NV_stream_socket, eglewIsSupported("EGL_NV_stream_socket"), eglewGetExtension("EGL_NV_stream_socket"));
+}
+
+#endif /* EGL_NV_stream_socket */
+
+#ifdef EGL_NV_stream_socket_inet
+
+static void _glewInfo_EGL_NV_stream_socket_inet (void)
+{
+  glewPrintExt("EGL_NV_stream_socket_inet", EGLEW_NV_stream_socket_inet, eglewIsSupported("EGL_NV_stream_socket_inet"), eglewGetExtension("EGL_NV_stream_socket_inet"));
+}
+
+#endif /* EGL_NV_stream_socket_inet */
+
+#ifdef EGL_NV_stream_socket_unix
+
+static void _glewInfo_EGL_NV_stream_socket_unix (void)
+{
+  glewPrintExt("EGL_NV_stream_socket_unix", EGLEW_NV_stream_socket_unix, eglewIsSupported("EGL_NV_stream_socket_unix"), eglewGetExtension("EGL_NV_stream_socket_unix"));
+}
+
+#endif /* EGL_NV_stream_socket_unix */
+
+#ifdef EGL_NV_stream_sync
+
+static void _glewInfo_EGL_NV_stream_sync (void)
+{
+  glewPrintExt("EGL_NV_stream_sync", EGLEW_NV_stream_sync, eglewIsSupported("EGL_NV_stream_sync"), eglewGetExtension("EGL_NV_stream_sync"));
+
+  glewInfoFunc("eglCreateStreamSyncNV", eglCreateStreamSyncNV == NULL);
+}
+
+#endif /* EGL_NV_stream_sync */
+
+#ifdef EGL_NV_sync
+
+static void _glewInfo_EGL_NV_sync (void)
+{
+  glewPrintExt("EGL_NV_sync", EGLEW_NV_sync, eglewIsSupported("EGL_NV_sync"), eglewGetExtension("EGL_NV_sync"));
+
+  glewInfoFunc("eglClientWaitSyncNV", eglClientWaitSyncNV == NULL);
+  glewInfoFunc("eglCreateFenceSyncNV", eglCreateFenceSyncNV == NULL);
+  glewInfoFunc("eglDestroySyncNV", eglDestroySyncNV == NULL);
+  glewInfoFunc("eglFenceNV", eglFenceNV == NULL);
+  glewInfoFunc("eglGetSyncAttribNV", eglGetSyncAttribNV == NULL);
+  glewInfoFunc("eglSignalSyncNV", eglSignalSyncNV == NULL);
+}
+
+#endif /* EGL_NV_sync */
+
+#ifdef EGL_NV_system_time
+
+static void _glewInfo_EGL_NV_system_time (void)
+{
+  glewPrintExt("EGL_NV_system_time", EGLEW_NV_system_time, eglewIsSupported("EGL_NV_system_time"), eglewGetExtension("EGL_NV_system_time"));
+
+  glewInfoFunc("eglGetSystemTimeFrequencyNV", eglGetSystemTimeFrequencyNV == NULL);
+  glewInfoFunc("eglGetSystemTimeNV", eglGetSystemTimeNV == NULL);
+}
+
+#endif /* EGL_NV_system_time */
+
+#ifdef EGL_TIZEN_image_native_buffer
+
+static void _glewInfo_EGL_TIZEN_image_native_buffer (void)
+{
+  glewPrintExt("EGL_TIZEN_image_native_buffer", EGLEW_TIZEN_image_native_buffer, eglewIsSupported("EGL_TIZEN_image_native_buffer"), eglewGetExtension("EGL_TIZEN_image_native_buffer"));
+}
+
+#endif /* EGL_TIZEN_image_native_buffer */
+
+#ifdef EGL_TIZEN_image_native_surface
+
+static void _glewInfo_EGL_TIZEN_image_native_surface (void)
+{
+  glewPrintExt("EGL_TIZEN_image_native_surface", EGLEW_TIZEN_image_native_surface, eglewIsSupported("EGL_TIZEN_image_native_surface"), eglewGetExtension("EGL_TIZEN_image_native_surface"));
+}
+
+#endif /* EGL_TIZEN_image_native_surface */
+
+#elif _WIN32
 
 #ifdef WGL_3DFX_multisample
 
@@ -7688,6 +11704,15 @@ static void _glewInfo_WGL_ARB_create_context (void)
 }
 
 #endif /* WGL_ARB_create_context */
+
+#ifdef WGL_ARB_create_context_no_error
+
+static void _glewInfo_WGL_ARB_create_context_no_error (void)
+{
+  glewPrintExt("WGL_ARB_create_context_no_error", WGLEW_ARB_create_context_no_error, wglewIsSupported("WGL_ARB_create_context_no_error"), wglewGetExtension("WGL_ARB_create_context_no_error"));
+}
+
+#endif /* WGL_ARB_create_context_no_error */
 
 #ifdef WGL_ARB_create_context_profile
 
@@ -7833,6 +11858,15 @@ static void _glewInfo_WGL_ATI_render_texture_rectangle (void)
 }
 
 #endif /* WGL_ATI_render_texture_rectangle */
+
+#ifdef WGL_EXT_colorspace
+
+static void _glewInfo_WGL_EXT_colorspace (void)
+{
+  glewPrintExt("WGL_EXT_colorspace", WGLEW_EXT_colorspace, wglewIsSupported("WGL_EXT_colorspace"), wglewGetExtension("WGL_EXT_colorspace"));
+}
+
+#endif /* WGL_EXT_colorspace */
 
 #ifdef WGL_EXT_create_context_es2_profile
 
@@ -8349,6 +12383,15 @@ static void _glewInfo_GLX_ARB_create_context (void)
 
 #endif /* GLX_ARB_create_context */
 
+#ifdef GLX_ARB_create_context_no_error
+
+static void _glewInfo_GLX_ARB_create_context_no_error (void)
+{
+  glewPrintExt("GLX_ARB_create_context_no_error", GLXEW_ARB_create_context_no_error, glxewIsSupported("GLX_ARB_create_context_no_error"), glxewGetExtension("GLX_ARB_create_context_no_error"));
+}
+
+#endif /* GLX_ARB_create_context_no_error */
+
 #ifdef GLX_ARB_create_context_profile
 
 static void _glewInfo_GLX_ARB_create_context_profile (void)
@@ -8510,6 +12553,15 @@ static void _glewInfo_GLX_EXT_import_context (void)
 }
 
 #endif /* GLX_EXT_import_context */
+
+#ifdef GLX_EXT_libglvnd
+
+static void _glewInfo_GLX_EXT_libglvnd (void)
+{
+  glewPrintExt("GLX_EXT_libglvnd", GLXEW_EXT_libglvnd, glxewIsSupported("GLX_EXT_libglvnd"), glxewGetExtension("GLX_EXT_libglvnd"));
+}
+
+#endif /* GLX_EXT_libglvnd */
 
 #ifdef GLX_EXT_scene_marker
 
@@ -8732,6 +12784,15 @@ static void _glewInfo_GLX_NV_present_video (void)
 }
 
 #endif /* GLX_NV_present_video */
+
+#ifdef GLX_NV_robustness_video_memory_purge
+
+static void _glewInfo_GLX_NV_robustness_video_memory_purge (void)
+{
+  glewPrintExt("GLX_NV_robustness_video_memory_purge", GLXEW_NV_robustness_video_memory_purge, glxewIsSupported("GLX_NV_robustness_video_memory_purge"), glxewGetExtension("GLX_NV_robustness_video_memory_purge"));
+}
+
+#endif /* GLX_NV_robustness_video_memory_purge */
 
 #ifdef GLX_NV_swap_group
 
@@ -9077,6 +13138,9 @@ static void glewInfo (void)
 #ifdef GL_VERSION_4_5
   _glewInfo_GL_VERSION_4_5();
 #endif /* GL_VERSION_4_5 */
+#ifdef GL_VERSION_4_6
+  _glewInfo_GL_VERSION_4_6();
+#endif /* GL_VERSION_4_6 */
 #ifdef GL_3DFX_multisample
   _glewInfo_GL_3DFX_multisample();
 #endif /* GL_3DFX_multisample */
@@ -9089,6 +13153,12 @@ static void glewInfo (void)
 #ifdef GL_AMD_blend_minmax_factor
   _glewInfo_GL_AMD_blend_minmax_factor();
 #endif /* GL_AMD_blend_minmax_factor */
+#ifdef GL_AMD_compressed_3DC_texture
+  _glewInfo_GL_AMD_compressed_3DC_texture();
+#endif /* GL_AMD_compressed_3DC_texture */
+#ifdef GL_AMD_compressed_ATC_texture
+  _glewInfo_GL_AMD_compressed_ATC_texture();
+#endif /* GL_AMD_compressed_ATC_texture */
 #ifdef GL_AMD_conservative_depth
   _glewInfo_GL_AMD_conservative_depth();
 #endif /* GL_AMD_conservative_depth */
@@ -9101,9 +13171,18 @@ static void glewInfo (void)
 #ifdef GL_AMD_draw_buffers_blend
   _glewInfo_GL_AMD_draw_buffers_blend();
 #endif /* GL_AMD_draw_buffers_blend */
+#ifdef GL_AMD_framebuffer_sample_positions
+  _glewInfo_GL_AMD_framebuffer_sample_positions();
+#endif /* GL_AMD_framebuffer_sample_positions */
 #ifdef GL_AMD_gcn_shader
   _glewInfo_GL_AMD_gcn_shader();
 #endif /* GL_AMD_gcn_shader */
+#ifdef GL_AMD_gpu_shader_half_float
+  _glewInfo_GL_AMD_gpu_shader_half_float();
+#endif /* GL_AMD_gpu_shader_half_float */
+#ifdef GL_AMD_gpu_shader_int16
+  _glewInfo_GL_AMD_gpu_shader_int16();
+#endif /* GL_AMD_gpu_shader_int16 */
 #ifdef GL_AMD_gpu_shader_int64
   _glewInfo_GL_AMD_gpu_shader_int64();
 #endif /* GL_AMD_gpu_shader_int64 */
@@ -9125,6 +13204,9 @@ static void glewInfo (void)
 #ifdef GL_AMD_pinned_memory
   _glewInfo_GL_AMD_pinned_memory();
 #endif /* GL_AMD_pinned_memory */
+#ifdef GL_AMD_program_binary_Z400
+  _glewInfo_GL_AMD_program_binary_Z400();
+#endif /* GL_AMD_program_binary_Z400 */
 #ifdef GL_AMD_query_buffer_object
   _glewInfo_GL_AMD_query_buffer_object();
 #endif /* GL_AMD_query_buffer_object */
@@ -9137,6 +13219,12 @@ static void glewInfo (void)
 #ifdef GL_AMD_shader_atomic_counter_ops
   _glewInfo_GL_AMD_shader_atomic_counter_ops();
 #endif /* GL_AMD_shader_atomic_counter_ops */
+#ifdef GL_AMD_shader_ballot
+  _glewInfo_GL_AMD_shader_ballot();
+#endif /* GL_AMD_shader_ballot */
+#ifdef GL_AMD_shader_explicit_vertex_parameter
+  _glewInfo_GL_AMD_shader_explicit_vertex_parameter();
+#endif /* GL_AMD_shader_explicit_vertex_parameter */
 #ifdef GL_AMD_shader_stencil_export
   _glewInfo_GL_AMD_shader_stencil_export();
 #endif /* GL_AMD_shader_stencil_export */
@@ -9152,6 +13240,9 @@ static void glewInfo (void)
 #ifdef GL_AMD_stencil_operation_extended
   _glewInfo_GL_AMD_stencil_operation_extended();
 #endif /* GL_AMD_stencil_operation_extended */
+#ifdef GL_AMD_texture_gather_bias_lod
+  _glewInfo_GL_AMD_texture_gather_bias_lod();
+#endif /* GL_AMD_texture_gather_bias_lod */
 #ifdef GL_AMD_texture_texture4
   _glewInfo_GL_AMD_texture_texture4();
 #endif /* GL_AMD_texture_texture4 */
@@ -9170,6 +13261,9 @@ static void glewInfo (void)
 #ifdef GL_AMD_vertex_shader_viewport_index
   _glewInfo_GL_AMD_vertex_shader_viewport_index();
 #endif /* GL_AMD_vertex_shader_viewport_index */
+#ifdef GL_ANDROID_extension_pack_es31a
+  _glewInfo_GL_ANDROID_extension_pack_es31a();
+#endif /* GL_ANDROID_extension_pack_es31a */
 #ifdef GL_ANGLE_depth_texture
   _glewInfo_GL_ANGLE_depth_texture();
 #endif /* GL_ANGLE_depth_texture */
@@ -9212,6 +13306,15 @@ static void glewInfo (void)
 #ifdef GL_APPLE_client_storage
   _glewInfo_GL_APPLE_client_storage();
 #endif /* GL_APPLE_client_storage */
+#ifdef GL_APPLE_clip_distance
+  _glewInfo_GL_APPLE_clip_distance();
+#endif /* GL_APPLE_clip_distance */
+#ifdef GL_APPLE_color_buffer_packed_float
+  _glewInfo_GL_APPLE_color_buffer_packed_float();
+#endif /* GL_APPLE_color_buffer_packed_float */
+#ifdef GL_APPLE_copy_texture_levels
+  _glewInfo_GL_APPLE_copy_texture_levels();
+#endif /* GL_APPLE_copy_texture_levels */
 #ifdef GL_APPLE_element_array
   _glewInfo_GL_APPLE_element_array();
 #endif /* GL_APPLE_element_array */
@@ -9224,6 +13327,9 @@ static void glewInfo (void)
 #ifdef GL_APPLE_flush_buffer_range
   _glewInfo_GL_APPLE_flush_buffer_range();
 #endif /* GL_APPLE_flush_buffer_range */
+#ifdef GL_APPLE_framebuffer_multisample
+  _glewInfo_GL_APPLE_framebuffer_multisample();
+#endif /* GL_APPLE_framebuffer_multisample */
 #ifdef GL_APPLE_object_purgeable
   _glewInfo_GL_APPLE_object_purgeable();
 #endif /* GL_APPLE_object_purgeable */
@@ -9239,6 +13345,21 @@ static void glewInfo (void)
 #ifdef GL_APPLE_specular_vector
   _glewInfo_GL_APPLE_specular_vector();
 #endif /* GL_APPLE_specular_vector */
+#ifdef GL_APPLE_sync
+  _glewInfo_GL_APPLE_sync();
+#endif /* GL_APPLE_sync */
+#ifdef GL_APPLE_texture_2D_limited_npot
+  _glewInfo_GL_APPLE_texture_2D_limited_npot();
+#endif /* GL_APPLE_texture_2D_limited_npot */
+#ifdef GL_APPLE_texture_format_BGRA8888
+  _glewInfo_GL_APPLE_texture_format_BGRA8888();
+#endif /* GL_APPLE_texture_format_BGRA8888 */
+#ifdef GL_APPLE_texture_max_level
+  _glewInfo_GL_APPLE_texture_max_level();
+#endif /* GL_APPLE_texture_max_level */
+#ifdef GL_APPLE_texture_packed_float
+  _glewInfo_GL_APPLE_texture_packed_float();
+#endif /* GL_APPLE_texture_packed_float */
 #ifdef GL_APPLE_texture_range
   _glewInfo_GL_APPLE_texture_range();
 #endif /* GL_APPLE_texture_range */
@@ -9263,6 +13384,9 @@ static void glewInfo (void)
 #ifdef GL_ARB_ES3_1_compatibility
   _glewInfo_GL_ARB_ES3_1_compatibility();
 #endif /* GL_ARB_ES3_1_compatibility */
+#ifdef GL_ARB_ES3_2_compatibility
+  _glewInfo_GL_ARB_ES3_2_compatibility();
+#endif /* GL_ARB_ES3_2_compatibility */
 #ifdef GL_ARB_ES3_compatibility
   _glewInfo_GL_ARB_ES3_compatibility();
 #endif /* GL_ARB_ES3_compatibility */
@@ -9380,6 +13504,9 @@ static void glewInfo (void)
 #ifdef GL_ARB_fragment_shader
   _glewInfo_GL_ARB_fragment_shader();
 #endif /* GL_ARB_fragment_shader */
+#ifdef GL_ARB_fragment_shader_interlock
+  _glewInfo_GL_ARB_fragment_shader_interlock();
+#endif /* GL_ARB_fragment_shader_interlock */
 #ifdef GL_ARB_framebuffer_no_attachments
   _glewInfo_GL_ARB_framebuffer_no_attachments();
 #endif /* GL_ARB_framebuffer_no_attachments */
@@ -9398,12 +13525,18 @@ static void glewInfo (void)
 #ifdef GL_ARB_get_texture_sub_image
   _glewInfo_GL_ARB_get_texture_sub_image();
 #endif /* GL_ARB_get_texture_sub_image */
+#ifdef GL_ARB_gl_spirv
+  _glewInfo_GL_ARB_gl_spirv();
+#endif /* GL_ARB_gl_spirv */
 #ifdef GL_ARB_gpu_shader5
   _glewInfo_GL_ARB_gpu_shader5();
 #endif /* GL_ARB_gpu_shader5 */
 #ifdef GL_ARB_gpu_shader_fp64
   _glewInfo_GL_ARB_gpu_shader_fp64();
 #endif /* GL_ARB_gpu_shader_fp64 */
+#ifdef GL_ARB_gpu_shader_int64
+  _glewInfo_GL_ARB_gpu_shader_int64();
+#endif /* GL_ARB_gpu_shader_int64 */
 #ifdef GL_ARB_half_float_pixel
   _glewInfo_GL_ARB_half_float_pixel();
 #endif /* GL_ARB_half_float_pixel */
@@ -9455,6 +13588,9 @@ static void glewInfo (void)
 #ifdef GL_ARB_occlusion_query2
   _glewInfo_GL_ARB_occlusion_query2();
 #endif /* GL_ARB_occlusion_query2 */
+#ifdef GL_ARB_parallel_shader_compile
+  _glewInfo_GL_ARB_parallel_shader_compile();
+#endif /* GL_ARB_parallel_shader_compile */
 #ifdef GL_ARB_pipeline_statistics_query
   _glewInfo_GL_ARB_pipeline_statistics_query();
 #endif /* GL_ARB_pipeline_statistics_query */
@@ -9467,6 +13603,12 @@ static void glewInfo (void)
 #ifdef GL_ARB_point_sprite
   _glewInfo_GL_ARB_point_sprite();
 #endif /* GL_ARB_point_sprite */
+#ifdef GL_ARB_polygon_offset_clamp
+  _glewInfo_GL_ARB_polygon_offset_clamp();
+#endif /* GL_ARB_polygon_offset_clamp */
+#ifdef GL_ARB_post_depth_coverage
+  _glewInfo_GL_ARB_post_depth_coverage();
+#endif /* GL_ARB_post_depth_coverage */
 #ifdef GL_ARB_program_interface_query
   _glewInfo_GL_ARB_program_interface_query();
 #endif /* GL_ARB_program_interface_query */
@@ -9488,6 +13630,9 @@ static void glewInfo (void)
 #ifdef GL_ARB_robustness_share_group_isolation
   _glewInfo_GL_ARB_robustness_share_group_isolation();
 #endif /* GL_ARB_robustness_share_group_isolation */
+#ifdef GL_ARB_sample_locations
+  _glewInfo_GL_ARB_sample_locations();
+#endif /* GL_ARB_sample_locations */
 #ifdef GL_ARB_sample_shading
   _glewInfo_GL_ARB_sample_shading();
 #endif /* GL_ARB_sample_shading */
@@ -9503,12 +13648,21 @@ static void glewInfo (void)
 #ifdef GL_ARB_separate_shader_objects
   _glewInfo_GL_ARB_separate_shader_objects();
 #endif /* GL_ARB_separate_shader_objects */
+#ifdef GL_ARB_shader_atomic_counter_ops
+  _glewInfo_GL_ARB_shader_atomic_counter_ops();
+#endif /* GL_ARB_shader_atomic_counter_ops */
 #ifdef GL_ARB_shader_atomic_counters
   _glewInfo_GL_ARB_shader_atomic_counters();
 #endif /* GL_ARB_shader_atomic_counters */
+#ifdef GL_ARB_shader_ballot
+  _glewInfo_GL_ARB_shader_ballot();
+#endif /* GL_ARB_shader_ballot */
 #ifdef GL_ARB_shader_bit_encoding
   _glewInfo_GL_ARB_shader_bit_encoding();
 #endif /* GL_ARB_shader_bit_encoding */
+#ifdef GL_ARB_shader_clock
+  _glewInfo_GL_ARB_shader_clock();
+#endif /* GL_ARB_shader_clock */
 #ifdef GL_ARB_shader_draw_parameters
   _glewInfo_GL_ARB_shader_draw_parameters();
 #endif /* GL_ARB_shader_draw_parameters */
@@ -9542,6 +13696,9 @@ static void glewInfo (void)
 #ifdef GL_ARB_shader_texture_lod
   _glewInfo_GL_ARB_shader_texture_lod();
 #endif /* GL_ARB_shader_texture_lod */
+#ifdef GL_ARB_shader_viewport_layer_array
+  _glewInfo_GL_ARB_shader_viewport_layer_array();
+#endif /* GL_ARB_shader_viewport_layer_array */
 #ifdef GL_ARB_shading_language_100
   _glewInfo_GL_ARB_shading_language_100();
 #endif /* GL_ARB_shading_language_100 */
@@ -9566,6 +13723,15 @@ static void glewInfo (void)
 #ifdef GL_ARB_sparse_texture
   _glewInfo_GL_ARB_sparse_texture();
 #endif /* GL_ARB_sparse_texture */
+#ifdef GL_ARB_sparse_texture2
+  _glewInfo_GL_ARB_sparse_texture2();
+#endif /* GL_ARB_sparse_texture2 */
+#ifdef GL_ARB_sparse_texture_clamp
+  _glewInfo_GL_ARB_sparse_texture_clamp();
+#endif /* GL_ARB_sparse_texture_clamp */
+#ifdef GL_ARB_spirv_extensions
+  _glewInfo_GL_ARB_spirv_extensions();
+#endif /* GL_ARB_spirv_extensions */
 #ifdef GL_ARB_stencil_texturing
   _glewInfo_GL_ARB_stencil_texturing();
 #endif /* GL_ARB_stencil_texturing */
@@ -9617,6 +13783,12 @@ static void glewInfo (void)
 #ifdef GL_ARB_texture_env_dot3
   _glewInfo_GL_ARB_texture_env_dot3();
 #endif /* GL_ARB_texture_env_dot3 */
+#ifdef GL_ARB_texture_filter_anisotropic
+  _glewInfo_GL_ARB_texture_filter_anisotropic();
+#endif /* GL_ARB_texture_filter_anisotropic */
+#ifdef GL_ARB_texture_filter_minmax
+  _glewInfo_GL_ARB_texture_filter_minmax();
+#endif /* GL_ARB_texture_filter_minmax */
 #ifdef GL_ARB_texture_float
   _glewInfo_GL_ARB_texture_float();
 #endif /* GL_ARB_texture_float */
@@ -9722,6 +13894,21 @@ static void glewInfo (void)
 #ifdef GL_ARB_window_pos
   _glewInfo_GL_ARB_window_pos();
 #endif /* GL_ARB_window_pos */
+#ifdef GL_ARM_mali_program_binary
+  _glewInfo_GL_ARM_mali_program_binary();
+#endif /* GL_ARM_mali_program_binary */
+#ifdef GL_ARM_mali_shader_binary
+  _glewInfo_GL_ARM_mali_shader_binary();
+#endif /* GL_ARM_mali_shader_binary */
+#ifdef GL_ARM_rgba8
+  _glewInfo_GL_ARM_rgba8();
+#endif /* GL_ARM_rgba8 */
+#ifdef GL_ARM_shader_framebuffer_fetch
+  _glewInfo_GL_ARM_shader_framebuffer_fetch();
+#endif /* GL_ARM_shader_framebuffer_fetch */
+#ifdef GL_ARM_shader_framebuffer_fetch_depth_stencil
+  _glewInfo_GL_ARM_shader_framebuffer_fetch_depth_stencil();
+#endif /* GL_ARM_shader_framebuffer_fetch_depth_stencil */
 #ifdef GL_ATIX_point_sprites
   _glewInfo_GL_ATIX_point_sprites();
 #endif /* GL_ATIX_point_sprites */
@@ -9785,15 +13972,30 @@ static void glewInfo (void)
 #ifdef GL_ATI_vertex_streams
   _glewInfo_GL_ATI_vertex_streams();
 #endif /* GL_ATI_vertex_streams */
+#ifdef GL_EGL_KHR_context_flush_control
+  _glewInfo_GL_EGL_KHR_context_flush_control();
+#endif /* GL_EGL_KHR_context_flush_control */
+#ifdef GL_EGL_NV_robustness_video_memory_purge
+  _glewInfo_GL_EGL_NV_robustness_video_memory_purge();
+#endif /* GL_EGL_NV_robustness_video_memory_purge */
 #ifdef GL_EXT_422_pixels
   _glewInfo_GL_EXT_422_pixels();
 #endif /* GL_EXT_422_pixels */
 #ifdef GL_EXT_Cg_shader
   _glewInfo_GL_EXT_Cg_shader();
 #endif /* GL_EXT_Cg_shader */
+#ifdef GL_EXT_EGL_image_array
+  _glewInfo_GL_EXT_EGL_image_array();
+#endif /* GL_EXT_EGL_image_array */
+#ifdef GL_EXT_YUV_target
+  _glewInfo_GL_EXT_YUV_target();
+#endif /* GL_EXT_YUV_target */
 #ifdef GL_EXT_abgr
   _glewInfo_GL_EXT_abgr();
 #endif /* GL_EXT_abgr */
+#ifdef GL_EXT_base_instance
+  _glewInfo_GL_EXT_base_instance();
+#endif /* GL_EXT_base_instance */
 #ifdef GL_EXT_bgra
   _glewInfo_GL_EXT_bgra();
 #endif /* GL_EXT_bgra */
@@ -9806,6 +14008,9 @@ static void glewInfo (void)
 #ifdef GL_EXT_blend_equation_separate
   _glewInfo_GL_EXT_blend_equation_separate();
 #endif /* GL_EXT_blend_equation_separate */
+#ifdef GL_EXT_blend_func_extended
+  _glewInfo_GL_EXT_blend_func_extended();
+#endif /* GL_EXT_blend_func_extended */
 #ifdef GL_EXT_blend_func_separate
   _glewInfo_GL_EXT_blend_func_separate();
 #endif /* GL_EXT_blend_func_separate */
@@ -9818,24 +14023,48 @@ static void glewInfo (void)
 #ifdef GL_EXT_blend_subtract
   _glewInfo_GL_EXT_blend_subtract();
 #endif /* GL_EXT_blend_subtract */
+#ifdef GL_EXT_buffer_storage
+  _glewInfo_GL_EXT_buffer_storage();
+#endif /* GL_EXT_buffer_storage */
+#ifdef GL_EXT_clear_texture
+  _glewInfo_GL_EXT_clear_texture();
+#endif /* GL_EXT_clear_texture */
+#ifdef GL_EXT_clip_cull_distance
+  _glewInfo_GL_EXT_clip_cull_distance();
+#endif /* GL_EXT_clip_cull_distance */
 #ifdef GL_EXT_clip_volume_hint
   _glewInfo_GL_EXT_clip_volume_hint();
 #endif /* GL_EXT_clip_volume_hint */
 #ifdef GL_EXT_cmyka
   _glewInfo_GL_EXT_cmyka();
 #endif /* GL_EXT_cmyka */
+#ifdef GL_EXT_color_buffer_float
+  _glewInfo_GL_EXT_color_buffer_float();
+#endif /* GL_EXT_color_buffer_float */
+#ifdef GL_EXT_color_buffer_half_float
+  _glewInfo_GL_EXT_color_buffer_half_float();
+#endif /* GL_EXT_color_buffer_half_float */
 #ifdef GL_EXT_color_subtable
   _glewInfo_GL_EXT_color_subtable();
 #endif /* GL_EXT_color_subtable */
 #ifdef GL_EXT_compiled_vertex_array
   _glewInfo_GL_EXT_compiled_vertex_array();
 #endif /* GL_EXT_compiled_vertex_array */
+#ifdef GL_EXT_compressed_ETC1_RGB8_sub_texture
+  _glewInfo_GL_EXT_compressed_ETC1_RGB8_sub_texture();
+#endif /* GL_EXT_compressed_ETC1_RGB8_sub_texture */
+#ifdef GL_EXT_conservative_depth
+  _glewInfo_GL_EXT_conservative_depth();
+#endif /* GL_EXT_conservative_depth */
 #ifdef GL_EXT_convolution
   _glewInfo_GL_EXT_convolution();
 #endif /* GL_EXT_convolution */
 #ifdef GL_EXT_coordinate_frame
   _glewInfo_GL_EXT_coordinate_frame();
 #endif /* GL_EXT_coordinate_frame */
+#ifdef GL_EXT_copy_image
+  _glewInfo_GL_EXT_copy_image();
+#endif /* GL_EXT_copy_image */
 #ifdef GL_EXT_copy_texture
   _glewInfo_GL_EXT_copy_texture();
 #endif /* GL_EXT_copy_texture */
@@ -9854,18 +14083,39 @@ static void glewInfo (void)
 #ifdef GL_EXT_direct_state_access
   _glewInfo_GL_EXT_direct_state_access();
 #endif /* GL_EXT_direct_state_access */
+#ifdef GL_EXT_discard_framebuffer
+  _glewInfo_GL_EXT_discard_framebuffer();
+#endif /* GL_EXT_discard_framebuffer */
+#ifdef GL_EXT_draw_buffers
+  _glewInfo_GL_EXT_draw_buffers();
+#endif /* GL_EXT_draw_buffers */
 #ifdef GL_EXT_draw_buffers2
   _glewInfo_GL_EXT_draw_buffers2();
 #endif /* GL_EXT_draw_buffers2 */
+#ifdef GL_EXT_draw_buffers_indexed
+  _glewInfo_GL_EXT_draw_buffers_indexed();
+#endif /* GL_EXT_draw_buffers_indexed */
+#ifdef GL_EXT_draw_elements_base_vertex
+  _glewInfo_GL_EXT_draw_elements_base_vertex();
+#endif /* GL_EXT_draw_elements_base_vertex */
 #ifdef GL_EXT_draw_instanced
   _glewInfo_GL_EXT_draw_instanced();
 #endif /* GL_EXT_draw_instanced */
 #ifdef GL_EXT_draw_range_elements
   _glewInfo_GL_EXT_draw_range_elements();
 #endif /* GL_EXT_draw_range_elements */
+#ifdef GL_EXT_external_buffer
+  _glewInfo_GL_EXT_external_buffer();
+#endif /* GL_EXT_external_buffer */
+#ifdef GL_EXT_float_blend
+  _glewInfo_GL_EXT_float_blend();
+#endif /* GL_EXT_float_blend */
 #ifdef GL_EXT_fog_coord
   _glewInfo_GL_EXT_fog_coord();
 #endif /* GL_EXT_fog_coord */
+#ifdef GL_EXT_frag_depth
+  _glewInfo_GL_EXT_frag_depth();
+#endif /* GL_EXT_frag_depth */
 #ifdef GL_EXT_fragment_lighting
   _glewInfo_GL_EXT_fragment_lighting();
 #endif /* GL_EXT_fragment_lighting */
@@ -9884,6 +14134,12 @@ static void glewInfo (void)
 #ifdef GL_EXT_framebuffer_sRGB
   _glewInfo_GL_EXT_framebuffer_sRGB();
 #endif /* GL_EXT_framebuffer_sRGB */
+#ifdef GL_EXT_geometry_point_size
+  _glewInfo_GL_EXT_geometry_point_size();
+#endif /* GL_EXT_geometry_point_size */
+#ifdef GL_EXT_geometry_shader
+  _glewInfo_GL_EXT_geometry_shader();
+#endif /* GL_EXT_geometry_shader */
 #ifdef GL_EXT_geometry_shader4
   _glewInfo_GL_EXT_geometry_shader4();
 #endif /* GL_EXT_geometry_shader4 */
@@ -9893,6 +14149,9 @@ static void glewInfo (void)
 #ifdef GL_EXT_gpu_shader4
   _glewInfo_GL_EXT_gpu_shader4();
 #endif /* GL_EXT_gpu_shader4 */
+#ifdef GL_EXT_gpu_shader5
+  _glewInfo_GL_EXT_gpu_shader5();
+#endif /* GL_EXT_gpu_shader5 */
 #ifdef GL_EXT_histogram
   _glewInfo_GL_EXT_histogram();
 #endif /* GL_EXT_histogram */
@@ -9908,18 +14167,51 @@ static void glewInfo (void)
 #ifdef GL_EXT_index_texture
   _glewInfo_GL_EXT_index_texture();
 #endif /* GL_EXT_index_texture */
+#ifdef GL_EXT_instanced_arrays
+  _glewInfo_GL_EXT_instanced_arrays();
+#endif /* GL_EXT_instanced_arrays */
 #ifdef GL_EXT_light_texture
   _glewInfo_GL_EXT_light_texture();
 #endif /* GL_EXT_light_texture */
+#ifdef GL_EXT_map_buffer_range
+  _glewInfo_GL_EXT_map_buffer_range();
+#endif /* GL_EXT_map_buffer_range */
+#ifdef GL_EXT_memory_object
+  _glewInfo_GL_EXT_memory_object();
+#endif /* GL_EXT_memory_object */
+#ifdef GL_EXT_memory_object_fd
+  _glewInfo_GL_EXT_memory_object_fd();
+#endif /* GL_EXT_memory_object_fd */
+#ifdef GL_EXT_memory_object_win32
+  _glewInfo_GL_EXT_memory_object_win32();
+#endif /* GL_EXT_memory_object_win32 */
 #ifdef GL_EXT_misc_attribute
   _glewInfo_GL_EXT_misc_attribute();
 #endif /* GL_EXT_misc_attribute */
 #ifdef GL_EXT_multi_draw_arrays
   _glewInfo_GL_EXT_multi_draw_arrays();
 #endif /* GL_EXT_multi_draw_arrays */
+#ifdef GL_EXT_multi_draw_indirect
+  _glewInfo_GL_EXT_multi_draw_indirect();
+#endif /* GL_EXT_multi_draw_indirect */
+#ifdef GL_EXT_multiple_textures
+  _glewInfo_GL_EXT_multiple_textures();
+#endif /* GL_EXT_multiple_textures */
 #ifdef GL_EXT_multisample
   _glewInfo_GL_EXT_multisample();
 #endif /* GL_EXT_multisample */
+#ifdef GL_EXT_multisample_compatibility
+  _glewInfo_GL_EXT_multisample_compatibility();
+#endif /* GL_EXT_multisample_compatibility */
+#ifdef GL_EXT_multisampled_render_to_texture
+  _glewInfo_GL_EXT_multisampled_render_to_texture();
+#endif /* GL_EXT_multisampled_render_to_texture */
+#ifdef GL_EXT_multisampled_render_to_texture2
+  _glewInfo_GL_EXT_multisampled_render_to_texture2();
+#endif /* GL_EXT_multisampled_render_to_texture2 */
+#ifdef GL_EXT_multiview_draw_buffers
+  _glewInfo_GL_EXT_multiview_draw_buffers();
+#endif /* GL_EXT_multiview_draw_buffers */
 #ifdef GL_EXT_packed_depth_stencil
   _glewInfo_GL_EXT_packed_depth_stencil();
 #endif /* GL_EXT_packed_depth_stencil */
@@ -9947,39 +14239,105 @@ static void glewInfo (void)
 #ifdef GL_EXT_polygon_offset
   _glewInfo_GL_EXT_polygon_offset();
 #endif /* GL_EXT_polygon_offset */
+#ifdef GL_EXT_polygon_offset_clamp
+  _glewInfo_GL_EXT_polygon_offset_clamp();
+#endif /* GL_EXT_polygon_offset_clamp */
+#ifdef GL_EXT_post_depth_coverage
+  _glewInfo_GL_EXT_post_depth_coverage();
+#endif /* GL_EXT_post_depth_coverage */
 #ifdef GL_EXT_provoking_vertex
   _glewInfo_GL_EXT_provoking_vertex();
 #endif /* GL_EXT_provoking_vertex */
+#ifdef GL_EXT_pvrtc_sRGB
+  _glewInfo_GL_EXT_pvrtc_sRGB();
+#endif /* GL_EXT_pvrtc_sRGB */
+#ifdef GL_EXT_raster_multisample
+  _glewInfo_GL_EXT_raster_multisample();
+#endif /* GL_EXT_raster_multisample */
+#ifdef GL_EXT_read_format_bgra
+  _glewInfo_GL_EXT_read_format_bgra();
+#endif /* GL_EXT_read_format_bgra */
+#ifdef GL_EXT_render_snorm
+  _glewInfo_GL_EXT_render_snorm();
+#endif /* GL_EXT_render_snorm */
 #ifdef GL_EXT_rescale_normal
   _glewInfo_GL_EXT_rescale_normal();
 #endif /* GL_EXT_rescale_normal */
+#ifdef GL_EXT_sRGB
+  _glewInfo_GL_EXT_sRGB();
+#endif /* GL_EXT_sRGB */
+#ifdef GL_EXT_sRGB_write_control
+  _glewInfo_GL_EXT_sRGB_write_control();
+#endif /* GL_EXT_sRGB_write_control */
 #ifdef GL_EXT_scene_marker
   _glewInfo_GL_EXT_scene_marker();
 #endif /* GL_EXT_scene_marker */
 #ifdef GL_EXT_secondary_color
   _glewInfo_GL_EXT_secondary_color();
 #endif /* GL_EXT_secondary_color */
+#ifdef GL_EXT_semaphore
+  _glewInfo_GL_EXT_semaphore();
+#endif /* GL_EXT_semaphore */
+#ifdef GL_EXT_semaphore_fd
+  _glewInfo_GL_EXT_semaphore_fd();
+#endif /* GL_EXT_semaphore_fd */
+#ifdef GL_EXT_semaphore_win32
+  _glewInfo_GL_EXT_semaphore_win32();
+#endif /* GL_EXT_semaphore_win32 */
 #ifdef GL_EXT_separate_shader_objects
   _glewInfo_GL_EXT_separate_shader_objects();
 #endif /* GL_EXT_separate_shader_objects */
 #ifdef GL_EXT_separate_specular_color
   _glewInfo_GL_EXT_separate_specular_color();
 #endif /* GL_EXT_separate_specular_color */
+#ifdef GL_EXT_shader_framebuffer_fetch
+  _glewInfo_GL_EXT_shader_framebuffer_fetch();
+#endif /* GL_EXT_shader_framebuffer_fetch */
+#ifdef GL_EXT_shader_group_vote
+  _glewInfo_GL_EXT_shader_group_vote();
+#endif /* GL_EXT_shader_group_vote */
 #ifdef GL_EXT_shader_image_load_formatted
   _glewInfo_GL_EXT_shader_image_load_formatted();
 #endif /* GL_EXT_shader_image_load_formatted */
 #ifdef GL_EXT_shader_image_load_store
   _glewInfo_GL_EXT_shader_image_load_store();
 #endif /* GL_EXT_shader_image_load_store */
+#ifdef GL_EXT_shader_implicit_conversions
+  _glewInfo_GL_EXT_shader_implicit_conversions();
+#endif /* GL_EXT_shader_implicit_conversions */
 #ifdef GL_EXT_shader_integer_mix
   _glewInfo_GL_EXT_shader_integer_mix();
 #endif /* GL_EXT_shader_integer_mix */
+#ifdef GL_EXT_shader_io_blocks
+  _glewInfo_GL_EXT_shader_io_blocks();
+#endif /* GL_EXT_shader_io_blocks */
+#ifdef GL_EXT_shader_non_constant_global_initializers
+  _glewInfo_GL_EXT_shader_non_constant_global_initializers();
+#endif /* GL_EXT_shader_non_constant_global_initializers */
+#ifdef GL_EXT_shader_pixel_local_storage
+  _glewInfo_GL_EXT_shader_pixel_local_storage();
+#endif /* GL_EXT_shader_pixel_local_storage */
+#ifdef GL_EXT_shader_pixel_local_storage2
+  _glewInfo_GL_EXT_shader_pixel_local_storage2();
+#endif /* GL_EXT_shader_pixel_local_storage2 */
+#ifdef GL_EXT_shader_texture_lod
+  _glewInfo_GL_EXT_shader_texture_lod();
+#endif /* GL_EXT_shader_texture_lod */
 #ifdef GL_EXT_shadow_funcs
   _glewInfo_GL_EXT_shadow_funcs();
 #endif /* GL_EXT_shadow_funcs */
+#ifdef GL_EXT_shadow_samplers
+  _glewInfo_GL_EXT_shadow_samplers();
+#endif /* GL_EXT_shadow_samplers */
 #ifdef GL_EXT_shared_texture_palette
   _glewInfo_GL_EXT_shared_texture_palette();
 #endif /* GL_EXT_shared_texture_palette */
+#ifdef GL_EXT_sparse_texture
+  _glewInfo_GL_EXT_sparse_texture();
+#endif /* GL_EXT_sparse_texture */
+#ifdef GL_EXT_sparse_texture2
+  _glewInfo_GL_EXT_sparse_texture2();
+#endif /* GL_EXT_sparse_texture2 */
 #ifdef GL_EXT_stencil_clear_tag
   _glewInfo_GL_EXT_stencil_clear_tag();
 #endif /* GL_EXT_stencil_clear_tag */
@@ -10004,6 +14362,15 @@ static void glewInfo (void)
 #ifdef GL_EXT_texture_buffer_object
   _glewInfo_GL_EXT_texture_buffer_object();
 #endif /* GL_EXT_texture_buffer_object */
+#ifdef GL_EXT_texture_compression_astc_decode_mode
+  _glewInfo_GL_EXT_texture_compression_astc_decode_mode();
+#endif /* GL_EXT_texture_compression_astc_decode_mode */
+#ifdef GL_EXT_texture_compression_astc_decode_mode_rgb9e5
+  _glewInfo_GL_EXT_texture_compression_astc_decode_mode_rgb9e5();
+#endif /* GL_EXT_texture_compression_astc_decode_mode_rgb9e5 */
+#ifdef GL_EXT_texture_compression_bptc
+  _glewInfo_GL_EXT_texture_compression_bptc();
+#endif /* GL_EXT_texture_compression_bptc */
 #ifdef GL_EXT_texture_compression_dxt1
   _glewInfo_GL_EXT_texture_compression_dxt1();
 #endif /* GL_EXT_texture_compression_dxt1 */
@@ -10019,6 +14386,9 @@ static void glewInfo (void)
 #ifdef GL_EXT_texture_cube_map
   _glewInfo_GL_EXT_texture_cube_map();
 #endif /* GL_EXT_texture_cube_map */
+#ifdef GL_EXT_texture_cube_map_array
+  _glewInfo_GL_EXT_texture_cube_map_array();
+#endif /* GL_EXT_texture_cube_map_array */
 #ifdef GL_EXT_texture_edge_clamp
   _glewInfo_GL_EXT_texture_edge_clamp();
 #endif /* GL_EXT_texture_edge_clamp */
@@ -10037,6 +14407,12 @@ static void glewInfo (void)
 #ifdef GL_EXT_texture_filter_anisotropic
   _glewInfo_GL_EXT_texture_filter_anisotropic();
 #endif /* GL_EXT_texture_filter_anisotropic */
+#ifdef GL_EXT_texture_filter_minmax
+  _glewInfo_GL_EXT_texture_filter_minmax();
+#endif /* GL_EXT_texture_filter_minmax */
+#ifdef GL_EXT_texture_format_BGRA8888
+  _glewInfo_GL_EXT_texture_format_BGRA8888();
+#endif /* GL_EXT_texture_format_BGRA8888 */
 #ifdef GL_EXT_texture_integer
   _glewInfo_GL_EXT_texture_integer();
 #endif /* GL_EXT_texture_integer */
@@ -10046,6 +14422,9 @@ static void glewInfo (void)
 #ifdef GL_EXT_texture_mirror_clamp
   _glewInfo_GL_EXT_texture_mirror_clamp();
 #endif /* GL_EXT_texture_mirror_clamp */
+#ifdef GL_EXT_texture_norm16
+  _glewInfo_GL_EXT_texture_norm16();
+#endif /* GL_EXT_texture_norm16 */
 #ifdef GL_EXT_texture_object
   _glewInfo_GL_EXT_texture_object();
 #endif /* GL_EXT_texture_object */
@@ -10055,9 +14434,18 @@ static void glewInfo (void)
 #ifdef GL_EXT_texture_rectangle
   _glewInfo_GL_EXT_texture_rectangle();
 #endif /* GL_EXT_texture_rectangle */
+#ifdef GL_EXT_texture_rg
+  _glewInfo_GL_EXT_texture_rg();
+#endif /* GL_EXT_texture_rg */
 #ifdef GL_EXT_texture_sRGB
   _glewInfo_GL_EXT_texture_sRGB();
 #endif /* GL_EXT_texture_sRGB */
+#ifdef GL_EXT_texture_sRGB_R8
+  _glewInfo_GL_EXT_texture_sRGB_R8();
+#endif /* GL_EXT_texture_sRGB_R8 */
+#ifdef GL_EXT_texture_sRGB_RG8
+  _glewInfo_GL_EXT_texture_sRGB_RG8();
+#endif /* GL_EXT_texture_sRGB_RG8 */
 #ifdef GL_EXT_texture_sRGB_decode
   _glewInfo_GL_EXT_texture_sRGB_decode();
 #endif /* GL_EXT_texture_sRGB_decode */
@@ -10067,21 +14455,36 @@ static void glewInfo (void)
 #ifdef GL_EXT_texture_snorm
   _glewInfo_GL_EXT_texture_snorm();
 #endif /* GL_EXT_texture_snorm */
+#ifdef GL_EXT_texture_storage
+  _glewInfo_GL_EXT_texture_storage();
+#endif /* GL_EXT_texture_storage */
 #ifdef GL_EXT_texture_swizzle
   _glewInfo_GL_EXT_texture_swizzle();
 #endif /* GL_EXT_texture_swizzle */
+#ifdef GL_EXT_texture_type_2_10_10_10_REV
+  _glewInfo_GL_EXT_texture_type_2_10_10_10_REV();
+#endif /* GL_EXT_texture_type_2_10_10_10_REV */
+#ifdef GL_EXT_texture_view
+  _glewInfo_GL_EXT_texture_view();
+#endif /* GL_EXT_texture_view */
 #ifdef GL_EXT_timer_query
   _glewInfo_GL_EXT_timer_query();
 #endif /* GL_EXT_timer_query */
 #ifdef GL_EXT_transform_feedback
   _glewInfo_GL_EXT_transform_feedback();
 #endif /* GL_EXT_transform_feedback */
+#ifdef GL_EXT_unpack_subimage
+  _glewInfo_GL_EXT_unpack_subimage();
+#endif /* GL_EXT_unpack_subimage */
 #ifdef GL_EXT_vertex_array
   _glewInfo_GL_EXT_vertex_array();
 #endif /* GL_EXT_vertex_array */
 #ifdef GL_EXT_vertex_array_bgra
   _glewInfo_GL_EXT_vertex_array_bgra();
 #endif /* GL_EXT_vertex_array_bgra */
+#ifdef GL_EXT_vertex_array_setXXX
+  _glewInfo_GL_EXT_vertex_array_setXXX();
+#endif /* GL_EXT_vertex_array_setXXX */
 #ifdef GL_EXT_vertex_attrib_64bit
   _glewInfo_GL_EXT_vertex_attrib_64bit();
 #endif /* GL_EXT_vertex_attrib_64bit */
@@ -10091,6 +14494,12 @@ static void glewInfo (void)
 #ifdef GL_EXT_vertex_weighting
   _glewInfo_GL_EXT_vertex_weighting();
 #endif /* GL_EXT_vertex_weighting */
+#ifdef GL_EXT_win32_keyed_mutex
+  _glewInfo_GL_EXT_win32_keyed_mutex();
+#endif /* GL_EXT_win32_keyed_mutex */
+#ifdef GL_EXT_window_rectangles
+  _glewInfo_GL_EXT_window_rectangles();
+#endif /* GL_EXT_window_rectangles */
 #ifdef GL_EXT_x11_sync_object
   _glewInfo_GL_EXT_x11_sync_object();
 #endif /* GL_EXT_x11_sync_object */
@@ -10136,9 +14545,15 @@ static void glewInfo (void)
 #ifdef GL_INGR_interlace_read
   _glewInfo_GL_INGR_interlace_read();
 #endif /* GL_INGR_interlace_read */
+#ifdef GL_INTEL_conservative_rasterization
+  _glewInfo_GL_INTEL_conservative_rasterization();
+#endif /* GL_INTEL_conservative_rasterization */
 #ifdef GL_INTEL_fragment_shader_ordering
   _glewInfo_GL_INTEL_fragment_shader_ordering();
 #endif /* GL_INTEL_fragment_shader_ordering */
+#ifdef GL_INTEL_framebuffer_CMAA
+  _glewInfo_GL_INTEL_framebuffer_CMAA();
+#endif /* GL_INTEL_framebuffer_CMAA */
 #ifdef GL_INTEL_map_texture
   _glewInfo_GL_INTEL_map_texture();
 #endif /* GL_INTEL_map_texture */
@@ -10163,6 +14578,12 @@ static void glewInfo (void)
 #ifdef GL_KHR_debug
   _glewInfo_GL_KHR_debug();
 #endif /* GL_KHR_debug */
+#ifdef GL_KHR_no_error
+  _glewInfo_GL_KHR_no_error();
+#endif /* GL_KHR_no_error */
+#ifdef GL_KHR_parallel_shader_compile
+  _glewInfo_GL_KHR_parallel_shader_compile();
+#endif /* GL_KHR_parallel_shader_compile */
 #ifdef GL_KHR_robust_buffer_access_behavior
   _glewInfo_GL_KHR_robust_buffer_access_behavior();
 #endif /* GL_KHR_robust_buffer_access_behavior */
@@ -10175,6 +14596,9 @@ static void glewInfo (void)
 #ifdef GL_KHR_texture_compression_astc_ldr
   _glewInfo_GL_KHR_texture_compression_astc_ldr();
 #endif /* GL_KHR_texture_compression_astc_ldr */
+#ifdef GL_KHR_texture_compression_astc_sliced_3d
+  _glewInfo_GL_KHR_texture_compression_astc_sliced_3d();
+#endif /* GL_KHR_texture_compression_astc_sliced_3d */
 #ifdef GL_KTX_buffer_region
   _glewInfo_GL_KTX_buffer_region();
 #endif /* GL_KTX_buffer_region */
@@ -10187,18 +14611,39 @@ static void glewInfo (void)
 #ifdef GL_MESA_resize_buffers
   _glewInfo_GL_MESA_resize_buffers();
 #endif /* GL_MESA_resize_buffers */
+#ifdef GL_MESA_shader_integer_functions
+  _glewInfo_GL_MESA_shader_integer_functions();
+#endif /* GL_MESA_shader_integer_functions */
 #ifdef GL_MESA_window_pos
   _glewInfo_GL_MESA_window_pos();
 #endif /* GL_MESA_window_pos */
 #ifdef GL_MESA_ycbcr_texture
   _glewInfo_GL_MESA_ycbcr_texture();
 #endif /* GL_MESA_ycbcr_texture */
+#ifdef GL_NVX_blend_equation_advanced_multi_draw_buffers
+  _glewInfo_GL_NVX_blend_equation_advanced_multi_draw_buffers();
+#endif /* GL_NVX_blend_equation_advanced_multi_draw_buffers */
 #ifdef GL_NVX_conditional_render
   _glewInfo_GL_NVX_conditional_render();
 #endif /* GL_NVX_conditional_render */
 #ifdef GL_NVX_gpu_memory_info
   _glewInfo_GL_NVX_gpu_memory_info();
 #endif /* GL_NVX_gpu_memory_info */
+#ifdef GL_NVX_linked_gpu_multicast
+  _glewInfo_GL_NVX_linked_gpu_multicast();
+#endif /* GL_NVX_linked_gpu_multicast */
+#ifdef GL_NV_3dvision_settings
+  _glewInfo_GL_NV_3dvision_settings();
+#endif /* GL_NV_3dvision_settings */
+#ifdef GL_NV_EGL_stream_consumer_external
+  _glewInfo_GL_NV_EGL_stream_consumer_external();
+#endif /* GL_NV_EGL_stream_consumer_external */
+#ifdef GL_NV_alpha_to_coverage_dither_control
+  _glewInfo_GL_NV_alpha_to_coverage_dither_control();
+#endif /* GL_NV_alpha_to_coverage_dither_control */
+#ifdef GL_NV_bgr
+  _glewInfo_GL_NV_bgr();
+#endif /* GL_NV_bgr */
 #ifdef GL_NV_bindless_multi_draw_indirect
   _glewInfo_GL_NV_bindless_multi_draw_indirect();
 #endif /* GL_NV_bindless_multi_draw_indirect */
@@ -10214,15 +14659,36 @@ static void glewInfo (void)
 #ifdef GL_NV_blend_equation_advanced_coherent
   _glewInfo_GL_NV_blend_equation_advanced_coherent();
 #endif /* GL_NV_blend_equation_advanced_coherent */
+#ifdef GL_NV_blend_minmax_factor
+  _glewInfo_GL_NV_blend_minmax_factor();
+#endif /* GL_NV_blend_minmax_factor */
 #ifdef GL_NV_blend_square
   _glewInfo_GL_NV_blend_square();
 #endif /* GL_NV_blend_square */
+#ifdef GL_NV_clip_space_w_scaling
+  _glewInfo_GL_NV_clip_space_w_scaling();
+#endif /* GL_NV_clip_space_w_scaling */
+#ifdef GL_NV_command_list
+  _glewInfo_GL_NV_command_list();
+#endif /* GL_NV_command_list */
 #ifdef GL_NV_compute_program5
   _glewInfo_GL_NV_compute_program5();
 #endif /* GL_NV_compute_program5 */
 #ifdef GL_NV_conditional_render
   _glewInfo_GL_NV_conditional_render();
 #endif /* GL_NV_conditional_render */
+#ifdef GL_NV_conservative_raster
+  _glewInfo_GL_NV_conservative_raster();
+#endif /* GL_NV_conservative_raster */
+#ifdef GL_NV_conservative_raster_dilate
+  _glewInfo_GL_NV_conservative_raster_dilate();
+#endif /* GL_NV_conservative_raster_dilate */
+#ifdef GL_NV_conservative_raster_pre_snap_triangles
+  _glewInfo_GL_NV_conservative_raster_pre_snap_triangles();
+#endif /* GL_NV_conservative_raster_pre_snap_triangles */
+#ifdef GL_NV_copy_buffer
+  _glewInfo_GL_NV_copy_buffer();
+#endif /* GL_NV_copy_buffer */
 #ifdef GL_NV_copy_depth_to_color
   _glewInfo_GL_NV_copy_depth_to_color();
 #endif /* GL_NV_copy_depth_to_color */
@@ -10241,24 +14707,45 @@ static void glewInfo (void)
 #ifdef GL_NV_depth_range_unclamped
   _glewInfo_GL_NV_depth_range_unclamped();
 #endif /* GL_NV_depth_range_unclamped */
+#ifdef GL_NV_draw_buffers
+  _glewInfo_GL_NV_draw_buffers();
+#endif /* GL_NV_draw_buffers */
+#ifdef GL_NV_draw_instanced
+  _glewInfo_GL_NV_draw_instanced();
+#endif /* GL_NV_draw_instanced */
 #ifdef GL_NV_draw_texture
   _glewInfo_GL_NV_draw_texture();
 #endif /* GL_NV_draw_texture */
+#ifdef GL_NV_draw_vulkan_image
+  _glewInfo_GL_NV_draw_vulkan_image();
+#endif /* GL_NV_draw_vulkan_image */
 #ifdef GL_NV_evaluators
   _glewInfo_GL_NV_evaluators();
 #endif /* GL_NV_evaluators */
+#ifdef GL_NV_explicit_attrib_location
+  _glewInfo_GL_NV_explicit_attrib_location();
+#endif /* GL_NV_explicit_attrib_location */
 #ifdef GL_NV_explicit_multisample
   _glewInfo_GL_NV_explicit_multisample();
 #endif /* GL_NV_explicit_multisample */
+#ifdef GL_NV_fbo_color_attachments
+  _glewInfo_GL_NV_fbo_color_attachments();
+#endif /* GL_NV_fbo_color_attachments */
 #ifdef GL_NV_fence
   _glewInfo_GL_NV_fence();
 #endif /* GL_NV_fence */
+#ifdef GL_NV_fill_rectangle
+  _glewInfo_GL_NV_fill_rectangle();
+#endif /* GL_NV_fill_rectangle */
 #ifdef GL_NV_float_buffer
   _glewInfo_GL_NV_float_buffer();
 #endif /* GL_NV_float_buffer */
 #ifdef GL_NV_fog_distance
   _glewInfo_GL_NV_fog_distance();
 #endif /* GL_NV_fog_distance */
+#ifdef GL_NV_fragment_coverage_to_color
+  _glewInfo_GL_NV_fragment_coverage_to_color();
+#endif /* GL_NV_fragment_coverage_to_color */
 #ifdef GL_NV_fragment_program
   _glewInfo_GL_NV_fragment_program();
 #endif /* GL_NV_fragment_program */
@@ -10271,15 +14758,36 @@ static void glewInfo (void)
 #ifdef GL_NV_fragment_program_option
   _glewInfo_GL_NV_fragment_program_option();
 #endif /* GL_NV_fragment_program_option */
+#ifdef GL_NV_fragment_shader_interlock
+  _glewInfo_GL_NV_fragment_shader_interlock();
+#endif /* GL_NV_fragment_shader_interlock */
+#ifdef GL_NV_framebuffer_blit
+  _glewInfo_GL_NV_framebuffer_blit();
+#endif /* GL_NV_framebuffer_blit */
+#ifdef GL_NV_framebuffer_mixed_samples
+  _glewInfo_GL_NV_framebuffer_mixed_samples();
+#endif /* GL_NV_framebuffer_mixed_samples */
+#ifdef GL_NV_framebuffer_multisample
+  _glewInfo_GL_NV_framebuffer_multisample();
+#endif /* GL_NV_framebuffer_multisample */
 #ifdef GL_NV_framebuffer_multisample_coverage
   _glewInfo_GL_NV_framebuffer_multisample_coverage();
 #endif /* GL_NV_framebuffer_multisample_coverage */
+#ifdef GL_NV_generate_mipmap_sRGB
+  _glewInfo_GL_NV_generate_mipmap_sRGB();
+#endif /* GL_NV_generate_mipmap_sRGB */
 #ifdef GL_NV_geometry_program4
   _glewInfo_GL_NV_geometry_program4();
 #endif /* GL_NV_geometry_program4 */
 #ifdef GL_NV_geometry_shader4
   _glewInfo_GL_NV_geometry_shader4();
 #endif /* GL_NV_geometry_shader4 */
+#ifdef GL_NV_geometry_shader_passthrough
+  _glewInfo_GL_NV_geometry_shader_passthrough();
+#endif /* GL_NV_geometry_shader_passthrough */
+#ifdef GL_NV_gpu_multicast
+  _glewInfo_GL_NV_gpu_multicast();
+#endif /* GL_NV_gpu_multicast */
 #ifdef GL_NV_gpu_program4
   _glewInfo_GL_NV_gpu_program4();
 #endif /* GL_NV_gpu_program4 */
@@ -10298,6 +14806,15 @@ static void glewInfo (void)
 #ifdef GL_NV_half_float
   _glewInfo_GL_NV_half_float();
 #endif /* GL_NV_half_float */
+#ifdef GL_NV_image_formats
+  _glewInfo_GL_NV_image_formats();
+#endif /* GL_NV_image_formats */
+#ifdef GL_NV_instanced_arrays
+  _glewInfo_GL_NV_instanced_arrays();
+#endif /* GL_NV_instanced_arrays */
+#ifdef GL_NV_internalformat_sample_query
+  _glewInfo_GL_NV_internalformat_sample_query();
+#endif /* GL_NV_internalformat_sample_query */
 #ifdef GL_NV_light_max_exponent
   _glewInfo_GL_NV_light_max_exponent();
 #endif /* GL_NV_light_max_exponent */
@@ -10307,12 +14824,24 @@ static void glewInfo (void)
 #ifdef GL_NV_multisample_filter_hint
   _glewInfo_GL_NV_multisample_filter_hint();
 #endif /* GL_NV_multisample_filter_hint */
+#ifdef GL_NV_non_square_matrices
+  _glewInfo_GL_NV_non_square_matrices();
+#endif /* GL_NV_non_square_matrices */
 #ifdef GL_NV_occlusion_query
   _glewInfo_GL_NV_occlusion_query();
 #endif /* GL_NV_occlusion_query */
+#ifdef GL_NV_pack_subimage
+  _glewInfo_GL_NV_pack_subimage();
+#endif /* GL_NV_pack_subimage */
 #ifdef GL_NV_packed_depth_stencil
   _glewInfo_GL_NV_packed_depth_stencil();
 #endif /* GL_NV_packed_depth_stencil */
+#ifdef GL_NV_packed_float
+  _glewInfo_GL_NV_packed_float();
+#endif /* GL_NV_packed_float */
+#ifdef GL_NV_packed_float_linear
+  _glewInfo_GL_NV_packed_float_linear();
+#endif /* GL_NV_packed_float_linear */
 #ifdef GL_NV_parameter_buffer_object
   _glewInfo_GL_NV_parameter_buffer_object();
 #endif /* GL_NV_parameter_buffer_object */
@@ -10322,36 +14851,78 @@ static void glewInfo (void)
 #ifdef GL_NV_path_rendering
   _glewInfo_GL_NV_path_rendering();
 #endif /* GL_NV_path_rendering */
+#ifdef GL_NV_path_rendering_shared_edge
+  _glewInfo_GL_NV_path_rendering_shared_edge();
+#endif /* GL_NV_path_rendering_shared_edge */
+#ifdef GL_NV_pixel_buffer_object
+  _glewInfo_GL_NV_pixel_buffer_object();
+#endif /* GL_NV_pixel_buffer_object */
 #ifdef GL_NV_pixel_data_range
   _glewInfo_GL_NV_pixel_data_range();
 #endif /* GL_NV_pixel_data_range */
+#ifdef GL_NV_platform_binary
+  _glewInfo_GL_NV_platform_binary();
+#endif /* GL_NV_platform_binary */
 #ifdef GL_NV_point_sprite
   _glewInfo_GL_NV_point_sprite();
 #endif /* GL_NV_point_sprite */
+#ifdef GL_NV_polygon_mode
+  _glewInfo_GL_NV_polygon_mode();
+#endif /* GL_NV_polygon_mode */
 #ifdef GL_NV_present_video
   _glewInfo_GL_NV_present_video();
 #endif /* GL_NV_present_video */
 #ifdef GL_NV_primitive_restart
   _glewInfo_GL_NV_primitive_restart();
 #endif /* GL_NV_primitive_restart */
+#ifdef GL_NV_read_depth
+  _glewInfo_GL_NV_read_depth();
+#endif /* GL_NV_read_depth */
+#ifdef GL_NV_read_depth_stencil
+  _glewInfo_GL_NV_read_depth_stencil();
+#endif /* GL_NV_read_depth_stencil */
+#ifdef GL_NV_read_stencil
+  _glewInfo_GL_NV_read_stencil();
+#endif /* GL_NV_read_stencil */
 #ifdef GL_NV_register_combiners
   _glewInfo_GL_NV_register_combiners();
 #endif /* GL_NV_register_combiners */
 #ifdef GL_NV_register_combiners2
   _glewInfo_GL_NV_register_combiners2();
 #endif /* GL_NV_register_combiners2 */
+#ifdef GL_NV_robustness_video_memory_purge
+  _glewInfo_GL_NV_robustness_video_memory_purge();
+#endif /* GL_NV_robustness_video_memory_purge */
+#ifdef GL_NV_sRGB_formats
+  _glewInfo_GL_NV_sRGB_formats();
+#endif /* GL_NV_sRGB_formats */
+#ifdef GL_NV_sample_locations
+  _glewInfo_GL_NV_sample_locations();
+#endif /* GL_NV_sample_locations */
+#ifdef GL_NV_sample_mask_override_coverage
+  _glewInfo_GL_NV_sample_mask_override_coverage();
+#endif /* GL_NV_sample_mask_override_coverage */
 #ifdef GL_NV_shader_atomic_counters
   _glewInfo_GL_NV_shader_atomic_counters();
 #endif /* GL_NV_shader_atomic_counters */
 #ifdef GL_NV_shader_atomic_float
   _glewInfo_GL_NV_shader_atomic_float();
 #endif /* GL_NV_shader_atomic_float */
+#ifdef GL_NV_shader_atomic_float64
+  _glewInfo_GL_NV_shader_atomic_float64();
+#endif /* GL_NV_shader_atomic_float64 */
+#ifdef GL_NV_shader_atomic_fp16_vector
+  _glewInfo_GL_NV_shader_atomic_fp16_vector();
+#endif /* GL_NV_shader_atomic_fp16_vector */
 #ifdef GL_NV_shader_atomic_int64
   _glewInfo_GL_NV_shader_atomic_int64();
 #endif /* GL_NV_shader_atomic_int64 */
 #ifdef GL_NV_shader_buffer_load
   _glewInfo_GL_NV_shader_buffer_load();
 #endif /* GL_NV_shader_buffer_load */
+#ifdef GL_NV_shader_noperspective_interpolation
+  _glewInfo_GL_NV_shader_noperspective_interpolation();
+#endif /* GL_NV_shader_noperspective_interpolation */
 #ifdef GL_NV_shader_storage_buffer_object
   _glewInfo_GL_NV_shader_storage_buffer_object();
 #endif /* GL_NV_shader_storage_buffer_object */
@@ -10361,6 +14932,15 @@ static void glewInfo (void)
 #ifdef GL_NV_shader_thread_shuffle
   _glewInfo_GL_NV_shader_thread_shuffle();
 #endif /* GL_NV_shader_thread_shuffle */
+#ifdef GL_NV_shadow_samplers_array
+  _glewInfo_GL_NV_shadow_samplers_array();
+#endif /* GL_NV_shadow_samplers_array */
+#ifdef GL_NV_shadow_samplers_cube
+  _glewInfo_GL_NV_shadow_samplers_cube();
+#endif /* GL_NV_shadow_samplers_cube */
+#ifdef GL_NV_stereo_view_rendering
+  _glewInfo_GL_NV_stereo_view_rendering();
+#endif /* GL_NV_stereo_view_rendering */
 #ifdef GL_NV_tessellation_program5
   _glewInfo_GL_NV_tessellation_program5();
 #endif /* GL_NV_tessellation_program5 */
@@ -10370,9 +14950,24 @@ static void glewInfo (void)
 #ifdef GL_NV_texgen_reflection
   _glewInfo_GL_NV_texgen_reflection();
 #endif /* GL_NV_texgen_reflection */
+#ifdef GL_NV_texture_array
+  _glewInfo_GL_NV_texture_array();
+#endif /* GL_NV_texture_array */
 #ifdef GL_NV_texture_barrier
   _glewInfo_GL_NV_texture_barrier();
 #endif /* GL_NV_texture_barrier */
+#ifdef GL_NV_texture_border_clamp
+  _glewInfo_GL_NV_texture_border_clamp();
+#endif /* GL_NV_texture_border_clamp */
+#ifdef GL_NV_texture_compression_latc
+  _glewInfo_GL_NV_texture_compression_latc();
+#endif /* GL_NV_texture_compression_latc */
+#ifdef GL_NV_texture_compression_s3tc
+  _glewInfo_GL_NV_texture_compression_s3tc();
+#endif /* GL_NV_texture_compression_s3tc */
+#ifdef GL_NV_texture_compression_s3tc_update
+  _glewInfo_GL_NV_texture_compression_s3tc_update();
+#endif /* GL_NV_texture_compression_s3tc_update */
 #ifdef GL_NV_texture_compression_vtc
   _glewInfo_GL_NV_texture_compression_vtc();
 #endif /* GL_NV_texture_compression_vtc */
@@ -10385,9 +14980,15 @@ static void glewInfo (void)
 #ifdef GL_NV_texture_multisample
   _glewInfo_GL_NV_texture_multisample();
 #endif /* GL_NV_texture_multisample */
+#ifdef GL_NV_texture_npot_2D_mipmap
+  _glewInfo_GL_NV_texture_npot_2D_mipmap();
+#endif /* GL_NV_texture_npot_2D_mipmap */
 #ifdef GL_NV_texture_rectangle
   _glewInfo_GL_NV_texture_rectangle();
 #endif /* GL_NV_texture_rectangle */
+#ifdef GL_NV_texture_rectangle_compressed
+  _glewInfo_GL_NV_texture_rectangle_compressed();
+#endif /* GL_NV_texture_rectangle_compressed */
 #ifdef GL_NV_texture_shader
   _glewInfo_GL_NV_texture_shader();
 #endif /* GL_NV_texture_shader */
@@ -10403,6 +15004,9 @@ static void glewInfo (void)
 #ifdef GL_NV_transform_feedback2
   _glewInfo_GL_NV_transform_feedback2();
 #endif /* GL_NV_transform_feedback2 */
+#ifdef GL_NV_uniform_buffer_unified_memory
+  _glewInfo_GL_NV_uniform_buffer_unified_memory();
+#endif /* GL_NV_uniform_buffer_unified_memory */
 #ifdef GL_NV_vdpau_interop
   _glewInfo_GL_NV_vdpau_interop();
 #endif /* GL_NV_vdpau_interop */
@@ -10439,18 +15043,18 @@ static void glewInfo (void)
 #ifdef GL_NV_video_capture
   _glewInfo_GL_NV_video_capture();
 #endif /* GL_NV_video_capture */
+#ifdef GL_NV_viewport_array
+  _glewInfo_GL_NV_viewport_array();
+#endif /* GL_NV_viewport_array */
+#ifdef GL_NV_viewport_array2
+  _glewInfo_GL_NV_viewport_array2();
+#endif /* GL_NV_viewport_array2 */
+#ifdef GL_NV_viewport_swizzle
+  _glewInfo_GL_NV_viewport_swizzle();
+#endif /* GL_NV_viewport_swizzle */
 #ifdef GL_OES_byte_coordinates
   _glewInfo_GL_OES_byte_coordinates();
 #endif /* GL_OES_byte_coordinates */
-#ifdef GL_OES_compressed_paletted_texture
-  _glewInfo_GL_OES_compressed_paletted_texture();
-#endif /* GL_OES_compressed_paletted_texture */
-#ifdef GL_OES_read_format
-  _glewInfo_GL_OES_read_format();
-#endif /* GL_OES_read_format */
-#ifdef GL_OES_single_precision
-  _glewInfo_GL_OES_single_precision();
-#endif /* GL_OES_single_precision */
 #ifdef GL_OML_interlace
   _glewInfo_GL_OML_interlace();
 #endif /* GL_OML_interlace */
@@ -10460,12 +15064,51 @@ static void glewInfo (void)
 #ifdef GL_OML_subsample
   _glewInfo_GL_OML_subsample();
 #endif /* GL_OML_subsample */
+#ifdef GL_OVR_multiview
+  _glewInfo_GL_OVR_multiview();
+#endif /* GL_OVR_multiview */
+#ifdef GL_OVR_multiview2
+  _glewInfo_GL_OVR_multiview2();
+#endif /* GL_OVR_multiview2 */
+#ifdef GL_OVR_multiview_multisampled_render_to_texture
+  _glewInfo_GL_OVR_multiview_multisampled_render_to_texture();
+#endif /* GL_OVR_multiview_multisampled_render_to_texture */
 #ifdef GL_PGI_misc_hints
   _glewInfo_GL_PGI_misc_hints();
 #endif /* GL_PGI_misc_hints */
 #ifdef GL_PGI_vertex_hints
   _glewInfo_GL_PGI_vertex_hints();
 #endif /* GL_PGI_vertex_hints */
+#ifdef GL_QCOM_alpha_test
+  _glewInfo_GL_QCOM_alpha_test();
+#endif /* GL_QCOM_alpha_test */
+#ifdef GL_QCOM_binning_control
+  _glewInfo_GL_QCOM_binning_control();
+#endif /* GL_QCOM_binning_control */
+#ifdef GL_QCOM_driver_control
+  _glewInfo_GL_QCOM_driver_control();
+#endif /* GL_QCOM_driver_control */
+#ifdef GL_QCOM_extended_get
+  _glewInfo_GL_QCOM_extended_get();
+#endif /* GL_QCOM_extended_get */
+#ifdef GL_QCOM_extended_get2
+  _glewInfo_GL_QCOM_extended_get2();
+#endif /* GL_QCOM_extended_get2 */
+#ifdef GL_QCOM_framebuffer_foveated
+  _glewInfo_GL_QCOM_framebuffer_foveated();
+#endif /* GL_QCOM_framebuffer_foveated */
+#ifdef GL_QCOM_perfmon_global_mode
+  _glewInfo_GL_QCOM_perfmon_global_mode();
+#endif /* GL_QCOM_perfmon_global_mode */
+#ifdef GL_QCOM_shader_framebuffer_fetch_noncoherent
+  _glewInfo_GL_QCOM_shader_framebuffer_fetch_noncoherent();
+#endif /* GL_QCOM_shader_framebuffer_fetch_noncoherent */
+#ifdef GL_QCOM_tiled_rendering
+  _glewInfo_GL_QCOM_tiled_rendering();
+#endif /* GL_QCOM_tiled_rendering */
+#ifdef GL_QCOM_writeonly_rendering
+  _glewInfo_GL_QCOM_writeonly_rendering();
+#endif /* GL_QCOM_writeonly_rendering */
 #ifdef GL_REGAL_ES1_0_compatibility
   _glewInfo_GL_REGAL_ES1_0_compatibility();
 #endif /* GL_REGAL_ES1_0_compatibility */
@@ -10493,6 +15136,9 @@ static void glewInfo (void)
 #ifdef GL_S3_s3tc
   _glewInfo_GL_S3_s3tc();
 #endif /* GL_S3_s3tc */
+#ifdef GL_SGIS_clip_band_hint
+  _glewInfo_GL_SGIS_clip_band_hint();
+#endif /* GL_SGIS_clip_band_hint */
 #ifdef GL_SGIS_color_range
   _glewInfo_GL_SGIS_color_range();
 #endif /* GL_SGIS_color_range */
@@ -10505,15 +15151,24 @@ static void glewInfo (void)
 #ifdef GL_SGIS_generate_mipmap
   _glewInfo_GL_SGIS_generate_mipmap();
 #endif /* GL_SGIS_generate_mipmap */
+#ifdef GL_SGIS_line_texgen
+  _glewInfo_GL_SGIS_line_texgen();
+#endif /* GL_SGIS_line_texgen */
 #ifdef GL_SGIS_multisample
   _glewInfo_GL_SGIS_multisample();
 #endif /* GL_SGIS_multisample */
+#ifdef GL_SGIS_multitexture
+  _glewInfo_GL_SGIS_multitexture();
+#endif /* GL_SGIS_multitexture */
 #ifdef GL_SGIS_pixel_texture
   _glewInfo_GL_SGIS_pixel_texture();
 #endif /* GL_SGIS_pixel_texture */
 #ifdef GL_SGIS_point_line_texgen
   _glewInfo_GL_SGIS_point_line_texgen();
 #endif /* GL_SGIS_point_line_texgen */
+#ifdef GL_SGIS_shared_multisample
+  _glewInfo_GL_SGIS_shared_multisample();
+#endif /* GL_SGIS_shared_multisample */
 #ifdef GL_SGIS_sharpen_texture
   _glewInfo_GL_SGIS_sharpen_texture();
 #endif /* GL_SGIS_sharpen_texture */
@@ -10544,63 +15199,192 @@ static void glewInfo (void)
 #ifdef GL_SGIX_async_pixel
   _glewInfo_GL_SGIX_async_pixel();
 #endif /* GL_SGIX_async_pixel */
+#ifdef GL_SGIX_bali_g_instruments
+  _glewInfo_GL_SGIX_bali_g_instruments();
+#endif /* GL_SGIX_bali_g_instruments */
+#ifdef GL_SGIX_bali_r_instruments
+  _glewInfo_GL_SGIX_bali_r_instruments();
+#endif /* GL_SGIX_bali_r_instruments */
+#ifdef GL_SGIX_bali_timer_instruments
+  _glewInfo_GL_SGIX_bali_timer_instruments();
+#endif /* GL_SGIX_bali_timer_instruments */
 #ifdef GL_SGIX_blend_alpha_minmax
   _glewInfo_GL_SGIX_blend_alpha_minmax();
 #endif /* GL_SGIX_blend_alpha_minmax */
+#ifdef GL_SGIX_blend_cadd
+  _glewInfo_GL_SGIX_blend_cadd();
+#endif /* GL_SGIX_blend_cadd */
+#ifdef GL_SGIX_blend_cmultiply
+  _glewInfo_GL_SGIX_blend_cmultiply();
+#endif /* GL_SGIX_blend_cmultiply */
+#ifdef GL_SGIX_calligraphic_fragment
+  _glewInfo_GL_SGIX_calligraphic_fragment();
+#endif /* GL_SGIX_calligraphic_fragment */
 #ifdef GL_SGIX_clipmap
   _glewInfo_GL_SGIX_clipmap();
 #endif /* GL_SGIX_clipmap */
+#ifdef GL_SGIX_color_matrix_accuracy
+  _glewInfo_GL_SGIX_color_matrix_accuracy();
+#endif /* GL_SGIX_color_matrix_accuracy */
+#ifdef GL_SGIX_color_table_index_mode
+  _glewInfo_GL_SGIX_color_table_index_mode();
+#endif /* GL_SGIX_color_table_index_mode */
+#ifdef GL_SGIX_complex_polar
+  _glewInfo_GL_SGIX_complex_polar();
+#endif /* GL_SGIX_complex_polar */
 #ifdef GL_SGIX_convolution_accuracy
   _glewInfo_GL_SGIX_convolution_accuracy();
 #endif /* GL_SGIX_convolution_accuracy */
+#ifdef GL_SGIX_cube_map
+  _glewInfo_GL_SGIX_cube_map();
+#endif /* GL_SGIX_cube_map */
+#ifdef GL_SGIX_cylinder_texgen
+  _glewInfo_GL_SGIX_cylinder_texgen();
+#endif /* GL_SGIX_cylinder_texgen */
+#ifdef GL_SGIX_datapipe
+  _glewInfo_GL_SGIX_datapipe();
+#endif /* GL_SGIX_datapipe */
+#ifdef GL_SGIX_decimation
+  _glewInfo_GL_SGIX_decimation();
+#endif /* GL_SGIX_decimation */
+#ifdef GL_SGIX_depth_pass_instrument
+  _glewInfo_GL_SGIX_depth_pass_instrument();
+#endif /* GL_SGIX_depth_pass_instrument */
 #ifdef GL_SGIX_depth_texture
   _glewInfo_GL_SGIX_depth_texture();
 #endif /* GL_SGIX_depth_texture */
+#ifdef GL_SGIX_dvc
+  _glewInfo_GL_SGIX_dvc();
+#endif /* GL_SGIX_dvc */
 #ifdef GL_SGIX_flush_raster
   _glewInfo_GL_SGIX_flush_raster();
 #endif /* GL_SGIX_flush_raster */
+#ifdef GL_SGIX_fog_blend
+  _glewInfo_GL_SGIX_fog_blend();
+#endif /* GL_SGIX_fog_blend */
+#ifdef GL_SGIX_fog_factor_to_alpha
+  _glewInfo_GL_SGIX_fog_factor_to_alpha();
+#endif /* GL_SGIX_fog_factor_to_alpha */
+#ifdef GL_SGIX_fog_layers
+  _glewInfo_GL_SGIX_fog_layers();
+#endif /* GL_SGIX_fog_layers */
 #ifdef GL_SGIX_fog_offset
   _glewInfo_GL_SGIX_fog_offset();
 #endif /* GL_SGIX_fog_offset */
+#ifdef GL_SGIX_fog_patchy
+  _glewInfo_GL_SGIX_fog_patchy();
+#endif /* GL_SGIX_fog_patchy */
+#ifdef GL_SGIX_fog_scale
+  _glewInfo_GL_SGIX_fog_scale();
+#endif /* GL_SGIX_fog_scale */
 #ifdef GL_SGIX_fog_texture
   _glewInfo_GL_SGIX_fog_texture();
 #endif /* GL_SGIX_fog_texture */
+#ifdef GL_SGIX_fragment_lighting_space
+  _glewInfo_GL_SGIX_fragment_lighting_space();
+#endif /* GL_SGIX_fragment_lighting_space */
 #ifdef GL_SGIX_fragment_specular_lighting
   _glewInfo_GL_SGIX_fragment_specular_lighting();
 #endif /* GL_SGIX_fragment_specular_lighting */
+#ifdef GL_SGIX_fragments_instrument
+  _glewInfo_GL_SGIX_fragments_instrument();
+#endif /* GL_SGIX_fragments_instrument */
 #ifdef GL_SGIX_framezoom
   _glewInfo_GL_SGIX_framezoom();
 #endif /* GL_SGIX_framezoom */
+#ifdef GL_SGIX_icc_texture
+  _glewInfo_GL_SGIX_icc_texture();
+#endif /* GL_SGIX_icc_texture */
+#ifdef GL_SGIX_igloo_interface
+  _glewInfo_GL_SGIX_igloo_interface();
+#endif /* GL_SGIX_igloo_interface */
+#ifdef GL_SGIX_image_compression
+  _glewInfo_GL_SGIX_image_compression();
+#endif /* GL_SGIX_image_compression */
+#ifdef GL_SGIX_impact_pixel_texture
+  _glewInfo_GL_SGIX_impact_pixel_texture();
+#endif /* GL_SGIX_impact_pixel_texture */
+#ifdef GL_SGIX_instrument_error
+  _glewInfo_GL_SGIX_instrument_error();
+#endif /* GL_SGIX_instrument_error */
 #ifdef GL_SGIX_interlace
   _glewInfo_GL_SGIX_interlace();
 #endif /* GL_SGIX_interlace */
 #ifdef GL_SGIX_ir_instrument1
   _glewInfo_GL_SGIX_ir_instrument1();
 #endif /* GL_SGIX_ir_instrument1 */
+#ifdef GL_SGIX_line_quality_hint
+  _glewInfo_GL_SGIX_line_quality_hint();
+#endif /* GL_SGIX_line_quality_hint */
 #ifdef GL_SGIX_list_priority
   _glewInfo_GL_SGIX_list_priority();
 #endif /* GL_SGIX_list_priority */
+#ifdef GL_SGIX_mpeg1
+  _glewInfo_GL_SGIX_mpeg1();
+#endif /* GL_SGIX_mpeg1 */
+#ifdef GL_SGIX_mpeg2
+  _glewInfo_GL_SGIX_mpeg2();
+#endif /* GL_SGIX_mpeg2 */
+#ifdef GL_SGIX_nonlinear_lighting_pervertex
+  _glewInfo_GL_SGIX_nonlinear_lighting_pervertex();
+#endif /* GL_SGIX_nonlinear_lighting_pervertex */
+#ifdef GL_SGIX_nurbs_eval
+  _glewInfo_GL_SGIX_nurbs_eval();
+#endif /* GL_SGIX_nurbs_eval */
+#ifdef GL_SGIX_occlusion_instrument
+  _glewInfo_GL_SGIX_occlusion_instrument();
+#endif /* GL_SGIX_occlusion_instrument */
+#ifdef GL_SGIX_packed_6bytes
+  _glewInfo_GL_SGIX_packed_6bytes();
+#endif /* GL_SGIX_packed_6bytes */
 #ifdef GL_SGIX_pixel_texture
   _glewInfo_GL_SGIX_pixel_texture();
 #endif /* GL_SGIX_pixel_texture */
 #ifdef GL_SGIX_pixel_texture_bits
   _glewInfo_GL_SGIX_pixel_texture_bits();
 #endif /* GL_SGIX_pixel_texture_bits */
+#ifdef GL_SGIX_pixel_texture_lod
+  _glewInfo_GL_SGIX_pixel_texture_lod();
+#endif /* GL_SGIX_pixel_texture_lod */
+#ifdef GL_SGIX_pixel_tiles
+  _glewInfo_GL_SGIX_pixel_tiles();
+#endif /* GL_SGIX_pixel_tiles */
+#ifdef GL_SGIX_polynomial_ffd
+  _glewInfo_GL_SGIX_polynomial_ffd();
+#endif /* GL_SGIX_polynomial_ffd */
+#ifdef GL_SGIX_quad_mesh
+  _glewInfo_GL_SGIX_quad_mesh();
+#endif /* GL_SGIX_quad_mesh */
 #ifdef GL_SGIX_reference_plane
   _glewInfo_GL_SGIX_reference_plane();
 #endif /* GL_SGIX_reference_plane */
 #ifdef GL_SGIX_resample
   _glewInfo_GL_SGIX_resample();
 #endif /* GL_SGIX_resample */
+#ifdef GL_SGIX_scalebias_hint
+  _glewInfo_GL_SGIX_scalebias_hint();
+#endif /* GL_SGIX_scalebias_hint */
 #ifdef GL_SGIX_shadow
   _glewInfo_GL_SGIX_shadow();
 #endif /* GL_SGIX_shadow */
 #ifdef GL_SGIX_shadow_ambient
   _glewInfo_GL_SGIX_shadow_ambient();
 #endif /* GL_SGIX_shadow_ambient */
+#ifdef GL_SGIX_slim
+  _glewInfo_GL_SGIX_slim();
+#endif /* GL_SGIX_slim */
+#ifdef GL_SGIX_spotlight_cutoff
+  _glewInfo_GL_SGIX_spotlight_cutoff();
+#endif /* GL_SGIX_spotlight_cutoff */
 #ifdef GL_SGIX_sprite
   _glewInfo_GL_SGIX_sprite();
 #endif /* GL_SGIX_sprite */
+#ifdef GL_SGIX_subdiv_patch
+  _glewInfo_GL_SGIX_subdiv_patch();
+#endif /* GL_SGIX_subdiv_patch */
+#ifdef GL_SGIX_subsample
+  _glewInfo_GL_SGIX_subsample();
+#endif /* GL_SGIX_subsample */
 #ifdef GL_SGIX_tag_sample_buffer
   _glewInfo_GL_SGIX_tag_sample_buffer();
 #endif /* GL_SGIX_tag_sample_buffer */
@@ -10613,15 +15397,30 @@ static void glewInfo (void)
 #ifdef GL_SGIX_texture_lod_bias
   _glewInfo_GL_SGIX_texture_lod_bias();
 #endif /* GL_SGIX_texture_lod_bias */
+#ifdef GL_SGIX_texture_mipmap_anisotropic
+  _glewInfo_GL_SGIX_texture_mipmap_anisotropic();
+#endif /* GL_SGIX_texture_mipmap_anisotropic */
 #ifdef GL_SGIX_texture_multi_buffer
   _glewInfo_GL_SGIX_texture_multi_buffer();
 #endif /* GL_SGIX_texture_multi_buffer */
+#ifdef GL_SGIX_texture_phase
+  _glewInfo_GL_SGIX_texture_phase();
+#endif /* GL_SGIX_texture_phase */
 #ifdef GL_SGIX_texture_range
   _glewInfo_GL_SGIX_texture_range();
 #endif /* GL_SGIX_texture_range */
 #ifdef GL_SGIX_texture_scale_bias
   _glewInfo_GL_SGIX_texture_scale_bias();
 #endif /* GL_SGIX_texture_scale_bias */
+#ifdef GL_SGIX_texture_supersample
+  _glewInfo_GL_SGIX_texture_supersample();
+#endif /* GL_SGIX_texture_supersample */
+#ifdef GL_SGIX_vector_ops
+  _glewInfo_GL_SGIX_vector_ops();
+#endif /* GL_SGIX_vector_ops */
+#ifdef GL_SGIX_vertex_array_object
+  _glewInfo_GL_SGIX_vertex_array_object();
+#endif /* GL_SGIX_vertex_array_object */
 #ifdef GL_SGIX_vertex_preclip
   _glewInfo_GL_SGIX_vertex_preclip();
 #endif /* GL_SGIX_vertex_preclip */
@@ -10631,12 +15430,27 @@ static void glewInfo (void)
 #ifdef GL_SGIX_ycrcb
   _glewInfo_GL_SGIX_ycrcb();
 #endif /* GL_SGIX_ycrcb */
+#ifdef GL_SGIX_ycrcb_subsample
+  _glewInfo_GL_SGIX_ycrcb_subsample();
+#endif /* GL_SGIX_ycrcb_subsample */
+#ifdef GL_SGIX_ycrcba
+  _glewInfo_GL_SGIX_ycrcba();
+#endif /* GL_SGIX_ycrcba */
 #ifdef GL_SGI_color_matrix
   _glewInfo_GL_SGI_color_matrix();
 #endif /* GL_SGI_color_matrix */
 #ifdef GL_SGI_color_table
   _glewInfo_GL_SGI_color_table();
 #endif /* GL_SGI_color_table */
+#ifdef GL_SGI_complex
+  _glewInfo_GL_SGI_complex();
+#endif /* GL_SGI_complex */
+#ifdef GL_SGI_complex_type
+  _glewInfo_GL_SGI_complex_type();
+#endif /* GL_SGI_complex_type */
+#ifdef GL_SGI_fft
+  _glewInfo_GL_SGI_fft();
+#endif /* GL_SGI_fft */
 #ifdef GL_SGI_texture_color_table
   _glewInfo_GL_SGI_texture_color_table();
 #endif /* GL_SGI_texture_color_table */
@@ -10667,6 +15481,9 @@ static void glewInfo (void)
 #ifdef GL_WIN_phong_shading
   _glewInfo_GL_WIN_phong_shading();
 #endif /* GL_WIN_phong_shading */
+#ifdef GL_WIN_scene_markerXXX
+  _glewInfo_GL_WIN_scene_markerXXX();
+#endif /* GL_WIN_scene_markerXXX */
 #ifdef GL_WIN_specular_fog
   _glewInfo_GL_WIN_specular_fog();
 #endif /* GL_WIN_specular_fog */
@@ -10677,7 +15494,7 @@ static void glewInfo (void)
 
 /* ------------------------------------------------------------------------ */
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(GLEW_EGL) && !defined(GLEW_OSMESA)
 
 static void wglewInfo ()
 {
@@ -10699,6 +15516,9 @@ static void wglewInfo ()
 #ifdef WGL_ARB_create_context
   _glewInfo_WGL_ARB_create_context();
 #endif /* WGL_ARB_create_context */
+#ifdef WGL_ARB_create_context_no_error
+  _glewInfo_WGL_ARB_create_context_no_error();
+#endif /* WGL_ARB_create_context_no_error */
 #ifdef WGL_ARB_create_context_profile
   _glewInfo_WGL_ARB_create_context_profile();
 #endif /* WGL_ARB_create_context_profile */
@@ -10741,6 +15561,9 @@ static void wglewInfo ()
 #ifdef WGL_ATI_render_texture_rectangle
   _glewInfo_WGL_ATI_render_texture_rectangle();
 #endif /* WGL_ATI_render_texture_rectangle */
+#ifdef WGL_EXT_colorspace
+  _glewInfo_WGL_EXT_colorspace();
+#endif /* WGL_EXT_colorspace */
 #ifdef WGL_EXT_create_context_es2_profile
   _glewInfo_WGL_EXT_create_context_es2_profile();
 #endif /* WGL_EXT_create_context_es2_profile */
@@ -10845,7 +15668,7 @@ static void wglewInfo ()
 #endif /* WGL_OML_sync_control */
 }
 
-#else /* _UNIX */
+#elif !defined(GLEW_EGL) && !defined(GLEW_OSMESA) /* _UNIX */
 
 static void glxewInfo ()
 {
@@ -10870,6 +15693,9 @@ static void glxewInfo ()
 #ifdef GLX_ARB_create_context
   _glewInfo_GLX_ARB_create_context();
 #endif /* GLX_ARB_create_context */
+#ifdef GLX_ARB_create_context_no_error
+  _glewInfo_GLX_ARB_create_context_no_error();
+#endif /* GLX_ARB_create_context_no_error */
 #ifdef GLX_ARB_create_context_profile
   _glewInfo_GLX_ARB_create_context_profile();
 #endif /* GLX_ARB_create_context_profile */
@@ -10921,6 +15747,9 @@ static void glxewInfo ()
 #ifdef GLX_EXT_import_context
   _glewInfo_GLX_EXT_import_context();
 #endif /* GLX_EXT_import_context */
+#ifdef GLX_EXT_libglvnd
+  _glewInfo_GLX_EXT_libglvnd();
+#endif /* GLX_EXT_libglvnd */
 #ifdef GLX_EXT_scene_marker
   _glewInfo_GLX_EXT_scene_marker();
 #endif /* GLX_EXT_scene_marker */
@@ -10984,6 +15813,9 @@ static void glxewInfo ()
 #ifdef GLX_NV_present_video
   _glewInfo_GLX_NV_present_video();
 #endif /* GLX_NV_present_video */
+#ifdef GLX_NV_robustness_video_memory_purge
+  _glewInfo_GLX_NV_robustness_video_memory_purge();
+#endif /* GLX_NV_robustness_video_memory_purge */
 #ifdef GLX_NV_swap_group
   _glewInfo_GLX_NV_swap_group();
 #endif /* GLX_NV_swap_group */
@@ -11055,63 +15887,473 @@ static void glxewInfo ()
 #endif /* GLX_SUN_video_resize */
 }
 
+#elif defined(GLEW_EGL)
+
+static void eglewInfo ()
+{
+#ifdef EGL_VERSION_1_0
+  _glewInfo_EGL_VERSION_1_0();
+#endif /* EGL_VERSION_1_0 */
+#ifdef EGL_VERSION_1_1
+  _glewInfo_EGL_VERSION_1_1();
+#endif /* EGL_VERSION_1_1 */
+#ifdef EGL_VERSION_1_2
+  _glewInfo_EGL_VERSION_1_2();
+#endif /* EGL_VERSION_1_2 */
+#ifdef EGL_VERSION_1_3
+  _glewInfo_EGL_VERSION_1_3();
+#endif /* EGL_VERSION_1_3 */
+#ifdef EGL_VERSION_1_4
+  _glewInfo_EGL_VERSION_1_4();
+#endif /* EGL_VERSION_1_4 */
+#ifdef EGL_VERSION_1_5
+  _glewInfo_EGL_VERSION_1_5();
+#endif /* EGL_VERSION_1_5 */
+#ifdef EGL_ANDROID_blob_cache
+  _glewInfo_EGL_ANDROID_blob_cache();
+#endif /* EGL_ANDROID_blob_cache */
+#ifdef EGL_ANDROID_create_native_client_buffer
+  _glewInfo_EGL_ANDROID_create_native_client_buffer();
+#endif /* EGL_ANDROID_create_native_client_buffer */
+#ifdef EGL_ANDROID_framebuffer_target
+  _glewInfo_EGL_ANDROID_framebuffer_target();
+#endif /* EGL_ANDROID_framebuffer_target */
+#ifdef EGL_ANDROID_front_buffer_auto_refresh
+  _glewInfo_EGL_ANDROID_front_buffer_auto_refresh();
+#endif /* EGL_ANDROID_front_buffer_auto_refresh */
+#ifdef EGL_ANDROID_image_native_buffer
+  _glewInfo_EGL_ANDROID_image_native_buffer();
+#endif /* EGL_ANDROID_image_native_buffer */
+#ifdef EGL_ANDROID_native_fence_sync
+  _glewInfo_EGL_ANDROID_native_fence_sync();
+#endif /* EGL_ANDROID_native_fence_sync */
+#ifdef EGL_ANDROID_presentation_time
+  _glewInfo_EGL_ANDROID_presentation_time();
+#endif /* EGL_ANDROID_presentation_time */
+#ifdef EGL_ANDROID_recordable
+  _glewInfo_EGL_ANDROID_recordable();
+#endif /* EGL_ANDROID_recordable */
+#ifdef EGL_ANGLE_d3d_share_handle_client_buffer
+  _glewInfo_EGL_ANGLE_d3d_share_handle_client_buffer();
+#endif /* EGL_ANGLE_d3d_share_handle_client_buffer */
+#ifdef EGL_ANGLE_device_d3d
+  _glewInfo_EGL_ANGLE_device_d3d();
+#endif /* EGL_ANGLE_device_d3d */
+#ifdef EGL_ANGLE_query_surface_pointer
+  _glewInfo_EGL_ANGLE_query_surface_pointer();
+#endif /* EGL_ANGLE_query_surface_pointer */
+#ifdef EGL_ANGLE_surface_d3d_texture_2d_share_handle
+  _glewInfo_EGL_ANGLE_surface_d3d_texture_2d_share_handle();
+#endif /* EGL_ANGLE_surface_d3d_texture_2d_share_handle */
+#ifdef EGL_ANGLE_window_fixed_size
+  _glewInfo_EGL_ANGLE_window_fixed_size();
+#endif /* EGL_ANGLE_window_fixed_size */
+#ifdef EGL_ARM_implicit_external_sync
+  _glewInfo_EGL_ARM_implicit_external_sync();
+#endif /* EGL_ARM_implicit_external_sync */
+#ifdef EGL_ARM_pixmap_multisample_discard
+  _glewInfo_EGL_ARM_pixmap_multisample_discard();
+#endif /* EGL_ARM_pixmap_multisample_discard */
+#ifdef EGL_EXT_buffer_age
+  _glewInfo_EGL_EXT_buffer_age();
+#endif /* EGL_EXT_buffer_age */
+#ifdef EGL_EXT_client_extensions
+  _glewInfo_EGL_EXT_client_extensions();
+#endif /* EGL_EXT_client_extensions */
+#ifdef EGL_EXT_create_context_robustness
+  _glewInfo_EGL_EXT_create_context_robustness();
+#endif /* EGL_EXT_create_context_robustness */
+#ifdef EGL_EXT_device_base
+  _glewInfo_EGL_EXT_device_base();
+#endif /* EGL_EXT_device_base */
+#ifdef EGL_EXT_device_drm
+  _glewInfo_EGL_EXT_device_drm();
+#endif /* EGL_EXT_device_drm */
+#ifdef EGL_EXT_device_enumeration
+  _glewInfo_EGL_EXT_device_enumeration();
+#endif /* EGL_EXT_device_enumeration */
+#ifdef EGL_EXT_device_openwf
+  _glewInfo_EGL_EXT_device_openwf();
+#endif /* EGL_EXT_device_openwf */
+#ifdef EGL_EXT_device_query
+  _glewInfo_EGL_EXT_device_query();
+#endif /* EGL_EXT_device_query */
+#ifdef EGL_EXT_gl_colorspace_bt2020_linear
+  _glewInfo_EGL_EXT_gl_colorspace_bt2020_linear();
+#endif /* EGL_EXT_gl_colorspace_bt2020_linear */
+#ifdef EGL_EXT_gl_colorspace_bt2020_pq
+  _glewInfo_EGL_EXT_gl_colorspace_bt2020_pq();
+#endif /* EGL_EXT_gl_colorspace_bt2020_pq */
+#ifdef EGL_EXT_gl_colorspace_scrgb_linear
+  _glewInfo_EGL_EXT_gl_colorspace_scrgb_linear();
+#endif /* EGL_EXT_gl_colorspace_scrgb_linear */
+#ifdef EGL_EXT_image_dma_buf_import
+  _glewInfo_EGL_EXT_image_dma_buf_import();
+#endif /* EGL_EXT_image_dma_buf_import */
+#ifdef EGL_EXT_image_dma_buf_import_modifiers
+  _glewInfo_EGL_EXT_image_dma_buf_import_modifiers();
+#endif /* EGL_EXT_image_dma_buf_import_modifiers */
+#ifdef EGL_EXT_multiview_window
+  _glewInfo_EGL_EXT_multiview_window();
+#endif /* EGL_EXT_multiview_window */
+#ifdef EGL_EXT_output_base
+  _glewInfo_EGL_EXT_output_base();
+#endif /* EGL_EXT_output_base */
+#ifdef EGL_EXT_output_drm
+  _glewInfo_EGL_EXT_output_drm();
+#endif /* EGL_EXT_output_drm */
+#ifdef EGL_EXT_output_openwf
+  _glewInfo_EGL_EXT_output_openwf();
+#endif /* EGL_EXT_output_openwf */
+#ifdef EGL_EXT_pixel_format_float
+  _glewInfo_EGL_EXT_pixel_format_float();
+#endif /* EGL_EXT_pixel_format_float */
+#ifdef EGL_EXT_platform_base
+  _glewInfo_EGL_EXT_platform_base();
+#endif /* EGL_EXT_platform_base */
+#ifdef EGL_EXT_platform_device
+  _glewInfo_EGL_EXT_platform_device();
+#endif /* EGL_EXT_platform_device */
+#ifdef EGL_EXT_platform_wayland
+  _glewInfo_EGL_EXT_platform_wayland();
+#endif /* EGL_EXT_platform_wayland */
+#ifdef EGL_EXT_platform_x11
+  _glewInfo_EGL_EXT_platform_x11();
+#endif /* EGL_EXT_platform_x11 */
+#ifdef EGL_EXT_protected_content
+  _glewInfo_EGL_EXT_protected_content();
+#endif /* EGL_EXT_protected_content */
+#ifdef EGL_EXT_protected_surface
+  _glewInfo_EGL_EXT_protected_surface();
+#endif /* EGL_EXT_protected_surface */
+#ifdef EGL_EXT_stream_consumer_egloutput
+  _glewInfo_EGL_EXT_stream_consumer_egloutput();
+#endif /* EGL_EXT_stream_consumer_egloutput */
+#ifdef EGL_EXT_surface_SMPTE2086_metadata
+  _glewInfo_EGL_EXT_surface_SMPTE2086_metadata();
+#endif /* EGL_EXT_surface_SMPTE2086_metadata */
+#ifdef EGL_EXT_swap_buffers_with_damage
+  _glewInfo_EGL_EXT_swap_buffers_with_damage();
+#endif /* EGL_EXT_swap_buffers_with_damage */
+#ifdef EGL_EXT_yuv_surface
+  _glewInfo_EGL_EXT_yuv_surface();
+#endif /* EGL_EXT_yuv_surface */
+#ifdef EGL_HI_clientpixmap
+  _glewInfo_EGL_HI_clientpixmap();
+#endif /* EGL_HI_clientpixmap */
+#ifdef EGL_HI_colorformats
+  _glewInfo_EGL_HI_colorformats();
+#endif /* EGL_HI_colorformats */
+#ifdef EGL_IMG_context_priority
+  _glewInfo_EGL_IMG_context_priority();
+#endif /* EGL_IMG_context_priority */
+#ifdef EGL_IMG_image_plane_attribs
+  _glewInfo_EGL_IMG_image_plane_attribs();
+#endif /* EGL_IMG_image_plane_attribs */
+#ifdef EGL_KHR_cl_event
+  _glewInfo_EGL_KHR_cl_event();
+#endif /* EGL_KHR_cl_event */
+#ifdef EGL_KHR_cl_event2
+  _glewInfo_EGL_KHR_cl_event2();
+#endif /* EGL_KHR_cl_event2 */
+#ifdef EGL_KHR_client_get_all_proc_addresses
+  _glewInfo_EGL_KHR_client_get_all_proc_addresses();
+#endif /* EGL_KHR_client_get_all_proc_addresses */
+#ifdef EGL_KHR_config_attribs
+  _glewInfo_EGL_KHR_config_attribs();
+#endif /* EGL_KHR_config_attribs */
+#ifdef EGL_KHR_context_flush_control
+  _glewInfo_EGL_KHR_context_flush_control();
+#endif /* EGL_KHR_context_flush_control */
+#ifdef EGL_KHR_create_context
+  _glewInfo_EGL_KHR_create_context();
+#endif /* EGL_KHR_create_context */
+#ifdef EGL_KHR_create_context_no_error
+  _glewInfo_EGL_KHR_create_context_no_error();
+#endif /* EGL_KHR_create_context_no_error */
+#ifdef EGL_KHR_debug
+  _glewInfo_EGL_KHR_debug();
+#endif /* EGL_KHR_debug */
+#ifdef EGL_KHR_fence_sync
+  _glewInfo_EGL_KHR_fence_sync();
+#endif /* EGL_KHR_fence_sync */
+#ifdef EGL_KHR_get_all_proc_addresses
+  _glewInfo_EGL_KHR_get_all_proc_addresses();
+#endif /* EGL_KHR_get_all_proc_addresses */
+#ifdef EGL_KHR_gl_colorspace
+  _glewInfo_EGL_KHR_gl_colorspace();
+#endif /* EGL_KHR_gl_colorspace */
+#ifdef EGL_KHR_gl_renderbuffer_image
+  _glewInfo_EGL_KHR_gl_renderbuffer_image();
+#endif /* EGL_KHR_gl_renderbuffer_image */
+#ifdef EGL_KHR_gl_texture_2D_image
+  _glewInfo_EGL_KHR_gl_texture_2D_image();
+#endif /* EGL_KHR_gl_texture_2D_image */
+#ifdef EGL_KHR_gl_texture_3D_image
+  _glewInfo_EGL_KHR_gl_texture_3D_image();
+#endif /* EGL_KHR_gl_texture_3D_image */
+#ifdef EGL_KHR_gl_texture_cubemap_image
+  _glewInfo_EGL_KHR_gl_texture_cubemap_image();
+#endif /* EGL_KHR_gl_texture_cubemap_image */
+#ifdef EGL_KHR_image
+  _glewInfo_EGL_KHR_image();
+#endif /* EGL_KHR_image */
+#ifdef EGL_KHR_image_base
+  _glewInfo_EGL_KHR_image_base();
+#endif /* EGL_KHR_image_base */
+#ifdef EGL_KHR_image_pixmap
+  _glewInfo_EGL_KHR_image_pixmap();
+#endif /* EGL_KHR_image_pixmap */
+#ifdef EGL_KHR_lock_surface
+  _glewInfo_EGL_KHR_lock_surface();
+#endif /* EGL_KHR_lock_surface */
+#ifdef EGL_KHR_lock_surface2
+  _glewInfo_EGL_KHR_lock_surface2();
+#endif /* EGL_KHR_lock_surface2 */
+#ifdef EGL_KHR_lock_surface3
+  _glewInfo_EGL_KHR_lock_surface3();
+#endif /* EGL_KHR_lock_surface3 */
+#ifdef EGL_KHR_mutable_render_buffer
+  _glewInfo_EGL_KHR_mutable_render_buffer();
+#endif /* EGL_KHR_mutable_render_buffer */
+#ifdef EGL_KHR_no_config_context
+  _glewInfo_EGL_KHR_no_config_context();
+#endif /* EGL_KHR_no_config_context */
+#ifdef EGL_KHR_partial_update
+  _glewInfo_EGL_KHR_partial_update();
+#endif /* EGL_KHR_partial_update */
+#ifdef EGL_KHR_platform_android
+  _glewInfo_EGL_KHR_platform_android();
+#endif /* EGL_KHR_platform_android */
+#ifdef EGL_KHR_platform_gbm
+  _glewInfo_EGL_KHR_platform_gbm();
+#endif /* EGL_KHR_platform_gbm */
+#ifdef EGL_KHR_platform_wayland
+  _glewInfo_EGL_KHR_platform_wayland();
+#endif /* EGL_KHR_platform_wayland */
+#ifdef EGL_KHR_platform_x11
+  _glewInfo_EGL_KHR_platform_x11();
+#endif /* EGL_KHR_platform_x11 */
+#ifdef EGL_KHR_reusable_sync
+  _glewInfo_EGL_KHR_reusable_sync();
+#endif /* EGL_KHR_reusable_sync */
+#ifdef EGL_KHR_stream
+  _glewInfo_EGL_KHR_stream();
+#endif /* EGL_KHR_stream */
+#ifdef EGL_KHR_stream_attrib
+  _glewInfo_EGL_KHR_stream_attrib();
+#endif /* EGL_KHR_stream_attrib */
+#ifdef EGL_KHR_stream_consumer_gltexture
+  _glewInfo_EGL_KHR_stream_consumer_gltexture();
+#endif /* EGL_KHR_stream_consumer_gltexture */
+#ifdef EGL_KHR_stream_cross_process_fd
+  _glewInfo_EGL_KHR_stream_cross_process_fd();
+#endif /* EGL_KHR_stream_cross_process_fd */
+#ifdef EGL_KHR_stream_fifo
+  _glewInfo_EGL_KHR_stream_fifo();
+#endif /* EGL_KHR_stream_fifo */
+#ifdef EGL_KHR_stream_producer_aldatalocator
+  _glewInfo_EGL_KHR_stream_producer_aldatalocator();
+#endif /* EGL_KHR_stream_producer_aldatalocator */
+#ifdef EGL_KHR_stream_producer_eglsurface
+  _glewInfo_EGL_KHR_stream_producer_eglsurface();
+#endif /* EGL_KHR_stream_producer_eglsurface */
+#ifdef EGL_KHR_surfaceless_context
+  _glewInfo_EGL_KHR_surfaceless_context();
+#endif /* EGL_KHR_surfaceless_context */
+#ifdef EGL_KHR_swap_buffers_with_damage
+  _glewInfo_EGL_KHR_swap_buffers_with_damage();
+#endif /* EGL_KHR_swap_buffers_with_damage */
+#ifdef EGL_KHR_vg_parent_image
+  _glewInfo_EGL_KHR_vg_parent_image();
+#endif /* EGL_KHR_vg_parent_image */
+#ifdef EGL_KHR_wait_sync
+  _glewInfo_EGL_KHR_wait_sync();
+#endif /* EGL_KHR_wait_sync */
+#ifdef EGL_MESA_drm_image
+  _glewInfo_EGL_MESA_drm_image();
+#endif /* EGL_MESA_drm_image */
+#ifdef EGL_MESA_image_dma_buf_export
+  _glewInfo_EGL_MESA_image_dma_buf_export();
+#endif /* EGL_MESA_image_dma_buf_export */
+#ifdef EGL_MESA_platform_gbm
+  _glewInfo_EGL_MESA_platform_gbm();
+#endif /* EGL_MESA_platform_gbm */
+#ifdef EGL_MESA_platform_surfaceless
+  _glewInfo_EGL_MESA_platform_surfaceless();
+#endif /* EGL_MESA_platform_surfaceless */
+#ifdef EGL_NOK_swap_region
+  _glewInfo_EGL_NOK_swap_region();
+#endif /* EGL_NOK_swap_region */
+#ifdef EGL_NOK_swap_region2
+  _glewInfo_EGL_NOK_swap_region2();
+#endif /* EGL_NOK_swap_region2 */
+#ifdef EGL_NOK_texture_from_pixmap
+  _glewInfo_EGL_NOK_texture_from_pixmap();
+#endif /* EGL_NOK_texture_from_pixmap */
+#ifdef EGL_NV_3dvision_surface
+  _glewInfo_EGL_NV_3dvision_surface();
+#endif /* EGL_NV_3dvision_surface */
+#ifdef EGL_NV_coverage_sample
+  _glewInfo_EGL_NV_coverage_sample();
+#endif /* EGL_NV_coverage_sample */
+#ifdef EGL_NV_coverage_sample_resolve
+  _glewInfo_EGL_NV_coverage_sample_resolve();
+#endif /* EGL_NV_coverage_sample_resolve */
+#ifdef EGL_NV_cuda_event
+  _glewInfo_EGL_NV_cuda_event();
+#endif /* EGL_NV_cuda_event */
+#ifdef EGL_NV_depth_nonlinear
+  _glewInfo_EGL_NV_depth_nonlinear();
+#endif /* EGL_NV_depth_nonlinear */
+#ifdef EGL_NV_device_cuda
+  _glewInfo_EGL_NV_device_cuda();
+#endif /* EGL_NV_device_cuda */
+#ifdef EGL_NV_native_query
+  _glewInfo_EGL_NV_native_query();
+#endif /* EGL_NV_native_query */
+#ifdef EGL_NV_post_convert_rounding
+  _glewInfo_EGL_NV_post_convert_rounding();
+#endif /* EGL_NV_post_convert_rounding */
+#ifdef EGL_NV_post_sub_buffer
+  _glewInfo_EGL_NV_post_sub_buffer();
+#endif /* EGL_NV_post_sub_buffer */
+#ifdef EGL_NV_robustness_video_memory_purge
+  _glewInfo_EGL_NV_robustness_video_memory_purge();
+#endif /* EGL_NV_robustness_video_memory_purge */
+#ifdef EGL_NV_stream_consumer_gltexture_yuv
+  _glewInfo_EGL_NV_stream_consumer_gltexture_yuv();
+#endif /* EGL_NV_stream_consumer_gltexture_yuv */
+#ifdef EGL_NV_stream_cross_display
+  _glewInfo_EGL_NV_stream_cross_display();
+#endif /* EGL_NV_stream_cross_display */
+#ifdef EGL_NV_stream_cross_object
+  _glewInfo_EGL_NV_stream_cross_object();
+#endif /* EGL_NV_stream_cross_object */
+#ifdef EGL_NV_stream_cross_partition
+  _glewInfo_EGL_NV_stream_cross_partition();
+#endif /* EGL_NV_stream_cross_partition */
+#ifdef EGL_NV_stream_cross_process
+  _glewInfo_EGL_NV_stream_cross_process();
+#endif /* EGL_NV_stream_cross_process */
+#ifdef EGL_NV_stream_cross_system
+  _glewInfo_EGL_NV_stream_cross_system();
+#endif /* EGL_NV_stream_cross_system */
+#ifdef EGL_NV_stream_fifo_next
+  _glewInfo_EGL_NV_stream_fifo_next();
+#endif /* EGL_NV_stream_fifo_next */
+#ifdef EGL_NV_stream_fifo_synchronous
+  _glewInfo_EGL_NV_stream_fifo_synchronous();
+#endif /* EGL_NV_stream_fifo_synchronous */
+#ifdef EGL_NV_stream_frame_limits
+  _glewInfo_EGL_NV_stream_frame_limits();
+#endif /* EGL_NV_stream_frame_limits */
+#ifdef EGL_NV_stream_metadata
+  _glewInfo_EGL_NV_stream_metadata();
+#endif /* EGL_NV_stream_metadata */
+#ifdef EGL_NV_stream_remote
+  _glewInfo_EGL_NV_stream_remote();
+#endif /* EGL_NV_stream_remote */
+#ifdef EGL_NV_stream_reset
+  _glewInfo_EGL_NV_stream_reset();
+#endif /* EGL_NV_stream_reset */
+#ifdef EGL_NV_stream_socket
+  _glewInfo_EGL_NV_stream_socket();
+#endif /* EGL_NV_stream_socket */
+#ifdef EGL_NV_stream_socket_inet
+  _glewInfo_EGL_NV_stream_socket_inet();
+#endif /* EGL_NV_stream_socket_inet */
+#ifdef EGL_NV_stream_socket_unix
+  _glewInfo_EGL_NV_stream_socket_unix();
+#endif /* EGL_NV_stream_socket_unix */
+#ifdef EGL_NV_stream_sync
+  _glewInfo_EGL_NV_stream_sync();
+#endif /* EGL_NV_stream_sync */
+#ifdef EGL_NV_sync
+  _glewInfo_EGL_NV_sync();
+#endif /* EGL_NV_sync */
+#ifdef EGL_NV_system_time
+  _glewInfo_EGL_NV_system_time();
+#endif /* EGL_NV_system_time */
+#ifdef EGL_TIZEN_image_native_buffer
+  _glewInfo_EGL_TIZEN_image_native_buffer();
+#endif /* EGL_TIZEN_image_native_buffer */
+#ifdef EGL_TIZEN_image_native_surface
+  _glewInfo_EGL_TIZEN_image_native_surface();
+#endif /* EGL_TIZEN_image_native_surface */
+}
+
 #endif /* _WIN32 */
 
 /* ------------------------------------------------------------------------ */
 
-#if defined(_WIN32) || !defined(__APPLE__) || defined(GLEW_APPLE_GLX)
 int main (int argc, char** argv)
-#else
-int main (void)
-#endif
 {
   GLuint err;
-
-#if defined(_WIN32) || !defined(__APPLE__) || defined(GLEW_APPLE_GLX)
-  char* display = NULL;
-  int visual = -1;
-
-  if (glewParseArgs(argc-1, argv+1, &display, &visual))
+  struct createParams params =
   {
-#if defined(_WIN32)
-    fprintf(stderr, "Usage: glewinfo [-pf <id>]\n");
-#else
-    fprintf(stderr, "Usage: glewinfo [-display <display>] [-visual <id>]\n");
+#if defined(GLEW_OSMESA)
+#elif defined(GLEW_EGL)
+#elif defined(_WIN32)
+    -1,  /* pixelformat */
+#elif !defined(__HAIKU__) && !defined(__APPLE__) || defined(GLEW_APPLE_GLX)
+    "",  /* display */
+    -1,  /* visual */
 #endif
+    0,   /* major */
+    0,   /* minor */
+    0,   /* profile mask */
+    0    /* flags */
+  };
+
+#if defined(GLEW_EGL)
+  typedef const GLubyte* (GLAPIENTRY * PFNGLGETSTRINGPROC) (GLenum name);
+  PFNGLGETSTRINGPROC getString;
+#endif
+
+  if (glewParseArgs(argc-1, argv+1, &params))
+  {
+    fprintf(stderr, "Usage: glewinfo "
+#if defined(GLEW_OSMESA)
+#elif defined(GLEW_EGL)
+#elif defined(_WIN32)
+      "[-pf <pixelformat>] "
+#elif !defined(__HAIKU__) && !defined(__APPLE__) || defined(GLEW_APPLE_GLX)
+      "[-display <display>] "
+      "[-visual <visual id>] "
+#endif
+      "[-version <OpenGL version>] "
+      "[-profile core|compatibility] "
+      "[-flag debug|forward]"
+      "\n");
     return 1;
   }
-#endif
 
-#if defined(_WIN32)
-  if (GL_TRUE == glewCreateContext(&visual))
-#elif defined(__APPLE__) && !defined(GLEW_APPLE_GLX)
-  if (GL_TRUE == glewCreateContext())
-#else
-  if (GL_TRUE == glewCreateContext(display, &visual))
-#endif
+  if (GL_TRUE == glewCreateContext(&params))
   {
     fprintf(stderr, "Error: glewCreateContext failed\n");
     glewDestroyContext();
     return 1;
   }
   glewExperimental = GL_TRUE;
-#ifdef GLEW_MX
-  err = glewContextInit(glewGetContext());
-#ifdef _WIN32
-  err = err || wglewContextInit(wglewGetContext());
-#elif !defined(__APPLE__) || defined(GLEW_APPLE_GLX)
-  err = err || glxewContextInit(glxewGetContext());
-#endif
-
-#else
   err = glewInit();
-#endif
   if (GLEW_OK != err)
   {
     fprintf(stderr, "Error [main]: glewInit failed: %s\n", glewGetErrorString(err));
     glewDestroyContext();
     return 1;
   }
+
+#if defined(GLEW_EGL)
+  getString = (PFNGLGETSTRINGPROC) eglGetProcAddress("glGetString");
+  if (!getString)
+  {
+    fprintf(stderr, "Error: eglGetProcAddress failed to fetch glGetString\n");
+    glewDestroyContext();
+    return 1;
+  }
+#endif
+
 #if defined(_WIN32)
 #if defined(_MSC_VER) && (_MSC_VER >= 1400)
   if (fopen_s(&f, "glewinfo.txt", "w") != 0)
@@ -11127,17 +16369,28 @@ int main (void)
   fprintf(f, "    GLEW Extension Info\n");
   fprintf(f, "---------------------------\n\n");
   fprintf(f, "GLEW version %s\n", glewGetString(GLEW_VERSION));
-#if defined(_WIN32)
-  fprintf(f, "Reporting capabilities of pixelformat %d\n", visual);
+#if defined(GLEW_OSMESA)
+#elif defined(GLEW_EGL)
+#elif defined(_WIN32)
+  fprintf(f, "Reporting capabilities of pixelformat %d\n", params.pixelformat);
 #elif !defined(__APPLE__) || defined(GLEW_APPLE_GLX)
-  fprintf(f, "Reporting capabilities of display %s, visual 0x%x\n", 
-    display == NULL ? getenv("DISPLAY") : display, visual);
+  fprintf(f, "Reporting capabilities of display %s, visual 0x%x\n",
+    params.display == NULL ? getenv("DISPLAY") : params.display, params.visual);
 #endif
-  fprintf(f, "Running on a %s from %s\n", 
-	  glGetString(GL_RENDERER), glGetString(GL_VENDOR));
+#if defined(GLEW_EGL)
+  fprintf(f, "Running on a %s from %s\n",
+    getString(GL_RENDERER), getString(GL_VENDOR));
+  fprintf(f, "OpenGL version %s is supported\n", getString(GL_VERSION));
+#else
+  fprintf(f, "Running on a %s from %s\n",
+    glGetString(GL_RENDERER), glGetString(GL_VENDOR));
   fprintf(f, "OpenGL version %s is supported\n", glGetString(GL_VERSION));
+#endif
   glewInfo();
-#if defined(_WIN32)
+#if defined(GLEW_OSMESA)
+#elif defined(GLEW_EGL)
+  eglewInfo();
+#elif defined(_WIN32)
   wglewInfo();
 #else
   glxewInfo();
@@ -11149,49 +16402,215 @@ int main (void)
 
 /* ------------------------------------------------------------------------ */
 
-#if defined(_WIN32) || !defined(__APPLE__) || defined(GLEW_APPLE_GLX)
-GLboolean glewParseArgs (int argc, char** argv, char** display, int* visual)
+GLboolean glewParseArgs (int argc, char** argv, struct createParams *params)
 {
   int p = 0;
   while (p < argc)
   {
-#if defined(_WIN32)
-    if (!strcmp(argv[p], "-pf") || !strcmp(argv[p], "-pixelformat"))
+    if (!strcmp(argv[p], "-version"))
     {
       if (++p >= argc) return GL_TRUE;
-      *display = 0;
-      *visual = strtol(argv[p++], NULL, 0);
+      if (sscanf(argv[p++], "%d.%d", &params->major, &params->minor) != 2) return GL_TRUE;
     }
-    else
-      return GL_TRUE;
-#else
-    if (!strcmp(argv[p], "-display"))
+    else if (!strcmp(argv[p], "-profile"))
     {
       if (++p >= argc) return GL_TRUE;
-      *display = argv[p++];
+      if      (strcmp("core",         argv[p]) == 0) params->profile |= 1;
+      else if (strcmp("compatibility",argv[p]) == 0) params->profile |= 2;
+      else return GL_TRUE;
+      ++p;
     }
+    else if (!strcmp(argv[p], "-flag"))
+    {
+      if (++p >= argc) return GL_TRUE;
+      if      (strcmp("debug",  argv[p]) == 0) params->flags |= 1;
+      else if (strcmp("forward",argv[p]) == 0) params->flags |= 2;
+      else return GL_TRUE;
+      ++p;
+    }
+#if defined(GLEW_OSMESA)
+#elif defined(GLEW_EGL)
+#elif defined(_WIN32)
+    else if (!strcmp(argv[p], "-pf") || !strcmp(argv[p], "-pixelformat"))
+    {
+      if (++p >= argc) return GL_TRUE;
+      params->pixelformat = strtol(argv[p++], NULL, 0);
+    }
+#elif !defined(__HAIKU__) && !defined(__APPLE__) || defined(GLEW_APPLE_GLX)
+    else if (!strcmp(argv[p], "-display"))
+    {
+      if (++p >= argc) return GL_TRUE;
+      params->display = argv[p++];
+     }
     else if (!strcmp(argv[p], "-visual"))
     {
       if (++p >= argc) return GL_TRUE;
-      *visual = (int)strtol(argv[p++], NULL, 0);
+      params->visual = (int)strtol(argv[p++], NULL, 0);
     }
+#endif
     else
       return GL_TRUE;
-#endif
   }
   return GL_FALSE;
 }
-#endif
 
 /* ------------------------------------------------------------------------ */
 
-#if defined(_WIN32)
+#if defined(GLEW_EGL)
+EGLDisplay  display;
+EGLContext  ctx;
+
+/* See: http://stackoverflow.com/questions/12662227/opengl-es2-0-offscreen-context-for-fbo-rendering */
+
+GLboolean glewCreateContext (struct createParams *params)
+{
+  EGLDeviceEXT devices[1];
+  EGLint numDevices;
+  EGLSurface  surface;
+  EGLint majorVersion, minorVersion;
+  EGLint configAttribs[] = {
+        EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
+        EGL_RED_SIZE, 1,
+        EGL_GREEN_SIZE, 1,
+        EGL_BLUE_SIZE, 1,
+        EGL_RENDERABLE_TYPE, EGL_OPENGL_BIT,
+        EGL_NONE
+   };
+  static const EGLint contextAttribs[] = {
+    EGL_CONTEXT_CLIENT_VERSION, 2,
+    EGL_NONE
+  };
+  static const EGLint pBufferAttribs[] = {
+    EGL_WIDTH,  128,
+    EGL_HEIGHT, 128,
+    EGL_NONE
+  };
+  EGLConfig config;
+  EGLint numConfig;
+  EGLBoolean pBuffer;
+
+  PFNEGLQUERYDEVICESEXTPROC       queryDevices = NULL;
+  PFNEGLGETPLATFORMDISPLAYEXTPROC getPlatformDisplay = NULL;
+  PFNEGLGETERRORPROC              getError = NULL;
+  PFNEGLGETDISPLAYPROC            getDisplay = NULL;
+  PFNEGLINITIALIZEPROC            initialize = NULL;
+  PFNEGLBINDAPIPROC               bindAPI    = NULL;
+  PFNEGLCHOOSECONFIGPROC          chooseConfig = NULL;
+  PFNEGLCREATEWINDOWSURFACEPROC   createWindowSurface = NULL;
+  PFNEGLCREATECONTEXTPROC         createContext = NULL;
+  PFNEGLMAKECURRENTPROC           makeCurrent = NULL;
+  PFNEGLCREATEPBUFFERSURFACEPROC  createPbufferSurface = NULL;
+
+  /* Load necessary entry points */
+  queryDevices         = (PFNEGLQUERYDEVICESEXTPROC)       eglGetProcAddress("eglQueryDevicesEXT");
+  getPlatformDisplay   = (PFNEGLGETPLATFORMDISPLAYEXTPROC) eglGetProcAddress("eglGetPlatformDisplayEXT");
+  getError             = (PFNEGLGETERRORPROC)              eglGetProcAddress("eglGetError");
+  getDisplay           = (PFNEGLGETDISPLAYPROC)            eglGetProcAddress("eglGetDisplay");
+  initialize           = (PFNEGLINITIALIZEPROC)            eglGetProcAddress("eglInitialize");
+  bindAPI              = (PFNEGLBINDAPIPROC)               eglGetProcAddress("eglBindAPI");
+  chooseConfig         = (PFNEGLCHOOSECONFIGPROC)          eglGetProcAddress("eglChooseConfig");
+  createWindowSurface  = (PFNEGLCREATEWINDOWSURFACEPROC)   eglGetProcAddress("eglCreateWindowSurface");
+  createPbufferSurface = (PFNEGLCREATEPBUFFERSURFACEPROC)  eglGetProcAddress("eglCreatePbufferSurface");
+  createContext        = (PFNEGLCREATECONTEXTPROC)         eglGetProcAddress("eglCreateContext");
+  makeCurrent          = (PFNEGLMAKECURRENTPROC)           eglGetProcAddress("eglMakeCurrent");
+  if (!getError || !getDisplay || !initialize || !bindAPI || !chooseConfig || !createWindowSurface || !createContext || !makeCurrent)
+    return GL_TRUE;
+
+  pBuffer = 0;
+  display = EGL_NO_DISPLAY;
+  if (queryDevices && getPlatformDisplay)
+  {
+    queryDevices(1, devices, &numDevices);
+    if (numDevices==1)
+    {
+      /* Nvidia EGL doesn't need X11 for p-buffer surface */
+      display = getPlatformDisplay(EGL_PLATFORM_DEVICE_EXT, devices[0], 0);
+      configAttribs[1] = EGL_PBUFFER_BIT;
+      pBuffer = 1;
+    }
+  }
+  if (display==EGL_NO_DISPLAY)
+  {
+    /* Fall-back to X11 surface, works on Mesa */
+    display = getDisplay(EGL_DEFAULT_DISPLAY);
+  }
+  if (display == EGL_NO_DISPLAY)
+    return GL_TRUE;
+
+  eglewInit(display);
+
+  if (bindAPI(EGL_OPENGL_API) != EGL_TRUE)
+    return GL_TRUE;
+
+  if (chooseConfig(display, configAttribs, &config, 1, &numConfig) != EGL_TRUE || (numConfig != 1))
+    return GL_TRUE;
+
+  ctx = createContext(display, config, EGL_NO_CONTEXT, pBuffer ? contextAttribs : NULL);
+  if (NULL == ctx)
+    return GL_TRUE;
+
+  surface = EGL_NO_SURFACE;
+  /* Create a p-buffer surface if possible */
+  if (pBuffer && createPbufferSurface)
+  {
+    surface = createPbufferSurface(display, config, pBufferAttribs);
+  }
+  /* Create a generic surface without a native window, if necessary */
+  if (surface==EGL_NO_SURFACE)
+  {
+    surface = createWindowSurface(display, config, (EGLNativeWindowType) NULL, NULL);
+  }
+#if 0
+  if (surface == EGL_NO_SURFACE)
+    return GL_TRUE;
+#endif
+
+  if (makeCurrent(display, surface, surface, ctx) != EGL_TRUE)
+    return GL_TRUE;
+
+  return GL_FALSE;
+}
+
+void glewDestroyContext ()
+{
+  if (NULL != ctx) eglDestroyContext(display, ctx);
+}
+
+#elif defined(GLEW_OSMESA)
+OSMesaContext ctx;
+
+static const GLint osmFormat = GL_UNSIGNED_BYTE;
+static const GLint osmWidth = 640;
+static const GLint osmHeight = 480;
+static GLubyte *osmPixels = NULL;
+
+GLboolean glewCreateContext (struct createParams *params)
+{
+  ctx = OSMesaCreateContext(OSMESA_RGBA, NULL);
+  if (NULL == ctx) return GL_TRUE;
+  if (NULL == osmPixels)
+  {
+    osmPixels = (GLubyte *) calloc(osmWidth*osmHeight*4, 1);
+  }
+  if (!OSMesaMakeCurrent(ctx, osmPixels, GL_UNSIGNED_BYTE, osmWidth, osmHeight))
+  {
+      return GL_TRUE;
+  }
+  return GL_FALSE;
+}
+
+void glewDestroyContext ()
+{
+  if (NULL != ctx) OSMesaDestroyContext(ctx);
+}
+
+#elif defined(_WIN32)
 
 HWND wnd = NULL;
 HDC dc = NULL;
 HGLRC rc = NULL;
 
-GLboolean glewCreateContext (int* pixelformat)
+GLboolean glewCreateContext (struct createParams* params)
 {
   WNDCLASS wc;
   PIXELFORMATDESCRIPTOR pfd;
@@ -11202,7 +16621,7 @@ GLboolean glewCreateContext (int* pixelformat)
   wc.lpszClassName = "GLEW";
   if (0 == RegisterClass(&wc)) return GL_TRUE;
   /* create window */
-  wnd = CreateWindow("GLEW", "GLEW", 0, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, 
+  wnd = CreateWindow("GLEW", "GLEW", 0, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,
                      CW_USEDEFAULT, NULL, NULL, GetModuleHandle(NULL), NULL);
   if (NULL == wnd) return GL_TRUE;
   /* get the device context */
@@ -11210,20 +16629,58 @@ GLboolean glewCreateContext (int* pixelformat)
   if (NULL == dc) return GL_TRUE;
   /* find pixel format */
   ZeroMemory(&pfd, sizeof(PIXELFORMATDESCRIPTOR));
-  if (*pixelformat == -1) /* find default */
+  if (params->pixelformat == -1) /* find default */
   {
     pfd.nSize = sizeof(PIXELFORMATDESCRIPTOR);
     pfd.nVersion = 1;
     pfd.dwFlags = PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL;
-    *pixelformat = ChoosePixelFormat(dc, &pfd);
-    if (*pixelformat == 0) return GL_TRUE;
+    params->pixelformat = ChoosePixelFormat(dc, &pfd);
+    if (params->pixelformat == 0) return GL_TRUE;
   }
   /* set the pixel format for the dc */
-  if (FALSE == SetPixelFormat(dc, *pixelformat, &pfd)) return GL_TRUE;
+  if (FALSE == SetPixelFormat(dc, params->pixelformat, &pfd)) return GL_TRUE;
   /* create rendering context */
   rc = wglCreateContext(dc);
   if (NULL == rc) return GL_TRUE;
   if (FALSE == wglMakeCurrent(dc, rc)) return GL_TRUE;
+  if (params->major || params->profile || params->flags)
+  {
+    HGLRC oldRC = rc;
+    int contextAttrs[20];
+    int i;
+
+    wglewInit();
+
+    /* Intel HD 3000 has WGL_ARB_create_context, but not WGL_ARB_create_context_profile */
+    if (!wglewGetExtension("WGL_ARB_create_context"))
+      return GL_TRUE;
+
+    i = 0;
+    if (params->major)
+    {
+      contextAttrs[i++] = WGL_CONTEXT_MAJOR_VERSION_ARB;
+      contextAttrs[i++] = params->major;
+      contextAttrs[i++] = WGL_CONTEXT_MINOR_VERSION_ARB;
+      contextAttrs[i++] = params->minor;
+    }
+    if (params->profile)
+    {
+      contextAttrs[i++] = WGL_CONTEXT_PROFILE_MASK_ARB;
+      contextAttrs[i++] = params->profile;
+    }
+    if (params->flags)
+    {
+      contextAttrs[i++] = WGL_CONTEXT_FLAGS_ARB;
+      contextAttrs[i++] = params->flags;
+    }
+    contextAttrs[i++] = 0;
+    rc = wglCreateContextAttribsARB(dc, 0, contextAttrs);
+
+    if (NULL == rc) return GL_TRUE;
+    if (!wglMakeCurrent(dc, rc)) return GL_TRUE;
+
+    wglDeleteContext(oldRC);
+  }
   return GL_FALSE;
 }
 
@@ -11240,26 +16697,44 @@ void glewDestroyContext ()
 
 #elif defined(__APPLE__) && !defined(GLEW_APPLE_GLX)
 
-#include <AGL/agl.h>
+#include <OpenGL/OpenGL.h>
+#include <OpenGL/CGLTypes.h>
 
-AGLContext ctx, octx;
+CGLContextObj ctx, octx;
 
-GLboolean glewCreateContext ()
+GLboolean glewCreateContext (struct createParams *params)
 {
-  int attrib[] = { AGL_RGBA, AGL_NONE };
-  AGLPixelFormat pf;
-  /*int major, minor;
-  SetPortWindowPort(wnd);
-  aglGetVersion(&major, &minor);
-  fprintf(stderr, "GL %d.%d\n", major, minor);*/
-  pf = aglChoosePixelFormat(NULL, 0, attrib);
-  if (NULL == pf) return GL_TRUE;
-  ctx = aglCreateContext(pf, NULL);
-  if (NULL == ctx || AGL_NO_ERROR != aglGetError()) return GL_TRUE;
-  aglDestroyPixelFormat(pf);
-  /*aglSetDrawable(ctx, GetWindowPort(wnd));*/
-  octx = aglGetCurrentContext();
-  if (GL_FALSE == aglSetCurrentContext(ctx)) return GL_TRUE;
+  CGLPixelFormatAttribute contextAttrs[20];
+  int i;
+  CGLPixelFormatObj pf;
+  GLint npix;
+  CGLError error;
+
+  i = 0;
+  contextAttrs[i++] = kCGLPFAAccelerated; /* No software rendering */
+
+  /* MAC_OS_X_VERSION_10_7  == 1070 */
+  #if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+  if (params->profile & GL_CONTEXT_CORE_PROFILE_BIT)
+  {
+    if ((params->major==3 && params->minor>=2) || params->major>3)
+    {
+      contextAttrs[i++] = kCGLPFAOpenGLProfile;                                /* OSX 10.7 Lion onwards */
+      contextAttrs[i++] = (CGLPixelFormatAttribute) kCGLOGLPVersion_3_2_Core;  /* 3.2 Core Context      */
+    }
+  }
+  #endif
+
+  contextAttrs[i++] = 0;
+
+  error = CGLChoosePixelFormat(contextAttrs, &pf, &npix);
+  if (error) return GL_TRUE;
+  error = CGLCreateContext(pf, NULL, &ctx);
+  if (error) return GL_TRUE;
+  CGLReleasePixelFormat(pf);
+  octx = CGLGetCurrentContext();
+  error = CGLSetCurrentContext(ctx);
+  if (error) return GL_TRUE;
   /* Needed for Regal on the Mac */
   #if defined(GLEW_REGAL) && defined(__APPLE__)
   RegalMakeCurrent(ctx);
@@ -11269,15 +16744,15 @@ GLboolean glewCreateContext ()
 
 void glewDestroyContext ()
 {
-  aglSetCurrentContext(octx);
-  if (NULL != ctx) aglDestroyContext(ctx);
+  CGLSetCurrentContext(octx);
+  CGLReleaseContext(ctx);
 }
 
 /* ------------------------------------------------------------------------ */
 
 #elif defined(__HAIKU__)
 
-GLboolean glewCreateContext ()
+GLboolean glewCreateContext (struct createParams *params)
 {
   /* TODO: Haiku: We need to call C++ code here */
   return GL_FALSE;
@@ -11299,22 +16774,22 @@ GLXContext ctx = NULL;
 Window wnd = 0;
 Colormap cmap = 0;
 
-GLboolean glewCreateContext (const char* display, int* visual)
+GLboolean glewCreateContext (struct createParams *params)
 {
   int attrib[] = { GLX_RGBA, GLX_DOUBLEBUFFER, None };
   int erb, evb;
   XSetWindowAttributes swa;
   /* open display */
-  dpy = XOpenDisplay(display);
+  dpy = XOpenDisplay(params->display);
   if (NULL == dpy) return GL_TRUE;
   /* query for glx */
   if (!glXQueryExtension(dpy, &erb, &evb)) return GL_TRUE;
   /* choose visual */
-  if (*visual == -1)
+  if (params->visual == -1)
   {
     vi = glXChooseVisual(dpy, DefaultScreen(dpy), attrib);
     if (NULL == vi) return GL_TRUE;
-    *visual = (int)XVisualIDFromVisual(vi->visual);
+    params->visual = (int)XVisualIDFromVisual(vi->visual);
   }
   else
   {
@@ -11322,7 +16797,7 @@ GLboolean glewCreateContext (const char* display, int* visual)
     vis = XGetVisualInfo(dpy, 0, NULL, &n_vis);
     for (i=0; i<n_vis; i++)
     {
-      if ((int)XVisualIDFromVisual(vis[i].visual) == *visual)
+      if ((int)XVisualIDFromVisual(vis[i].visual) == params->visual)
         vi = &vis[i];
     }
     if (vi == NULL) return GL_TRUE;
@@ -11335,11 +16810,59 @@ GLboolean glewCreateContext (const char* display, int* visual)
   cmap = XCreateColormap(dpy, RootWindow(dpy, vi->screen), vi->visual, AllocNone);
   swa.border_pixel = 0;
   swa.colormap = cmap;
-  wnd = XCreateWindow(dpy, RootWindow(dpy, vi->screen), 
-                      0, 0, 1, 1, 0, vi->depth, InputOutput, vi->visual, 
+  wnd = XCreateWindow(dpy, RootWindow(dpy, vi->screen),
+                      0, 0, 1, 1, 0, vi->depth, InputOutput, vi->visual,
                       CWBorderPixel | CWColormap, &swa);
   /* make context current */
   if (!glXMakeCurrent(dpy, wnd, ctx)) return GL_TRUE;
+  if (params->major || params->profile || params->flags)
+  {
+    GLXContext oldCtx = ctx;
+    GLXFBConfig *FBConfigs;
+    int FBConfigAttrs[] = { GLX_FBCONFIG_ID, 0, None };
+    int contextAttrs[20];
+    int nelems, i;
+
+    glxewInit();
+
+    if (!glxewGetExtension("GLX_ARB_create_context"))
+      return GL_TRUE;
+
+    if (glXQueryContext(dpy, oldCtx, GLX_FBCONFIG_ID, &FBConfigAttrs[1]))
+      return GL_TRUE;
+    FBConfigs = glXChooseFBConfig(dpy, vi->screen, FBConfigAttrs, &nelems);
+
+    if (nelems < 1)
+      return GL_TRUE;
+
+    i = 0;
+    if (params->major)
+    {
+      contextAttrs[i++] = GLX_CONTEXT_MAJOR_VERSION_ARB;
+      contextAttrs[i++] = params->major;
+      contextAttrs[i++] = GLX_CONTEXT_MINOR_VERSION_ARB;
+      contextAttrs[i++] = params->minor;
+    }
+    if (params->profile)
+    {
+      contextAttrs[i++] = GLX_CONTEXT_PROFILE_MASK_ARB;
+      contextAttrs[i++] = params->profile;
+    }
+    if (params->flags)
+    {
+      contextAttrs[i++] = GLX_CONTEXT_FLAGS_ARB;
+      contextAttrs[i++] = params->flags;
+    }
+    contextAttrs[i++] = None;
+    ctx = glXCreateContextAttribsARB(dpy, *FBConfigs, NULL, True, contextAttrs);
+
+    if (NULL == ctx) return GL_TRUE;
+    if (!glXMakeCurrent(dpy, wnd, ctx)) return GL_TRUE;
+
+    glXDestroyContext(dpy, oldCtx);
+
+    XFree(FBConfigs);
+  }
   return GL_FALSE;
 }
 


### PR DESCRIPTION
Previous version was a modified GLEW 1.11.0 (2014). The STK modifications meant
to address https://sourceforge.net/p/glew/patches/40/ which is now fixed since
GLEW 2.0.0.

I've tested that it builds fine on Linux (Mageia 6 x86_64), though I haven't tried running STK itself with these changes as I did not checkout the assets. It should likely be tested on Windows before merging to make sure that it builds out of the box (*Edit:* Ah well, AppVeyor will make sure of that).

---

For the reference, here's the diff between pristine 1.11.0 and STK's version before this patch:
```diff
diff --git a/lib/glew/src/glew.c b/lib/glew/src/glew.c
index a78f14e1e..f8df0d758 100644
--- a/lib/glew/src/glew.c
+++ b/lib/glew/src/glew.c
@@ -296,30 +296,6 @@ static GLboolean _glewStrSame3 (GLubyte** a, GLuint* na, const GLubyte* b, GLuin
   return GL_FALSE;
 }

-#include <string.h>
-#include <stdlib.h>
-
-/* A simple open addressing hashset for extensions on OpenGL 3+. */
-static const char ** ext_hashset = NULL;
-size_t ext_hashset_size = 0;
-
-static unsigned hash_string(const char * key)
-{
-  unsigned hash = 0;
-  unsigned i = 0;
-  for (; i < strlen(key); ++i)
-  {
-    hash += key[i];
-    hash += (hash << 10);
-    hash ^= (hash >> 6);
-  }
-  hash += (hash << 3);
-  hash ^= (hash >> 11);
-  hash += (hash << 15);
-
-  return hash;
-}
-
 /*
  * Search for name in the extensions string. Use of strstr()
  * is not sufficient because extension names can be prefixes of
@@ -328,37 +304,14 @@ static unsigned hash_string(const char * key)
  */
 static GLboolean _glewSearchExtension (const char* name, const GLubyte *start, const GLubyte *end)
 {
-  if (ext_hashset != NULL)
+  const GLubyte* p;
+  GLuint len = _glewStrLen((const GLubyte*)name);
+  p = start;
+  while (p < end)
   {
-    unsigned hash = hash_string(name);
-
-    /*
-     * As the hashset is bigger than the number of extensions
-     * this will eventually break.
-     */
-    while(1)
-    {
-        unsigned index = hash % ext_hashset_size;
-        if (ext_hashset[index] == NULL)
-            break;
-
-        if (!strcmp(ext_hashset[index], name))
-            return GL_TRUE;
-
-        hash++;
-    }
-  }
-  else
-  {
-    const GLubyte* p;
-    GLuint len = _glewStrLen((const GLubyte*)name);
-    p = start;
-    while (p < end)
-    {
-      GLuint n = _glewStrCLen(p, ' ');
-      if (len == n && _glewStrSame((const GLubyte*)name, p, n)) return GL_TRUE;
-      p += n+1;
-    }
+    GLuint n = _glewStrCLen(p, ' ');
+    if (len == n && _glewStrSame((const GLubyte*)name, p, n)) return GL_TRUE;
+    p += n+1;
   }
   return GL_FALSE;
 }
@@ -10099,13 +10052,9 @@ static GLboolean _glewInit_GL_WIN_swap_hint (GLEW_CONTEXT_ARG_DEF_INIT)
 /* ------------------------------------------------------------------------- */

 GLboolean GLEWAPIENTRY glewGetExtension (const char* name)
-{
+{
   const GLubyte* start;
   const GLubyte* end;
-
-  if (ext_hashset != NULL)
-      return _glewSearchExtension(name, NULL, NULL);
-
   start = (const GLubyte*)glGetString(GL_EXTENSIONS);
   if (start == 0)
     return GL_FALSE;
@@ -10165,39 +10114,9 @@ GLenum GLEWAPIENTRY glewContextInit (GLEW_CONTEXT_ARG_DEF_LIST)
     GLEW_VERSION_1_2   = GLEW_VERSION_1_2_1 == GL_TRUE || ( major == 1 && minor >= 2 ) ? GL_TRUE : GL_FALSE;
     GLEW_VERSION_1_1   = GLEW_VERSION_1_2   == GL_TRUE || ( major == 1 && minor >= 1 ) ? GL_TRUE : GL_FALSE;
   }
-
-  if (major >= 3) /* glGetString method is deprecated */
-  {
-    GLint n, i;
-    glGetIntegerv(GL_NUM_EXTENSIONS, &n);
-    glGetStringi = (PFNGLGETSTRINGIPROC)glewGetProcAddress((const GLubyte*)"glGetStringi");
-
-    free(ext_hashset); /* In case we get called a second time. */
-
-    ext_hashset_size = (n * 3) / 2;
-    ext_hashset = calloc(ext_hashset_size, sizeof(const char *));
-    for (i = 0; i < n; ++i)
-    {
-      const char * extension;
-      unsigned hash;
-
-      extension = (const char *)glGetStringi(GL_EXTENSIONS, i);
-      hash = hash_string(extension);
-
-      while(ext_hashset[hash % ext_hashset_size] != NULL)
-        hash++;
-
-      ext_hashset[hash % ext_hashset_size] = extension;
-    }
-
-    extStart = 0;
-  }
-  else
-  {
-    /* query opengl extensions string */
-    extStart = glGetString(GL_EXTENSIONS);
-  }

+  /* query opengl extensions string */
+  extStart = glGetString(GL_EXTENSIONS);
   if (extStart == 0)
     extStart = (const GLubyte*)"";
   extEnd = extStart + _glewStrLen(extStart);
@@ -14064,9 +13983,6 @@ GLenum glxewContextInit (GLXEW_CONTEXT_ARG_DEF_LIST)
   GLXEW_VERSION_1_2 = GL_TRUE;
   GLXEW_VERSION_1_3 = GL_TRUE;
   GLXEW_VERSION_1_4 = GL_TRUE;
-  /* Check if GLX display is available */
-  if (glXGetCurrentDisplay == NULL || glXGetCurrentDisplay() == NULL)
-    return GLEW_OK;
   /* query GLX version */
   glXQueryVersion(glXGetCurrentDisplay(), &major, &minor);
   if (major == 1 && minor <= 3)
```