### PR TITLE
Always update font size in DynamicRibbonWidget

### DIFF
--- a/src/guiengine/widgets/dynamic_ribbon_widget.cpp
+++ b/src/guiengine/widgets/dynamic_ribbon_widget.cpp
@@ -399,13 +399,6 @@ void DynamicRibbonWidget::buildInternalStructure()
         ribbon->m_properties[PROP_ID] = name.str();
         ribbon->m_event_handler = this;
 
-        // calculate font size
-        if (m_col_amount > 0)
-        {
-            m_font->setScale(GUIEngine::getFont()->getScale() *
-                getFontScale((ribbon->m_w / m_col_amount) - 30));
-        }
-
         // add columns
         for (int i=0; i<m_col_amount; i++)
         {
@@ -419,7 +412,6 @@ void DynamicRibbonWidget::buildInternalStructure()
             icon->m_properties[PROP_HEIGHT] = m_properties[PROP_CHILD_HEIGHT];
             icon->m_w = atoi(icon->m_properties[PROP_WIDTH].c_str());
             icon->m_h = atoi(icon->m_properties[PROP_HEIGHT].c_str());
-            icon->setLabelFont(m_font);
 
             // If we want each icon to have its own label, we must make it non-empty, otherwise
             // it will assume there is no label and none will be created (FIXME: that's ugly)
@@ -977,6 +969,14 @@ void DynamicRibbonWidget::updateItemDisplay()
         //std::cout << "Row " << n << "\n{\n";
 
         const unsigned int items_in_row = row.m_children.size();
+
+        // calculate font size
+        if (m_col_amount > 0)
+        {
+            m_font->setScale(GUIEngine::getFont()->getScale() *
+                getFontScale((row.m_w / m_col_amount) - 30));
+        }
+
         for (unsigned int i=0; i<items_in_row; i++)
         {
             IconButtonWidget* icon = dynamic_cast<IconButtonWidget*>(&row.m_children[i]);
@@ -994,6 +994,7 @@ void DynamicRibbonWidget::updateItemDisplay()
                     icon->setImage( item_icon.c_str(), m_items[icon_id].m_image_path_type );
 
                     icon->m_properties[PROP_ID]   = m_items[icon_id].m_code_name;
+                    icon->setLabelFont(m_font);
                     icon->setLabel(m_items[icon_id].m_user_name);
                     icon->m_text                  = m_items[icon_id].m_user_name;
                     icon->m_badges                = m_items[icon_id].m_badges;


### PR DESCRIPTION
Partially fixes #3474 

This pull request ensures that the font size is always updated when DynamicRibbonWidget items are updated by moving the font sizing code to updateItemDisplay() instead up buildInternalStructure(), which is only called when the number of items is changed. The text overlap occurred because the build-in prixs have the same number of items and switching between them didn't call buildInternalStructure(), so the font size wasn't updated.

This pull request doesn't implement word wrap, it only ensures DynamicRibbonWidget behaves consistently and as expected.