### PR TITLE
Don't count ghost karts for highscores

### DIFF
--- a/src/modes/world.cpp
+++ b/src/modes/world.cpp
@@ -1116,7 +1116,7 @@ Highscores* World::getHighscores() const
 
     Highscores * highscores =
         highscore_manager->getHighscores(type,
-                                         getNumKarts(),
+                                         race_manager->getNumNonGhostKarts(),
                                          race_manager->getDifficulty(),
                                          race_manager->getTrackName(),
                                          race_manager->getNumLaps(),

--- a/src/race/highscores.cpp
+++ b/src/race/highscores.cpp
@@ -184,7 +184,7 @@ int Highscores::addData(const std::string& kart_name,
     if(position>=0)
     {
         m_track               = race_manager->getTrackName();
-        m_number_of_karts     = race_manager->getNumberOfKarts();
+        m_number_of_karts     = race_manager->getNumNonGhostKarts();
         m_difficulty          = race_manager->getDifficulty();
         m_number_of_laps      = race_manager->getNumLaps();
         m_reverse             = race_manager->getReverseTrack();

--- a/src/race/race_manager.cpp
+++ b/src/race/race_manager.cpp
@@ -69,6 +69,7 @@ RaceManager::RaceManager()
     // Several code depends on this, e.g. kart_properties
     assert(DIFFICULTY_FIRST == 0);
     m_num_karts          = UserConfigParams::m_default_num_karts;
+    m_num_ghost_karts    = 0;
     m_difficulty         = DIFFICULTY_HARD;
     m_major_mode         = MAJOR_MODE_SINGLE;
     m_minor_mode         = MINOR_MODE_NORMAL_RACE;
@@ -321,9 +322,9 @@ void RaceManager::computeRandomKartList()
  */
 void RaceManager::startNew(bool from_overworld)
 {
-    unsigned int gk = 0;
+    m_num_ghost_karts = 0;
     if (m_has_ghost_karts)
-        gk = ReplayPlay::get()->getNumGhostKart();
+        m_num_ghost_karts = ReplayPlay::get()->getNumGhostKart();
 
     m_started_from_overworld = from_overworld;
     m_saved_gp = NULL; // There will be checks for this being NULL done later
@@ -376,21 +377,21 @@ void RaceManager::startNew(bool from_overworld)
     // Create the kart status data structure to keep track of scores, times, ...
     // ==========================================================================
     m_kart_status.clear();
-    if (gk > 0)
-        m_num_karts += gk;
+    if (m_num_ghost_karts > 0)
+        m_num_karts += m_num_ghost_karts;
 
     Log::verbose("RaceManager", "Nb of karts=%u, ghost karts:%u ai:%lu players:%lu\n",
-        (unsigned int) m_num_karts, gk, m_ai_kart_list.size(), m_player_karts.size());
+        (unsigned int) m_num_karts, m_num_ghost_karts, m_ai_kart_list.size(), m_player_karts.size());
 
-    assert((unsigned int)m_num_karts == gk+m_ai_kart_list.size()+m_player_karts.size());
+    assert((unsigned int)m_num_karts == m_num_ghost_karts+m_ai_kart_list.size()+m_player_karts.size());
 
     // First add the ghost karts (if any)
     // ----------------------------------------
     // GP ranks start with -1 for the leader.
     int init_gp_rank = getMinorMode()==MINOR_MODE_FOLLOW_LEADER ? -1 : 0;
-    if (gk > 0)
+    if (m_num_ghost_karts > 0)
     {
-        for(unsigned int i = 0; i < gk; i++)
+        for(unsigned int i = 0; i < m_num_ghost_karts; i++)
         {
             m_kart_status.push_back(KartStatus(ReplayPlay::get()->getGhostKartName(i),
                 i, -1, -1, init_gp_rank, KT_GHOST, PLAYER_DIFFICULTY_NORMAL));

--- a/src/race/race_manager.hpp
+++ b/src/race/race_manager.hpp
@@ -334,6 +334,7 @@ private:
     GrandPrixData                    m_grand_prix;
     SavedGrandPrix*                  m_saved_gp;
     int                              m_num_karts;
+    unsigned int                     m_num_ghost_karts;
     unsigned int                     m_num_spare_tire_karts;
     unsigned int                     m_num_finished_karts;
     unsigned int                     m_num_finished_players;
@@ -510,6 +511,8 @@ public:
     /** Returns the selected number of karts (selected number of players and
      *  AI karts. */
     unsigned int getNumberOfKarts() const {return m_num_karts; }
+    // ------------------------------------------------------------------------
+    unsigned int getNumNonGhostKarts() const {printf("There are %u ghost karts\n", m_num_ghost_karts); return m_num_karts - m_num_ghost_karts; }
     // ------------------------------------------------------------------------
     MajorRaceModeType getMajorMode() const { return m_major_mode; }
     // ------------------------------------------------------------------------

--- a/src/race/race_manager.hpp
+++ b/src/race/race_manager.hpp
@@ -512,7 +512,7 @@ public:
      *  AI karts. */
     unsigned int getNumberOfKarts() const {return m_num_karts; }
     // ------------------------------------------------------------------------
-    unsigned int getNumNonGhostKarts() const {printf("There are %u ghost karts\n", m_num_ghost_karts); return m_num_karts - m_num_ghost_karts; }
+    unsigned int getNumNonGhostKarts() const { return m_num_karts - m_num_ghost_karts; }
     // ------------------------------------------------------------------------
     MajorRaceModeType getMajorMode() const { return m_major_mode; }
     // ------------------------------------------------------------------------


### PR DESCRIPTION
Races against a ghost replay were erroneously considered by highscore code as 2-karts races ; this PR makes the ghost kart not count.

Fix #3413