### PR TITLE
Fix the turn radius bug

### DIFF
--- a/data/kart_characteristics.xml
+++ b/data/kart_characteristics.xml
@@ -67,7 +67,7 @@
                 The actual turn radius is piece-wise linearly interpolated. This
                 allows for tighter turning at lower speeds, and also avoids that
                 the kart becomes too hard to control at high speed (speeds of
-                higher than 23 can only be reached with powerups).
+                higher than 25 can only be reached with powerups).
             time-full-steer: This is the amount of change in steering depending
                 on current steering. So if the steering is between 0 and 0.5,
                 the time-for-steering-change is 0.15. If the current steering is

--- a/src/karts/kart.cpp
+++ b/src/karts/kart.cpp
@@ -1319,10 +1319,6 @@ void Kart::eliminate()
  */
 void Kart::update(int ticks)
 {
-    //FIXME : theses are debug prints, don't forget to remove them afterwards !
-    printf("Position is x: %f ; y: %f ; z: %f\n",getXYZ().x(), getXYZ().y(), getXYZ().z());
-
-
     if (m_network_finish_check_ticks != 0 &&
         World::getWorld()->getTicksSinceStart() >
         m_network_finish_check_ticks &&

--- a/src/karts/kart.cpp
+++ b/src/karts/kart.cpp
@@ -875,22 +875,27 @@ float Kart::getSpeedForTurnRadius(float radius) const
     InterpolationArray turn_angle_at_speed = m_kart_properties->getTurnRadius();
     // Convert the turn radius into turn angle
     for(int i = 0; i < (int)turn_angle_at_speed.size(); i++)
-        turn_angle_at_speed.setY(i, sin(m_kart_properties->getWheelBase() /
-            turn_angle_at_speed.getY(i)));
+        turn_angle_at_speed.setY(i, sin( 1.0 / turn_angle_at_speed.getY(i)));
 
-    float angle = sin(m_kart_properties->getWheelBase() / radius);
+    float angle = sin(1.0 / radius);
     return turn_angle_at_speed.getReverse(angle);
 }   // getSpeedForTurnRadius
 
 // ------------------------------------------------------------------------
-/** Returns the maximum steering angle (depending on speed). */
+/** Returns the maximum steering angle (depending on speed).
+    This is proportional to kart length because physics reverse this effect,
+    the results of this function should not be used to determine the
+    real raw steer angle. */
 float Kart::getMaxSteerAngle(float speed) const
 {
     InterpolationArray turn_angle_at_speed = m_kart_properties->getTurnRadius();
     // Convert the turn radius into turn angle
+    // We multiply by wheel base to keep turn radius identical
+    // across karts of different lengths sharing the same
+    // turn radius properties
     for(int i = 0; i < (int)turn_angle_at_speed.size(); i++)
-        turn_angle_at_speed.setY(i, sin(m_kart_properties->getWheelBase() /
-            turn_angle_at_speed.getY(i)));
+        turn_angle_at_speed.setY(i, sin( 1.0 / turn_angle_at_speed.getY(i))
+                                    * m_kart_properties->getWheelBase());
 
     return turn_angle_at_speed.get(speed);
 }   // getMaxSteerAngle
@@ -1314,6 +1319,10 @@ void Kart::eliminate()
  */
 void Kart::update(int ticks)
 {
+    //FIXME : theses are debug prints, don't forget to remove them afterwards !
+    printf("Position is x: %f ; y: %f ; z: %f\n",getXYZ().x(), getXYZ().y(), getXYZ().z());
+
+
     if (m_network_finish_check_ticks != 0 &&
         World::getWorld()->getTicksSinceStart() >
         m_network_finish_check_ticks &&

--- a/src/karts/kart_properties.cpp
+++ b/src/karts/kart_properties.cpp
@@ -303,17 +303,12 @@ void KartProperties::load(const std::string &filename, const std::string &node)
         m_gravity_center_shift.setZ(0);
     }
 
-    // In older STK versions the physical wheels where moved 'wheel_radius'
-    // into the physical body (i.e. 'hypothetical' wheel shape would not
-    // poke out of the physical shape). In order to make the karts a bit more
-    // stable, the physical wheel position (i.e. location of raycast) were
-    // moved to be on the corner of the shape. In order to retain the same
-    // steering behaviour, the wheel base (which in turn determines the
-    // turn angle at certain speeds) is shortened by 2*wheel_radius
-    // Wheel radius was always 0.25, and is now not used anymore, but in order
-    // to keep existing steering behaviour, the same formula is still
-    // used.
-    m_wheel_base = fabsf(m_kart_model->getLength() - 2*0.25f);
+    // The longer the kart,the bigger its turn radius if using an identical
+    // wheel base, exactly proportionally to its length.
+    // The wheel base is used to compensate this
+    // We divide by 1.425 to have a default turn radius which conforms
+    // closely (+-0,1%) with the specifications in kart_characteristics.xml
+    m_wheel_base = fabsf(m_kart_model->getLength()/1.425f);
 
     m_shadow_material = material_manager->getMaterialSPM(m_shadow_file, "",
         "alphablend");

--- a/src/karts/skidding.cpp
+++ b/src/karts/skidding.cpp
@@ -421,6 +421,7 @@ void Skidding::update(int ticks, bool is_on_ground,
             m_predicted_curve->setHeading(m_kart->getHeading());
             float angle = m_kart->getMaxSteerAngle(SPEED)
                         * fabsf(getSteeringFraction());
+            //FIXME : what is this for ?
             float r = kp->getWheelBase()
                     / asin(angle)*1.0f;
 


### PR DESCRIPTION
This PR makes the turn radius of all karts independent of their length. It now only depends on the value defined in kart_characteristics.xml.

I have deliberately not included a rework of the values in kart_characteristics.xml ; but for information, they are close to the tighter turn radius observed before.

The turn radius at 25 of speed is now ~15 ; while the previous values for a few karts were : 
- Wilber : ~14,88
- Tux : ~16,15
- Emule : ~18,65
- Adiumy : ~22,4