### PR TITLE
Remove "Final lap!" message in one-lap races

### DIFF
--- a/src/modes/linear_world.cpp
+++ b/src/modes/linear_world.cpp
@@ -282,10 +282,13 @@ void LinearWorld::newLap(unsigned int kart_index)
             + getDistanceDownTrackForKart(kart->getWorldKartId());
     }
     // Last lap message (kart_index's assert in previous block already)
-    if (raceHasLaps() && kart_info.m_race_lap+1 == lap_count)
+    if (raceHasLaps() && kart_info.m_race_lap+1 == lap_count )
     {
-        m_race_gui->addMessage(_("Final lap!"), kart,
+        if (lap_count > 1)
+        {
+            m_race_gui->addMessage(_("Final lap!"), kart,
                                3.0f, GUIEngine::getSkin()->getColor("font::normal"), true);
+        }
         if(!m_last_lap_sfx_played && lap_count > 1)
         {
             if (UserConfigParams::m_music)

--- a/src/modes/linear_world.cpp
+++ b/src/modes/linear_world.cpp
@@ -282,7 +282,7 @@ void LinearWorld::newLap(unsigned int kart_index)
             + getDistanceDownTrackForKart(kart->getWorldKartId());
     }
     // Last lap message (kart_index's assert in previous block already)
-    if (raceHasLaps() && kart_info.m_race_lap+1 == lap_count )
+    if (raceHasLaps() && kart_info.m_race_lap+1 == lap_count)
     {
         if (lap_count > 1)
         {


### PR DESCRIPTION
This change fixes the issue #3126 that I opened. From a player standpoint, I disagree with having the message "Final lap!" appear when starting a one-lap race. This change makes the "Final lap!" message only appear in races that have more than one lap.