### PR TITLE
Assign kart type to karts not having a valid one

### DIFF
--- a/src/karts/kart_properties.cpp
+++ b/src/karts/kart_properties.cpp
@@ -355,13 +355,10 @@ void KartProperties::combineCharacteristics(PerPlayerDifficulty difficulty)
 
     // Try to get the kart type
     const AbstractCharacteristic *characteristic = kart_properties_manager->
-        getKartTypeCharacteristic(m_kart_type);
-    if (!characteristic)
-        Log::warn("KartProperties", "Can't find kart type '%s' for kart '%s'",
-            m_kart_type.c_str(), m_name.c_str());
-    else
-        // Kart type found
-        m_combined_characteristic->addCharacteristic(characteristic);
+        getKartTypeCharacteristic(m_kart_type, m_name);
+
+    // Combine kart type
+    m_combined_characteristic->addCharacteristic(characteristic);
 
     m_combined_characteristic->addCharacteristic(kart_properties_manager->
         getPlayerCharacteristic(getPerPlayerDifficultyAsString(difficulty)));

--- a/src/karts/kart_properties_manager.cpp
+++ b/src/karts/kart_properties_manager.cpp
@@ -77,7 +77,6 @@ void KartPropertiesManager::unloadAllKarts()
     m_kart_available.clear();
     m_groups_2_indices.clear();
     m_all_groups.clear();
-    m_kart_types.clear();
 }   // unloadAllKarts
 
 //-----------------------------------------------------------------------------

--- a/src/karts/kart_properties_manager.cpp
+++ b/src/karts/kart_properties_manager.cpp
@@ -312,21 +312,14 @@ const AbstractCharacteristic* KartPropertiesManager::getKartTypeCharacteristic(c
     for (unsigned i=0; i < m_kart_types.size(); i++)
     {
         if (type == m_kart_types[i])
-        {
             type_is_valid = true;
-            break;
-        }
     }
 
     if (!type_is_valid)
-    {
         Log::warn("KartProperties", "Can't find kart type '%s' for kart '%s', defaulting to '%s'.",
             type.c_str(), name.c_str(), m_kart_types[0].c_str());
-    }
 
     std::string valid_type = (type_is_valid) ? type : m_kart_types[0];
-
-    printf("Valid type is %s\n.", valid_type.c_str());
 
     std::map<std::string, std::unique_ptr<AbstractCharacteristic> >::const_iterator
         it = m_kart_type_characteristics.find(valid_type);

--- a/src/karts/kart_properties_manager.cpp
+++ b/src/karts/kart_properties_manager.cpp
@@ -77,6 +77,7 @@ void KartPropertiesManager::unloadAllKarts()
     m_kart_available.clear();
     m_groups_2_indices.clear();
     m_all_groups.clear();
+    m_kart_types.clear();
 }   // unloadAllKarts
 
 //-----------------------------------------------------------------------------
@@ -215,6 +216,7 @@ void KartPropertiesManager::loadCharacteristics(const XMLNode *root)
     for (const XMLNode *type : nodes)
     {
         type->get("name", &name);
+        m_kart_types.push_back(name);
         m_kart_type_characteristics.insert(std::pair<const std::string,
             std::unique_ptr<AbstractCharacteristic> >(name,
             std::unique_ptr<AbstractCharacteristic>(new XmlCharacteristic(type))));
@@ -303,10 +305,31 @@ const AbstractCharacteristic* KartPropertiesManager::getDifficultyCharacteristic
 }   // getDifficultyCharacteristic
 
 //-----------------------------------------------------------------------------
-const AbstractCharacteristic* KartPropertiesManager::getKartTypeCharacteristic(const std::string &type) const
+const AbstractCharacteristic* KartPropertiesManager::getKartTypeCharacteristic(const std::string &type,
+                                                                               const std::string &name) const
 {
+    bool type_is_valid = false;
+    for (unsigned i=0; i < m_kart_types.size(); i++)
+    {
+        if (type == m_kart_types[i])
+        {
+            type_is_valid = true;
+            break;
+        }
+    }
+
+    if (!type_is_valid)
+    {
+        Log::warn("KartProperties", "Can't find kart type '%s' for kart '%s', defaulting to '%s'.",
+            type.c_str(), name.c_str(), m_kart_types[0].c_str());
+    }
+
+    std::string valid_type = (type_is_valid) ? type : m_kart_types[0];
+
+    printf("Valid type is %s\n.", valid_type.c_str());
+
     std::map<std::string, std::unique_ptr<AbstractCharacteristic> >::const_iterator
-        it = m_kart_type_characteristics.find(type);
+        it = m_kart_type_characteristics.find(valid_type);
     if (it == m_kart_type_characteristics.cend())
         return nullptr;
     return it->second.get();

--- a/src/karts/kart_properties_manager.hpp
+++ b/src/karts/kart_properties_manager.hpp
@@ -49,6 +49,9 @@ private:
     /** List of all kart groups. */
     std::vector<std::string>                 m_all_groups;
 
+    /** List of all kart types. */
+    std::vector<std::string>                 m_kart_types;
+
     /** Mapping of group names to list of kart indices in each group. */
     std::map<std::string, std::vector<int> > m_groups_2_indices;
 
@@ -105,7 +108,7 @@ public:
     const AbstractCharacteristic* getDifficultyCharacteristic(const std::string &type) const;
     // ------------------------------------------------------------------------
     /** Get a characteristic that holds the values for a kart type. */
-    const AbstractCharacteristic* getKartTypeCharacteristic(const std::string &type) const;
+    const AbstractCharacteristic* getKartTypeCharacteristic(const std::string &type, const std::string &name) const;
     // ------------------------------------------------------------------------
     /** Get a characteristic that holds the values for a player difficulty. */
     const AbstractCharacteristic* getPlayerCharacteristic(const std::string &type) const;


### PR DESCRIPTION
This uses the list of kart types in the XML file, without hardcoding valid types in code ; so it still works if someone change the names and/or numbers of kart types.

Consequently, the default type is "light" because it is the first in the list.

Fixes #3375