### PR TITLE
Fix egg hunt finish time

### DIFF
--- a/src/modes/easter_egg_hunt.cpp
+++ b/src/modes/easter_egg_hunt.cpp
@@ -33,6 +33,7 @@ EasterEggHunt::EasterEggHunt() : LinearWorld()
     m_use_highscores = true;
     m_eggs_found     = 0;
     m_only_ghosts    = false;
+    m_finish_time    = 0;
 }   // EasterEggHunt
 
 //-----------------------------------------------------------------------------
@@ -192,7 +193,8 @@ bool EasterEggHunt::isRaceOver()
 {
     if(!m_only_ghosts && m_eggs_found == m_number_of_eggs)
     {
-        m_finish_time = getTime();
+        if (m_finish_time == 0)
+            m_finish_time = getTime();
         return true;
     }
     else if (m_only_ghosts)

--- a/src/modes/easter_egg_hunt.cpp
+++ b/src/modes/easter_egg_hunt.cpp
@@ -191,7 +191,10 @@ void EasterEggHunt::update(int ticks)
 bool EasterEggHunt::isRaceOver()
 {
     if(!m_only_ghosts && m_eggs_found == m_number_of_eggs)
+    {
+        m_finish_time = getTime();
         return true;
+    }
     else if (m_only_ghosts)
     {
         for (unsigned int i=0 ; i<m_eggs_collected.size();i++)
@@ -263,5 +266,5 @@ float EasterEggHunt::estimateFinishTimeForKart(AbstractKart* kart)
         return gk->getGhostFinishTime();
     }
 
-    return getTime();
+    return m_finish_time;
 }   // estimateFinishTimeForKart

--- a/src/modes/easter_egg_hunt.hpp
+++ b/src/modes/easter_egg_hunt.hpp
@@ -45,6 +45,8 @@ private:
     int   m_eggs_found;
 
     bool  m_only_ghosts;
+
+    float m_finish_time;
 public:
              EasterEggHunt();
     virtual ~EasterEggHunt();


### PR DESCRIPTION
getTime() is called immediately when the end condition (all egs collected) is detected, and the result is saved (and not changed afterwards : isRaceOver is called every frame even after it has return true) ; instead of calling it only later when the time is going to be displayed.

The time displayed at the end of the race now matches the ghost's finish time.