### PR TITLE
GP Editor Word Wrap

### DIFF
--- a/data/gui/screens/grand_prix_editor.stkgui
+++ b/data/gui/screens/grand_prix_editor.stkgui
@@ -24,7 +24,7 @@
             <label id="gpname" text_align="center" width="100%" text="" />
             <ribbon_grid id="tracks" proportion="1" width="100%" square_items="true"
                 label_location="each" align="left" max_rows="1"
-                child_width="160" child_height="120" />
+                child_width="160" child_height="120" word_wrap="true" />
         </box>
 
         <spacer height="20" />

--- a/src/guiengine/widgets/dynamic_ribbon_widget.cpp
+++ b/src/guiengine/widgets/dynamic_ribbon_widget.cpp
@@ -418,7 +418,16 @@ void DynamicRibbonWidget::buildInternalStructure()
             icon->m_properties[PROP_HEIGHT] = m_properties[PROP_CHILD_HEIGHT];
             icon->m_w = atoi(icon->m_properties[PROP_WIDTH].c_str());
             icon->m_h = atoi(icon->m_properties[PROP_HEIGHT].c_str());
-            icon->setLabelFont(m_font);
+
+            if (m_properties[PROP_WORD_WRAP] == "true")
+            {
+                icon->m_properties[PROP_WORD_WRAP] = "true";
+            }
+            else
+            {
+
+                icon->setLabelFont(m_font);
+            }
 
             // If we want each icon to have its own label, we must make it non-empty, otherwise
             // it will assume there is no label and none will be created (FIXME: that's ugly)

--- a/src/guiengine/widgets/dynamic_ribbon_widget.cpp
+++ b/src/guiengine/widgets/dynamic_ribbon_widget.cpp
@@ -39,7 +39,6 @@ DynamicRibbonWidget::DynamicRibbonWidget(const bool combo, const bool multi_row)
     m_scroll_offset        = 0;
     m_needed_cols          = 0;
     m_col_amount           = 0;
-    m_previous_item_count  = 0;
     m_max_label_length     = 0;
     m_multi_row            = multi_row;
     m_combo                = combo;
@@ -537,7 +536,6 @@ void DynamicRibbonWidget::clearItems()
 void DynamicRibbonWidget::elementRemoved()
 {
     Widget::elementRemoved();
-    m_previous_item_count = 0;
     m_rows.clearWithoutDeleting();
     m_left_widget = NULL;
     m_right_widget = NULL;
@@ -890,12 +888,8 @@ void DynamicRibbonWidget::updateLabel(RibbonWidget* from_this_ribbon)
 
 void DynamicRibbonWidget::updateItemDisplay()
 {
-    // ---- Check if we need to update the number of icons in the ribbon
-    if ((int)m_items.size() != m_previous_item_count)
-    {
-        buildInternalStructure();
-        m_previous_item_count = (int)m_items.size();
-    }
+
+    buildInternalStructure();
 
     // ---- some variables
     int icon_id = 0;

--- a/src/guiengine/widgets/dynamic_ribbon_widget.hpp
+++ b/src/guiengine/widgets/dynamic_ribbon_widget.hpp
@@ -98,8 +98,6 @@ namespace GUIEngine
           */
         bool m_scrolling_enabled;
 
-        /** Used to keep track of item count changes */
-        int m_previous_item_count;
 
         /** List of items in the ribbon */
         std::vector<ItemDescription> m_items;

--- a/src/guiengine/widgets/ribbon_widget.cpp
+++ b/src/guiengine/widgets/ribbon_widget.cpp
@@ -396,8 +396,9 @@ void RibbonWidget::add()
                 has_label = false;
             }
 
+            const int font_size = m_active_children[i].m_properties[PROP_WORD_WRAP] == "true" ? GUIEngine::getFontHeight() * 2 : GUIEngine::getFontHeight();
             const int needed_space_under_button = has_label
-                                                ? GUIEngine::getFontHeight()
+                                                ? font_size
                                                 : 10;
 
             float imageRatio =


### PR DESCRIPTION
Fixes issue #3474 

The issue would only occur as shown in the issue screenshot when you clicked another prix first, and then clicked one where the names were too long. This is because font scaling is done in buildInternalStructure() which was not being called if the number of items was the same as the previous list. This issue was fixed with the first commit.

Second commit adds word wrap, which was suggested in the issue and looks better than tiny text.
![image](https://user-images.githubusercontent.com/1860011/47123095-f0833e00-d236-11e8-869f-a602af8b9507.png)
