### PR TITLE
Gyroscope support for Android

### DIFF
--- a/data/gui/dialogs/android/init_android.stkgui
+++ b/data/gui/dialogs/android/init_android.stkgui
@@ -10,6 +10,8 @@
             <ribbon id="control_type" proportion="1" width="100%" align="center">
                 <icon-button id="accelerometer" width="fit" height="fit" icon="gui/icons/difficulty_medium.png"
                         I18N="Control type" text="Accelerometer"/>
+                <icon-button id="gyroscope" width="fit" height="fit" icon="gui/icons/difficulty_best.png"
+                        I18N="Control type" text="Gyroscope"/>
                 <icon-button id="steering_wheel" width="fit" height="fit" icon="gui/icons/difficulty_hard.png"
                         I18N="Control type"  text="Steering wheel"/>
             </ribbon>

--- a/data/gui/dialogs/android/multitouch_settings.stkgui
+++ b/data/gui/dialogs/android/multitouch_settings.stkgui
@@ -39,6 +39,14 @@
             </div>
         </div>
 
+        <div width="75%" layout="horizontal-row" proportion="1">
+            <label proportion="1" align="center" text_align="right" I18N="In the multitouch settings screen" text="Gyroscope"/>
+            <div proportion="1" align="center" height="fit" layout="horizontal-row" >
+                <spacer width="40" height="10" />
+                <checkbox id="gyroscope"/>
+            </div>
+        </div>
+
         <label width="100%" I18N="In the multitouch settings screen" text="Advanced"/>
 
         <div width="75%" layout="horizontal-row" proportion="1">

--- a/data/po/supertuxkart.pot
+++ b/data/po/supertuxkart.pot
@@ -170,6 +170,13 @@ msgstr ""
 
 #. I18N: ./data/gui/dialogs/android/init_android.stkgui
 #. I18N: Control type
+#. I18N: ./data/gui/dialogs/android/multitouch_settings.stkgui
+#. I18N: In the multitouch settings screen
+msgid "Gyroscope"
+msgstr ""
+
+#. I18N: ./data/gui/dialogs/android/init_android.stkgui
+#. I18N: Control type
 msgid "Steering wheel"
 msgstr ""
 

--- a/src/config/user_config.hpp
+++ b/src/config/user_config.hpp
@@ -352,6 +352,14 @@ enum GeometryLevel
     GEOLEVEL_2    = 2
 };
 
+enum MultitouchControls
+{
+    MULTITOUCH_CONTROLS_UNDEFINED = 0,
+    MULTITOUCH_CONTROLS_STEERING_WHEEL = 1,
+    MULTITOUCH_CONTROLS_ACCELEROMETER = 2,
+    MULTITOUCH_CONTROLS_GYROSCOPE = 3,
+};
+
 /** Using X-macros for setting-possible values is not very pretty, but it's a
  *  no-maintenance case :
  *  when you want to add a new parameter, just add one signle line below and

--- a/src/config/user_config.hpp
+++ b/src/config/user_config.hpp
@@ -488,7 +488,7 @@ namespace UserConfigParams
     PARAM_PREFIX IntUserConfigParam         m_multitouch_controls
             PARAM_DEFAULT( IntUserConfigParam(0, "multitouch_controls",
             &m_multitouch_group,
-            "Multitouch mode: 0 = undefined, 1 = steering wheel, 2 = accelerometer"));
+            "Multitouch mode: 0 = undefined, 1 = steering wheel, 2 = accelerometer, 3 = gyroscope"));
 
     PARAM_PREFIX FloatUserConfigParam         m_multitouch_deadzone_center
             PARAM_DEFAULT( FloatUserConfigParam(0.1f, "multitouch_deadzone_center",

--- a/src/graphics/camera_end.cpp
+++ b/src/graphics/camera_end.cpp
@@ -135,7 +135,7 @@ void CameraEnd::update(float dt)
 
             positionCamera(dt, /*above_kart*/0.75f,
                            cam_angle, /*side_way*/0,
-                           2.0f*getDistanceToKart(), /*smoothing*/false);
+                           2.0f*getDistanceToKart(), /*smoothing*/false, 0.0f);
             break;
         }
     default: break;

--- a/src/graphics/camera_normal.hpp
+++ b/src/graphics/camera_normal.hpp
@@ -55,10 +55,11 @@ private:
     void handleEndCamera(float dt);
     void getCameraSettings(float *above_kart, float *cam_angle,
                            float *side_way, float *distance,
-                           bool *smoothing);
+                           bool *smoothing, float *cam_roll_angle);
     
     void positionCamera(float dt, float above_kart, float cam_angle,
-                        float side_way, float distance, float smoothing);
+                        float side_way, float distance, float smoothing,
+                        float cam_roll_angle);
 
     btVector3 m_kart_position;
     btQuaternion m_kart_rotation;

--- a/src/guiengine/event_handler.cpp
+++ b/src/guiengine/event_handler.cpp
@@ -202,7 +202,8 @@ bool EventHandler::OnEvent (const SEvent &event)
              event.EventType == EET_TOUCH_INPUT_EVENT ||
              event.EventType == EET_KEY_INPUT_EVENT   ||
              event.EventType == EET_JOYSTICK_INPUT_EVENT ||
-             event.EventType == EET_ACCELEROMETER_EVENT)
+             event.EventType == EET_ACCELEROMETER_EVENT ||
+             event.EventType == EET_GYROSCOPE_EVENT)
     {
         // Remember the mouse position
         if (event.EventType == EET_MOUSE_INPUT_EVENT &&

--- a/src/input/multitouch_device.cpp
+++ b/src/input/multitouch_device.cpp
@@ -171,6 +171,9 @@ void MultitouchDevice::reset()
         event.x = 0;
         event.y = 0;
     }
+
+    m_orientation = 0.0f;
+    m_gyro_time = 0.0;
 } // reset
 
 // ----------------------------------------------------------------------------
@@ -207,6 +210,45 @@ bool MultitouchDevice::isAccelerometerActive()
 {
 #ifdef ANDROID
     return m_android_device->isAccelerometerActive();
+#endif
+
+    return false;
+}
+
+// ----------------------------------------------------------------------------
+/** Activates gyroscope
+ */
+void MultitouchDevice::activateGyroscope()
+{
+#ifdef ANDROID
+    if (!m_android_device->isGyroscopeActive())
+    {
+        m_android_device->activateGyroscope(1.0f / 60); // Assume 60 FPS, some phones can do 90 and 120 FPS but we won't handle them now
+    }
+#endif
+}
+
+// ----------------------------------------------------------------------------
+/** Deativates gyroscope
+ */
+void MultitouchDevice::deactivateGyroscope()
+{
+#ifdef ANDROID
+    if (m_android_device->isGyroscopeActive())
+    {
+        m_android_device->deactivateGyroscope();
+    }
+#endif
+}
+
+// ----------------------------------------------------------------------------
+/** Get gyroscope state
+ *  \return true if gyroscope is active
+ */
+bool MultitouchDevice::isGyroscopeActive()
+{
+#ifdef ANDROID
+    return m_android_device->isGyroscopeActive();
 #endif
 
     return false;
@@ -378,6 +420,87 @@ void MultitouchDevice::updateAxisY(float value)
         m_controller->action(PA_BRAKE, 0);
         m_controller->action(PA_ACCEL, 0);
     }
+}
+
+// ----------------------------------------------------------------------------
+
+float MultitouchDevice::getOrientation()
+{
+    return m_orientation;
+}
+
+// ----------------------------------------------------------------------------
+
+void MultitouchDevice::updateOrientationFromAccelerometer(float x, float y)
+{
+    const float ACCEL_DISCARD_THRESHOLD = 4.0f;
+    const float ACCEL_MULTIPLIER = 0.05f; // Slowly adjust the angle over time, this prevents shaking
+    const float ACCEL_CHANGE_THRESHOLD = 0.01f; // ~0.5 degrees
+
+    if (fabsf(x) + fabsf(y) < ACCEL_DISCARD_THRESHOLD)
+    {
+        // The device is flat on the table, cannot reliably determine the orientation
+        return;
+    }
+
+    float angle = atan2f(y, x);
+    if (angle > (M_PI / 2.0))
+    {
+        angle = (M_PI / 2.0);
+    }
+    if (angle < -(M_PI / 2.0))
+    {
+        angle = -(M_PI / 2.0);
+    }
+
+    float delta = angle - m_orientation;
+    delta *= ACCEL_MULTIPLIER;
+    if (delta > ACCEL_CHANGE_THRESHOLD)
+    {
+        delta = ACCEL_CHANGE_THRESHOLD;
+    }
+    if (delta < -ACCEL_CHANGE_THRESHOLD)
+    {
+        delta = -ACCEL_CHANGE_THRESHOLD;
+    }
+
+    m_orientation += delta;
+
+    //Log::warn("Accel", "X %03.4f Y %03.4f angle %03.4f delta %03.4f orientation %03.4f", x, y, angle, delta, m_orientation);
+}
+
+// ----------------------------------------------------------------------------
+
+void MultitouchDevice::updateOrientationFromGyroscope(float z)
+{
+    const float GYRO_SPEED_THRESHOLD = 0.005f;
+
+    double now = StkTime::getRealTime();
+    float timedelta = now - m_gyro_time;
+    m_gyro_time = now;
+    if (timedelta > 0.5f)
+    {
+        timedelta = 0.1f;
+    }
+
+    float angular_speed = -z;
+
+    if (fabsf(angular_speed) < GYRO_SPEED_THRESHOLD)
+    {
+        angular_speed = 0.0f;
+    }
+
+    m_orientation += angular_speed * timedelta;
+    if (m_orientation > (M_PI / 2.0))
+    {
+        m_orientation = (M_PI / 2.0);
+    }
+    if (m_orientation < -(M_PI / 2.0))
+    {
+        m_orientation = -(M_PI / 2.0);
+    }
+
+    //Log::warn("Gyro", "Z %03.4f angular_speed %03.4f delta %03.4f orientation %03.4f", z, angular_speed, angular_speed * timedelta, m_orientation);
 }
 
 // ----------------------------------------------------------------------------

--- a/src/input/multitouch_device.cpp
+++ b/src/input/multitouch_device.cpp
@@ -484,8 +484,6 @@ void MultitouchDevice::updateOrientationFromAccelerometer(float x, float y)
  */
 void MultitouchDevice::updateOrientationFromGyroscope(float z)
 {
-    const float GYRO_SPEED_THRESHOLD = 0.005f;
-
     double now = StkTime::getRealTime();
     float timedelta = now - m_gyro_time;
     m_gyro_time = now;
@@ -494,12 +492,15 @@ void MultitouchDevice::updateOrientationFromGyroscope(float z)
         timedelta = 0.1f;
     }
 
-    float angular_speed = -z;
+    m_gyro_filter.collectNoiseData(z);
 
-    if (fabsf(angular_speed) < GYRO_SPEED_THRESHOLD)
+    if (z > m_gyro_filter.filterMin && z < m_gyro_filter.filterMax)
     {
-        angular_speed = 0.0f;
+        return;
     }
+    z -= m_gyro_filter.filterCenter;
+
+    float angular_speed = -z;
 
     m_orientation += angular_speed * timedelta;
     if (m_orientation > (M_PI / 2.0))
@@ -589,3 +590,145 @@ void MultitouchDevice::updateController()
 }
 
 // ----------------------------------------------------------------------------
+
+MultitouchDevice::GyroscopeFilterData::GyroscopeFilterData()
+{
+	// Noise filter with sane initial values, so user will be able
+	// to move gyroscope during the first 10 seconds, while the noise is measured.
+	// After that the values are replaced by noiseMin/noiseMax.
+	filterMin = -0.05f;
+	filterMax = 0.05f;
+	filterCenter = 0.0f;
+
+	// The noise levels we're measuring.
+	// Large initial values, they will decrease, but never increase.
+	noiseMin = -1.0f;
+	noiseMax = 1.0f;
+
+	// The gyro data buffer, from which we care calculating min/max noise values.
+	// The bigger it is, the more precise the calclations, and the longer it takes to converge.
+	for (int i = 0; i < NOISE_DATA_SIZE; i++)
+	{
+		noiseData[i] = 0.0f;
+	}
+	noiseDataIdx = 0;
+
+	// When we detect movement, we remove last few values of the measured data.
+	// The movement is detected by comparing values to noiseMin/noiseMax of the previous iteration.
+	movementBackoff = 0;
+
+	// Difference between min/max in the previous measurement iteration,
+	// used to determine when we should stop measuring, when the change becomes negligilbe.
+	measuredNoiseRange = -1.0f;
+
+	// How long the algorithm is running, to stop it when measurements are finished.
+	measurementIteration = 0;
+}
+
+/** Collect gyroscope measurements and calculate noise min/max values */
+void MultitouchDevice::GyroscopeFilterData::collectNoiseData(float data)
+{
+	if (measurementIteration >= MAX_ITERATIONS)
+	{
+		return;
+	}
+
+	if (data < noiseMin || data > noiseMax)
+	{
+		// Movement detected, this can converge our min/max too early, so we're discarding last few values
+		if (movementBackoff < 0)
+		{
+			int discard = 10;
+			if (-movementBackoff < discard)
+				discard = -movementBackoff;
+			noiseDataIdx -= discard;
+			if (noiseDataIdx < 0)
+				noiseDataIdx = 0;
+		}
+		movementBackoff = 10;
+		return;
+	}
+	noiseData[noiseDataIdx] = data;
+
+	movementBackoff--;
+	if (movementBackoff >= 0)
+	{
+		return; // Also discard several values after the movement stopped
+	}
+	noiseDataIdx++;
+
+	if (noiseDataIdx < NOISE_DATA_SIZE)
+	{
+		return;
+	}
+
+	measurementIteration++;
+	Log::info("GyroscopeFilterData", "Measuring in progress, iteration %d / %d", measurementIteration, MAX_ITERATIONS);
+	if (measurementIteration >= MAX_ITERATIONS / 3)
+	{
+		// We've collected enough data to use our noise min/max values as a new filter
+		filterMin = noiseMin;
+		filterMax = noiseMax;
+		filterCenter = (filterMin + filterMax) / 2.0f;
+	}
+	if (measurementIteration >= MAX_ITERATIONS)
+	{
+		Log::info("GyroscopeFilterData", "Measuring done! Maximum number of iterations reached: %d", measurementIteration);
+		return;
+	}
+
+	noiseDataIdx = 0;
+	bool changed = false;
+	float min = 1.0f;
+	float max = -1.0f;
+	for (int i = 0; i < NOISE_DATA_SIZE; i++)
+	{
+		if( min > noiseData[i] )
+			min = noiseData[i];
+		if( max < noiseData[i] )
+			max = noiseData[i];
+	}
+	// Increase the range a bit, for safe conservative filtering
+	float middle = (min + max) / 2.0f;
+	min += (min - middle) * 0.2f;
+	max += (max - middle) * 0.2f;
+	// Check if range between min/max is less then the current range, as a safety measure,
+	// and min/max range is not jumping outside of previously measured range
+	if (max - min < noiseMax - noiseMin && min >= noiseMin && max <= noiseMax)
+	{
+		// Move old min/max closer to the measured min/max, but do not replace the values altogether
+		noiseMin = (noiseMin + min * 4.0f) / 5.0f;
+		noiseMax = (noiseMax + max * 4.0f) / 5.0f;
+		changed = true;
+	}
+
+	Log::info("GyroscopeFilterData", "Measured noise min: %03.5f max: %03.5f", noiseMin, noiseMax);
+
+	if( !changed )
+		return;
+
+	// Determine when to stop measuring - check that the previous min/max range is close enough to the current one
+
+	float range = noiseMax - noiseMin;
+
+	Log::info("GyroscopeFilterData", "Measured noise range: %03.5f old range: %03.5f", range, measuredNoiseRange);
+
+	if (measuredNoiseRange < 0.0f)
+	{
+		measuredNoiseRange = range;
+		return; // First iteration, skip further checks
+	}
+
+	if( measuredNoiseRange / range > 1.2f )
+	{
+		measuredNoiseRange = range;
+		return;
+	}
+
+	// We converged to the final min/max filter values, stop measuring
+	Log::info("GyroscopeFilterData", "Measuring done! Range converged on iteration %d", measurementIteration);
+	filterMin = noiseMin;
+	filterMax = noiseMax;
+	filterCenter = (filterMin + filterMax) / 2.0f;
+	measurementIteration = MAX_ITERATIONS;
+}

--- a/src/input/multitouch_device.cpp
+++ b/src/input/multitouch_device.cpp
@@ -424,6 +424,8 @@ void MultitouchDevice::updateAxisY(float value)
 
 // ----------------------------------------------------------------------------
 
+/** Returns device orientation Z angle, in radians, where 0 is landscape orientation parallel to the floor.
+ */
 float MultitouchDevice::getOrientation()
 {
     return m_orientation;
@@ -431,6 +433,11 @@ float MultitouchDevice::getOrientation()
 
 // ----------------------------------------------------------------------------
 
+/** Update device orientation from the accelerometer measurements.
+ *  Accelerometer is shaky, so it adjusts the orientation angle slowly.
+ *  \param x Accelerometer X axis
+ *  \param y Accelerometer Y axis
+ */
 void MultitouchDevice::updateOrientationFromAccelerometer(float x, float y)
 {
     const float ACCEL_DISCARD_THRESHOLD = 4.0f;
@@ -471,6 +478,10 @@ void MultitouchDevice::updateOrientationFromAccelerometer(float x, float y)
 
 // ----------------------------------------------------------------------------
 
+/** Update device orientation from the gyroscope measurements.
+ *  Gyroscope is not shaky and very sensitive, but drifts over time.
+ *  \param x Gyroscope Z axis
+ */
 void MultitouchDevice::updateOrientationFromGyroscope(float z)
 {
     const float GYRO_SPEED_THRESHOLD = 0.005f;

--- a/src/input/multitouch_device.hpp
+++ b/src/input/multitouch_device.hpp
@@ -87,6 +87,9 @@ private:
      *  at the edge of button */
     float m_deadzone_edge;
 
+    float m_orientation;
+    double m_gyro_time;
+
 #ifdef ANDROID
     /** Pointer to the Android irrlicht device */
     CIrrDeviceAndroid* m_android_device;
@@ -125,9 +128,16 @@ public:
     void activateAccelerometer();
     void deactivateAccelerometer();
     bool isAccelerometerActive();
-    
+
+    void activateGyroscope();
+    void deactivateGyroscope();
+    bool isGyroscopeActive();
+
     void updateAxisX(float value);
     void updateAxisY(float value);
+    float getOrientation();
+    void updateOrientationFromAccelerometer(float x, float y);
+    void updateOrientationFromGyroscope(float z);
     void updateDeviceState(unsigned int event_id);
     void updateController();
     void updateConfigParams();

--- a/src/input/multitouch_device.hpp
+++ b/src/input/multitouch_device.hpp
@@ -90,6 +90,44 @@ private:
     float m_orientation;
     double m_gyro_time;
 
+	class GyroscopeFilterData
+	{
+		public:
+		GyroscopeFilterData();
+		void collectNoiseData(float data);
+
+		// Noise filter with sane initial values, so user will be able
+		// to move gyroscope during the first 10 seconds, while the noise is measured.
+		// After that the values are replaced by noiseMin/noiseMax.
+		float filterMin;
+		float filterMax;
+		float filterCenter;
+
+		// The noise levels we're measuring.
+		// Large initial values, they will decrease, but never increase.
+		float noiseMin;
+		float noiseMax;
+
+		// The gyro data buffer, from which we care calculating min/max noise values.
+		// The bigger it is, the more precise the calclations, and the longer it takes to converge.
+		enum { NOISE_DATA_SIZE = 200, MAX_ITERATIONS = 15 };
+		float noiseData[NOISE_DATA_SIZE];
+		int noiseDataIdx = 0;
+
+		// When we detect movement, we remove last few values of the measured data.
+		// The movement is detected by comparing values to noiseMin/noiseMax of the previous iteration.
+		int movementBackoff = 0;
+
+		// Difference between min/max in the previous measurement iteration,
+		// used to determine when we should stop measuring, when the change becomes negligilbe.
+		float measuredNoiseRange = -1.0f;
+
+		// How long the algorithm is running, to stop it when measurements are finished.
+		int measurementIteration = 0;
+	};
+
+	GyroscopeFilterData m_gyro_filter;
+
 #ifdef ANDROID
     /** Pointer to the Android irrlicht device */
     CIrrDeviceAndroid* m_android_device;

--- a/src/input/multitouch_device.hpp
+++ b/src/input/multitouch_device.hpp
@@ -90,44 +90,6 @@ private:
     float m_orientation;
     double m_gyro_time;
 
-	class GyroscopeFilterData
-	{
-		public:
-		GyroscopeFilterData();
-		void collectNoiseData(float data);
-
-		// Noise filter with sane initial values, so user will be able
-		// to move gyroscope during the first 10 seconds, while the noise is measured.
-		// After that the values are replaced by noiseMin/noiseMax.
-		float filterMin;
-		float filterMax;
-		float filterCenter;
-
-		// The noise levels we're measuring.
-		// Large initial values, they will decrease, but never increase.
-		float noiseMin;
-		float noiseMax;
-
-		// The gyro data buffer, from which we care calculating min/max noise values.
-		// The bigger it is, the more precise the calclations, and the longer it takes to converge.
-		enum { NOISE_DATA_SIZE = 200, MAX_ITERATIONS = 15 };
-		float noiseData[NOISE_DATA_SIZE];
-		int noiseDataIdx = 0;
-
-		// When we detect movement, we remove last few values of the measured data.
-		// The movement is detected by comparing values to noiseMin/noiseMax of the previous iteration.
-		int movementBackoff = 0;
-
-		// Difference between min/max in the previous measurement iteration,
-		// used to determine when we should stop measuring, when the change becomes negligilbe.
-		float measuredNoiseRange = -1.0f;
-
-		// How long the algorithm is running, to stop it when measurements are finished.
-		int measurementIteration = 0;
-	};
-
-	GyroscopeFilterData m_gyro_filter;
-
 #ifdef ANDROID
     /** Pointer to the Android irrlicht device */
     CIrrDeviceAndroid* m_android_device;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2083,7 +2083,7 @@ int main(int argc, char *argv[] )
             }
             
             #ifdef ANDROID
-            if (UserConfigParams::m_multitouch_controls == 0)
+            if (UserConfigParams::m_multitouch_controls == MULTITOUCH_CONTROLS_UNDEFINED)
             {
                 int32_t touch = AConfiguration_getTouchscreen(
                                                     global_android_app->config);

--- a/src/states_screens/dialogs/init_android_dialog.cpp
+++ b/src/states_screens/dialogs/init_android_dialog.cpp
@@ -83,9 +83,9 @@ void InitAndroidDialog::beforeAddingWidgets()
         Widget* accelerometer = &control_type->getChildren()[index];
         accelerometer->setActive(false);
         
-        if (UserConfigParams::m_multitouch_controls == 2)
+        if (UserConfigParams::m_multitouch_controls == MULTITOUCH_CONTROLS_ACCELEROMETER)
         {
-            UserConfigParams::m_multitouch_controls = 1;
+            UserConfigParams::m_multitouch_controls = MULTITOUCH_CONTROLS_STEERING_WHEEL;
         }
     }
 
@@ -98,9 +98,9 @@ void InitAndroidDialog::beforeAddingWidgets()
         Widget* gyroscope = &control_type->getChildren()[index];
         gyroscope->setActive(false);
         
-        if (UserConfigParams::m_multitouch_controls == 3)
+        if (UserConfigParams::m_multitouch_controls == MULTITOUCH_CONTROLS_GYROSCOPE)
         {
-            UserConfigParams::m_multitouch_controls = 1;
+            UserConfigParams::m_multitouch_controls = MULTITOUCH_CONTROLS_STEERING_WHEEL;
         }
     }
 
@@ -127,15 +127,15 @@ GUIEngine::EventPropagation InitAndroidDialog::processEvent(
         
         if (selected == "steering_wheel")
         {
-            UserConfigParams::m_multitouch_controls = 1;
+            UserConfigParams::m_multitouch_controls = MULTITOUCH_CONTROLS_STEERING_WHEEL;
         }
         else if (selected == "accelerometer")
         {
-            UserConfigParams::m_multitouch_controls = 2;
+            UserConfigParams::m_multitouch_controls = MULTITOUCH_CONTROLS_ACCELEROMETER;
         }
         else if (selected == "gyroscope")
         {
-            UserConfigParams::m_multitouch_controls = 3;
+            UserConfigParams::m_multitouch_controls = MULTITOUCH_CONTROLS_GYROSCOPE;
         }
         
         user_config->saveConfig();
@@ -154,12 +154,12 @@ void InitAndroidDialog::updateValues()
     RibbonWidget* control_type = getWidget<RibbonWidget>("control_type");
     assert(control_type != NULL);
     
-    if (UserConfigParams::m_multitouch_controls == 2)
+    if (UserConfigParams::m_multitouch_controls == MULTITOUCH_CONTROLS_ACCELEROMETER)
     {
         int id = control_type->findItemNamed("accelerometer");
         control_type->setSelection(id, PLAYER_ID_GAME_MASTER);
     }
-    else if (UserConfigParams::m_multitouch_controls == 3)
+    else if (UserConfigParams::m_multitouch_controls == MULTITOUCH_CONTROLS_GYROSCOPE)
     {
         int id = control_type->findItemNamed("gyroscope");
         control_type->setSelection(id, PLAYER_ID_GAME_MASTER);
@@ -175,7 +175,7 @@ void InitAndroidDialog::updateValues()
 
 bool InitAndroidDialog::onEscapePressed()
 {
-    UserConfigParams::m_multitouch_controls = 1;
+    UserConfigParams::m_multitouch_controls = MULTITOUCH_CONTROLS_STEERING_WHEEL;
     user_config->saveConfig();
     ModalDialog::dismiss();
     return true;

--- a/src/states_screens/dialogs/init_android_dialog.cpp
+++ b/src/states_screens/dialogs/init_android_dialog.cpp
@@ -64,12 +64,14 @@ void InitAndroidDialog::load()
 void InitAndroidDialog::beforeAddingWidgets()
 {
     bool accelerometer_available = false;
+    bool gyroscope_available = false;
     
 #ifdef ANDROID
     CIrrDeviceAndroid* android_device = dynamic_cast<CIrrDeviceAndroid*>(
                                                     irr_driver->getDevice());
     assert(android_device != NULL);
     accelerometer_available = android_device->isAccelerometerAvailable();
+    gyroscope_available = android_device->isGyroscopeAvailable() && accelerometer_available;
 #endif
 
     if (!accelerometer_available)
@@ -82,6 +84,21 @@ void InitAndroidDialog::beforeAddingWidgets()
         accelerometer->setActive(false);
         
         if (UserConfigParams::m_multitouch_controls == 2)
+        {
+            UserConfigParams::m_multitouch_controls = 1;
+        }
+    }
+
+    if (!gyroscope_available)
+    {
+        RibbonWidget* control_type = getWidget<RibbonWidget>("control_type");
+        assert(control_type != NULL);
+
+        int index = control_type->findItemNamed("gyroscope");
+        Widget* gyroscope = &control_type->getChildren()[index];
+        gyroscope->setActive(false);
+        
+        if (UserConfigParams::m_multitouch_controls == 3)
         {
             UserConfigParams::m_multitouch_controls = 1;
         }
@@ -116,6 +133,10 @@ GUIEngine::EventPropagation InitAndroidDialog::processEvent(
         {
             UserConfigParams::m_multitouch_controls = 2;
         }
+        else if (selected == "gyroscope")
+        {
+            UserConfigParams::m_multitouch_controls = 3;
+        }
         
         user_config->saveConfig();
         
@@ -136,6 +157,11 @@ void InitAndroidDialog::updateValues()
     if (UserConfigParams::m_multitouch_controls == 2)
     {
         int id = control_type->findItemNamed("accelerometer");
+        control_type->setSelection(id, PLAYER_ID_GAME_MASTER);
+    }
+    else if (UserConfigParams::m_multitouch_controls == 3)
+    {
+        int id = control_type->findItemNamed("gyroscope");
         control_type->setSelection(id, PLAYER_ID_GAME_MASTER);
     }
     else

--- a/src/states_screens/dialogs/multitouch_settings_dialog.cpp
+++ b/src/states_screens/dialogs/multitouch_settings_dialog.cpp
@@ -119,16 +119,16 @@ GUIEngine::EventPropagation MultitouchSettingsDialog::processEvent(
         CheckBoxWidget* gyroscope = getWidget<CheckBoxWidget>("gyroscope");
         assert(gyroscope != NULL);
 
-        UserConfigParams::m_multitouch_controls = 1;
+        UserConfigParams::m_multitouch_controls = MULTITOUCH_CONTROLS_STEERING_WHEEL;
 
         if (accelerometer->getState())
         {
-            UserConfigParams::m_multitouch_controls = 2;
+            UserConfigParams::m_multitouch_controls = MULTITOUCH_CONTROLS_ACCELEROMETER;
         }
 
         if (gyroscope->getState())
         {
-            UserConfigParams::m_multitouch_controls = 3;
+            UserConfigParams::m_multitouch_controls = MULTITOUCH_CONTROLS_GYROSCOPE;
         }
 
         MultitouchDevice* touch_device = input_manager->getDeviceManager()->
@@ -224,11 +224,11 @@ void MultitouchSettingsDialog::updateValues()
 
     CheckBoxWidget* accelerometer = getWidget<CheckBoxWidget>("accelerometer");
     assert(accelerometer != NULL);
-    accelerometer->setState(UserConfigParams::m_multitouch_controls == 2);
+    accelerometer->setState(UserConfigParams::m_multitouch_controls == MULTITOUCH_CONTROLS_ACCELEROMETER);
 
     CheckBoxWidget* gyroscope = getWidget<CheckBoxWidget>("gyroscope");
     assert(gyroscope != NULL);
-    gyroscope->setState(UserConfigParams::m_multitouch_controls == 3);
+    gyroscope->setState(UserConfigParams::m_multitouch_controls == MULTITOUCH_CONTROLS_GYROSCOPE);
 }
 
 // -----------------------------------------------------------------------------

--- a/src/states_screens/dialogs/multitouch_settings_dialog.cpp
+++ b/src/states_screens/dialogs/multitouch_settings_dialog.cpp
@@ -57,12 +57,14 @@ MultitouchSettingsDialog::~MultitouchSettingsDialog()
 void MultitouchSettingsDialog::beforeAddingWidgets()
 {
     bool accelerometer_available = false;
+    bool gyroscope_available = false;
     
 #ifdef ANDROID
     CIrrDeviceAndroid* android_device = dynamic_cast<CIrrDeviceAndroid*>(
                                                     irr_driver->getDevice());
     assert(android_device != NULL);
     accelerometer_available = android_device->isAccelerometerAvailable();
+    gyroscope_available = android_device->isGyroscopeAvailable() && accelerometer_available;
 #endif
 
     if (!accelerometer_available)
@@ -70,6 +72,13 @@ void MultitouchSettingsDialog::beforeAddingWidgets()
         CheckBoxWidget* accelerometer = getWidget<CheckBoxWidget>("accelerometer");
         assert(accelerometer != NULL);
         accelerometer->setActive(false);
+    }
+
+    if (!gyroscope_available)
+    {
+        CheckBoxWidget* gyroscope = getWidget<CheckBoxWidget>("gyroscope");
+        assert(gyroscope != NULL);
+        gyroscope->setActive(false);
     }
 
     updateValues();
@@ -107,8 +116,20 @@ GUIEngine::EventPropagation MultitouchSettingsDialog::processEvent(
         CheckBoxWidget* accelerometer = getWidget<CheckBoxWidget>("accelerometer");
         assert(accelerometer != NULL);
 
-        UserConfigParams::m_multitouch_controls = accelerometer->
-                                                            getState() ? 2 : 1;
+        CheckBoxWidget* gyroscope = getWidget<CheckBoxWidget>("gyroscope");
+        assert(gyroscope != NULL);
+
+        UserConfigParams::m_multitouch_controls = 1;
+
+        if (accelerometer->getState())
+        {
+            UserConfigParams::m_multitouch_controls = 2;
+        }
+
+        if (gyroscope->getState())
+        {
+            UserConfigParams::m_multitouch_controls = 3;
+        }
 
         MultitouchDevice* touch_device = input_manager->getDeviceManager()->
                                                         getMultitouchDevice();
@@ -159,6 +180,18 @@ GUIEngine::EventPropagation MultitouchSettingsDialog::processEvent(
 
         return GUIEngine::EVENT_BLOCK;
     }
+    else if (eventSource == "accelerometer")
+    {
+        CheckBoxWidget* gyroscope = getWidget<CheckBoxWidget>("gyroscope");
+        assert(gyroscope != NULL);
+        gyroscope->setState(false);
+    }
+    else if (eventSource == "gyroscope")
+    {
+        CheckBoxWidget* accelerometer = getWidget<CheckBoxWidget>("accelerometer");
+        assert(accelerometer != NULL);
+        accelerometer->setState(false);
+    }
 
     return GUIEngine::EVENT_LET;
 }   // processEvent
@@ -192,6 +225,10 @@ void MultitouchSettingsDialog::updateValues()
     CheckBoxWidget* accelerometer = getWidget<CheckBoxWidget>("accelerometer");
     assert(accelerometer != NULL);
     accelerometer->setState(UserConfigParams::m_multitouch_controls == 2);
+
+    CheckBoxWidget* gyroscope = getWidget<CheckBoxWidget>("gyroscope");
+    assert(gyroscope != NULL);
+    gyroscope->setState(UserConfigParams::m_multitouch_controls == 3);
 }
 
 // -----------------------------------------------------------------------------

--- a/src/states_screens/race_gui_multitouch.cpp
+++ b/src/states_screens/race_gui_multitouch.cpp
@@ -116,7 +116,7 @@ void RaceGUIMultitouch::init()
     if (m_device == NULL)
         return;
         
-    if (UserConfigParams::m_multitouch_controls == 2)
+    if (UserConfigParams::m_multitouch_controls == MULTITOUCH_CONTROLS_ACCELEROMETER)
     {
         m_device->activateAccelerometer();
     }

--- a/src/states_screens/race_gui_multitouch.cpp
+++ b/src/states_screens/race_gui_multitouch.cpp
@@ -104,6 +104,11 @@ void RaceGUIMultitouch::close()
     {
         m_device->deactivateAccelerometer();
     }
+
+    if (m_device->isGyroscopeActive())
+    {
+        m_device->deactivateGyroscope();
+    }
 }   // close
 
 
@@ -119,6 +124,11 @@ void RaceGUIMultitouch::init()
     if (UserConfigParams::m_multitouch_controls == MULTITOUCH_CONTROLS_ACCELEROMETER)
     {
         m_device->activateAccelerometer();
+    }
+    if (UserConfigParams::m_multitouch_controls == MULTITOUCH_CONTROLS_GYROSCOPE)
+    {
+        m_device->activateAccelerometer();
+        m_device->activateGyroscope();
     }
 
     const float scale = UserConfigParams::m_multitouch_scale;
@@ -155,7 +165,7 @@ void RaceGUIMultitouch::init()
 
     m_height = (unsigned int)(2 * col_size + margin / 2);
     
-    if (m_device->isAccelerometerActive())
+    if (m_device->isAccelerometerActive() || m_device->isGyroscopeActive())
     {
         m_device->addButton(BUTTON_UP_DOWN,
                     int(steering_accel_x), int(steering_accel_y),


### PR DESCRIPTION
Gyroscope is superior to accelerometer in every way - it's more responsive, less shaky, has cool camera tilt effect, and works even when the phone lies flat on the table.