### PR TITLE
Don't remove red skid bonus when getting a yellow skid bonus

### DIFF
--- a/src/karts/max_speed.cpp
+++ b/src/karts/max_speed.cpp
@@ -323,6 +323,14 @@ void MaxSpeed::update(int ticks)
         m_current_max_speed += speedup.getSpeedIncrease();
         m_add_engine_force  += speedup.getEngineForce();
     }
+    if (getSpeedIncreaseTicksLeft(MS_INCREASE_SKIDDING) > 0 &&
+        getSpeedIncreaseTicksLeft(MS_INCREASE_RED_SKIDDING) > 0)
+    {
+        SpeedIncrease &speedup = m_speed_increase[MS_INCREASE_SKIDDING];
+        m_current_max_speed -= speedup.getSpeedIncrease();
+        m_add_engine_force  -= speedup.getEngineForce();
+    }
+
     m_current_max_speed *= slowdown_factor;
 
     // Then cap the current speed of the kart

--- a/src/karts/max_speed.hpp
+++ b/src/karts/max_speed.hpp
@@ -37,6 +37,7 @@ public:
            MS_INCREASE_NITRO,
            MS_INCREASE_RUBBER,
            MS_INCREASE_SKIDDING,
+           MS_INCREASE_RED_SKIDDING,
            MS_INCREASE_MAX};
 
     /** The categories to use for decreasing the speed of a kart:

--- a/src/karts/skidding.cpp
+++ b/src/karts/skidding.cpp
@@ -503,8 +503,10 @@ void Skidding::update(int ticks, bool is_on_ground,
                           ->setCreationRateRelative(KartGFX::KGFX_SKIDL, 1.0f);
                     m_kart->getKartGFX()
                           ->setCreationRateRelative(KartGFX::KGFX_SKIDR, 1.0f);
+                    unsigned int bonus_cat = (level == 1) ? MaxSpeed::MS_INCREASE_SKIDDING :
+                                                            MaxSpeed::MS_INCREASE_RED_SKIDDING;
                     m_kart->m_max_speed->
-                        instantSpeedIncrease(MaxSpeed::MS_INCREASE_SKIDDING,
+                        instantSpeedIncrease(bonus_cat,
                                bonus_speed, bonus_speed,
                                bonus_force,
                                stk_config->time2Ticks(bonus_time),


### PR DESCRIPTION
Fixes #3387

This implements the desired behavior described in the issue : 

> the red bonus lasts to its normal end, but if the yellow bonus is supposed to finish later, the kart transitions from the red bonus to the yellow bonus rather than having none

If the yellow skid bonus is obtained during the red skid fade-out phase, the two bonus can overlap for a split second, but it's both very minor in effect and hard to trigger, so negligible.