### PR TITLE
Completely revised random powerup weights system

### DIFF
--- a/data/powerup.xml
+++ b/data/powerup.xml
@@ -74,38 +74,123 @@
         force-updown="35"     force-to-target="15"
         max-distance="25"                               />
 
+    <!-- This defines the number of karts for which there is a
+       defined weight list. The value between two nodes will be
+       interpolated as a linear average of the value at each node,
+       except under the minimum node and above the maximum node
+       (in which case it stays identical to the minimum/maximum node)
+
+       The num of karts associated with each reference point should be
+       sorted in ascending order to guarantee correct behavior.
+
+       This doesn't apply to follow the leader, battle & tutorial weights
+       If the max karts number is increased, think to add values for
+       higher kart numbers. Otherwhise, it will default to value for 20. -->
+  <reference_points ref1="1" ref2="5" ref3="9" ref4="14" ref5="20" />
+
   <!-- Distribution of the items depending on position of the 
-       kart (first kart, top 33%, middle 33%, bottom 33% (but
-       not last), last kart. i
+       kart. There are defined value for first kart, last kart, and
+       at three equally spaced points between those.
+       For example, with 5 karts those points will match positon 2, 3, 4.
+       With 10 karts, they will correspond to 3,25 ; 5,5 ; 7,75.
+       It is not an issue for it to be a float, as the weights for positions
+       are linearly averaged.
        The order of items must correspond to powerup_manager.hpp.
-       The first line (w=...) corresponds to the weights of 
-       getting a single item, the second line (w-multi) to 
-       getting three identical items instead of just a single one.
-       E.g. as the first kart, you have 3/8 of a chance to get
-       a single bubble gum, 1/8 to get a bowling ball or switch,
-       and 3/8 to get a triple bubble gum.
-       'Global' items which affect all karts (switch) should
+
+       The first line (w1=...) corresponds to the weights of 
+       getting a specific item, the second line (w-multi1) to 
+       the weight at which it will yeld a triple item
+       rather than a single one
+
+       The probability to get an item is its weight divided by
+       sum of weights of all items (single AND multi). It is recommended 
+       to keep that sum equal to 200 to easily keep track of probabilities.
+
+       'Global' items which affect all karts (switch, parachute) should
        be quite rare, since otherwise the item might be used
        too often (compared with many items which will only
-       affect a karts or two).                                -->
+       affect a karts or two).
+
+       The distribution should give more similar item to different ranks
+       when there are few karts, but have more important differences when
+       there are more karts.                               -->
   <!--      bubble  cake  bowl  zipper  plunger  switch swattr rubber para  anvil -->
-  <first  w="25       5    15     5      10       10      10     0     0     0"
-    w-multi=" 0       0     5     0       0        0       0     0     0     0"    />
-  <top33  w="30      30    30    30      30       10      10    10    10     0"
-    w-multi=" 0      10    10     0      10        0       0     0     0     0"    />
-  <mid33  w="30      30    30    30      30       10      20    20    20     0"
-    w-multi=" 0      20    20    20      20        0       0     0     0     0"    />
-  <end33  w=" 0      30    30    30      30       10      20    30    30     0"
-    w-multi=" 0      30    30    30      30        0       0     0     0     0"    />
-  <last   w=" 0      30    10    90      60        0      10    60    60     0"
-    w-multi=" 0      30    30   100      60        0       0     0     0     0"    />
+  <first  w1="28       0    60    20      45       15      32     0     0     0"
+    w-multi1=" 0       0     0     0       0        0       0     0     0     0"
+          w2="26      16    52    15      46       12      33     0     0     0"
+    w-multi2=" 0       0     0     0       0        0       0     0     0     0"
+          w3="24      12    58    10      54        8      34     0     0     0"
+    w-multi3=" 0       0     0     0       0        0       0     0     0     0"
+          w4="22       8    64     5      60        6      35     0     0     0"
+    w-multi4=" 0       0     0     0       0        0       0     0     0     0"
+          w5="20       0    74     0      66        4      36     0     0     0"
+    w-multi5=" 0       0     0     0       0        0       0     0     0     0" 
+          wf="35       0    25    35      25       15      25     0     0     0"
+    w-multif="20       0     0    20       0        0       0     0     0     0"  />
+
+  <!--      bubble  cake  bowl  zipper  plunger  switch swattr rubber para  anvil -->
+  <top33  w1="30       0    59    26      40       14      27     0     0     0"
+    w-multi1=" 0       0     4     0       0        0       0     0     0     0"
+          w2="30      27    48    25      28       10      27     0     0     0"
+    w-multi2=" 0       0     5     0       0        0       0     0     0     0"
+          w3="29      30    45    24      32        7      27     0     0     0"
+    w-multi3=" 0       0     6     0       0        0       0     0     0     0"
+          w4="28      31    48    22      34        4      27     0     0     0"
+    w-multi4=" 0       0     6     0       0        0       0     0     0     0"
+          w5="27      32    48    20      37        3      27     0     0     0"
+    w-multi5=" 0       0     6     0       0        0       0     0     0     0"
+          wf="25       0    60    25      58        2      30     0     0     0"
+    w-multif=" 0       0     0     0       0        0       0     0     0     0"    />
+
+  <!--      bubble  cake  bowl  zipper  plunger  switch swattr rubber para  anvil -->
+  <mid33  w1="30       0    62    27      36       13      27     0     0     0"
+    w-multi1=" 0       0     5     0       0        0       0     0     0     0"
+          w2="30      27    45    27      27        9      27     3     0     0"
+    w-multi2=" 0       0     5     0       0        0       0     0     0     0"
+          w3="30      26    41    28      26        6      26    10     0     0"
+    w-multi3=" 0       0     7     0       0        0       0     0     0     0"
+          w4="30      25    42    29      29        3      24    10     0     0"
+    w-multi4=" 0       0     8     0       0        0       0     0     0     0"
+          w5="30      24    40    30      28        2      21    10     0     0"
+    w-multi5=" 0       0    10     0       5        0       0     0     0     0"
+          wf="35       0    55    35      25        3      25     0     0     0"
+    w-multif=" 0       0    10     0      12        0       0     0     0     0"    />
+
+  <!--      bubble  cake  bowl  zipper  plunger  switch swattr rubber para  anvil -->
+  <end33  w1="31       0    56    36      34       12      25     0     0     0"
+    w-multi1=" 0       0     6     0       0        0       0     0     0     0"
+          w2="32      24    28    38      22        7      20    16     6     0"
+    w-multi2=" 0       0     7     0       0        0       0     0     0     0"
+          w3="33      23    26    45      14        5      16    12     8     0"
+    w-multi3=" 0       0    12     0       6        0       0     0     0     0"
+          w4="27      21    23    44      12        3      14     8     6     0"
+    w-multi4=" 8       0    16     8      10        0       0     0     0     0"
+          w5="25      18    20    50      10        2      10     6     3     0"
+    w-multi5="10       0    20    10      16        0       0     0     0     0"
+          wf="25       0    40    45      15        5      15    10     5     0"
+    w-multif="10       0    15    15       0        0       0     0     0     0"    />
+
+  <!--      bubble  cake  bowl  zipper  plunger  switch swattr rubber para  anvil -->
+  <last   w1="34       0    36    55      30       10      17     0     0     0"
+    w-multi1=" 0       0    18     0       0        0       0     0     0     0"
+          w2="28      21     9    45       0        6       0    10    18     0"
+    w-multi2=" 8       0    16    35       4        0       0     0     0     0"
+          w3="20      16     7    37       0        3       0     4    15     0"
+    w-multi3="18       0    18    58       4        0       0     0     0     0"
+          w4="18      14     3    35       0        0       0     0    10     0"
+    w-multi4="24       0    25    65       6        0       0     0     0     0"
+          w5="15      12     0    25       0        0       0     0     7     0"
+    w-multi5="30       0    31    80       0        0       0     0     0     0"
+          wf="20       0    15    25       0        0       0     0    15     0"
+    w-multif="20       0    25    80       0        0       0     0     0     0"    />
+
+  <!--      bubble  cake  bowl  zipper  plunger  switch swattr rubber para  anvil -->
   <battle w="10      30    60     0       0       10      30     0     0     0"
     w-multi=" 0       0     5     0       0        0       0     0     0     0"    />
   <soccer w=" 0      30    60     0       0       10      30     0     0     0"
     w-multi=" 0       0     5     0       0        0       0     0     0     0"    />
   <tuto   w=" 0       0     0     0       0        0       0     0     0     0"
-    w-multi=" 0       0   100     0       0        0       0     0     0     0"    />
+    w-multi=" 0       0   100     0       0        0       0     0     0     0" />
 
     
 </powerup>
-

--- a/data/powerup.xml
+++ b/data/powerup.xml
@@ -88,10 +88,11 @@
        higher kart numbers. Otherwhise, it will default to value for 20. -->
   <reference_points ref1="1" ref2="5" ref3="9" ref4="14" ref5="20" />
 
-  <!-- Distribution of the items depending on position of the 
-       kart. There are defined value for first kart, last kart, and
+  <!-- This defines the probabilities to get each type of item depending on
+       the position of the kart.
+       There are defined value for first kart, last kart, and
        at three equally spaced points between those.
-       For example, with 5 karts those points will match positon 2, 3, 4.
+       For example, with 5 karts those points will match positions 2, 3, 4.
        With 10 karts, they will correspond to 3,25 ; 5,5 ; 7,75.
        It is not an issue for it to be a float, as the weights for positions
        are linearly averaged.
@@ -102,6 +103,13 @@
        the weight at which it will yeld a triple item
        rather than a single one
 
+       w1 corresponds to the weights at ref1, w2 to the weights at ref2, etc.
+       When the number of karts in the race fall between refi and refj,
+       the weights used are a weighted average between wi and wj.
+       
+       wf and w-multif are the weights associated with the follow-the-leader
+       mode. Those are the same for all kart numbers.
+
        The probability to get an item is its weight divided by
        sum of weights of all items (single AND multi). It is recommended 
        to keep that sum equal to 200 to easily keep track of probabilities.
@@ -111,7 +119,7 @@
        too often (compared with many items which will only
        affect a karts or two).
 
-       The distribution should give more similar item to different ranks
+       The distribution should give more similar items to different ranks
        when there are few karts, but have more important differences when
        there are more karts.                               -->
   <!--      bubble  cake  bowl  zipper  plunger  switch swattr rubber para  anvil -->

--- a/src/graphics/irr_driver.cpp
+++ b/src/graphics/irr_driver.cpp
@@ -942,7 +942,6 @@ void IrrDriver::applyResolutionSettings()
         material_manager->addSharedMaterial(materials_file);
     }
 
-    powerup_manager->loadAllPowerups ();
     ItemManager::loadDefaultItemMeshes();
     projectile_manager->loadData();
     Referee::init();

--- a/src/graphics/irr_driver.cpp
+++ b/src/graphics/irr_driver.cpp
@@ -942,6 +942,7 @@ void IrrDriver::applyResolutionSettings()
         material_manager->addSharedMaterial(materials_file);
     }
 
+    powerup_manager->loadPowerupsModels();
     ItemManager::loadDefaultItemMeshes();
     projectile_manager->loadData();
     Referee::init();

--- a/src/items/powerup_manager.cpp
+++ b/src/items/powerup_manager.cpp
@@ -403,8 +403,15 @@ void PowerupManager::loadWeights(const XMLNode &root,
         float ref_diff = (float) (sup_num - inf_num);
         float sup_diff = (float) (sup_num - num_karts);
         float inf_diff = (float) (num_karts - inf_num);
-        float weight = (sup_diff/ref_diff)*weight_inf
-                      +(inf_diff/ref_diff)*weight_sup;
+        float weight;
+        
+        if (ref_diff != 0)
+            weight = (sup_diff/ref_diff)*weight_inf
+                    +(inf_diff/ref_diff)*weight_sup;
+        
+        //the sup and inf weights are the same here, take one of them
+        else
+            weight = weight_inf;
         int rounded_weight = (int) weight;
 
         m_weights[position_class].push_back(rounded_weight);

--- a/src/items/powerup_manager.cpp
+++ b/src/items/powerup_manager.cpp
@@ -231,9 +231,9 @@ void PowerupManager::loadWeights(const XMLNode &root,
 
     /** Adds to w_inf and w_sup the suffixe of the closest num_karts reference classes
      */
-    if(position_class!=POSITION_BATTLE_MODE 
-    && position_class!=POSITION_TUTORIAL_MODE
-    && position_class!=POSITION_SOCCER_MODE)
+    if(position_class!=POSITION_BATTLE_MODE &&
+       position_class!=POSITION_TUTORIAL_MODE &&
+       position_class!=POSITION_SOCCER_MODE)
     {
         //First step : get the reference points
 
@@ -313,7 +313,8 @@ void PowerupManager::loadWeights(const XMLNode &root,
         class_node->get(w_sup_multi, &values_sup_multi );
     }
 
-    if(!class_node || values_inf=="" || values_inf_multi=="" || values_sup=="" || values_sup_multi=="")
+    if(!class_node || values_inf=="" || values_inf_multi==""
+                   || values_sup=="" || values_sup_multi=="")
     {
         Log::error("[PowerupManager]", "No weights found for class '%s'"
                     " - probabilities will be incorrect.",
@@ -583,11 +584,12 @@ unsigned int PowerupManager::convertPositionToClassWeight(unsigned int num_karts
 PowerupManager::PowerupType PowerupManager::getRandomPowerup(unsigned int pos,
                                                              unsigned int *n)
 {
+   int random = rand();
+   int random_class = random%RAND_CLASS_RANGE;
+   int random_item = (random/RAND_CLASS_RANGE)%m_powerups_for_reference_pos[pos_class].size();
+
     //First step : select at random a class according to the weights of class for this position
-
     // Positions start with 1, while the index starts with 0 - so subtract 1
-   int random_class = rand()%RAND_CLASS_RANGE;
-
     PositionClass pos_class =
         (race_manager->isBattleMode() ? POSITION_BATTLE_MODE :
          race_manager->isSoccerMode() ? POSITION_SOCCER_MODE :
@@ -596,9 +598,8 @@ PowerupManager::PowerupType PowerupManager::getRandomPowerup(unsigned int pos,
                                                          m_position_to_class_sup[pos-1]);
 
     //Second step : select an item at random
-
-    int random = rand()%m_powerups_for_reference_pos[pos_class].size();
-    int i=m_powerups_for_reference_pos[pos_class][random];
+    
+    int i=m_powerups_for_reference_pos[pos_class][random_item];
     if(i>=POWERUP_MAX)
     {
         i -= POWERUP_MAX;

--- a/src/items/powerup_manager.cpp
+++ b/src/items/powerup_manager.cpp
@@ -107,10 +107,9 @@ PowerupManager::PowerupType
 }   // getPowerupType
 
 //-----------------------------------------------------------------------------
-/** Loads all powerups from the powerup.xml file.
- *  Uses num_karts to get the good weights
+/** Loads powerups models and icons from the powerup.xml file.
  */
-void PowerupManager::loadAllPowerups(unsigned int num_karts)
+void PowerupManager::loadPowerupsModels()
 {
     const std::string file_name = file_manager->getAsset("powerup.xml");
     XMLNode *root               = file_manager->createXMLTree(file_name);
@@ -131,6 +130,18 @@ void PowerupManager::loadAllPowerups(unsigned int num_karts)
             exit(-1);
         }
     }
+    delete root;
+}  // loadPowerupsModels
+
+//-----------------------------------------------------------------------------
+/** Loads all powerups weights from the powerup.xml file.
+ *  Uses num_karts to get the good weights
+ */
+void PowerupManager::loadAllPowerups(unsigned int num_karts)
+{
+    const std::string file_name = file_manager->getAsset("powerup.xml");
+    XMLNode *root               = file_manager->createXMLTree(file_name);
+
     //loadWeights takes care of loading specific weight in follow-the-leader
     //They also vary depending on rank in race, so they use the usual position classes
     loadWeights(*root, num_karts, "first",   POSITION_FIRST      );

--- a/src/items/powerup_manager.cpp
+++ b/src/items/powerup_manager.cpp
@@ -586,7 +586,6 @@ PowerupManager::PowerupType PowerupManager::getRandomPowerup(unsigned int pos,
 {
    int random = rand();
    int random_class = random%RAND_CLASS_RANGE;
-   int random_item = (random/RAND_CLASS_RANGE)%m_powerups_for_reference_pos[pos_class].size();
 
     //First step : select at random a class according to the weights of class for this position
     // Positions start with 1, while the index starts with 0 - so subtract 1
@@ -599,6 +598,8 @@ PowerupManager::PowerupType PowerupManager::getRandomPowerup(unsigned int pos,
 
     //Second step : select an item at random
     
+   int random_item = (random/RAND_CLASS_RANGE)%m_powerups_for_reference_pos[pos_class].size();
+
     int i=m_powerups_for_reference_pos[pos_class][random_item];
     if(i>=POWERUP_MAX)
     {

--- a/src/items/powerup_manager.cpp
+++ b/src/items/powerup_manager.cpp
@@ -374,14 +374,14 @@ void PowerupManager::loadWeights(const XMLNode &root,
 
         if (!StringUtils::parseString(weight_list_inf[i].c_str(), &weight_inf))
         {
-            Log::error("[PowerupManager]","Incorrect reference point values, "
+            Log::error("[PowerupManager]","Incorrect powerup weight values, "
                                      "probabilities will be incorrect");
             weight_inf = 0;//default to zero
         }
 
         if (!StringUtils::parseString(weight_list_sup[i].c_str(), &weight_sup))
         {
-            Log::error("[PowerupManager]","Incorrect reference point values, "
+            Log::error("[PowerupManager]","Incorrect powerup weight values, "
                                      "probabilities will be incorrect");
             weight_sup = 0;
         }

--- a/src/items/powerup_manager.cpp
+++ b/src/items/powerup_manager.cpp
@@ -108,8 +108,9 @@ PowerupManager::PowerupType
 
 //-----------------------------------------------------------------------------
 /** Loads all powerups from the powerup.xml file.
+ *  Uses num_karts to get the good weights
  */
-void PowerupManager::loadAllPowerups()
+void PowerupManager::loadAllPowerups(unsigned int num_karts)
 {
     const std::string file_name = file_manager->getAsset("powerup.xml");
     XMLNode *root               = file_manager->createXMLTree(file_name);
@@ -130,14 +131,16 @@ void PowerupManager::loadAllPowerups()
             exit(-1);
         }
     }
-    loadWeights(*root, "first",   POSITION_FIRST      );
-    loadWeights(*root, "top33",   POSITION_TOP33      );
-    loadWeights(*root, "mid33",   POSITION_MID33      );
-    loadWeights(*root, "end33",   POSITION_END33      );
-    loadWeights(*root, "last" ,   POSITION_LAST       );
-    loadWeights(*root, "battle" , POSITION_BATTLE_MODE);
-    loadWeights(*root, "soccer" , POSITION_SOCCER_MODE);
-    loadWeights(*root, "tuto",    POSITION_TUTORIAL_MODE);
+    //loadWeights takes care of loading specific weight in follow-the-leader
+    //They also vary depending on rank in race, so they use the usual position classes
+    loadWeights(*root, num_karts, "first",   POSITION_FIRST      );
+    loadWeights(*root, num_karts, "top33",   POSITION_TOP33      );
+    loadWeights(*root, num_karts, "mid33",   POSITION_MID33      );
+    loadWeights(*root, num_karts, "end33",   POSITION_END33      );
+    loadWeights(*root, num_karts, "last" ,   POSITION_LAST       );
+    loadWeights(*root, num_karts, "battle" , POSITION_BATTLE_MODE);
+    loadWeights(*root, num_karts, "soccer" , POSITION_SOCCER_MODE);
+    loadWeights(*root, num_karts, "tuto",    POSITION_TUTORIAL_MODE);
 
     delete root;
 
@@ -205,22 +208,103 @@ void PowerupManager::LoadPowerup(PowerupType type, const XMLNode &node)
 }   // LoadNode
 
 // ----------------------------------------------------------------------------
-/** Loads a weight list specified in powerup.xml. The different position
- *  classes must be loaded in the right order
+/** Loads a weight list specified in powerup.xml.
+ *  Calculates a linear average of the weight specified for the reference points
+ *  of num_karts higher and lower (unless it exactly matches one)
  *  \param root The root node of powerup.xml
+ *  \param num_karts The number of karts in the race
  *  \param class_name The name of the position class to load.
  *  \param position_class The class for which the weights are read.
  */
 void PowerupManager::loadWeights(const XMLNode &root,
+                                 unsigned int num_karts,
                                  const std::string &class_name,
                                  PositionClass position_class)
 {
-    const XMLNode *node = root.getNode(class_name);
-    std::string s(""), s_multi("");
-    if(node) node->get("w",       &s      );
-    if(node) node->get("w-multi", &s_multi);
+    const XMLNode *node = root.getNode(class_name), *node2 = root.getNode("reference_points");
+    std::string s_inf(""), s_inf_multi(""), s_sup(""), s_sup_multi(""), ref;
+    std::string w_inf("w"), w_sup("w"), w_inf_multi("w-multi"), w_sup_multi("w-multi");
+    int inf_num = 1, sup_num = 1; //The number of karts associated with the reference points
 
-    if(!node || s=="" || s_multi=="")
+    /** Adds to w_inf and w_sup the suffixe of the closest num_karts reference classes
+     */
+    if(position_class!=POSITION_BATTLE_MODE 
+    && position_class!=POSITION_TUTORIAL_MODE
+    && position_class!=POSITION_SOCCER_MODE)
+    {
+        //First step : get the reference points
+
+        if(!node2)
+        {
+            Log::error("[PowerupManager]","No reference points found, "
+                         "probabilities will be incorrect");
+        }
+
+        if (node2)
+        {
+            if(race_manager->isFollowMode())
+            {
+                w_inf = w_sup = "wf";
+            }
+            
+            else
+            {
+                // With default config it won't loop more than five time
+                // This is mainly to let full config editing power
+                for(int i=1;i<=50;i++)
+                {
+                    ref = "ref" + StringUtils::toString(i);
+                    std::string ref_pos;
+                    if (!node2->get(ref, &ref_pos))
+                        break;
+                    unsigned int ref_value = atoi(ref_pos.c_str());
+                    if (ref_value <= num_karts)
+                    {
+                        inf_num = ref_value;
+                        //Useful if config is edited so num_kar > highest reference position
+                        sup_num = ref_value;
+                        w_inf = "w" + StringUtils::toString(i);
+                        w_inf_multi = "w-multi" + StringUtils::toString(i);
+                    }
+                    //No else if, it can be equal
+                    if (ref_value >= num_karts)
+                    {
+                        sup_num = ref_value;
+                        w_sup = w_sup + StringUtils::toString(i);
+                        w_sup_multi = w_sup_multi + StringUtils::toString(i);
+                        break;
+                    }
+                } // for i<=50
+            } //else
+        }
+
+        if(w_inf=="w" || w_sup=="w")
+        {
+            w_inf = "w3";            //fallback values
+            w_inf_multi = "w-multi3";//fallback values
+            w_sup = "w3";            //fallback values
+            w_sup_multi = "w-multi3";//fallback values
+            inf_num = sup_num = num_karts;//fallback values
+            Log::error("[PowerupManager]","Uncorrect reference points in powerup.xml."
+                      "%d karts - fallback probabilities will be used.",
+                      num_karts);
+        }
+
+        // Now w_inf and w_sup contain the weight classes to use
+        // for the weights calculations
+
+    }
+    
+    //Second step : load the node values
+    if(node)
+    {
+        node->get(w_inf,       &s_inf       );
+        node->get(w_inf_multi, &s_inf_multi );
+        node->get(w_sup,       &s_sup       );
+        node->get(w_sup_multi, &s_sup_multi );
+    }
+
+    if(!node || s_inf=="" || s_inf_multi=="" || s_sup=="" || s_sup_multi=="")
     {
         Log::error("[PowerupManager]", "No weights found for class '%s'"
                     " - probabilities will be incorrect.",
@@ -228,88 +312,142 @@ void PowerupManager::loadWeights(const XMLNode &root,
         return;
     }
 
-    std::vector<std::string> weight_list = StringUtils::split(s+" "+s_multi,' ');
+    //Third step : split in discrete values
+    std::vector<std::string> weight_list_inf = StringUtils::split(s_inf+" "+s_inf_multi,' ');
+    std::vector<std::string> weight_list_sup = StringUtils::split(s_sup+" "+s_sup_multi,' ');
 
-    std::vector<std::string>::iterator i=weight_list.begin();
-    while(i!=weight_list.end())
+    std::vector<std::string>::iterator i=weight_list_inf.begin();
+    while(i!=weight_list_inf.end())
     {
         if(*i=="")
         {
-            std::vector<std::string>::iterator next=weight_list.erase(i);
+            std::vector<std::string>::iterator next=weight_list_inf.erase(i);
             i=next;
         }
         else
             i++;
     }
-    // Fill missing entries with 0s
-    while(weight_list.size()<2*(int)POWERUP_LAST)
-        weight_list.push_back(0);
 
-    if(weight_list.size()!=2*(int)POWERUP_LAST)
+    i=weight_list_sup.begin();
+    while(i!=weight_list_sup.end())
+    {
+        if(*i=="")
+        {
+            std::vector<std::string>::iterator next=weight_list_sup.erase(i);
+            i=next;
+        }
+        else
+            i++;
+    }
+
+    // Fill missing entries with 0s
+    while(weight_list_inf.size()<2*(int)POWERUP_LAST)
+        weight_list_inf.push_back(0);
+
+    while(weight_list_sup.size()<2*(int)POWERUP_LAST)
+        weight_list_sup.push_back(0);
+
+    //This also tests that the two lists are of equal size
+    if(weight_list_inf.size()!=2*(int)POWERUP_LAST ||
+       weight_list_sup.size()!=2*(int)POWERUP_LAST)
     {
         Log::error("[PowerupManager]", "Incorrect number of weights found in class '%s':",
                class_name.c_str());
-        Log::error("[PowerupManager]", "%d instead of %d - probabilities will be incorrect.",
-               (int)weight_list.size(), (int)POWERUP_LAST);
+        Log::error("[PowerupManager]", "%d and %d instead of twice %d - probabilities will be incorrect.",
+               (int)weight_list_inf.size(), (int)weight_list_sup.size(), (int)POWERUP_LAST);
         return;
     }
 
-    for(unsigned int i=0; i<weight_list.size(); i++)
+    //Fourth step : finally compute the searched values
+    for(unsigned int i=0; i<2*(int)POWERUP_LAST; i++)
     {
-        int w = atoi(weight_list[i].c_str());
-        m_weights[position_class].push_back(w);
-    }
+        int weight_inf = atoi(weight_list_inf[i].c_str());
+        int weight_sup = atoi(weight_list_sup[i].c_str());
 
+        //Do a linear average of the inf and sup values
+        //Use float calculations to reduce the rounding errors
+        float ref_diff = (float) (sup_num - inf_num);
+        float sup_diff = (float) (sup_num - num_karts);
+        float inf_diff = (float) (num_karts - inf_num);
+        float weight = (sup_diff/ref_diff)*weight_inf
+                      +(inf_diff/ref_diff)*weight_sup;
+        int rounded_weight = (int) weight;
+
+        m_weights[position_class].push_back(rounded_weight);
+    }
 }   // loadWeights
+
 
 // ----------------------------------------------------------------------------
 /** This function set up various arrays for faster lookup later. It first
  *  determines which race position correspond to which position class, and
  *  then filters which powerups are available (not all powerups might be
- *  available in all races). It sets up two arrays: m_position_to_class
+ *  available in all races). It sets up two arrays: m_position_to_class_[inf/sup]
  *  which maps which race position corresponds to which position class
  *  \param num_kart Number of karts.
  */
 void PowerupManager::updateWeightsForRace(unsigned int num_karts)
 {
-    m_position_to_class.clear();
+    //This loads the appropriate weights
+    loadAllPowerups(num_karts);
+
     // In battle mode no positions exist, so use only position 1
     unsigned int end_position = (race_manager->isBattleMode() ||
         race_manager->isSoccerMode()) ? 1 : num_karts;
+
+    m_position_to_class_inf.clear();
+    m_position_to_class_sup.clear();
+    m_position_to_class_cutoff.clear();
+
     for(unsigned int position =1; position <= end_position; position++)
     {
-        // Set up the mapping of position to position class:
+        // Set up the mapping of position to position class,
+        // Using a linear average of the superior and inferor position class
         // -------------------------------------------------
-        PositionClass pos_class = convertPositionToClass(num_karts, position);
-        m_position_to_class.push_back(pos_class);
-
-        // Then determine which items are available. This loop actually goes
-        // over the powerups twice: first the single item version, then the
-        // multi-item version. The assignment to type takes care of this
-        m_powerups_for_position[pos_class].clear();
-        for(unsigned int i= POWERUP_FIRST; i<=2*POWERUP_LAST; i++)
-        {
-            PowerupType type =
-                (PowerupType) ((i<=POWERUP_LAST) ? i
-                                                 : i+POWERUP_FIRST);
-            unsigned int w =m_weights[pos_class][i-POWERUP_FIRST];
-            // The 'global' powerups (i.e. powerups that affect
-            // all karts, not only the ones close by) appear too
-            // frequently with larger number of karts. To reduce
-            // this effect their weight is reduced by the number
-            // of karts.
-            if(w!=0 && num_karts > 4 &&
-                 (type==POWERUP_PARACHUTE || type==POWERUP_SWITCH) )
-            {
-                w = w / (num_karts/4);
-                if(w==0) w=1;
-            }
-            for(unsigned int j=0; j<w; j++)
-                m_powerups_for_position[pos_class].push_back(type);
-        }   // for type in [POWERUP_FIRST, POWERUP_LAST]
+        m_position_to_class_inf.push_back(convertPositionToClass(num_karts, position, false));
+        m_position_to_class_sup.push_back(convertPositionToClass(num_karts, position, true));
+        m_position_to_class_cutoff.push_back(convertPositionToClassWeight(num_karts, position));
     }
 
+    // Then determine which items are available.
+    if (race_manager->isBattleMode())
+         updatePowerupClass(POSITION_BATTLE_MODE);
+    else if(race_manager->isSoccerMode())
+         updatePowerupClass(POSITION_SOCCER_MODE);
+    else if(race_manager->isTutorialMode())
+         updatePowerupClass(POSITION_TUTORIAL_MODE);
+    else
+    {
+        //TODO : replace this by a nice loop   
+        updatePowerupClass(POSITION_FIRST);
+        updatePowerupClass(POSITION_TOP33);
+        updatePowerupClass(POSITION_MID33);
+        updatePowerupClass(POSITION_END33);
+        updatePowerupClass(POSITION_LAST);
+    }
 }   // updateWeightsForRace
+
+// ----------------------------------------------------------------------------
+/** This function update the powerup array of a position class
+ *  \param pos_class The position class to update
+ */
+void PowerupManager::updatePowerupClass(PowerupManager::PositionClass pos_class)
+{
+
+    m_powerups_for_reference_pos[pos_class].clear();
+
+    // This loop actually goes over the powerups twice: first the single item version,
+    // then the multi-item version. The assignment to type takes care of this
+    for(unsigned int i= POWERUP_FIRST; i<=2*POWERUP_LAST; i++)
+    {
+        PowerupType type =
+            (PowerupType) ((i<=POWERUP_LAST) ? i
+                                             : i+POWERUP_FIRST);
+        unsigned int w =m_weights[pos_class][i-POWERUP_FIRST];
+        for(unsigned int j=0; j<w; j++)
+            m_powerups_for_reference_pos[pos_class].push_back(type);
+    }   // for type in [POWERUP_FIRST, POWERUP_LAST]
+} //updatePowerupClass
 
 // ----------------------------------------------------------------------------
 /** Determines the position class for a given position. If the race is a
@@ -318,10 +456,12 @@ void PowerupManager::updateWeightsForRace(unsigned int num_karts)
  *  for all karts).
  *  \param num_karts  Number of karts in the race.
  *  \param position The position for which to determine the position class.
+ *  \param class_sup true if it should send a class matching a >= position
+ *                   false if it should match a <= position
  */
 PowerupManager::PositionClass
                PowerupManager::convertPositionToClass(unsigned int num_karts,
-                                                     unsigned int position)
+                                                     unsigned int position, bool class_sup)
 {
     if(race_manager->isBattleMode()) return POSITION_BATTLE_MODE;
     if(race_manager->isSoccerMode()) return POSITION_SOCCER_MODE;
@@ -329,17 +469,81 @@ PowerupManager::PositionClass
     if(position==1)         return POSITION_FIRST;
     if(position==num_karts) return POSITION_LAST;
 
-    // Now num_karts must be >2, since position <=num_players
+    // Now num_karts must be >=3, since position <=num_players
 
-    unsigned int third = (unsigned int)floor((float)(num_karts-1)/3.0f);
-    // 1 < Position <= 1+third is top33
-    if(position <= 1 + third) return POSITION_TOP33;
+    //Special case for Follow the Leader : top33 is mapped to the first non-leader kart
+    if (race_manager->isFollowMode())
+    {
+        float third = (float) (num_karts-2)/3.0f;
 
-    // num_players-third < position is end33
-    if(num_karts - third <= position) return POSITION_END33;
+        if(position == 2) return POSITION_TOP33;
 
-    return POSITION_MID33;
+        if (class_sup)
+        {
+            if(position <= 2 + third) return POSITION_MID33;
+            else if(position <= 2 + 2*third) return POSITION_END33;
+            else return POSITION_LAST;
+        }
+        else
+        {
+            if(position >= 2 + 2*third) return POSITION_END33;
+            else if(position >= 2 + third) return POSITION_MID33;
+            else return POSITION_TOP33;
+        }
+    }
+
+    //Three points divide a line in 4 sections
+    float quarter = (float) (num_karts-1)/4.0f;
+    if (class_sup)
+    {
+        if(position <= 1 + quarter) return POSITION_TOP33;
+        else if(position <= 1 + 2*quarter) return POSITION_MID33;
+        else if(position <= 1 + 3*quarter) return POSITION_END33;
+        else return POSITION_LAST;
+    }
+    else
+    {
+        if(position >= 1 + 3*quarter) return POSITION_END33;
+        else if(position >= 1 + 2*quarter) return POSITION_MID33;
+        else if(position >= 1 + 1*quarter) return POSITION_TOP33;
+        else return POSITION_FIRST;
+    }
 }   // convertPositionToClass
+
+// ----------------------------------------------------------------------------
+/** Computes the proportion of the inf position class for a given position.
+ *  \param num_karts  Number of karts in the race.
+ *  \param position The position for which to determine the proportion.
+ */
+unsigned int PowerupManager::convertPositionToClassWeight(unsigned int num_karts,
+                                                     unsigned int position)
+{
+    if(race_manager->isBattleMode() || race_manager->isSoccerMode() ||
+       race_manager->isTutorialMode() || position==1 || position==num_karts)
+        return 1;
+
+    // Now num_karts must be >=3, since position <=num_players
+
+    //Special case for Follow the Leader : top33 is mapped to the first non-leader kart
+    if (race_manager->isFollowMode())
+    {
+        float third = (float) (num_karts-2)/3.0f;
+
+        if(position == 2) return 1;
+
+        if(position <= 2 + third) return (int) RAND_CLASS_RANGE-((RAND_CLASS_RANGE*(position - 2))/third);
+        else if(position <= 2 + 2*third) return (int) RAND_CLASS_RANGE-((RAND_CLASS_RANGE*(position - (2+third)))/third);
+        else return (int) RAND_CLASS_RANGE-((RAND_CLASS_RANGE*(position - (2+2*third)))/third);
+    }
+
+    //Three points divide a line in 4 sections
+    float quarter = (float) (num_karts-1)/4.0f;
+
+    if(position <= 1 + quarter) return (int) RAND_CLASS_RANGE-((RAND_CLASS_RANGE*(position - 1))/quarter);
+    else if(position <= 1 + 2*quarter) return (int) RAND_CLASS_RANGE-((RAND_CLASS_RANGE*(position - (1+quarter)))/quarter);
+    else if(position <= 1 + 3*quarter) return (int) RAND_CLASS_RANGE-((RAND_CLASS_RANGE*(position - (1+2*quarter)))/quarter);
+    else return  (int) RAND_CLASS_RANGE-(RAND_CLASS_RANGE*((position - (1+3*quarter)))/quarter);
+}   // convertPositionToClassWeight
 
 // ----------------------------------------------------------------------------
 /** Returns a random powerup for a kart at a given position. If the race mode
@@ -354,15 +558,22 @@ PowerupManager::PositionClass
 PowerupManager::PowerupType PowerupManager::getRandomPowerup(unsigned int pos,
                                                              unsigned int *n)
 {
+    //First step : select at random a class according to the weights of class for this position
+
     // Positions start with 1, while the index starts with 0 - so subtract 1
+   int random_class = rand()%RAND_CLASS_RANGE;
+
     PositionClass pos_class =
         (race_manager->isBattleMode() ? POSITION_BATTLE_MODE :
          race_manager->isSoccerMode() ? POSITION_SOCCER_MODE :
-         (race_manager->isTutorialMode() ? POSITION_TUTORIAL_MODE :
-                                     m_position_to_class[pos-1]));
+         race_manager->isTutorialMode() ? POSITION_TUTORIAL_MODE :
+         random_class > m_position_to_class_cutoff[pos-1] ? m_position_to_class_inf[pos-1] :
+                                                         m_position_to_class_sup[pos-1]);
 
-    int random = rand()%m_powerups_for_position[pos_class].size();
-    int i=m_powerups_for_position[pos_class][random];
+    //Second step : select an item at random
+
+    int random = rand()%m_powerups_for_reference_pos[pos_class].size();
+    int i=m_powerups_for_reference_pos[pos_class][random];
     if(i>=POWERUP_MAX)
     {
         i -= POWERUP_MAX;

--- a/src/items/powerup_manager.hpp
+++ b/src/items/powerup_manager.hpp
@@ -54,7 +54,7 @@ namespace irr
  *  between the weights of the reference positions immediately lower and higher.
  *  e.g. ; if the reference positions are 1 and 4,5 ; the 3rd will have
  *  weights equal to (4,5-3)/(4,5-1) times the weight of the reference position
- *  at 4,5 and (3-1)/(4,5-1à times the weight of the reference position at 1.
+ *  at 4,5 and (3-1)/(4,5-1) times the weight of the reference position at 1.
  *
  *  At the start of each race three mappings are computed in updateWeightsForRace:
  *  m_position_to_class maps each postion to a list of class using
@@ -157,7 +157,7 @@ private:
 public:
                   PowerupManager  ();
                  ~PowerupManager  ();
-    void          loadAllPowerups (unsigned int num_karts=10);
+    void          loadAllPowerups (unsigned int num_karts);
     void          unloadPowerups  ();
     void          LoadPowerup     (PowerupType type, const XMLNode &node);
     void          updateWeightsForRace(unsigned int num_karts);

--- a/src/items/powerup_manager.hpp
+++ b/src/items/powerup_manager.hpp
@@ -157,6 +157,7 @@ private:
 public:
                   PowerupManager  ();
                  ~PowerupManager  ();
+    void          loadPowerupsModels ();
     void          loadAllPowerups (unsigned int num_karts);
     void          unloadPowerups  ();
     void          LoadPowerup     (PowerupType type, const XMLNode &node);

--- a/src/items/powerup_manager.hpp
+++ b/src/items/powerup_manager.hpp
@@ -44,21 +44,22 @@ namespace irr
  *  items depending on position. The latter is done so that as the first player
  *  you get less advantageous items (but no useless ones either, e.g. anchor),
  *  while as the last you get more useful ones.
+ *
  *  The weight distribution works as follow:
- *  The position in a race is mapped to one of five position classes:
- *  first, top, middle, bottom, last - e.g. for a 6 player game the distribution
- *  is:
- *  position  1     2   3      4      5      6
- *  class     first top middle middle bottom last
- *  For each class the weight distribution is read in from powerup.xml:
+ *  Depending on the number of karts, 5 reference points are mapped to positions.
+ *  For each reference point the weight distribution is read in from powerup.xml:
  *   <!--      bubble cake bowl zipper plunger switch para anvil -->
  *   <last  w="0      1    1    2      2       0      2    2"     />
- *  So a (well, in this case 'the') player belonging to the class 'last'
- *  will not get a bubble gum or switch. Cakes and bowling balls have
- *  lower probability.
- *  At the start of each race two mappings are computed in updateWeightsForRace:
- *  m_position_to_class maps each postion to the class using the function
- *                      convertPositionToClass.
+ *  Then, the weights for the real position are calculated as a linear average
+ *  between the weights of the reference positions immediately lower and higher.
+ *  e.g. ; if the reference positions are 1 and 4,5 ; the 3rd will have
+ *  weights equal to (4,5-3)/(4,5-1) times the weight of the reference position
+ *  at 4,5 and (3-1)/(4,5-1à times the weight of the reference position at 1.
+ *
+ *  At the start of each race three mappings are computed in updateWeightsForRace:
+ *  m_position_to_class maps each postion to a list of class using
+ *  the function convertPositionToClass, with a class with a higher weight
+ *  included more times so picking at random gives us the right class distribution
  *  m_powerups_for_position contains a list of items for each class. A item
  *  with higher weight is included more than once, so at runtime we can
  *  just pick a random item from this list to get the right distribution.
@@ -100,6 +101,8 @@ public:
                         POSITION_COUNT};
 
 private:
+    const int     RAND_CLASS_RANGE = 1000;
+
     /** The icon for each powerup. */
     Material*     m_all_icons [POWERUP_MAX];
 
@@ -126,30 +129,35 @@ private:
 
     /** For each powerup the weight (probability) used depending on the
      *  number of players. */
-    std::vector<int> m_weights[POSITION_COUNT];
+    std::vector<unsigned int> m_weights[POSITION_COUNT];
 
     /** A list of all powerups for a specific class. If a powerup
      *  has weight 5, it will be listed 5 times in this list, so
      *  randomly picking an entry from this for a position class will
      *  result in the right distribution of items. */
-    std::vector<PowerupType> m_powerups_for_position[POSITION_COUNT];
+    std::vector<PowerupType> m_powerups_for_reference_pos[POSITION_COUNT];
 
-    /** The mapping of each position to the corresponding position class.
-     *  There is one map for each different number of players, so it is
-     *  used like  m_position_to_class[number_players][position] */
-    std::vector<PositionClass> m_position_to_class;
+    /** The mapping of each position to the corresponding position class. */
+
+    std::vector<PositionClass> m_position_to_class_inf;
+    std::vector<PositionClass> m_position_to_class_sup;
+    std::vector<int> m_position_to_class_cutoff;
 
     PowerupType   getPowerupType(const std::string &name) const;
 
     void          loadWeights(const XMLNode &root,
+                              unsigned int num_karts,
                               const std::string &class_name,
                               PositionClass position_class);
+    void          updatePowerupClass(PowerupManager::PositionClass pos_class);
     PositionClass convertPositionToClass(unsigned int num_karts,
+                                         unsigned int position, bool class_sup = false);
+    unsigned int           convertPositionToClassWeight(unsigned int num_karts,
                                          unsigned int position);
 public:
                   PowerupManager  ();
                  ~PowerupManager  ();
-    void          loadAllPowerups ();
+    void          loadAllPowerups (unsigned int num_karts=10);
     void          unloadPowerups  ();
     void          LoadPowerup     (PowerupType type, const XMLNode &node);
     void          updateWeightsForRace(unsigned int num_karts);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1737,6 +1737,7 @@ int main(int argc, char *argv[] )
             material_manager->addSharedMaterial(materials_file);
         }
         Referee::init();
+        powerup_manager->loadPowerupsModels();
         ItemManager::loadDefaultItemMeshes();
 
         GUIEngine::addLoadingIcon( irr_driver->getTexture(FileManager::GUI,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1737,7 +1737,6 @@ int main(int argc, char *argv[] )
             material_manager->addSharedMaterial(materials_file);
         }
         Referee::init();
-        powerup_manager->loadAllPowerups();
         ItemManager::loadDefaultItemMeshes();
 
         GUIEngine::addLoadingIcon( irr_driver->getTexture(FileManager::GUI,

--- a/src/race/race_manager.hpp
+++ b/src/race/race_manager.hpp
@@ -672,6 +672,13 @@ public:
     {
         return m_minor_mode == MINOR_MODE_TUTORIAL;
     }   // isTutorialMode
+ 
+    // ------------------------------------------------------------------------
+    bool isFollowMode()
+    {
+        return m_minor_mode == MINOR_MODE_FOLLOW_LEADER;
+    }
+ 
     // ------------------------------------------------------------------------
     /** \brief Returns true if the current mode has laps. */
     bool modeHasLaps()

--- a/src/race/race_manager.hpp
+++ b/src/race/race_manager.hpp
@@ -511,6 +511,20 @@ public:
     // ------------------------------------------------------------------------
     MinorRaceModeType getMinorMode() const { return m_minor_mode; }
     // ------------------------------------------------------------------------
+    std::string getMinorModeName() const
+    {
+        switch (m_minor_mode)
+        {
+            case MINOR_MODE_NORMAL_RACE:    return "normal";
+            case MINOR_MODE_TIME_TRIAL:     return "time-trial";
+            case MINOR_MODE_FOLLOW_LEADER:  return "follow-the-leader";
+            case MINOR_MODE_3_STRIKES:      return "battle";
+            case MINOR_MODE_EASTER_EGG:     return "egg-hunt";
+            case MINOR_MODE_SOCCER:         return "soccer";
+            default: assert(false);         return "";
+        }
+    }
+    // ------------------------------------------------------------------------
     unsigned int getNumPlayers() const 
     {
         return (unsigned int) m_player_karts.size(); 
@@ -524,8 +538,10 @@ public:
      */
     int getNumLaps() const
     {
-        if(m_minor_mode==MINOR_MODE_3_STRIKES     ||
-            m_minor_mode==MINOR_MODE_FOLLOW_LEADER    )
+        if(m_minor_mode==MINOR_MODE_3_STRIKES      ||
+            m_minor_mode==MINOR_MODE_FOLLOW_LEADER ||
+            m_minor_mode==MINOR_MODE_SOCCER        ||
+            m_minor_mode==MINOR_MODE_EASTER_EGG  )
             return 9999;
         return m_num_laps[m_track_number];
     }   // getNumLaps
@@ -635,7 +651,7 @@ public:
         return m_ai_kart_list;
     }   // getAIKartList
     // ------------------------------------------------------------------------
-    /** \brief get information about given mode (returns true if 'mode' is of
+    /** \brief get information about current mode (returns true if 'mode' is of
     *  linear races type) */
     bool isLinearRaceMode()
     {
@@ -645,6 +661,19 @@ public:
         if(id > 999 && id < 2000) return true;
         else return false;
     }   // isLinearRaceMode
+
+    // ------------------------------------------------------------------------
+    /** \brief get information about given mode (returns true if 'mode' is of
+    *  linear races type) */
+    bool isLinearRaceMode(const MinorRaceModeType mode)
+    {
+        const int id = (int)mode;
+        // info is stored in its ID for conveniance, see the macros LINEAR_RACE
+        // and BATTLE_ARENA above for exact meaning.
+        if(id > 999 && id < 2000) return true;
+        else return false;
+    }   // isLinearRaceMode
+
     // ------------------------------------------------------------------------
     /** \brief Returns true if the current mode is a battle mode. */
     bool isBattleMode()
@@ -672,13 +701,24 @@ public:
     {
         return m_minor_mode == MINOR_MODE_TUTORIAL;
     }   // isTutorialMode
- 
+
     // ------------------------------------------------------------------------
     bool isFollowMode()
     {
         return m_minor_mode == MINOR_MODE_FOLLOW_LEADER;
     }
  
+    // ------------------------------------------------------------------------
+    bool isEggHuntMode()
+    {
+        return m_minor_mode == MINOR_MODE_EASTER_EGG;
+    }   //  isEggHuntMode
+
+    // ------------------------------------------------------------------------
+    bool isTimeTrialMode()
+    {
+        return m_minor_mode == MINOR_MODE_TIME_TRIAL;
+    }   //  isTimeTrialMode
     // ------------------------------------------------------------------------
     /** \brief Returns true if the current mode has laps. */
     bool modeHasLaps()


### PR DESCRIPTION
Before going into what is in the patch, let's understand the limitation of the current system.

STK uses one weight list to determine what items a kart will get. There are 5 "position class" to which all the karts are mapped (first, last, and a division in 3 of the rest), and all karts in a position class have the same probability of receiving one kind of powerup or another. Each position class has its own weights.

Be there 5 karts or 20 karts, the same weights are used, which creates balancing issues. There is a code limiting global items to limit the worst, but that's just not enough ; as trying to catchup from 20th is much harder as from 5th.

If we consider that being at a position N in a race with M karts in the race is a unique situation, there are 210 possible combinations (not even taking into account FTL, which uses the same 5 weights). 5 combinations can't reflect this properly enough. However, it's abundantly clear that a lot of those combinations are rather close, and creating specific weights for each would be overkill (and by much).

The main goal of this patch is to replace this by a much better system, flexible enough to cover adequately the range of situations which can be encountered in STK. Of course, it also contains new weights lists which by nature differs from the old one.

What this PR does : 
- Adds 5 reference points (number and value determined in config), which each corresponds to a certain number of karts in the race. Each of those reference point gets a list with 5 weights.
- Uses linear interpolation to compute the weights used with a number of kart K. For example, if the reference points are at 9 and 14 ; when there are 12 karts in the race, the weights will be equal to 0,6* the weights at 14 + 0,4* the weights at 9. This approach allows to take into account the specific situations of a race with a low, medium or high number of karts without writing an enormous number of weights lists.
- Rather than having all the karts in a position class sharing the same probabilities, those class are repurposed as reference points. This patch uses linear interpolation to vary the weights used by each kart. For example, say we have a kart at rank N, a reference point at N-2 and another at N+1. The kart will randomly choose to use either the weights of N+1 or N-2, with probability two-thirds with N+1 and one-third with N-2. This smooths things a lot : gaining or losing a place will have gradual effects on items received ; rather than plateaus followed by sudden jumps ; while keeping the list in config at a reasonable size.
- Adds specific weights for FTL (only one reference point, but the leader gets special treatment).
- Adds new weight lists to take advantage of the new possibilities offered.

I expect that most points will be non-controversial, as they allow to improve the gameplay by offering a better balance.

However, the implicit changes to the probabilities to receive an item may beg some questions as to my choices, so I'll discuss them more in-depth.

First of all, the old distribution looked like this : 

![item_distribution_old](https://user-images.githubusercontent.com/25536748/39104039-b010be38-46ae-11e8-976a-123afd2bb895.png)

There was also a code applied to make the parachute and the switch more rare with more karts.

In the config file, it is rather confusing as the sum of the weights differ for each position class, making direct comparison very hard.

Here are what the new distributions look like : 

![item_distribution_20karts](https://user-images.githubusercontent.com/25536748/39104051-c7688e08-46ae-11e8-9108-34f172788b99.png)
![item_distribution_14](https://user-images.githubusercontent.com/25536748/39104052-c7810780-46ae-11e8-8589-8dd865c2f39a.png)
![item_distribution_9karts](https://user-images.githubusercontent.com/25536748/39104053-c814e5d6-46ae-11e8-931f-5c7a3603910c.png)
![item_distribution_5karts](https://user-images.githubusercontent.com/25536748/39104055-c82dc40c-46ae-11e8-9092-f3cf0f711760.png)
![item_distribution_1kart](https://user-images.githubusercontent.com/25536748/39104056-c84630e6-46ae-11e8-9e5b-2f7f61dc04fa.png)

To fully understand the changes, we need to separate the items into a few general type : 1)the positive items which help one given kart ; 2)the negative item which hinders one (or a few) kart not far ; 3)the global item which affects kart globally.

Giving more item of the 1st sort at rank N tends to make the kart at rank N faster. Giving more item of the 2nd sort tends to make karts around rank N slower.

Comments : 
- There is not anymore code to make global items more rare. The list by themselves ensure that the switch, the parachute and also the basket ball occurs at roughly the same overall rate (1 item per 4 boxes*number of karts in the race was my rough target, it varies slightly around it), except when there are very few karts. The averaging of weights between the reference points helps a lot here.
- The reference points at 1 kart may look weird, but the values are used in the averages when there are 2, 3 or 4 karts, and it has been designed with this in mind.
- Before, cakes were more common in worse ranks. The graphs don't show this, but the old distribution also have a significant number of triple cakes among its cakes. The thought was that giving more powerful weapons would help them. However, badly ranked karts throws those at each other. It hinders them overall. In the new design, more cakes are given in better positions, and this is done to hinder the karts in those positions compared to those in worse positions ; except for the first (and a bit less those just behind), as then the cake would mostly be used backwards against overtaking.
- The bubble gum is a very good defensive item when used as a shield. It is useful at any position. The old weights date of a time when there was no shield, and so make it too common for the first and too rare for the others. The new weights balance this out.
- Swatters are used to slow down karts close around, or as a weak defensive item (much less useful than the gum in that role, but still sometimes good). Giving more of them in better positions is, again, not really a boon.
- The differences in the quality/usefulness of the item received are more stark between the better positions and the worse positions when there are more karts in a race, because it's harder to get back from 20th than from 10th or 5th.
- The FTL weights have no cake as those are a big part of why FTL is horribly random.
- Much less plungers in bad positions. Those can be quite useful, but they are situational and often fail.

Overall, I don't pretend that the new weights are perfect. Obviously, I couldn't playtest them in the aforementioned 210 situations : they are mostly based on my knowledge of the game and its balance but could certainly benefit from tweaks following testing feedback. Still, I'm confident they are significantly better than what we have now and that the new system with averaging is more efficient and powerful.