### PR TITLE
added lap icon to the the kart icons in RaceUI that have finished the race already

### DIFF
--- a/src/states_screens/race_gui.cpp
+++ b/src/states_screens/race_gui.cpp
@@ -191,7 +191,6 @@ RaceGUI::RaceGUI()
     //createMarkerTexture();
 
     // Load icon textures for later reuse
-    m_lap_flag = irr_driver->getTexture(FileManager::GUI_ICON, "lap_flag.png");
     m_red_team = irr_driver->getTexture(FileManager::GUI_ICON, "soccer_ball_red.png");
     m_blue_team = irr_driver->getTexture(FileManager::GUI_ICON, "soccer_ball_blue.png");
     m_red_flag = irr_driver->getTexture(FileManager::GUI_ICON, "red_flag.png");

--- a/src/states_screens/race_gui.hpp
+++ b/src/states_screens/race_gui.hpp
@@ -93,7 +93,6 @@ private:
 
     /** Icon textures (stored as variables to not look up
         their location on every frame) */
-    irr::video::ITexture *m_lap_flag;
     irr::video::ITexture *m_red_team;
     irr::video::ITexture *m_blue_team;
     irr::video::ITexture *m_red_flag;

--- a/src/states_screens/race_gui_base.cpp
+++ b/src/states_screens/race_gui_base.cpp
@@ -1039,6 +1039,21 @@ void RaceGUIBase::drawPlayerIcon(AbstractKart *kart, int x, int y, int w)
                                                       NULL, true);
         }
     }
+
+	//lap flag for finished karts
+	if (kart->hasFinishedRace())
+	{
+		video::ITexture *icon_lapflag = irr_driver->getTexture(FileManager::GUI_ICON, "lap_flag.png");
+		if (icon_lapflag != NULL)
+		{
+			const core::rect<s32> rect(core::position2d<s32>(0, 0),
+				icon_lapflag->getSize());
+			const core::rect<s32> pos1(x - 20, y - 10, x + w - 20, y + w - 10);
+			draw2DImage(icon_lapflag,
+				pos1, rect, NULL,
+				NULL, true);
+		}
+	}
 #endif
 }   // drawPlayerIcon
 

--- a/src/states_screens/race_gui_base.cpp
+++ b/src/states_screens/race_gui_base.cpp
@@ -99,6 +99,7 @@ RaceGUIBase::RaceGUIBase()
     m_gauge_full_bright     = irr_driver->getTexture(file_manager->getAsset(FileManager::GUI_ICON,"gauge_full_bright.png"));
     m_gauge_empty           = irr_driver->getTexture(file_manager->getAsset(FileManager::GUI_ICON,"gauge_empty.png"));
     m_gauge_goal            = irr_driver->getTexture(file_manager->getAsset(FileManager::GUI_ICON,"gauge_goal.png" ));
+    m_lap_flag              = irr_driver->getTexture(FileManager::GUI_ICON, "lap_flag.png");
     m_dist_show_overlap     = 2;
     m_icons_inertia         = 2;
 
@@ -1041,17 +1042,14 @@ void RaceGUIBase::drawPlayerIcon(AbstractKart *kart, int x, int y, int w)
     }
 
 	//lap flag for finished karts
-	if (kart->hasFinishedRace())
+    if (kart->hasFinishedRace())
 	{
-        video::ITexture *icon_lapflag = irr_driver->getTexture(FileManager::GUI_ICON, "lap_flag.png");
-        if (icon_lapflag != NULL)
+        if (m_lap_flag != NULL)
 		{
             const core::rect<s32> rect(core::position2d<s32>(0, 0),
-                                       icon_lapflag->getSize());
+                m_lap_flag->getSize());
             const core::rect<s32> pos1(x - 20, y - 10, x + w - 20, y + w - 10);
-            draw2DImage(icon_lapflag,
-                                                      pos1, rect, NULL,
-                                                      NULL, true);
+            draw2DImage(m_lap_flag, pos1, rect, NULL, NULL, true);
 		}
 	}
 #endif

--- a/src/states_screens/race_gui_base.cpp
+++ b/src/states_screens/race_gui_base.cpp
@@ -1043,15 +1043,15 @@ void RaceGUIBase::drawPlayerIcon(AbstractKart *kart, int x, int y, int w)
 	//lap flag for finished karts
 	if (kart->hasFinishedRace())
 	{
-		video::ITexture *icon_lapflag = irr_driver->getTexture(FileManager::GUI_ICON, "lap_flag.png");
-		if (icon_lapflag != NULL)
+        video::ITexture *icon_lapflag = irr_driver->getTexture(FileManager::GUI_ICON, "lap_flag.png");
+        if (icon_lapflag != NULL)
 		{
-			const core::rect<s32> rect(core::position2d<s32>(0, 0),
-				icon_lapflag->getSize());
-			const core::rect<s32> pos1(x - 20, y - 10, x + w - 20, y + w - 10);
-			draw2DImage(icon_lapflag,
-				pos1, rect, NULL,
-				NULL, true);
+            const core::rect<s32> rect(core::position2d<s32>(0, 0),
+                                       icon_lapflag->getSize());
+            const core::rect<s32> pos1(x - 20, y - 10, x + w - 20, y + w - 10);
+            draw2DImage(icon_lapflag,
+                                                      pos1, rect, NULL,
+                                                      NULL, true);
 		}
 	}
 #endif

--- a/src/states_screens/race_gui_base.hpp
+++ b/src/states_screens/race_gui_base.hpp
@@ -186,6 +186,9 @@ protected:
 
     /** The frame around player karts in the mini map. */
     video::ITexture* m_icons_frame;
+
+    /** Texture for the lap icon*/
+    video::ITexture* m_lap_flag;
     
     RaceGUIMultitouch* m_multitouch_gui;
 


### PR DESCRIPTION
This PR adds the lap flag, that is used in the current Race UI as a symbol for the lap, to the kart icons if they have finished the race. I think this is really informative because you may adjust your strategy if you know the karts in front of you are already finished.

I tested this in single player, splitscreen and online play and made sure there are no problems with the other game modes (The lap icons will only be shown for normal races and time trials)

![lapiconforfinishedkarts](https://user-images.githubusercontent.com/33566379/47939098-6ac5ea80-dee6-11e8-9511-a17a17872e6c.png)

Here is a video: https://youtu.be/Em5OfQT3cBk