### PR TITLE
Align column header with cells in lists

### DIFF
--- a/src/guiengine/widgets/list_widget.cpp
+++ b/src/guiengine/widgets/list_widget.cpp
@@ -149,7 +149,8 @@ void ListWidget::createHeader()
         }
 
         int x = m_x;
-        for (unsigned int n=0; n<m_header.size(); n++)
+        int scrollbar_width = GUIEngine::getSkin()->getSize(EGDS_SCROLLBAR_SIZE);
+        for (unsigned int n=0; n<m_header.size()+1; n++)
         {
             std::ostringstream name;
             name << m_properties[PROP_ID];
@@ -164,12 +165,22 @@ void ListWidget::createHeader()
             header->m_h = header_height;
 
             header->m_x = x;
-            header->m_w = (int)(m_w * float(m_header[n].m_proportion)
-                                /float(proportion_total));
+            if (n == m_header.size())
+            {
+                header->m_w = scrollbar_width;
+                header->setActive(false);
+            }
+            else
+            {
+                int header_width = m_w - scrollbar_width;
+                header->m_w = (int)(header_width * float(m_header[n].m_proportion)
+                                    /float(proportion_total));
+            }
 
             x += header->m_w;
 
-            header->setText( m_header[n].m_text );
+            if (n < m_header.size())
+                header->setText( m_header[n].m_text );
             header->m_properties[PROP_ID] = name.str();
 
             header->add();


### PR DESCRIPTION
The buttons for the headers use the width of the list minus the scrollbar, and a dummy disabled button allows to not have an empty top-right corner.