### PR TITLE
Dynamic basket ball speed

### DIFF
--- a/data/powerup.xml
+++ b/data/powerup.xml
@@ -15,19 +15,45 @@
         model="anchor.spm"                              />
   <item name="switch"         icon="swap-icon.png"      />
   <item name="swatter"        icon="swatter-icon.png"   />
-  <!--  interval: How long a single bounce takes.
+  <!--  min-speed-offset: The speed of the ball is calculated
+                    by adding the speed-offset to the difficulty's
+                    max-speed. min-speed-offset is used when the
+                    ball is closer than min-offset-distance
+                    to the target.
+        max-speed-offset: The additional speed of the ball when
+                    farther than max-offset-distance.
+        speed : defines the initial speed. Mainly kept for
+                    compatibility with flyable class
+        min-offset-distance: The distance under which the ball is
+                    at minimal speed.
+        max-offset-distance: The distance under which the ball is
+                    at maximal speed. If it is not equal to
+                    min-offset-distance, the ball speeds between
+                    both is a weighted average of the min and
+                    max speed.
+        interval: How long a single bounce takes.
         max-height: The maximum height of a bounce.
         min-height: Unused mostly, but defines implicitly
                     the starting height (as average of
                     max and min height).
+        fast-ping-distance: When the ball is closer than 
+                    this to the target, it will bounce
+                    at a high rate and low.
+        early-target-factor: the rubber ball can use the
+                    relative position of the kart to the
+                    center of the track for improved targeting
+                    (i.e. the ball will align its relative
+                    position to the center of the track early).
+                    This allows a lower target-distance to be
+                    used since the ball is better aligned,
+                    hopefully reducing the frequency of 
+                    tunneling.
         target-distance: When the ball is closer than 
                     this to the target, it will aim
                     directly at the target.
         target-max-angle: Once the ball is aiming for its
                     target, it can at most change the angle
                     this much per second(!).
-        time-between-balls:  Reduces the frequency with which rubber 
-                    balls are found to 1 every 'timer' seconds.
         min-interpolation-distance: how far the control
                     points (which are center of squads)
                     must be from each other. A large value
@@ -40,30 +66,28 @@
                     bouncing on the pyramid). Quite
                     catastrophal on the startrack and
                     skyline).
+        time-between-balls:  Reduces the frequency with which rubber 
+                    balls are found to 1 every 'timer' seconds.
         squash-slowdown: How much karts that are 
                     squashed are slowed down.
         squash-duration: How long karts stay squashed.
         delete-timer: How long before the ball is removed
                     if no suitable target is found.
-        early-target-factor: the rubber ball can use the
-                    relative position of the kart to the
-                    center of the track for improved targeting
-                    (i.e. the ball will align its relative
-                    position to the center of the track early).
-                    This allows a lower target-distance to be
-                    used since the ball is better aligned,
-                    hopefully reducing the frequency of 
-                    tunneling.
    -->
   <item name="rubber-ball"    icon="rubber_ball-icon.png"
-        model="rubber_ball.spm" speed="35.0"
+        model="rubber_ball.spm"
+        speed="42.0"
+        min-speed-offset="9.0"
+        max-speed-offset="29.0"
+        min-offset-distance="50.0"
+        max-offset-distance="250.0"
         scale="1 1 1"         interval="1"
         max-height="4.0"      min-height="0"
         fast-ping-distance="50" 
         early-target-factor="1"
         target-distance="15"  target-max-angle = "90"
         min-interpolation-distance="5"
-        time-between-balls="15"
+        time-between-balls="25"
         squash-slowdown="0.5" squash-duration="2"
         delete-time="5.0"     max-height-difference="10" />
   <item name="parachute"      icon="parachute-icon.png"
@@ -108,4 +132,3 @@
 
     
 </powerup>
-

--- a/src/items/rubber_ball.cpp
+++ b/src/items/rubber_ball.cpp
@@ -33,6 +33,7 @@
 #include "tracks/drive_graph.hpp"
 #include "tracks/drive_node.hpp"
 #include "tracks/track.hpp"
+#include "karts/kart_properties.hpp"
 
 #include "utils/log.hpp" //TODO: remove after debugging is done
 
@@ -46,6 +47,10 @@ float RubberBall::m_st_delete_time;
 float RubberBall::m_st_max_height_difference;
 float RubberBall::m_st_fast_ping_distance;
 float RubberBall::m_st_early_target_factor;
+float RubberBall::m_st_min_speed_offset;
+float RubberBall::m_st_max_speed_offset;
+float RubberBall::m_st_min_offset_distance;
+float RubberBall::m_st_max_offset_distance;
 int   RubberBall::m_next_id = 0;
 int   RubberBall::m_ticks_between_balls;
 
@@ -262,53 +267,76 @@ void RubberBall::getNextControlPoint()
  */
 void RubberBall::init(const XMLNode &node, scene::IMesh *rubberball)
 {
-    m_st_interval                   =  1.0f;
-    m_st_squash_duration            =  3.0f;
-    m_st_squash_slowdown            =  0.5f;
-    m_st_min_interpolation_distance = 30.0f;
-    m_st_target_distance            = 50.0f;
-    m_st_target_max_angle           = 25.0f;
-    m_st_delete_time                = 10.0f;
-    m_st_max_height_difference      = 10.0f;
-    m_st_fast_ping_distance         = 50.0f;
-    m_st_early_target_factor        =  1.0f;
+    m_st_interval                   =   1.0f;
+    m_st_squash_duration            =   3.0f;
+    m_st_squash_slowdown            =   0.5f;
+    m_st_min_interpolation_distance =  30.0f;
+    m_st_target_distance            =  50.0f;
+    m_st_target_max_angle           =  25.0f;
+    m_st_delete_time                =  10.0f;
+    m_st_max_height_difference      =  10.0f;
+    m_st_fast_ping_distance         =  50.0f;
+    m_st_early_target_factor        =   1.0f;
+    m_st_min_speed_offset           =   8.0f;
+    m_st_max_speed_offset           =  28.0f;
+    m_st_min_offset_distance        =  50.0f;
+    m_st_max_offset_distance        = 250.0f;
     m_ticks_between_balls           = stk_config->time2Ticks(15.0f);
 
     if(!node.get("interval", &m_st_interval))
-        Log::warn("powerup", "No interval specified for rubber ball.");
+        Log::warn("powerup", "No interval specified for basket ball.");
     if(!node.get("squash-duration", &m_st_squash_duration))
         Log::warn("powerup",
-                  "No squash-duration specified for rubber ball.");
+                  "No squash-duration specified for basket ball.");
     if(!node.get("squash-slowdown", &m_st_squash_slowdown))
-        Log::warn("powerup", "No squash-slowdown specified for rubber ball.");
+        Log::warn("powerup", "No squash-slowdown specified for basket ball.");
     if(!node.get("min-interpolation-distance",
                  &m_st_min_interpolation_distance))
         Log::warn("powerup", "No min-interpolation-distance specified "
-                             "for rubber ball.");
+                             "for basket ball.");
     if(!node.get("target-distance", &m_st_target_distance))
         Log::warn("powerup",
-                  "No target-distance specified for rubber ball.");
+                  "No target-distance specified for basket ball.");
     if(!node.get("delete-time", &m_st_delete_time))
-        Log::warn("powerup", "No delete-time specified for rubber ball.");
+        Log::warn("powerup", "No delete-time specified for basket ball.");
     if(!node.get("target-max-angle", &m_st_target_max_angle))
-        Log::warn("powerup", "No target-max-angle specified for rubber ball.");
+        Log::warn("powerup", "No target-max-angle specified for basket ball.");
     m_st_target_max_angle *= DEGREE_TO_RAD;
     if(!node.get("max-height-difference", &m_st_max_height_difference))
         Log::warn("powerup",
-                  "No max-height-difference specified for rubber ball.");
+                  "No max-height-difference specified for basket ball.");
     if(!node.get("fast-ping-distance", &m_st_fast_ping_distance))
         Log::warn("powerup",
-                  "No fast-ping-distance specified for rubber ball.");
+                  "No fast-ping-distance specified for basket ball.");
     if(m_st_fast_ping_distance < m_st_target_distance)
         Log::warn("powerup",
                    "Ping-distance is smaller than target distance.\n"
                    "That should not happen, but is ignored for now.");
     if(!node.get("early-target-factor", &m_st_early_target_factor))
         Log::warn("powerup",
-                  "No early-target-factor specified for rubber ball.");
+                  "No early-target-factor specified for basket ball.");
     if(!node.get("time-between-balls", &m_ticks_between_balls))
         Log::warn("powerup",
-                  "No time-between-balls specified for rubber ball.");
+                  "No time-between-balls specified for basket ball.");
+    if(!node.get("min-speed-offset", &m_st_min_speed_offset))
+        Log::warn("powerup", "No min-speed-offset specified for basket ball.");
+    if(!node.get("max-speed-offset", &m_st_max_speed_offset))
+        Log::warn("powerup", "No max-speed-offset specified for basket ball.");
+    if(!node.get("min-offset-distance", &m_st_min_offset_distance))
+        Log::warn("powerup", "No min-offset-distance specified for basket ball.");
+    if(!node.get("max-offset-distance", &m_st_max_offset_distance))
+        Log::warn("powerup", "No max-offset-distance specified for basket ball.");
+
+    //sanity checks
+    if (m_st_min_speed_offset > m_st_max_speed_offset)
+    {
+        m_st_max_speed_offset = m_st_min_speed_offset;
+    }
+    if (m_st_max_offset_distance <= m_st_min_offset_distance)
+    {
+        m_st_max_offset_distance = m_st_min_offset_distance + 1.àf;
+    }
+
     m_ticks_between_balls = stk_config->time2Ticks(float(m_ticks_between_balls));
     Flyable::init(node, rubberball, PowerupManager::POWERUP_RUBBERBALL);
 }   // init
@@ -350,6 +378,9 @@ bool RubberBall::updateAndDelete(float dt)
     // finished the race).
     computeTarget();
     updateDistanceToTarget();
+
+    //Update the speed
+    updateWeightedSpeed(dt);
 
     // Determine the new position. This new position is only temporary,
     // since it still needs to be adjusted for the height of the terrain.
@@ -443,6 +474,7 @@ void RubberBall::moveTowardsTarget(Vec3 *next_xyz, float dt)
     // towards it.
     Vec3 diff = m_target->getXYZ() - getXYZ();
     diff = diff - diff.dot(getNormal())*getNormal();
+
     // Avoid potential division by zero
     if(diff.length2()==0)
         *next_xyz = getXYZ() - getNormal()*m_previous_height;
@@ -458,6 +490,69 @@ void RubberBall::moveTowardsTarget(Vec3 *next_xyz, float dt)
     assert(!std::isnan((*next_xyz)[2]));
 
 }   // moveTowardsTarget
+
+// ----------------------------------------------------------------------------
+/** Calculates the current speed of the basket ball.
+ *  The base basket ball speed is the target's normal max speed.
+ *  Then an offset is applied.
+ *  If closer than m_st_min_offset_distance ; it is m_st_min_speed_offset
+ *  If farther than m_st_max_offset_distance ; it is m_st_max_speed_offset
+ *  Else, it is a weighted average.
+ *  It takes up to 5 seconds to fully change its speed
+ *  (to avoid sudden big speed changes when the distance change suddenly
+ *  at ball throwing, because of paths, shortcuts, etc.)
+ *  If there is no target, it will keep its current speed
+ */
+void RubberBall::updateWeightedSpeed(float dt)
+{
+
+    // Don't change the speed if there is no target
+    if (m_delete_timer >= 0.2f)
+    {
+        return;
+    }
+
+    const KartProperties *kp = m_target->getKartProperties();
+    float targeted_speed = kp->getEngineMaxSpeed();
+
+    //Calculate the targeted weighted speed
+    if (m_distance_to_target <= m_st_min_offset_distance)
+    {
+        targeted_speed += m_st_min_speed_offset;
+    }
+    else if (m_distance_to_target > m_st_max_offset_distance)
+    {
+        targeted_speed += m_st_max_speed_offset;
+    }
+    else
+    {
+        float weight = 1.0f;
+        float offset = 0.0f;
+        weight = (m_st_max_offset_distance - m_distance_to_target)
+                /(m_st_max_offset_distance - m_st_min_offset_distance);
+        offset = weight * m_st_min_speed_offset  + (1-weight) * m_st_max_speed_offset;
+        targeted_speed += offset;
+    }
+
+    //Update the real speed
+
+    //Always >= 0
+    float max_change = (m_st_max_speed_offset - m_st_min_speed_offset)*dt/(5.0f);
+
+    if (m_speed-targeted_speed <= max_change && m_speed-targeted_speed >= -max_change)
+    {
+        m_speed = targeted_speed;
+    }
+
+    else if (m_speed < targeted_speed)
+    {
+        m_speed += max_change;
+    }
+    else
+    {
+        m_speed -= max_change;
+    }
+}   // updateWeightedSpeed
 
 // ----------------------------------------------------------------------------
 /** Uses Hermite splines (Catmull-Rom) to interpolate the position of the

--- a/src/items/rubber_ball.cpp
+++ b/src/items/rubber_ball.cpp
@@ -334,7 +334,7 @@ void RubberBall::init(const XMLNode &node, scene::IMesh *rubberball)
     }
     if (m_st_max_offset_distance <= m_st_min_offset_distance)
     {
-        m_st_max_offset_distance = m_st_min_offset_distance + 1.àf;
+        m_st_max_offset_distance = m_st_min_offset_distance + 1.0f;
     }
 
     m_ticks_between_balls = stk_config->time2Ticks(float(m_ticks_between_balls));

--- a/src/items/rubber_ball.hpp
+++ b/src/items/rubber_ball.hpp
@@ -81,6 +81,20 @@ private:
      *  ball will be deleted. */
     static float m_st_delete_time;
 
+    /** If the ball is closer to its target than min_offset_distance, the speed
+     *  in addition to the difficulty's default max speed. */
+    static float m_st_min_speed_offset;
+
+    /** If the ball is farther to its target than max_offset_distance, the speed
+     *  in addition to the difficulty's default max speed. */
+    static float m_st_max_speed_offset;
+
+    /** The distance to target under which the ball is the slowest */
+    static float m_st_min_offset_distance;
+
+    /** The distance to target over which the ball is the fastest */
+    static float m_st_max_offset_distance;
+
     /** Timer before another rubber ball can be picked up. This is to ensure
      *  that there are not too many rubber balls on the track in races with many
      *  karts. */
@@ -194,6 +208,7 @@ private:
     float        updateHeight();
     void         interpolate(Vec3 *next_xyz, float dt);
     void         moveTowardsTarget(Vec3 *next_xyz, float dt);
+    void         updateWeightedSpeed(float dt);
     void         initializeControlPoints(const Vec3 &xyz);
     float        getTunnelHeight(const Vec3 &next_xyz, 
                                      const float vertical_offset) const;


### PR DESCRIPTION
Fixes #2783 

The speed depends on distance and difficulty (by using the target kart base max speed ; so it incidentally depends on whether or not the leading kart is light, but the difference is small).

In easier difficulties, it is slower than before when very close to the target (in SuperTux too, but by a very small amount) ; but in all difficulties it is significantly faster when moderately far (from 42 to 54 depending on kart type and difficulty ; compared to 35 before ; which makes the time the ball takes to catch up depend a lot less on how far behind its user is).

I've tested in a few tracks (though not all) ; I've not encountered tunneling issues related to the increased speed (but there are general tunneling issues in volcano island). Additional testing may still be helpful.