### PR TITLE
Fixes the cushioning issues

### DIFF
--- a/src/karts/rescue_animation.cpp
+++ b/src/karts/rescue_animation.cpp
@@ -25,6 +25,7 @@
 #include "karts/kart_properties.hpp"
 #include "modes/three_strikes_battle.hpp"
 #include "network/network_config.hpp"
+#include "physics/btKart.hpp"
 #include "physics/physics.hpp"
 #include "physics/triangle_mesh.hpp"
 #include "tracks/drive_graph.hpp"
@@ -61,6 +62,7 @@ RescueAnimation::RescueAnimation(AbstractKart *kart, bool is_auto_rescue,
     m_up_vector   = m_kart->getTrans().getBasis().getColumn(1);
     m_xyz         = m_kart->getXYZ();
     m_kart->getAttachment()->clear();
+    m_kart->getVehicle()->resetGroundHeight();
 
     if (NetworkConfig::get()->isNetworking() &&
         NetworkConfig::get()->isServer())

--- a/src/physics/btKart.cpp
+++ b/src/physics/btKart.cpp
@@ -22,6 +22,7 @@
 #include "LinearMath/btIDebugDraw.h"
 #include "BulletDynamics/ConstraintSolver/btContactConstraint.h"
 
+#include "config/stk_config.hpp"
 #include "graphics/material.hpp"
 #include "karts/kart.hpp"
 #include "karts/kart_model.hpp"
@@ -130,11 +131,22 @@ void btKart::reset()
     m_max_speed                  = -1.0f;
     m_min_speed                  = 0.0f;
     m_cushioning_disable_time    = 0;
+    resetGroundHeight();
 
     // Set the brakes so that karts don't slide downhill
     setAllBrakes(5.0f);
 
 }   // reset
+
+// ----------------------------------------------------------------------------
+/** Resets the ground height of a kart. This is also called on rescues.
+ */
+void btKart::resetGroundHeight()
+{
+    m_ground_height              = 0.15;
+    m_ground_height_old          = 0.15;
+    m_max_ground_height          = 0.15;
+}   // resetGroundHeight
 
 // ----------------------------------------------------------------------------
 const btTransform& btKart::getWheelTransformWS( int wheelIndex ) const
@@ -277,10 +289,10 @@ btScalar btKart::rayCast(unsigned int index, float fraction)
     btScalar max_susp_len = wheel.getSuspensionRestLength()
                           + wheel.m_maxSuspensionTravel;
 
-    // Do a slightly longer raycast to see if the kart might soon hit the 
+    // Do a longer raycast to see if the kart might soon hit the 
     // ground and some 'cushioning' is needed to avoid that the chassis
     // hits the ground.
-    btScalar raylen = max_susp_len + 0.5f;
+    btScalar raylen = max_susp_len*10 + 0.5f;
 
     btVector3 rayvector = wheel.m_raycastInfo.m_wheelDirectionWS * (raylen);
     const btVector3& source = wheel.m_raycastInfo.m_hardPointWS;
@@ -296,6 +308,11 @@ btScalar btKart::rayCast(unsigned int index, float fraction)
     wheel.m_raycastInfo.m_groundObject = 0;
 
     btScalar depth =  raylen * rayResults.m_distFraction;
+
+    if (depth < m_ground_height)
+        m_ground_height = depth;
+    if (depth > m_max_ground_height)
+        m_max_ground_height = depth;
     if (object &&  depth < max_susp_len)
     {
         wheel.m_raycastInfo.m_contactNormalWS  = rayResults.m_hitNormalInWorld;
@@ -517,17 +534,18 @@ void btKart::updateVehicle( btScalar step )
     if(m_cushioning_disable_time>0) m_cushioning_disable_time --;
 
     bool needed_cushioning = false;
+
     btVector3 v =
         m_chassisBody->getVelocityInLocalPoint(m_wheelInfo[wheel_index]
                                                .m_chassisConnectionPointCS);
     btVector3 down = -m_chassisBody->getGravity();
     down.normalize();
     btVector3 v_down = (v * down) * down;
-    btScalar offset=0.1f;
+    btScalar offset=0.24;
 
 #ifdef DEBUG_CUSHIONING
     Log::verbose("physics",
-        "World %d wheel %d  lsuspl %f vdown %f overall speed %f lenght %f",
+        "World %d wheel %d  lsuspl %f vdown %f overall speed %f length %f",
         World::getWorld()->getTimeTicks(),
         wheel_index,
         m_wheelInfo[wheel_index].m_raycastInfo.m_suspensionLength,
@@ -543,19 +561,30 @@ void btKart::updateVehicle( btScalar step )
     // predict the upcoming collision correcty - so we add an offset
     // to the predicted kart movement, which was found experimentally:
     btScalar gravity = m_chassisBody->getGravity().length();
-    if (v_down.getY()<0 && m_cushioning_disable_time==0 &&
-        m_wheelInfo[wheel_index].m_raycastInfo.m_suspensionLength 
-                            < step * (-v_down.getY()+gravity*step)+offset)
+
+    btScalar absolute_fall = step*(-v_down.getY() + gravity*step);
+    btScalar predicted_fall = gravity*step*step +
+                              (m_ground_height_old-m_ground_height);
+
+    // if the ground height is below offset-0.01f, if predicted_fall > 0.4,
+    // or if max ground height is significantly different,
+    // the terrain has unexpectedly changed - avoid sending the kart flying
+    // TODO : check length between front and back wheels
+    if (absolute_fall > 0.06 && m_cushioning_disable_time==0 &&
+        m_ground_height < predicted_fall + offset &&
+        m_ground_height > (offset-0.01f) && m_ground_height_old > 0.3 &&
+        predicted_fall < 0.4 && m_max_ground_height > 0 &&
+        m_max_ground_height < 0.8)
     {
         // Disable more cushioning for 1 second. This avoids the problem
         // of hovering: a kart gets cushioned on a down-sloping area, still
         // moves forwards, gets cushioned again etc. --> kart is hovering
         // and not controllable. 
-        m_cushioning_disable_time = 120;
+        m_cushioning_disable_time = stk_config->time2Ticks(1);
 
         needed_cushioning = true;
-        btVector3 impulse = down * (-v_down.getY() + gravity*step)
-                          / m_chassisBody->getInvMass();
+        btVector3 impulse = down * (predicted_fall/step)
+                            / m_chassisBody->getInvMass();
 #ifdef DEBUG_CUSHIONING
         float v_old = m_chassisBody->getLinearVelocity().getY();
 #endif
@@ -563,12 +592,13 @@ void btKart::updateVehicle( btScalar step )
 #ifdef DEBUG_CUSHIONING
         Log::verbose("physics",
             "World %d Cushioning imp %f vdown %f from %f m/s to %f m/s "
-            "contact %f kart %f susp %f relspeed %f",
+            "height %f contact %f kart %f susp %f relspeed %f",
             World::getWorld()->getTimeTicks(),
             impulse.getY(),
             -v_down.getY(),
             v_old,
             m_chassisBody->getLinearVelocity().getY(),
+            m_ground_height,
             m_wheelInfo[wheel_index].m_raycastInfo.m_isInContact ?
             m_wheelInfo[wheel_index].m_raycastInfo.m_contactPointWS.getY()
             : -100,
@@ -579,6 +609,10 @@ void btKart::updateVehicle( btScalar step )
         );
 #endif
     }
+    // Update the ground height history
+    m_ground_height_old = m_ground_height;
+    m_ground_height = 999.9f;
+    m_max_ground_height = -100.0f;
 
 
     // Update friction (i.e. forward force)
@@ -1123,4 +1157,5 @@ btScalar btKart::rayCast(btWheelInfo& wheel, const btVector3& ray)
 }   // rayCast(btWheelInfo& wheel, const btVector3& ray
 
 // ----------------------------------------------------------------------------
+
 

--- a/src/physics/btKart.hpp
+++ b/src/physics/btKart.hpp
@@ -11,6 +11,8 @@
 #ifndef BT_KART_HPP
 #define BT_KART_HPP
 
+#include <vector>
+
 #include "BulletDynamics/Dynamics/btRigidBody.h"
 #include "BulletDynamics/ConstraintSolver/btTypedConstraint.h"
 #include "physics/btKartRaycast.hpp"
@@ -117,6 +119,12 @@ private:
      *  physics steps, so need to be set again by the application. */
     btScalar m_max_speed;
 
+    /** Smallest wheel height to the ground */
+    btScalar m_ground_height;
+    btScalar m_ground_height_old;
+    /** Highest wheel height to the ground (to detect brutal changes) */
+    btScalar m_max_ground_height;
+
     /** True if the visual wheels touch the ground. */
     bool m_visual_wheels_touch_ground;
 
@@ -142,6 +150,7 @@ public:
                               Kart *kart);
      virtual          ~btKart();
     void               reset();
+    void               resetGroundHeight();
     void               debugDraw(btIDebugDraw* debugDrawer);
     const btTransform& getChassisWorldTransform() const;
     btScalar           rayCast(unsigned int index, float fraction=1.0f);


### PR DESCRIPTION
This PR fixes the two main issues which plagued cushioning since its last revision this summer : 
- The kart abruptly slowing its fall mid-air (with a big but not so big jump) and flying off-ground in some downward slopes (snow peak, shifting sands, green valley, black forest).
- The kart slowing down too much and flying a bit again after landing on a downward slope ; or not enough and having the chassis crash when landing on an upward slope.

These two issues were the result of determining if the cushioning should be triggered on the base of the vertical speed without taking into account the real height at which the kart evolves.

By using the current height and the height in the previous frame, it is possible to entirely remove the issue of cushioning incorrectly mid-air or lying off the ground ; and to cushion the kart just right for the slope it lands on.

The downside of that approach is that if other factors than the kart falling trigger a brutal height change, this method could be tricked in a wrong cushioning catapulting the kart very high in the air.

I have iteratively identified several situations where this could happen and fixed of all them with additional sanity checks.

The code in this PR fixes all the gameplay issues I'm aware of with cushioning ; but it may be possible to simplify/clean-up some parts which are unneeded leftovers from the previous fixes attempts and the several iterations of this one.

By the way, I suspect that the 1s "no cushioning" duration could be reduced significantly, if it is even needed in the first place. 1s is long enough that sometimes, it would be useful to cushion twice.