### PR TITLE
Install tuxkart to external media by default

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -3,7 +3,7 @@
           package="org.supertuxkart.stk_dbg"
           android:versionCode="1"
           android:versionName="git"
-          android:installLocation="auto">
+          android:installLocation="preferExternal">
 
     <!-- This .apk has no Java code itself, so set hasCode to false. -->
     <application android:label="@string/app_name"


### PR DESCRIPTION
Tuxkart being a big game should be installed to external media by default in my opinion in line with recommendations from https://developer.android.com/guide/topics/data/install-location  Note, this change does not prevent the game to be installed to internal memory, it merely sets a sane default.