### PR TITLE
Better random items

### DIFF
--- a/data/powerup.xml
+++ b/data/powerup.xml
@@ -121,7 +121,7 @@
        a triple item rather than a single one. The probability to get
        an item is its weight divided by the sum of weights of all items
        (single AND multi). It is recommended to keep that sum equal
-       to 200 to easily keep track of probabilities.
+       to 1000 to easily keep track of probabilities.
 
        'Global' items which affect all karts (switch, parachute) should
        be quite rare, since otherwise the item might be used
@@ -138,70 +138,69 @@
       <!-- The entry for '1' kart lists more than a single weight
            because the others are used for interpolation when
            there are two karts or more. -->
-      <!--              bubble  cake  bowl  zipper  plunger  switch swattr rubber para  anvil -->
-      <weight single  ="28       0    60    20      45       15      32     0     0     0"
-              multi   =" 0       0     0     0       0        0       0     0     0     0" />
-      <weight single  ="30       0    59    26      40       14      27     0     0     0"
-              multi   =" 0       0     4     0       0        0       0     0     0     0" />
-      <weight single  ="30       0    62    27      36       13      27     0     0     0"
-              multi   =" 0       0     5     0       0        0       0     0     0     0" />
-      <weight single  ="31       0    56    36      34       12      25     0     0     0"
-              multi   =" 0       0     6     0       0        0       0     0     0     0" />
-      <weight single  ="34       0    36    55      30       10      17     0     0     0"
-              multi   =" 0       0    18     0       0        0       0     0     0     0" />
+      <!--            bubble   cake  bowl zipper  plunger  switch swattr rubber para  anvil -->
+      <weight single  ="140      0   300   100      225      75     160     0     0     0"
+              multi   ="  0      0     0     0        0       0       0     0     0     0" />
+      <weight single  ="150      0   295   130      200      70     135     0     0     0"
+              multi   ="  0      0    20     0        0       0       0     0     0     0" />
+      <weight single  ="150      0   310   135      180      65     135     0     0     0"
+              multi   ="  0      0    25     0        0       0       0     0     0     0" />
+      <weight single  ="155      0   280   180      170      60     125     0     0     0"
+              multi   ="  0      0    30     0        0       0       0     0     0     0" />
+      <weight single  ="170      0   180   275      150      50      85     0     0     0"
+              multi   ="  0      0    90     0        0       0       0     0     0     0" />
     </weights>
-
     <weights num-karts="5">
-      <!--              bubble  cake  bowl  zipper  plunger  switch swattr rubber para  anvil -->
-      <weight single  ="26      16    52    15      46       12      33     0     0     0"
-              multi   =" 0       0     0     0       0        0       0     0     0     0" />
-      <weight single  ="30      27    48    25      28       10      27     0     0     0"
-              multi   =" 0       0     5     0       0        0       0     0     0     0" />
-      <weight single  ="30      27    45    27      27        9      27     3     0     0"
-              multi   =" 0       0     5     0       0        0       0     0     0     0" />
-      <weight single  ="32      24    28    38      22        7      20    16     6     0"
-              multi   =" 0       0     7     0       0        0       0     0     0     0" />
-      <weight single  ="28      21     9    45       0        6       0    10    18     0"
-              multi   =" 8       0    16    35       4        0       0     0     0     0" />
+      <!--            bubble   cake  bowl zipper  plunger  switch swattr rubber para  anvil -->
+      <weight single  ="130     80   260    75      230      60     165     0     0     0"
+              multi   ="  0      0     0     0        0       0       0     0     0     0" />
+      <weight single  ="150    135   240   125      140      50     135     0     0     0"
+              multi   ="  0      0    25     0        0       0       0     0     0     0" />
+      <weight single  ="150    135   225   135      135      45     135    15     0     0"
+              multi   ="  0      0    25     0        0       0       0     0     0     0" />
+      <weight single  ="160    120   140   190      110      35     100    80    30     0"
+              multi   ="  0      0    35     0        0       0       0     0     0     0" />
+      <weight single  ="140    105    45   225        0      30       0    50    90     0"
+              multi   =" 40      0    80   175       20       0       0     0     0     0" />
     </weights>
     <weights num-karts="9">
-      <!--              bubble  cake  bowl  zipper  plunger  switch swattr rubber para  anvil -->
-      <weight single  ="24      12    58    10      54        8      34     0     0     0"
-              multi   =" 0       0     0     0       0        0       0     0     0     0" />
-      <weight single  ="29      30    45    24      32        7      27     0     0     0"
-              multi   =" 0       0     6     0       0        0       0     0     0     0" />
-      <weight single  ="30      26    41    28      26        6      26    10     0     0"
-              multi   =" 0       0     7     0       0        0       0     0     0     0" />
-      <weight single  ="33      23    26    45      14        5      16    12     8     0"
-              multi   =" 0       0    12     0       6        0       0     0     0     0" />
-      <weight single  ="20      16     7    37       0        3       0     4    15     0"
-              multi   ="18       0    18    58       4        0       0     0     0     0" />
+      <!--            bubble   cake  bowl zipper  plunger  switch swattr rubber para  anvil -->
+      <weight single  ="120     60   290    50      270      40     170     0     0     0"
+              multi   ="  0      0     0     0        0       0       0     0     0     0" />
+      <weight single  ="145    150   225   120      160      35     135     0     0     0"
+              multi   ="  0      0    30     0        0       0       0     0     0     0" />
+      <weight single  ="150    130   205   140      130      30     130    50     0     0"
+              multi   ="  0      0    35     0        0       0       0     0     0     0" />
+      <weight single  ="165    115   130   225       70      25      80    60    40     0"
+              multi   ="  0      0    60     0       30       0       0     0     0     0" />
+      <weight single  ="100     80    35   185        0      15       0    20    75     0"
+              multi   =" 90      0    90   290       20       0       0     0     0     0" />
     </weights>
     <weights num-karts="14">
-      <!--              bubble  cake  bowl  zipper  plunger  switch swattr rubber para  anvil -->
-      <weight single  ="22       8    64     5      60        6      35     0     0     0"
-              multi   =" 0       0     0     0       0        0       0     0     0     0" />
-      <weight single  ="28      31    48    22      34        4      27     0     0     0"
-              multi   =" 0       0     6     0       0        0       0     0     0     0" />
-      <weight single  ="30      25    42    29      29        3      24    10     0     0"
-              multi   =" 0       0     8     0       0        0       0     0     0     0" />
-      <weight single  ="27      21    23    44      12        3      14     8     6     0"
-              multi   =" 8       0    16     8      10        0       0     0     0     0" />
-      <weight single  ="18      14     3    35       0        0       0     0    10     0"
-              multi   ="24       0    25    65       6        0       0     0     0     0" />
+      <!--            bubble   cake  bowl zipper  plunger  switch swattr rubber para  anvil -->
+      <weight single  ="110     40   320    25      300      30     175     0     0     0"
+              multi   ="  0      0     0     0        0       0       0     0     0     0" />
+      <weight single  ="140    155   240   110      170      20     135     0     0     0"
+              multi   ="  0      0    30     0        0       0       0     0     0     0" />
+      <weight single  ="150    125   210   145      145      15     120    50     0     0"
+              multi   ="  0      0    40     0        0       0       0     0     0     0" />
+      <weight single  ="135    105   115   220       60      15      70    40    30     0"
+              multi   =" 40      0    80    40       50       0       0     0     0     0" />
+      <weight single  =" 90     70    15   175        0       0       0     0    50     0"
+              multi   ="120      0   125   325       30       0       0     0     0     0" />
     </weights>
     <weights num-karts="20">
-      <!--              bubble  cake  bowl  zipper  plunger  switch swattr rubber para  anvil -->
-      <weight single  ="20       0    74     0      66        4      36     0     0     0"
-              multi   =" 0       0     0     0       0        0       0     0     0     0" />
-      <weight single  ="27      32    48    20      37        3      27     0     0     0"
-              multi   =" 0       0     6     0       0        0       0     0     0     0" />
-      <weight single  ="30      24    40    30      28        2      21    10     0     0"
-              multi   =" 0       0    10     0       5        0       0     0     0     0" />
-      <weight single  ="25      18    20    50      10        2      10     6     3     0"
-              multi   ="10       0    20    10      16        0       0     0     0     0" />
-      <weight single  ="15      12     0    25       0        0       0     0     7     0"
-              multi   ="30       0    31    80       0        0       0     0     0     0" />
+      <!--            bubble   cake  bowl zipper  plunger  switch swattr rubber para  anvil -->
+      <weight single  ="100      0   370     0      330      20     180     0     0     0"
+              multi   ="  0      0     0     0        0       0       0     0     0     0" />
+      <weight single  ="135    160   240   100      185      15     135     0     0     0"
+              multi   ="  0      0    30     0        0       0       0     0     0     0" />
+      <weight single  ="150    120   200   150      140      10     105    50     0     0"
+              multi   ="  0      0    50     0       25       0       0     0     0     0" />
+      <weight single  ="125     90   100   250       50      10      50    30    15     0"
+              multi   =" 50      0   100    50       80       0       0     0     0     0" />
+      <weight single  =" 75     60     0   125        0       0       0     0    35     0"
+              multi   ="150      0   155   400        0       0       0     0     0     0" />
     </weights>
   </race-weight-list>
 

--- a/src/items/powerup.hpp
+++ b/src/items/powerup.hpp
@@ -51,6 +51,9 @@ private:
     /** The owner (kart) of this powerup. */
     AbstractKart*               m_kart;
 
+    /** Returns an integer in the 0-32767 range.*/
+    int simplePRNG(const int seed, const int item_id, const int position);
+
 public:
                     Powerup      (AbstractKart* kart_);
                    ~Powerup      ();

--- a/src/items/powerup_manager.hpp
+++ b/src/items/powerup_manager.hpp
@@ -19,6 +19,8 @@
 #ifndef HEADER_POWERUPMANAGER_HPP
 #define HEADER_POWERUPMANAGER_HPP
 
+#undef ITEM_DISTRIBUTION_DEBUG
+
 #include "utils/no_copy.hpp"
 #include "utils/leak_check.hpp"
 


### PR DESCRIPTION
This PR fixes most of the remaining issues in the random item code :
- Add a simple PRNG whose outputs are statistically random for a few thousand items (more than enough for a race) ; and easy to sync as it depends only on race state and a seed (usual PRNGs update their state when generating a PRN, this one do not). Currently, its input seed is 0. It works decently with this, but ideally a unique seed per race (an usual 32-bit int) would be provided, as for the first item boxes for the first kart on a given track, the sequences are quite repeatable.
- Fix a nasty bug which inverted weights in WeightsData interpolation (e.g. : for 8 karts, with reference points at 5 and 9, the obtained value was 0,75x that of 5 and 0,25x that of 9, that is, the value expected for 6 karts)
- Guarantee that the sum of the weights in an interpolated WeightsData are the same as that of the two reference WeightsData (assuming they have the same sum)
- Guarantee that the sum of the precomputed weights per rank is identical
- Scale the sum of the precomputed weights to match the range of the random number outputed by the PRNG ; so that the beginning of the distribution has not a higher likelihood to get a matching random number than the end. This also makes rounding error in the precomputed weights per rank insignificant.
- Make the sum of weights in powerup.xml equal to 1000 per weight node instead of 200 (I simply multiplied by 5, I didn't try to tweak). It's as easy to read as %, if not more, and it reduces WeightsData interpolation rounding error, especially for rare items.


The documentation has only been partially updated.