### PR TITLE
Fix list sorting

### DIFF
--- a/src/guiengine/widgets/list_widget.cpp
+++ b/src/guiengine/widgets/list_widget.cpp
@@ -479,7 +479,7 @@ EventPropagation ListWidget::transmitEvent(Widget* w,
         m_header_elements[col].getIrrlichtElement<IGUIButton>()->setPressed(true);
         */
 
-        if (m_listener) m_listener->onColumnClicked(m_sort_col);
+        if (m_listener) m_listener->onColumnClicked(m_sort_col, m_sort_desc, m_sort_default);
 
         return EVENT_BLOCK;
     }

--- a/src/guiengine/widgets/list_widget.hpp
+++ b/src/guiengine/widgets/list_widget.hpp
@@ -39,7 +39,7 @@ namespace GUIEngine
     public:
         virtual ~IListWidgetHeaderListener(){}
         
-        virtual void onColumnClicked(int columnId) = 0;
+        virtual void onColumnClicked(int column_id, bool sort_desc, bool sort_default) = 0;
     };
     
     /** \brief A vertical list widget with text entries

--- a/src/states_screens/addons_screen.cpp
+++ b/src/states_screens/addons_screen.cpp
@@ -162,10 +162,6 @@ void AddonsScreen::init()
 
     m_reloading = false;
 
-    m_sort_desc = false;
-    m_sort_default = true;
-    m_sort_col = 0;
-
     getWidget<GUIEngine::RibbonWidget>("category")->setActive(false);
 
     if(UserConfigParams::logAddons())
@@ -232,7 +228,7 @@ void AddonsScreen::tearDown()
  *  updated.
  *  \param type Must be 'kart' or 'track'.
  */
-void AddonsScreen::loadList()
+void AddonsScreen::loadList(bool sort_desc)
 {
 #ifndef SERVER_ONLY
     // Get the filter by words.
@@ -287,7 +283,7 @@ void AddonsScreen::loadList()
 
         sorted_list.push_back(&addon);
     }
-    sorted_list.insertionSort(/*start=*/0, m_sort_desc);
+    sorted_list.insertionSort(/*start=*/0, sort_desc);
 
     GUIEngine::ListWidget* w_list =
         getWidget<GUIEngine::ListWidget>("list_addons");
@@ -420,33 +416,20 @@ void AddonsScreen::loadList()
 }   // loadList
 
 // ----------------------------------------------------------------------------
-void AddonsScreen::onColumnClicked(int column_id)
+void AddonsScreen::onColumnClicked(int column_id, bool sort_desc, bool sort_default)
 {
-    if (m_sort_col != column_id)
-    {
-        m_sort_desc = false;
-        m_sort_default = false;
-    }
-    else
-    {
-        if (!m_sort_default) m_sort_desc = !m_sort_desc;
-        m_sort_default = !m_sort_desc && !m_sort_default;
-    }
-    
-    m_sort_col = column_id;
-
     switch(column_id)
     {
     case 0:
-        Addon::setSortOrder(m_sort_default ? Addon::SO_DEFAULT : Addon::SO_NAME);
+        Addon::setSortOrder(sort_default ? Addon::SO_DEFAULT : Addon::SO_NAME);
         break;
     case 1:
-        Addon::setSortOrder(m_sort_default ? Addon::SO_DEFAULT : Addon::SO_DATE);
+        Addon::setSortOrder(sort_default ? Addon::SO_DEFAULT : Addon::SO_DATE);
         break;
     default: assert(0); break;
     }   // switch
     /** \brief Toggle the sort order after column click **/
-    loadList();
+    loadList(sort_desc && !sort_default);
 }   // onColumnClicked
 
 // ----------------------------------------------------------------------------

--- a/src/states_screens/addons_screen.hpp
+++ b/src/states_screens/addons_screen.hpp
@@ -73,13 +73,6 @@ private:
 
     bool             m_reloading;
 
-    /** \brief To check (and set) if sort order is descending **/
-    bool             m_sort_desc;
-
-    bool             m_sort_default;
-    
-    int              m_sort_col;
-
     /** List of date filters **/
     std::vector<DateFilter> m_date_filters;
 
@@ -88,7 +81,7 @@ private:
 public:
 
     /** Load the addons into the main list.*/
-    void loadList();
+    void loadList(bool sort_desc = false);
 
     /** \brief implement callback from parent class GUIEngine::Screen */
     virtual void loadedFromFile() OVERRIDE;
@@ -102,7 +95,7 @@ public:
     /** \brief implement callback from parent class GUIEngine::Screen */
     virtual void beforeAddingWidget() OVERRIDE;
 
-    virtual void onColumnClicked(int columnId) OVERRIDE;
+    virtual void onColumnClicked(int column_id, bool sort_desc, bool sort_default) OVERRIDE;
 
     virtual void init() OVERRIDE;
     virtual void tearDown() OVERRIDE;

--- a/src/states_screens/ghost_replay_selection.cpp
+++ b/src/states_screens/ghost_replay_selection.cpp
@@ -32,7 +32,6 @@ using namespace GUIEngine;
  */
 GhostReplaySelection::GhostReplaySelection() : Screen("ghost_replay_selection.stkgui")
 {
-    m_sort_desc = true;
     m_is_comparing = false;
     m_replay_to_compare_uid = 0;
 }   // GhostReplaySelection
@@ -424,11 +423,16 @@ void GhostReplaySelection::onConfirm()
 /** Change the sort order if a column was clicked.
  *  \param column_id ID of the column that was clicked.
  */
-void GhostReplaySelection::onColumnClicked(int column_id)
+void GhostReplaySelection::onColumnClicked(int column_id, bool sort_desc, bool sort_default)
 {
     // Begin by resorting the list to default
     defaultSort();
 
+    if (sort_default)
+    {
+        loadList();
+        return;
+    }
 
     int diff_difficulty = m_same_difficulty ? 1 : 0;
     int diff_linear = m_active_mode_is_linear ? 0 : 1;
@@ -461,10 +465,7 @@ void GhostReplaySelection::onColumnClicked(int column_id)
     else
         assert(0);
 
-    /** \brief Toggle the sort order after column click **/
-    m_sort_desc = !m_sort_desc;
-
-    ReplayPlay::get()->sortReplay(m_sort_desc);
+    ReplayPlay::get()->sortReplay(sort_desc);
 
     loadList();
 }   // onColumnClicked

--- a/src/states_screens/ghost_replay_selection.hpp
+++ b/src/states_screens/ghost_replay_selection.hpp
@@ -54,7 +54,6 @@ private:
     bool                       m_same_difficulty;
     bool                       m_same_version;
     bool                       m_best_times;
-    bool                       m_sort_desc;
     bool                       m_is_comparing;
     bool                       m_active_mode_is_linear;
     RaceManager::MinorRaceModeType m_active_mode;
@@ -90,7 +89,7 @@ public:
     /** \brief implement callback from parent class GUIEngine::Screen */
     virtual void beforeAddingWidget() OVERRIDE;
 
-    virtual void onColumnClicked(int columnId) OVERRIDE;
+    virtual void onColumnClicked(int column_id, bool sort_desc, bool sort_default) OVERRIDE;
 
     virtual void init() OVERRIDE;
 

--- a/src/states_screens/online_profile_friends.hpp
+++ b/src/states_screens/online_profile_friends.hpp
@@ -48,11 +48,13 @@ private:
     GUIEngine::TextBoxWidget *m_search_box_widget;
 
     bool                        m_waiting_for_friends;
+
     /** Which column to use for sorting. */
     static int m_sort_column;
 
-    /** True is sorting should be increasing. */
-    static bool m_sort_increasing;
+    static bool m_sort_desc;
+
+    static bool m_sort_default;
 
     void displayResults();
     static bool compareFriends(int f1, int f2);
@@ -72,7 +74,7 @@ public:
 
     virtual void onUpdate(float delta) OVERRIDE;
     virtual void beforeAddingWidget() OVERRIDE;
-    virtual void onColumnClicked(int columnId) OVERRIDE;
+    virtual void onColumnClicked(int column_id, bool sort_desc, bool sort_default) OVERRIDE;
 
     // ------------------------------------------------------------------------
     /** Triggers a reload of the friend list next time this menu is shown. */

--- a/src/states_screens/server_selection.cpp
+++ b/src/states_screens/server_selection.cpp
@@ -200,10 +200,18 @@ void ServerSelection::loadList(unsigned sort_case)
 /** Change the sort order if a column was clicked.
  *  \param column_id ID of the column that was clicked.
  */
-void ServerSelection::onColumnClicked(int column_id)
+void ServerSelection::onColumnClicked(int column_id, bool sort_desc, bool sort_default)
 {
-    m_sort_desc = !m_sort_desc;
-    loadList(column_id);
+    if (sort_default)
+    {
+        m_sort_desc = false;
+        loadList(/* distance */ 5);
+    }
+    else
+    {
+        m_sort_desc = sort_desc;
+        loadList(column_id);
+    }
 }   // onColumnClicked
 
 // ----------------------------------------------------------------------------

--- a/src/states_screens/server_selection.hpp
+++ b/src/states_screens/server_selection.hpp
@@ -80,7 +80,7 @@ public:
     /** \brief implement callback from parent class GUIEngine::Screen */
     virtual void beforeAddingWidget() OVERRIDE;
 
-    virtual void onColumnClicked(int columnId) OVERRIDE;
+    virtual void onColumnClicked(int column_id, bool sort_desc, bool sort_default) OVERRIDE;
 
     virtual void init() OVERRIDE;
 


### PR DESCRIPTION
Some sortable lists (ghost replay list, server selection) inverted sorting order on each click on a column, even if it was another one. This behavior didn't match the UI sorting indication (up/down triangle) and was weird and confusing.

Some others had custom code managing this.

With this PR, the main logic to decide to use default/ascending/descending sorting is done in the list widget, reusing the values computed for the UI indicator ; and all lists have been adapted accordingly.

The friends comparison is also made less redundant and a default sort to show the closest server by distance for the server selection screen has been added.

Fix #3366 