### PR TITLE
android/make.sh: Use bash

### DIFF
--- a/android/make.sh
+++ b/android/make.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # (C) 2016-2017 Dawid Gan, under the GPLv3
 #


### PR DESCRIPTION
A user on IRC reported this error: "make.sh: 8: export: Builds/STK_8-7-2018/stk-code/android: bad variable name"
It was fixed by running `bash make.sh`