### PR TITLE
Fix close inputs being throttled, and speed up scrolling when a key is held

### DIFF
--- a/src/input/input_manager.cpp
+++ b/src/input/input_manager.cpp
@@ -82,7 +82,7 @@ InputManager::InputManager() : m_mode(BOOTSTRAP),
     m_timer_in_use = false;
     m_master_player_only = false;
     m_timer = 0;
-	m_timer_use_count = 0;
+    m_timer_use_count = 0;
 
 }
 // -----------------------------------------------------------------------------
@@ -117,7 +117,7 @@ void InputManager::handleStaticAction(int key, int value)
 
     // When no players... a cutscene
     if (race_manager->getNumPlayers() == 0 && world != NULL && value > 0 &&
-        (key == IRR_KEY_SPACE || key == IRR_KEY_RETURN || 
+        (key == IRR_KEY_SPACE || key == IRR_KEY_RETURN ||
         key == IRR_KEY_BUTTON_A))
     {
         world->onFirePressed(NULL);
@@ -856,9 +856,9 @@ void InputManager::dispatchInput(Input::InputType type, int deviceID,
                 {
                     m_timer_in_use = true;
 
-					// After three iterations of the timer, pick up the scrolling pace
-					m_timer_use_count++;
-					m_timer = m_timer_use_count > 3 ? 0.05 : 0.25;
+                    // After three iterations of the timer, pick up the scrolling pace
+                    m_timer_use_count++;
+                    m_timer = m_timer_use_count > 3 ? 0.05 : 0.25;
                 }
 
                 // player may be NULL in early menus, before player setup has
@@ -884,15 +884,15 @@ void InputManager::dispatchInput(Input::InputType type, int deviceID,
                 GUIEngine::EventHandler::get()
                     ->processGUIAction(action, deviceID, abs(value), type,
                                        playerID);
-			}
+            }
 
-			// reset timer when released
-			if (abs(value) == 0)
-			{
-				m_timer_in_use = false;
-				m_timer = 0;
-				m_timer_use_count = 0;
-			}
+            // reset timer when released
+            if (abs(value) == 0)
+            {
+                m_timer_in_use = false;
+                m_timer = 0;
+                m_timer_use_count = 0;
+            }
         }
     }
     else if (type == Input::IT_KEYBOARD)
@@ -1035,7 +1035,7 @@ EventPropagation InputManager::input(const SEvent& event)
             // single letter). Same for spacebar. Same for letters.
             if (GUIEngine::isWithinATextBox())
             {
-                if (key == IRR_KEY_BACK || key == IRR_KEY_SPACE || 
+                if (key == IRR_KEY_BACK || key == IRR_KEY_SPACE ||
                     key == IRR_KEY_SHIFT)
                 {
                     return EVENT_LET;
@@ -1068,7 +1068,7 @@ EventPropagation InputManager::input(const SEvent& event)
             // single letter). Same for spacebar. Same for letters.
             if (GUIEngine::isWithinATextBox())
             {
-                if (key == IRR_KEY_BACK || key == IRR_KEY_SPACE || 
+                if (key == IRR_KEY_BACK || key == IRR_KEY_SPACE ||
                     key == IRR_KEY_SHIFT)
                 {
                     return EVENT_LET;

--- a/src/input/input_manager.hpp
+++ b/src/input/input_manager.hpp
@@ -46,9 +46,6 @@ public:
         BOOTSTRAP
     };
 
-    // to put a delay before a new gamepad axis move is considered in menu
-    bool m_timer_in_use;
-    float m_timer;
 
 private:
 
@@ -67,6 +64,11 @@ private:
     * makes the mouse behave like an analog axis on a gamepad/joystick.
     */
     int m_mouse_val_x, m_mouse_val_y;
+
+	// to put a delay before a new gamepad axis move is considered in menu
+	bool m_timer_in_use;
+	int m_timer_use_count;
+	float m_timer;
 
     void   dispatchInput(Input::InputType, int deviceID, int btnID,
                          Input::AxisDirection direction, int value,

--- a/src/input/input_manager.hpp
+++ b/src/input/input_manager.hpp
@@ -65,10 +65,10 @@ private:
     */
     int m_mouse_val_x, m_mouse_val_y;
 
-	// to put a delay before a new gamepad axis move is considered in menu
-	bool m_timer_in_use;
-	int m_timer_use_count;
-	float m_timer;
+    // to put a delay before a new gamepad axis move is considered in menu
+    bool m_timer_in_use;
+    int m_timer_use_count;
+    float m_timer;
 
     void   dispatchInput(Input::InputType, int deviceID, int btnID,
                          Input::AxisDirection direction, int value,


### PR DESCRIPTION
Fixes issue #3304 

Previously, the timer only worked properly on joysticks I believe, which has now been fixed, and scrolling speeds up if you hold the key!