### PR TITLE
Fix #3351

### DIFF
--- a/src/challenges/story_mode_status.cpp
+++ b/src/challenges/story_mode_status.cpp
@@ -274,8 +274,9 @@ void StoryModeStatus::unlockFeature(ChallengeStatus* c, RaceManager::Difficulty 
         m_locked_features.erase(p);
     }
 
-    // Add to list of recently unlocked features if the challenge is newly completed
-    if (!c->isSolvedAtAnyDifficulty())
+    // Add to list of recently unlocked features
+    // if the challenge is newly completed at the current difficulty
+    if (!c->isSolved(d))
         m_unlocked_features.push_back(c->getData());
 
     c->setSolved(d);  // reset isActive flag


### PR DESCRIPTION
Having a challenge completed at a given difficulty and then completing it at a higher one should now work properly, showing the button towards the trophy cutscene.