### PR TITLE
Fix #3306

### DIFF
--- a/src/states_screens/main_menu_screen.cpp
+++ b/src/states_screens/main_menu_screen.cpp
@@ -520,14 +520,26 @@ void MainMenuScreen::eventCallback(Widget* widget, const std::string& name,
     {
         // Don't go to addons if there is no internet, unless some addons are
         // already installed (so that you can delete addons without being online).
-        if(UserConfigParams::m_internet_status!=RequestManager::IPERM_ALLOWED &&
-            !addons_manager->anyAddonsInstalled())
+        if(UserConfigParams::m_internet_status!=RequestManager::IPERM_ALLOWED)
         {
-            new MessageDialog(_("You can not download addons without internet access. "
-                                "If you want to download addons, go to options, select "
-                                " tab 'User Interface', and edit "
-                                "\"Connect to the Internet\"."));
-            return;
+            if (!addons_manager->anyAddonsInstalled())
+            {
+                new MessageDialog(_("You can not download addons without internet access. "
+                                    "If you want to download addons, go to options, select "
+                                    "the 'User Interface' tab, and check "
+                                    "\"Connect to the Internet\"."));
+                return;
+            }
+            else
+            {
+                AddonsScreen::getInstance()->push();
+                new MessageDialog(_("You can not download addons without internet access. "
+                                    "If you want to download addons, go to options, select "
+                                    "the 'User Interface' tab, and check "
+                                    "\"Connect to the Internet\".\n\n"
+                                    "You can however delete already downloaded addons."));
+                return;
+            }
         }
         AddonsScreen::getInstance()->push();
     }


### PR DESCRIPTION
There is a bit of redundancy in the code to display a slightly different message depending on the situation, it may be changed if needed.