### PR TITLE
Add kart icons to the ghost replay list

### DIFF
--- a/data/gui/ghost_replay_selection.stkgui
+++ b/data/gui/ghost_replay_selection.stkgui
@@ -38,8 +38,13 @@
         <div width="99%" align="center" layout="horizontal-row" height="fit">
             <div proportion="2" height="fit" layout="horizontal-row" >
                 <checkbox width="fit" id="replay_difficulty_toggle" text_align="left"/>
-                <spacer width="1%" height="fit"/>
+                <spacer width="2%" height="fit"/>
                 <label height="100%" text_align="left" I18N="In the ghost replay selection screen" text="Only show replays matching the current difficulty"/>
+            </div>
+            <div proportion="1" height="fit" layout="horizontal-row" >
+                <checkbox width="fit" id="replay_multiplayer_toggle" text_align="left"/>
+                <spacer width="2%" height="fit"/>
+                <label height="100%" text_align="left" I18N="In the ghost replay selection screen" text="Hide multiplayer replays"/>
             </div>
         </div>
 

--- a/src/guiengine/widgets/CGUISTKListBox.cpp
+++ b/src/guiengine/widgets/CGUISTKListBox.cpp
@@ -572,7 +572,8 @@ void CGUISTKListBox::draw()
                             Items[i].m_contents[x].m_center, true, &clientClip);
                     }
                     //Position back to inital pos
-                    textRect.UpperLeftCorner.X -= ItemsIconWidth+6;
+                    if (IconBank && (Items[i].m_contents[x].m_icon > -1))
+                        textRect.UpperLeftCorner.X -= ItemsIconWidth+6;
                     //Calculate new beginning
                     textRect.UpperLeftCorner.X += Items[i].m_contents[x].m_proportion * part_size;
                 }
@@ -779,5 +780,4 @@ void CGUISTKListBox::setDrawBackground(bool draw)
 
 } // end namespace gui
 } // end namespace irr
-
 

--- a/src/states_screens/dialogs/ghost_replay_info_dialog.cpp
+++ b/src/states_screens/dialogs/ghost_replay_info_dialog.cpp
@@ -19,7 +19,10 @@
 #include "states_screens/dialogs/ghost_replay_info_dialog.hpp"
 
 #include "config/player_manager.hpp"
+#include "guiengine/CGUISpriteBank.hpp"
 #include "graphics/stk_tex_manager.hpp"
+#include "karts/kart_properties.hpp"
+#include "karts/kart_properties_manager.hpp"
 #include "replay/replay_play.hpp"
 #include "states_screens/ghost_replay_selection.hpp"
 #include "states_screens/state_manager.hpp"
@@ -32,7 +35,7 @@ using namespace irr::core;
 // -----------------------------------------------------------------------------
 GhostReplayInfoDialog::GhostReplayInfoDialog(unsigned int replay_id,
                      uint64_t compare_replay_uid, bool compare_ghost)
-                      : ModalDialog(0.85f,0.65f), m_replay_id(replay_id)
+                      : ModalDialog(0.9f,0.75f), m_replay_id(replay_id)
 {
     m_self_destroy         = false;
     m_record_race          = false;
@@ -69,6 +72,11 @@ GhostReplayInfoDialog::GhostReplayInfoDialog(unsigned int replay_id,
     //        to make this unselectable by keyboard/mouse
     m_replay_info_widget = getWidget<GUIEngine::ListWidget>("current_replay_info");
     assert(m_replay_info_widget != NULL);
+
+    /* Used to display kart icons for the selected replay(s) */
+    irr::gui::STKModifiedSpriteBank *icon_bank = GhostReplaySelection::getInstance()->getIconBank();
+    int icon_height = getHeight()/18.0f;
+    m_replay_info_widget->setIcons(icon_bank, (int)icon_height);
 
     updateReplayDisplayedInfo();
 
@@ -141,6 +149,8 @@ void GhostReplayInfoDialog::updateReplayDisplayedInfo()
     row.push_back(GUIEngine::ListWidget::ListCell
         (_("Time"), -1, 4, true));
     row.push_back(GUIEngine::ListWidget::ListCell
+        (_("Kart"), -1, 1, true));
+    row.push_back(GUIEngine::ListWidget::ListCell
         (_("User"), -1, 5, true));
     row.push_back(GUIEngine::ListWidget::ListCell
         (_("Version"), -1, 3, true));
@@ -164,6 +174,24 @@ void GhostReplayInfoDialog::updateReplayDisplayedInfo()
 
         const ReplayPlay::ReplayData& rd = ReplayPlay::get()->getReplayData(id);
 
+        int icon = -1;
+
+        for(unsigned int i=0; i<kart_properties_manager->getNumberOfKarts(); i++)
+        {
+            const KartProperties* prop = kart_properties_manager->getKartById(i);
+            if (rd.m_kart_list[0] == prop->getIdent())
+            {
+                icon = i;
+                break;
+            }
+        }
+
+        if (icon == -1)
+        {
+            icon = GhostReplaySelection::getInstance()->getUnknownKartIcon();
+            Log::warn("GhostReplayInfoDialog", "Kart not found, using default icon.");
+        }
+
         if (is_linear)
             row.push_back(GUIEngine::ListWidget::ListCell
                 (rd.m_reverse ? _("Yes") : _("No"), -1, 3, true));
@@ -176,6 +204,8 @@ void GhostReplayInfoDialog::updateReplayDisplayedInfo()
                 (StringUtils::toWString(rd.m_laps), -1, 3, true));
         row.push_back(GUIEngine::ListWidget::ListCell
             (StringUtils::toWString(rd.m_min_time) + L"s", -1, 4, true));
+        row.push_back(GUIEngine::ListWidget::ListCell
+            ("", icon, 1, true));
         row.push_back(GUIEngine::ListWidget::ListCell
             (rd.m_user_name.empty() ? " " : rd.m_user_name, -1, 5, true));
         row.push_back(GUIEngine::ListWidget::ListCell

--- a/src/states_screens/ghost_replay_selection.cpp
+++ b/src/states_screens/ghost_replay_selection.cpp
@@ -375,7 +375,7 @@ void GhostReplaySelection::loadList()
         row.push_back(GUIEngine::ListWidget::ListCell
             (StringUtils::toWString(rd.m_min_time) + L"s", -1, 4, true));
         row.push_back(GUIEngine::ListWidget::ListCell
-            (" ", icon, 1, true));
+            ("", icon, 1, true));
         row.push_back(GUIEngine::ListWidget::ListCell
             (rd.m_user_name.empty() ? " " : rd.m_user_name, -1, 5, true));
         if (m_multiplayer)

--- a/src/states_screens/ghost_replay_selection.cpp
+++ b/src/states_screens/ghost_replay_selection.cpp
@@ -45,8 +45,14 @@ GhostReplaySelection::GhostReplaySelection() : Screen("ghost_replay_selection.st
  */
 GhostReplaySelection::~GhostReplaySelection()
 {
-    delete m_icon_bank;
 }   // GhostReplaySelection
+
+// ----------------------------------------------------------------------------
+void GhostReplaySelection::tearDown()
+{
+    delete m_icon_bank;
+    m_icon_bank = NULL;
+}
 
 // ----------------------------------------------------------------------------
 /** Triggers a refresh of the replay file list.

--- a/src/states_screens/ghost_replay_selection.cpp
+++ b/src/states_screens/ghost_replay_selection.cpp
@@ -18,6 +18,10 @@
 
 #include "states_screens/ghost_replay_selection.hpp"
 
+#include "graphics/material.hpp"
+#include "guiengine/CGUISpriteBank.hpp"
+#include "karts/kart_properties.hpp"
+#include "karts/kart_properties_manager.hpp"
 #include "states_screens/dialogs/ghost_replay_info_dialog.hpp"
 #include "states_screens/state_manager.hpp"
 #include "states_screens/tracks_screen.hpp"
@@ -41,6 +45,7 @@ GhostReplaySelection::GhostReplaySelection() : Screen("ghost_replay_selection.st
  */
 GhostReplaySelection::~GhostReplaySelection()
 {
+    delete m_icon_bank;
 }   // GhostReplaySelection
 
 // ----------------------------------------------------------------------------
@@ -70,6 +75,14 @@ void GhostReplaySelection::refresh(bool forced_update, bool update_columns)
  */
 void GhostReplaySelection::loadedFromFile()
 {
+    m_icon_bank = new irr::gui::STKModifiedSpriteBank( GUIEngine::getGUIEnv());
+
+    for(unsigned int i=0; i<kart_properties_manager->getNumberOfKarts(); i++)
+    {
+        const KartProperties* prop = kart_properties_manager->getKartById(i);
+        m_icon_bank->addTextureAsSprite(prop->getIconMaterial()->getTexture());
+    }
+
     m_replay_list_widget = getWidget<GUIEngine::ListWidget>("replay_list");
     assert(m_replay_list_widget != NULL);
     m_replay_list_widget->setColumnListener(this);
@@ -78,6 +91,11 @@ void GhostReplaySelection::loadedFromFile()
         getWidget<GUIEngine::CheckBoxWidget>("replay_difficulty_toggle");
     m_replay_difficulty_toggle_widget->setState(/* default value */ true);
     m_same_difficulty = m_replay_difficulty_toggle_widget->getState();
+
+    m_replay_multiplayer_toggle_widget =
+        getWidget<GUIEngine::CheckBoxWidget>("replay_multiplayer_toggle");
+    m_replay_multiplayer_toggle_widget->setState(/* default value */ true /* hide */);
+    m_multiplayer = !m_replay_multiplayer_toggle_widget->getState();
 
     m_replay_version_toggle_widget =
         getWidget<GUIEngine::CheckBoxWidget>("replay_version_toggle");
@@ -107,7 +125,6 @@ void GhostReplaySelection::loadedFromFile()
 void GhostReplaySelection::beforeAddingWidget()
 {
     m_replay_list_widget->addColumn( _("Track"), 9 );
-    m_replay_list_widget->addColumn( _("Players"), 3);
     if (m_active_mode_is_linear)
         m_replay_list_widget->addColumn( _("Reverse"), 3);
     if (!m_same_difficulty)
@@ -115,7 +132,10 @@ void GhostReplaySelection::beforeAddingWidget()
     if (m_active_mode_is_linear)
         m_replay_list_widget->addColumn( _("Laps"), 3);
     m_replay_list_widget->addColumn( _("Time"), 4);
+    m_replay_list_widget->addColumn( _("Kart"), 1);
     m_replay_list_widget->addColumn( _("User"), 5);
+    if (m_multiplayer)
+        m_replay_list_widget->addColumn( _("Players"), 3);
     if (!m_same_version)
         m_replay_list_widget->addColumn( _("Version"), 3);
 
@@ -127,6 +147,14 @@ void GhostReplaySelection::init()
 {
     Screen::init();
     m_cur_difficulty = race_manager->getDifficulty();
+
+    int icon_height = getHeight()/24.0f;
+    // 128 is the height of the image file
+    //FIXME : this isn't guaranteed
+    // Amanda's icon is 300x300
+    m_icon_bank->setScale(icon_height/128.0f);
+    m_replay_list_widget->setIcons(m_icon_bank, (int)icon_height);
+
     refresh(/*reload replay files*/ false, /* update columns */ true);
 }   // init
 
@@ -162,6 +190,9 @@ void GhostReplaySelection::loadList()
 
             core::stringw current_version = STK_VERSION;
             if (m_same_version && current_version != rd.m_stk_version)
+                continue;
+
+            if (!m_multiplayer && (rd.m_kart_list.size() > 1))
                 continue;
 
             Track* track = track_manager->getTrack(rd.m_track_name);
@@ -268,6 +299,9 @@ void GhostReplaySelection::loadList()
         if (m_same_version && current_version != rd.m_stk_version)
             continue;
 
+        if (!m_multiplayer && (rd.m_kart_list.size() > 1))
+            continue;
+
         // Only display replays comparable with the replay selected for comparison
         if (m_is_comparing)
         {
@@ -300,12 +334,28 @@ void GhostReplaySelection::loadList()
         if (track == NULL)
             continue;
 
+        int icon = -1;
+
+        for(unsigned int i=0; i<kart_properties_manager->getNumberOfKarts(); i++)
+        {
+            const KartProperties* prop = kart_properties_manager->getKartById(i);
+            if (rd.m_kart_list[0] == prop->getIdent())
+            {
+                icon = i;
+                break;
+            }
+        }
+
+        if (icon == -1)
+        {
+            icon = 0;
+            Log::warn("GhostReplaySelection", "Kart not found, using default icon.");
+        }
+
         std::vector<GUIEngine::ListWidget::ListCell> row;
         //The third argument should match the numbers used in beforeAddingWidget
         row.push_back(GUIEngine::ListWidget::ListCell
             (translations->fribidize(track->getName()) , -1, 9));
-        row.push_back(GUIEngine::ListWidget::ListCell
-            (StringUtils::toWString(rd.m_kart_list.size()), -1, 3, true));
         if (m_active_mode_is_linear)
             row.push_back(GUIEngine::ListWidget::ListCell
                 (rd.m_reverse ? _("Yes") : _("No"), -1, 3, true));
@@ -320,7 +370,12 @@ void GhostReplaySelection::loadList()
         row.push_back(GUIEngine::ListWidget::ListCell
             (StringUtils::toWString(rd.m_min_time) + L"s", -1, 4, true));
         row.push_back(GUIEngine::ListWidget::ListCell
+            (" ", icon, 1, true));
+        row.push_back(GUIEngine::ListWidget::ListCell
             (rd.m_user_name.empty() ? " " : rd.m_user_name, -1, 5, true));
+        if (m_multiplayer)
+            row.push_back(GUIEngine::ListWidget::ListCell
+                (StringUtils::toWString(rd.m_kart_list.size()), -1, 3, true));
         if (!m_same_version)
             row.push_back(GUIEngine::ListWidget::ListCell
                 (rd.m_stk_version.empty() ? " " : rd.m_stk_version, -1, 3, true));
@@ -381,6 +436,11 @@ void GhostReplaySelection::eventCallback(GUIEngine::Widget* widget,
         m_same_difficulty = m_replay_difficulty_toggle_widget->getState();
         refresh(/*reload replay files*/ false, /* update columns */ true);
     }
+    else if (name == "replay_multiplayer_toggle")
+    {
+        m_multiplayer = !m_replay_multiplayer_toggle_widget->getState();
+        refresh(/*reload replay files*/ false, /* update columns */ true);
+    }
     else if (name == "replay_version_toggle")
     {
         m_same_version = m_replay_version_toggle_widget->getState();
@@ -436,31 +496,37 @@ void GhostReplaySelection::onColumnClicked(int column_id, bool sort_desc, bool s
 
     int diff_difficulty = m_same_difficulty ? 1 : 0;
     int diff_linear = m_active_mode_is_linear ? 0 : 1;
+    int diff_multiplayer = m_multiplayer ? 0 : 1;
+
+    if (column_id >= 1)
+        column_id += diff_linear;
 
     if (column_id >= 2)
-        column_id += diff_linear;
-
-    if (column_id >= 3)
         column_id += diff_difficulty;
 
-    if (column_id >= 4)
+    if (column_id >= 3)
         column_id += diff_linear;
+
+    if (column_id >= 7)
+        column_id += diff_multiplayer;
 
     if (column_id == 0)
         ReplayPlay::setSortOrder(ReplayPlay::SO_TRACK);
     else if (column_id == 1)
-        ReplayPlay::setSortOrder(ReplayPlay::SO_KART_NUM);
-    else if (column_id == 2)
         ReplayPlay::setSortOrder(ReplayPlay::SO_REV);
-    else if (column_id == 3)
+    else if (column_id == 2)
         ReplayPlay::setSortOrder(ReplayPlay::SO_DIFF);
-    else if (column_id == 4)
+    else if (column_id == 3)
         ReplayPlay::setSortOrder(ReplayPlay::SO_LAPS);
-    else if (column_id == 5)
+    else if (column_id == 4)
         ReplayPlay::setSortOrder(ReplayPlay::SO_TIME);
+    else if (column_id == 5)
+        return; // no sorting by kart icon (yet ?)
     else if (column_id == 6)
         ReplayPlay::setSortOrder(ReplayPlay::SO_USER);
-    else if (column_id == 7)    
+    else if (column_id == 7)
+        ReplayPlay::setSortOrder(ReplayPlay::SO_KART_NUM);
+    else if (column_id == 8)    
         ReplayPlay::setSortOrder(ReplayPlay::SO_VERSION);
     else
         assert(0);

--- a/src/states_screens/ghost_replay_selection.cpp
+++ b/src/states_screens/ghost_replay_selection.cpp
@@ -75,14 +75,6 @@ void GhostReplaySelection::refresh(bool forced_update, bool update_columns)
  */
 void GhostReplaySelection::loadedFromFile()
 {
-    m_icon_bank = new irr::gui::STKModifiedSpriteBank( GUIEngine::getGUIEnv());
-
-    for(unsigned int i=0; i<kart_properties_manager->getNumberOfKarts(); i++)
-    {
-        const KartProperties* prop = kart_properties_manager->getKartById(i);
-        m_icon_bank->addTextureAsSprite(prop->getIconMaterial()->getTexture());
-    }
-
     m_replay_list_widget = getWidget<GUIEngine::ListWidget>("replay_list");
     assert(m_replay_list_widget != NULL);
     m_replay_list_widget->setColumnListener(this);
@@ -147,6 +139,19 @@ void GhostReplaySelection::init()
 {
     Screen::init();
     m_cur_difficulty = race_manager->getDifficulty();
+
+    m_icon_bank = new irr::gui::STKModifiedSpriteBank( GUIEngine::getGUIEnv());
+
+    for(unsigned int i=0; i<kart_properties_manager->getNumberOfKarts(); i++)
+    {
+        const KartProperties* prop = kart_properties_manager->getKartById(i);
+        m_icon_bank->addTextureAsSprite(prop->getIconMaterial()->getTexture());
+    }
+
+    video::ITexture* kart_not_found = irr_driver->getTexture( file_manager->getAsset(FileManager::GUI,
+                                                              "main_help.png"         ));
+
+    m_icon_unknown_kart = m_icon_bank->addTextureAsSprite(kart_not_found);
 
     int icon_height = getHeight()/24.0f;
     // 128 is the height of the image file
@@ -348,7 +353,7 @@ void GhostReplaySelection::loadList()
 
         if (icon == -1)
         {
-            icon = 0;
+            icon = m_icon_unknown_kart;
             Log::warn("GhostReplaySelection", "Kart not found, using default icon.");
         }
 

--- a/src/states_screens/ghost_replay_selection.hpp
+++ b/src/states_screens/ghost_replay_selection.hpp
@@ -44,6 +44,7 @@ private:
 
     GUIEngine::ListWidget*     m_replay_list_widget;
     GUIEngine::CheckBoxWidget* m_replay_difficulty_toggle_widget;
+    GUIEngine::CheckBoxWidget* m_replay_multiplayer_toggle_widget;
     GUIEngine::CheckBoxWidget* m_replay_version_toggle_widget;
     GUIEngine::CheckBoxWidget* m_best_times_toggle_widget;
     GUIEngine::CheckBoxWidget* m_compare_toggle_widget;
@@ -53,6 +54,7 @@ private:
     std::vector<unsigned int>  m_best_times_index;
     bool                       m_same_difficulty;
     bool                       m_same_version;
+    bool                       m_multiplayer;
     bool                       m_best_times;
     bool                       m_is_comparing;
     bool                       m_active_mode_is_linear;
@@ -60,6 +62,8 @@ private:
     // The index id of a replay file can change with sorting, etc.
     // Using the UID guarantees exact matchess
     uint64_t                   m_replay_to_compare_uid;
+
+    irr::gui::STKModifiedSpriteBank *m_icon_bank;
 
     void defaultSort();
 

--- a/src/states_screens/ghost_replay_selection.hpp
+++ b/src/states_screens/ghost_replay_selection.hpp
@@ -65,6 +65,9 @@ private:
 
     irr::gui::STKModifiedSpriteBank *m_icon_bank;
 
+    /** Icon for unknown karts */
+    int                        m_icon_unknown_kart;
+
     void defaultSort();
 
 public:

--- a/src/states_screens/ghost_replay_selection.hpp
+++ b/src/states_screens/ghost_replay_selection.hpp
@@ -103,6 +103,8 @@ public:
 
     virtual void init() OVERRIDE;
 
+    virtual void tearDown() OVERRIDE;
+
     virtual bool onEscapePressed() OVERRIDE;
 
     /** \brief Implement IConfirmDialogListener callback */

--- a/src/states_screens/ghost_replay_selection.hpp
+++ b/src/states_screens/ghost_replay_selection.hpp
@@ -71,6 +71,9 @@ private:
     void defaultSort();
 
 public:
+    irr::gui::STKModifiedSpriteBank* getIconBank() { return m_icon_bank; }
+
+    int  getUnknownKartIcon() { return m_icon_unknown_kart; }
 
     void setCompareReplayUid(uint64_t uid) { m_replay_to_compare_uid = uid; }
     void setCompare(bool compare) { m_is_comparing = compare; }


### PR DESCRIPTION
The icons are based on the kart model listed in the replay files. If the model is unknown, a "?" icon is displayed.

This PR also adds the ghost icon to the replay info dialog (when selecting a specific replay in the list).

To avoid the replay list being crammed, the number of players column is now hidden by default (only displayed if a checkbox is unchecked), considering that >99% of replays are single player.

Known issue : the replay info dialog list overflows slightly to the right of the dialog.

Fix #3365