### PR TITLE
Better GP points distribution

### DIFF
--- a/data/stk_config.xml
+++ b/data/stk_config.xml
@@ -38,29 +38,29 @@
     <points points="2" /> <!-- added with 5 karts -->
     <points points="1" /> <!-- added with 6 karts -->
     <points points="3" /> <!-- added with 7 karts -->
-    <points points="2" /> <!-- added with 8 karts -->
+    <points points="1" /> <!-- added with 8 karts -->
     <points points="3" /> <!-- added with 9 karts -->
-    <points points="1" /> <!-- added with 10 karts -->
-    <points points="4" /> <!-- added with 11 karts -->
+    <points points="4" /> <!-- added with 10 karts -->
+    <points points="1" /> <!-- added with 11 karts -->
     <points points="2" /> <!-- added with 12 karts -->
-    <points points="1" /> <!-- added with 13 karts -->
-    <points points="3" /> <!-- added with 14 karts -->
-    <points points="2" /> <!-- added with 15 karts -->
-    <points points="1" /> <!-- added with 16 karts -->
+    <points points="5" /> <!-- added with 13 karts -->
+    <points points="1" /> <!-- added with 14 karts -->
+    <points points="3" /> <!-- added with 15 karts -->
+    <points points="6" /> <!-- added with 16 karts -->
     <points points="4" /> <!-- added with 17 karts -->
     <points points="2" /> <!-- added with 18 karts -->
-    <points points="3" /> <!-- added with 19 karts -->
+    <points points="7" /> <!-- added with 19 karts -->
     <points points="1" /> <!-- added with 20 karts -->
-    <points points="5" /> <!-- added with 21 karts -->
-    <points points="2" /> <!-- added with 22 karts -->
-    <points points="1" /> <!-- added with 23 karts -->
-    <points points="3" /> <!-- added with 24 karts -->
-    <points points="4" /> <!-- added with 25 karts -->
-    <points points="1" /> <!-- added with 26 karts -->
-    <points points="2" /> <!-- added with 27 karts -->
-    <points points="1" /> <!-- added with 28 karts -->
-    <points points="3" /> <!-- added with 29 karts -->
-    <points points="5" /> <!-- added with 30 karts -->
+    <points points="8" /> <!-- added with 21 karts -->
+    <points points="1" /> <!-- added with 22 karts -->
+    <points points="2" /> <!-- added with 23 karts -->
+    <points points="1" /> <!-- added with 24 karts -->
+    <points points="9" /> <!-- added with 25 karts -->
+    <points points="4" /> <!-- added with 26 karts -->
+    <points points="1" /> <!-- added with 27 karts -->
+    <points points="10" /><!-- added with 28 karts -->
+    <points points="2" /> <!-- added with 29 karts -->
+    <points points="12" /><!-- added with 30 karts -->
   </grand-prix>
 
   <!-- Time in follow-the-leader after which karts are removed.


### PR DESCRIPTION
Revisiting my contribution from last year, I've improved the GP points distribution.

The improvements are twofold : 

- Better reward victory and the places close after ; as the previous distribution wasn't aggressive enough, especially with a lot of karts.
- Smooth significantly the point rewards

This is with the old distribution : 

![gp_old](https://user-images.githubusercontent.com/25536748/38256964-abe0215e-375f-11e8-8122-11af2916ad87.png)

This is with the new one : 

![gp_new](https://user-images.githubusercontent.com/25536748/38256962-abc51364-375f-11e8-910f-441d08931507.png)

The total of points distributed don't increase too much (especially with 20 karts or less : 10 karts : the 1st get from 16 to 18; 15 karts : 28->30 ; 20 karts : 39->50) ; as the additional high value nodes are compensated by less middle-value nodes ; so the player won't be confronted with excessive numbers.