### PR TITLE
Fix unit testing, closes #2929

### DIFF
--- a/src/network/transport_address.cpp
+++ b/src/network/transport_address.cpp
@@ -107,6 +107,6 @@ void TransportAddress::unitTesting()
 
     TransportAddress t17("128.0.0.0");
     assert(t17.getIP() == (128 << 24));
-    assert(t17.isLAN());
+    assert(!t17.isLAN());
 
 }   // unitTesting


### PR DESCRIPTION
AFAIK 128.* should not be treated as LAN.

For some reason STK segfaults in `libopenal.so.1` for me, will open a new issue once this is merged.