### PR TITLE
Reduce number of places version number needs to be changed on release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 2.8.4)
 # root CMakeLists for the SuperTuxKart project
 project(SuperTuxKart)
 set(PROJECT_VERSION "git")
+add_definitions( -DSUPERTUXKART_VERSION="${PROJECT_VERSION}" )
 
 if(NOT (CMAKE_MAJOR_VERSION VERSION_LESS 3))
   cmake_policy(SET CMP0043 OLD)

--- a/data/CREDITS
+++ b/data/CREDITS
@@ -1,6 +1,6 @@
 = SuperTuxKart =
 A Kart Racing Game Featuring Tux & Friends
-- Version git
+- Version $STKVERSION$
 - Visit us at supertuxkart.net
 - SuperTuxKart is released under GPL 3.0
 - Assets are released under Creative Commons and other licenses

--- a/src/states_screens/credits.cpp
+++ b/src/states_screens/credits.cpp
@@ -30,6 +30,7 @@ using irr::core::stringc;
 #include "guiengine/widget.hpp"
 #include "io/file_manager.hpp"
 #include "states_screens/state_manager.hpp"
+#include "utils/constants.hpp"
 #include "utils/string_utils.hpp"
 #include "utils/translation.hpp"
 
@@ -91,6 +92,10 @@ bool CreditsScreen::getLineAsWide(std::ifstream& file, core::stringw* out)
 
     std::string line;
     std::getline(file, line);
+
+    // Replace "STKVERSION" with the actual version number
+    line = StringUtils::findAndReplace(line, "$STKVERSION$", STK_VERSION);
+
     *out = StringUtils::utf8ToWide(line);
     return file.good();
 

--- a/src/utils/constants.cpp
+++ b/src/utils/constants.cpp
@@ -29,4 +29,5 @@ static const char* endianness_test_ptr = (const char*)&endianness_test;
 // in little-endian, byte 0 will be 0. in big endian, byte 0 will be 1
 const bool IS_LITTLE_ENDIAN = (endianness_test_ptr[0] == 0);
 
-const char STK_VERSION[] = "git";
+// "SUPERTUXKART_VERSION" is defined from CMakeLists.txt from the project version
+const char STK_VERSION[] = SUPERTUXKART_VERSION;

--- a/src/utils/string_utils.cpp
+++ b/src/utils/string_utils.cpp
@@ -779,6 +779,23 @@ namespace StringUtils
         return version;
     }   // versionToInt
 
+    // ------------------------------------------------------------------------
+    /** Searches for text in a string and replaces it with the desired text */
+    std::string findAndReplace(const std::string& source, const std::string& find, const std::string& replace)
+    {
+        std::string destination = source;
+        std::string::size_type found_position = 0;
+
+        // Replace until we can't find anymore the find string
+        while ((found_position = destination.find(find, found_position)) != std::string::npos)
+        {
+            destination.replace(found_position, find.length(), replace);
+            // Advanced pass the replaced string
+            found_position += replace.length();
+        }
+        return destination;
+    } //findAndReplace
+
 } // namespace StringUtils
 
 

--- a/src/utils/string_utils.hpp
+++ b/src/utils/string_utils.hpp
@@ -230,6 +230,7 @@ namespace StringUtils
     irr::core::stringw utf8ToWide(const std::string &input);
     std::string wideToUtf8(const wchar_t* input);
     std::string wideToUtf8(const irr::core::stringw& input);
+    std::string findAndReplace(const std::string& source, const std::string& find, const std::string& replace);
 
 } // namespace StringUtils
 


### PR DESCRIPTION
Just greasing the wheels of the releasing process a little bit. :)  ~Note that std::regex_replace is cpp11~ (no longer needed).