### PR TITLE
Makes nitro increase slightly acceleration

### DIFF
--- a/src/karts/kart.cpp
+++ b/src/karts/kart.cpp
@@ -2460,6 +2460,10 @@ void Kart::updateEnginePowerAndBrakes(float dt)
     updateNitro(dt);
     float engine_power = getActualWheelForce();
 
+    // apply nitro boost if relevant
+    if(getSpeedIncreaseTimeLeft(MaxSpeed::MS_INCREASE_NITRO))
+    engine_power*=1.2f;
+   
     // apply parachute physics if relevant
     if(m_attachment->getType()==Attachment::ATTACH_PARACHUTE)
         engine_power*=0.2f;


### PR DESCRIPTION
New PR opened as requested, as the change was cut out being not AI-related.

Summary of the issue : in current STK, nitro increases max speed, and only max speed. Therefore, trying to use nitro to accelerate when at a slow speed is absolutely useless, it doesn't change at all the kart's speed.

This is extremely counter-intuitive (casual STK players are probably not aware of it and use nitro in situations where it is useless), and also makes the optimal utilization of nitro "use only when at max speed" without any sort of nuance.

The proposed patch gives a slight boost to acceleration for nitro. The speed gained when going already fast is small ; it makes the kart accelerate to the new max speed obtained faster but by a small amount. However, when at a slow speed, and trying to accelerate to max speed (an acceleration which takes more time), the boost is more significant.

The goal is to make it have some use when trying to reaccelerate (like after rescue) without otherwise upsetting the game-balance too much.