### PR TITLE
Fix sound issue with spinner in audio options

### DIFF
--- a/src/guiengine/widgets/spinner_widget.cpp
+++ b/src/guiengine/widgets/spinner_widget.cpp
@@ -242,7 +242,7 @@ EventPropagation SpinnerWidget::rightPressed(const int playerID)
     else
         setSelectedButton(/* right*/ true);
 
-    return EVENT_LET;
+    return EVENT_BLOCK_BUT_HANDLED;
 } // rightPressed
 
 // -----------------------------------------------------------------------------
@@ -262,7 +262,7 @@ EventPropagation SpinnerWidget::leftPressed(const int playerID)
     else
         return EVENT_BLOCK;
 
-    return EVENT_LET;
+    return EVENT_BLOCK_BUT_HANDLED;
 } // leftPressed
 
 void SpinnerWidget::activateSelectedButton()


### PR DESCRIPTION
This fixes the sound issue reported by not triggering the callback when moving to the other arrow of the spinner with keyboard navigation.

As the eventCallback for spinner was previously only used when the state of the spinner was changed, this should not break anything ; the callback is still triggered when changing the spinner state with the select/fire keys.