### PR TITLE
Fix for when attempting to input a server IP address on the num pad

### DIFF
--- a/lib/irrlicht/source/Irrlicht/CIrrDeviceLinux.cpp
+++ b/lib/irrlicht/source/Irrlicht/CIrrDeviceLinux.cpp
@@ -1557,7 +1557,7 @@ EKEY_CODE CIrrDeviceLinux::getKeyCode(XEvent &event)
 	{
 		mp.X11Key = XkbKeycodeToKeysym(display, event.xkey.keycode, 0, 1);
 		
-		if (mp.X11Key >=XK_KP_0 && mp.X11Key <= XK_KP_9)
+		if ((mp.X11Key >=XK_KP_0 && mp.X11Key <= XK_KP_9 ) || mp.X11Key == XK_KP_Decimal)
 			is_numpad_key = true;
 	}
 	


### PR DESCRIPTION
The decimal key was not registering on the number pad as the decimal
key, it was deleting the numbers of the IP address making it impossible
to use the num pad solely for entering an IP.

Fixes #3602