### PR TITLE
Display soccer timer after a goal

### DIFF
--- a/src/modes/soccer_world.hpp
+++ b/src/modes/soccer_world.hpp
@@ -328,6 +328,8 @@ public:
     virtual const std::string& getIdent() const OVERRIDE;
 
     virtual void update(int ticks) OVERRIDE;
+
+    bool shouldDrawTimer() const OVERRIDE { return !isStartPhase(); }
     // ------------------------------------------------------------------------
     void onCheckGoalTriggered(bool first_goal);
     // ------------------------------------------------------------------------

--- a/src/modes/tutorial_world.hpp
+++ b/src/modes/tutorial_world.hpp
@@ -45,6 +45,7 @@ public:
         return WorldWithRank::getRescueTransform(index);
     }
 
+    bool shouldDrawTimer() const OVERRIDE { return false; }
 
 
 };   // class TutorialWorld

--- a/src/modes/world.hpp
+++ b/src/modes/world.hpp
@@ -327,7 +327,7 @@ public:
     /** The code that draws the timer should call this first to know
      *  whether the game mode wants a timer drawn. */
     virtual bool shouldDrawTimer() const
-                    { return isRacePhase() && getClockMode() != CLOCK_NONE; }
+                    { return isActiveRacePhase() && getClockMode() != CLOCK_NONE; }
     // ------------------------------------------------------------------------
     /** \return whether this world can generate/have highscores */
     bool useHighScores() const { return m_use_highscores; }

--- a/src/modes/world_status.hpp
+++ b/src/modes/world_status.hpp
@@ -156,6 +156,9 @@ public:
     bool     isRacePhase()  const  { return m_phase>=GO_PHASE &&
                                             m_phase<FINISH_PHASE;           }
     // ------------------------------------------------------------------------
+    bool     isActiveRacePhase() const { return m_phase>=GO_PHASE &&
+                                                m_phase<DELAY_FINISH_PHASE; }
+    // ------------------------------------------------------------------------
     /** While the race menu is being displayed, m_phase is limbo, and
      *  m_previous_phase is finish. So we have to test this case, too.  */
     bool     isFinishPhase() const { return m_phase==FINISH_PHASE ||

--- a/src/states_screens/race_gui.cpp
+++ b/src/states_screens/race_gui.cpp
@@ -245,13 +245,11 @@ void RaceGUI::renderGlobal(float dt)
     if(!world->isRacePhase()) return;
     if (!m_enabled) return;
 
+    //drawGlobalTimer checks if it should display in the current phase/mode
+    drawGlobalTimer();
 
     if (!m_is_tutorial)
     {
-        //stop displaying timer as soon as race is over
-        if (world->getPhase()<WorldStatus::DELAY_FINISH_PHASE)
-           drawGlobalTimer();
-
         if (race_manager->isLinearRaceMode() &&
             race_manager->hasGhostKarts() &&
             race_manager->getNumberOfKarts() >= 2 )


### PR DESCRIPTION
The timer doesn't stop after a goal, having it not displayed gives the wrong impression it is.

I also rewrote some related code, as there was a duplication of checks between shouldDrawTimer and custom checks in race_gui.cpp