### PR TITLE
Use a stable sort for replay list sorting

### DIFF
--- a/src/replay/replay_play.hpp
+++ b/src/replay/replay_play.hpp
@@ -133,8 +133,8 @@ public:
     // ------------------------------------------------------------------------
     void               sortReplay(bool reverse)
     {
-        (reverse ? std::sort(m_replay_file_list.rbegin(),
-            m_replay_file_list.rend()) : std::sort(m_replay_file_list.begin(),
+        (reverse ? std::stable_sort(m_replay_file_list.rbegin(),
+            m_replay_file_list.rend()) : std::stable_sort(m_replay_file_list.begin(),
             m_replay_file_list.end()));
     }
     // ------------------------------------------------------------------------

--- a/src/states_screens/ghost_replay_selection.cpp
+++ b/src/states_screens/ghost_replay_selection.cpp
@@ -51,6 +51,7 @@ void GhostReplaySelection::refresh(bool forced_update, bool update_columns)
 {
     if (ReplayPlay::get()->getNumReplayFile() == 0 || forced_update)
         ReplayPlay::get()->loadAllReplayFile();
+    defaultSort();
     loadList();
 
     // Allow to disable a comparison, but not to start one
@@ -136,7 +137,6 @@ void GhostReplaySelection::init()
  */
 void GhostReplaySelection::loadList()
 {
-    ReplayPlay::get()->sortReplay(m_sort_desc);
     m_replay_list_widget->clear();
 
     if (ReplayPlay::get()->getNumReplayFile() == 0)
@@ -426,6 +426,10 @@ void GhostReplaySelection::onConfirm()
  */
 void GhostReplaySelection::onColumnClicked(int column_id)
 {
+    // Begin by resorting the list to default
+    defaultSort();
+
+
     int diff_difficulty = m_same_difficulty ? 1 : 0;
     int diff_linear = m_active_mode_is_linear ? 0 : 1;
 
@@ -457,12 +461,28 @@ void GhostReplaySelection::onColumnClicked(int column_id)
     else
         assert(0);
 
-    printf("column_id is %d\n", column_id);
-
     /** \brief Toggle the sort order after column click **/
     m_sort_desc = !m_sort_desc;
+
+    ReplayPlay::get()->sortReplay(m_sort_desc);
+
     loadList();
 }   // onColumnClicked
+
+// ----------------------------------------------------------------------------
+/** Apply the default sorting to the replay list
+ */
+void GhostReplaySelection::defaultSort()
+{
+    ReplayPlay::setSortOrder(ReplayPlay::SO_TIME);
+    ReplayPlay::get()->sortReplay(/* decreasing order */ false);
+    ReplayPlay::setSortOrder(ReplayPlay::SO_LAPS);
+    ReplayPlay::get()->sortReplay(/* decreasing order */ false);
+    ReplayPlay::setSortOrder(ReplayPlay::SO_REV);
+    ReplayPlay::get()->sortReplay(/* decreasing order */ false);
+    ReplayPlay::setSortOrder(ReplayPlay::SO_TRACK);
+    ReplayPlay::get()->sortReplay(/* decreasing order */ false);
+}   // defaultSort
 
 // ----------------------------------------------------------------------------
 bool GhostReplaySelection::onEscapePressed()

--- a/src/states_screens/ghost_replay_selection.hpp
+++ b/src/states_screens/ghost_replay_selection.hpp
@@ -62,6 +62,7 @@ private:
     // Using the UID guarantees exact matchess
     uint64_t                   m_replay_to_compare_uid;
 
+    void defaultSort();
 
 public:
 


### PR DESCRIPTION
This allows better sorting by preserving relative order when elements are equal according to the main sorting key.

For example, you can sort by time and then by track name, and you'll get replays grouped by track, and for each track they will be sorted by time.

This is also useful when using the compare ghost feature : if you sort by time, select a ghost, use the compare ghost option, then all the possibilities will be sorted by time.

The code change is trivial, as it's simply replacing std::sort by std::stable_sort