### PR TITLE
Don't have the distance frozen when going off-road/in cannons

### DIFF
--- a/src/modes/linear_world.cpp
+++ b/src/modes/linear_world.cpp
@@ -24,6 +24,7 @@
 #include "audio/sfx_manager.hpp"
 #include "config/user_config.hpp"
 #include "karts/abstract_kart.hpp"
+#include "karts/cannon_animation.hpp"
 #include "karts/controller/controller.hpp"
 #include "karts/ghost_kart.hpp"
 #include "karts/kart_properties.hpp"
@@ -240,7 +241,9 @@ void LinearWorld::updateTrackSectors()
 
         // Nothing to do for karts that are currently being
         // rescued or eliminated
-        if(kart->getKartAnimation()) continue;
+        if(kart->getKartAnimation() &&
+           !dynamic_cast<CannonAnimation*>(kart->getKartAnimation()))
+            continue;
         // If the kart is off road, and 'flying' over a reset plane
         // don't adjust the distance of the kart, to avoid a jump
         // in the position of the kart (e.g. while falling the kart

--- a/src/tracks/track_sector.cpp
+++ b/src/tracks/track_sector.cpp
@@ -39,10 +39,11 @@ TrackSector::TrackSector()
 // ----------------------------------------------------------------------------
 void TrackSector::reset()
 {
-    m_current_graph_node       = Graph::UNKNOWN_SECTOR;
-    m_last_valid_graph_node    = Graph::UNKNOWN_SECTOR;
-    m_on_road                  = false;
-    m_last_triggered_checkline = -1;
+    m_current_graph_node         = Graph::UNKNOWN_SECTOR;
+    m_last_valid_graph_node      = Graph::UNKNOWN_SECTOR;
+    m_estimated_valid_graph_node = Graph::UNKNOWN_SECTOR;
+    m_on_road                    = false;
+    m_last_triggered_checkline   = -1;
 }   // reset
 
 // ----------------------------------------------------------------------------
@@ -84,12 +85,15 @@ void TrackSector::update(const Vec3 &xyz, bool ignore_vertical)
     }
 
     // keep the current quad as the latest valid one IF the player has one
-    // of the required checklines
+    // of the required checklines AND is on road
+    // The on-road condition isn't required for the estimated valid node
+    // used for distances.
     const DriveNode* dn = DriveGraph::get()->getNode(m_current_graph_node);
     const std::vector<int>& checkline_requirements = dn->getChecklineRequirements();
 
     if (checkline_requirements.size() == 0)
     {
+        m_estimated_valid_graph_node = m_current_graph_node;
         if (m_on_road)
             m_last_valid_graph_node = m_current_graph_node;
     }
@@ -97,16 +101,17 @@ void TrackSector::update(const Vec3 &xyz, bool ignore_vertical)
     {
         for (unsigned int i=0; i<checkline_requirements.size(); i++)
         {
-            if (m_last_triggered_checkline == checkline_requirements[i])
+            if (m_last_triggered_checkline >= checkline_requirements[i])
             {
                 //has_prerequisite = true;
+                m_estimated_valid_graph_node = m_current_graph_node;
                 if (m_on_road)
                     m_last_valid_graph_node = m_current_graph_node;
                 break;
             }
         }
 
-        // TODO: show a message when we detect a user cheated.
+        // TODO: show a message when we detect a user missed a checkline.
 
     }
 
@@ -119,6 +124,12 @@ void TrackSector::update(const Vec3 &xyz, bool ignore_vertical)
     {
         DriveGraph::get()->spatialToTrack(&m_latest_valid_track_coords, xyz,
             m_last_valid_graph_node);
+    }
+
+    if (m_estimated_valid_graph_node != Graph::UNKNOWN_SECTOR)
+    {
+        DriveGraph::get()->spatialToTrack(&m_estimated_valid_track_coords, xyz,
+            m_estimated_valid_graph_node);
     }
 }   // update
 
@@ -139,6 +150,7 @@ void TrackSector::rescue()
                                             ->getPredecessor(0);
     m_last_valid_graph_node = DriveGraph::get()->getNode(m_current_graph_node)
                                                ->getPredecessor(0);
+    m_estimated_valid_graph_node = m_current_graph_node;
 }    // rescue
 
 // ----------------------------------------------------------------------------

--- a/src/tracks/track_sector.hpp
+++ b/src/tracks/track_sector.hpp
@@ -41,13 +41,18 @@ private:
     /** The graph node the object is on. */
     int  m_current_graph_node;
 
-    /** The index of the last valid graph node. */
+    /** The index of the estimated valid graph node. Used for distance. */
+    int  m_estimated_valid_graph_node;
+
+    /** The index of the last valid graph node. Used for rescue */
     int  m_last_valid_graph_node;
 
     /** The coordinates of this object on the track, i.e. how far from
      *  the start of the track, and how far to the left or right
      *  of the center driveline. */
     Vec3 m_current_track_coords;
+
+    Vec3 m_estimated_valid_track_coords;
 
     Vec3 m_latest_valid_track_coords;
 
@@ -64,10 +69,12 @@ public:
     float getRelativeDistanceToCenter() const;
     // ------------------------------------------------------------------------
     /** Returns how far the the object is from the start line. */
-    float getDistanceFromStart(bool account_for_checklines) const
+    float getDistanceFromStart(bool account_for_checklines, bool strict=false) const
     {
-        if (account_for_checklines)
+        if (account_for_checklines && strict)
             return m_latest_valid_track_coords.getZ();
+        else if (account_for_checklines)
+            return m_estimated_valid_track_coords.getZ();
         else
             return m_current_track_coords.getZ();
     }


### PR DESCRIPTION
This fixes :
- Kart being incorrectly considered first when crossing the lapline off-road
- Distance freezing when going outside of the drivequads, which can happen with normal driving in many places. This had a slightly bad effect on kart positions, and a very bad effects on the live difference feature.
- Distance freezing in cannons (but it only works well if the kart is considered ~on-road, the interpolation tends to fail badly ; for example it works fine in Cornfield Crossing if I go in the cannon slowly, but if I go fast entering it, it will do a very poor interpolation midway in the cannon). I suspect that a full fix may require alterations of the tracks with cannons where it doesn't work well.

The rescue node is kept at the last drivegraph where the kart was on-road, so e.g. rescuing in the middle of a shortcut (invalid or not) can never allow to win time.

An important reason I'm not merging this right away is that it requires some change in the network code.

m_estimated_valid_track_coords do not need to be fully sent ; only the Z coord is ever used.

However, several optimizations are clearly possible in the existing state synching for TrackSector : 
- The graph nodes are sent as INT32 ; however there is not even one track remotely approaching the limits of an INT16, as far as I can tell.
- The last triggered checkline is sent as an INT32 ; an INT8 would certainly suffice as no track has more than a few checklines
- The on-road status could even be merged with the last triggered checkline (one bit used for it, the 7 others for the last triggered checkline)
- It does not seem useful to send the full track_coords variables. For the current coord ; the Y variable seems unused (the Z is used for distances without checklines check, the X for distance to center of track). For last_valid one ; only the Z coord seems ever used.

So while the new values add 48 bits to synch, there is up to 160 bits to save on the existing state ; i.e. there should be no issue for networking to integrate the new values in the game.