### PR TITLE
Dynamic basket ball speed (bis)

### DIFF
--- a/data/kart_characteristics.xml
+++ b/data/kart_characteristics.xml
@@ -87,6 +87,9 @@
             power: The power of the kart (the engine power needed to accelerate
                    at a given pace is proportional to mass)
             max-speed: The base maximum speed of the kart in m/s
+            generic-max-speed: Must have the same value as max-speed. This
+                       is the max speed independently of kart type and
+                       of handicap, which is used by basket balls.
             brake-factor: Value used when braking.
             brake-time-increase: The brake force is multiplied by
                 (1 + brake_time) * brake_time_increase - i.e. the longer the
@@ -94,7 +97,7 @@
             max-speed-reverse-ratio is the percentage of max speed for reverse
                 gear.
           -->
-        <engine power="950" max-speed="25" brake-factor="15"
+        <engine power="950" max-speed="25" generic-max-speed="25" brake-factor="15"
                 brake-time-increase="6" max-speed-reverse-ratio="0.65" />
 
         <!-- Simulated gears
@@ -342,15 +345,15 @@
     <!-- The different difficulties (like easy, medium, hard) -->
     <difficulties>
         <characteristic name="easy">
-            <engine power="*0.7" max-speed="*0.6" />
+            <engine power="*0.7" max-speed="*0.6" generic-max-speed="*0.6" />
             <plunger in-face-time="3" />
         </characteristic>
         <characteristic name="medium">
-            <engine power="*0.83" max-speed="*0.8" />
+            <engine power="*0.83" max-speed="*0.8" generic-max-speed="*0.8" />
             <plunger in-face-time="4" />
         </characteristic>
         <characteristic name="hard">
-            <engine power="*0.92" max-speed="*0.92" />
+            <engine power="*0.92" max-speed="*0.92" generic-max-speed="*0.92" />
         </characteristic>
         <!-- This doesn't need to be changed because the most fast/heavy/extreme
             values should also be the default ones. -->

--- a/data/powerup.xml
+++ b/data/powerup.xml
@@ -16,6 +16,22 @@
   <item name="switch"         icon="swap-icon.png"      />
   <item name="swatter"        icon="swatter-icon.png"   />
   <!--  interval: How long a single bounce takes.
+        min-speed-offset: The speed of the ball is calculated
+                    by adding the speed-offset to the difficulty's
+                    max-speed. min-speed-offset is used when the
+                    ball is closer than min-offset-distance
+                    to the target.
+        max-speed-offset: The additional speed of the ball when
+                    farther than max-offset-distance.
+        speed : defines the initial speed. Mainly kept for
+                    compatibility with flyable class
+        min-offset-distance: The distance under which the ball is
+                    at minimal speed.
+        max-offset-distance: The distance over which the ball is
+                    at maximal speed. If it is not equal to
+                    min-offset-distance, the ball speeds between
+                    both is a weighted average of the min and
+                    max speed.
         max-height: The maximum height of a bounce.
         min-height: Unused mostly, but defines implicitly
                     the starting height (as average of
@@ -57,7 +73,12 @@
                     tunneling.
    -->
   <item name="rubber-ball"    icon="rubber_ball-icon.png"
-        model="rubber_ball.spm" speed="35.0"
+        model="rubber_ball.spm"
+        speed="40.0"
+        min-speed-offset="9.0"
+        max-speed-offset="29.0"
+        min-offset-distance="50.0"
+        max-offset-distance="250.0"
         interval="1"
         max-height="4.0"      min-height="0"
         fast-ping-distance="50" 

--- a/src/items/powerup.cpp
+++ b/src/items/powerup.cpp
@@ -526,6 +526,7 @@ void Powerup::hitBonusBox(const ItemState &item_state)
     // (1) The item id
     // (2) The time
     // (3) The position of the kart
+    // (4) An extra random 64bit integer
     // Using (1) means that not all boxes at a certain time for a kart
     // will give the same box. Using (2) means that the item will
     // change over time - even if the next item is displayed, it 
@@ -533,7 +534,8 @@ void Powerup::hitBonusBox(const ItemState &item_state)
     // of the time component it will also be difficult to get the
     // item at the right time. Using (3) adds another cheat-prevention
     // layer: even if a cheater is waiting for the right sequence
-    // of items, if he is overtaken the sequence will change.
+    // of items, if he is overtaken the sequence will change, using (4)
+    // to avoid same item sequence when starting
     //
     // In order to increase the probability of correct client prediction
     // in networking (where there might be 1 or 2 frames difference
@@ -544,7 +546,8 @@ void Powerup::hitBonusBox(const ItemState &item_state)
     // number to spread the random values across the (typically 200)
     // weights used in the PowerupManager - same for the position.
     uint64_t random_number = item_state.getItemId() * 31 +
-        world->getTicksSinceStart() / 10 + position * 23;
+        world->getTicksSinceStart() / 10 + position * 23 +
+        powerup_manager->getRandomSeed();
 
     // Use this random number as a seed of a PRNG (based on the one in 
     // bullet's btSequentialImpulseConstraintSolver) to avoid getting

--- a/src/items/powerup_manager.cpp
+++ b/src/items/powerup_manager.cpp
@@ -43,6 +43,7 @@ PowerupManager* powerup_manager=0;
 /** The constructor initialises everything to zero. */
 PowerupManager::PowerupManager()
 {
+    m_random_seed.store(0);
     for(int i=0; i<POWERUP_MAX; i++)
     {
         m_all_meshes[i] = NULL;

--- a/src/items/powerup_manager.hpp
+++ b/src/items/powerup_manager.hpp
@@ -19,11 +19,13 @@
 #ifndef HEADER_POWERUPMANAGER_HPP
 #define HEADER_POWERUPMANAGER_HPP
 
-#include "utils/no_copy.hpp"
 #include "utils/leak_check.hpp"
+#include "utils/no_copy.hpp"
+#include "utils/types.hpp"
 
 #include "btBulletDynamicsCommon.h"
 
+#include <atomic>
 #include <map>
 #include <string>
 #include <vector>
@@ -151,6 +153,11 @@ private:
     WeightsData m_current_item_weights;
 
     PowerupType   getPowerupType(const std::string &name) const;
+
+    /** Seed for random powerup, for local game it will use a random number,
+     *  for network games it will use the start time from server. */
+    std::atomic<uint64_t> m_random_seed;
+
 public:
     static void unitTesting();
 
@@ -171,6 +178,11 @@ public:
     /** Returns the mesh for a certain powerup.
      *  \param type Mesh type for which the model is returned. */
     irr::scene::IMesh *getMesh(int type) const {return m_all_meshes[type];}
+    // ------------------------------------------------------------------------
+    uint64_t getRandomSeed() const { return m_random_seed.load(); }
+    // ------------------------------------------------------------------------
+    void setRandomSeed(uint64_t seed) { m_random_seed.store(seed); }
+
 };   // class PowerupManager
 
 extern PowerupManager* powerup_manager;

--- a/src/items/rubber_ball.hpp
+++ b/src/items/rubber_ball.hpp
@@ -82,6 +82,20 @@ private:
      *  ball will be deleted. */
     static int m_st_delete_ticks;
 
+    /** If the ball is closer to its target than min_offset_distance, the speed
+     *  in addition to the difficulty's default max speed. */
+    static float m_st_min_speed_offset;
+
+    /** If the ball is farther to its target than max_offset_distance, the speed
+     *  in addition to the difficulty's default max speed. */
+    static float m_st_max_speed_offset;
+
+    /** The distance to target under which the ball is the slowest */
+    static float m_st_min_offset_distance;
+
+    /** The distance to target over which the ball is the fastest */
+    static float m_st_max_offset_distance;
+
     /** This factor is used to influence how much the rubber ball should aim
      *  at its target early. It used the 'distance to center of track' of its
      *  target, and adjusts the interpolation control points to be more or
@@ -195,6 +209,7 @@ private:
     float        updateHeight();
     void         interpolate(Vec3 *next_xyz, int ticks);
     void         moveTowardsTarget(Vec3 *next_xyz, int ticks);
+    void         updateWeightedSpeed(int ticks);
     void         initializeControlPoints(const Vec3 &xyz);
     float        getTunnelHeight(const Vec3 &next_xyz, 
                                      const float vertical_offset) const;

--- a/src/karts/abstract_characteristic.cpp
+++ b/src/karts/abstract_characteristic.cpp
@@ -89,6 +89,8 @@ AbstractCharacteristic::ValueType AbstractCharacteristic::getType(
         return TYPE_FLOAT;
     case ENGINE_MAX_SPEED:
         return TYPE_FLOAT;
+    case ENGINE_GENERIC_MAX_SPEED:
+        return TYPE_FLOAT;
     case ENGINE_BRAKE_FACTOR:
         return TYPE_FLOAT;
     case ENGINE_BRAKE_TIME_INCREASE:
@@ -726,6 +728,18 @@ float AbstractCharacteristic::getEngineMaxSpeed() const
                     getName(ENGINE_MAX_SPEED).c_str());
     return result;
 }  // getEngineMaxSpeed
+
+// ----------------------------------------------------------------------------
+float AbstractCharacteristic::getEngineGenericMaxSpeed() const
+{
+    float result;
+    bool is_set = false;
+    process(ENGINE_GENERIC_MAX_SPEED, &result, &is_set);
+    if (!is_set)
+        Log::fatal("AbstractCharacteristic", "Can't get characteristic %s",
+                    getName(ENGINE_GENERIC_MAX_SPEED).c_str());
+    return result;
+}  // getEngineGenericMaxSpeed
 
 // ----------------------------------------------------------------------------
 float AbstractCharacteristic::getEngineBrakeFactor() const

--- a/src/karts/abstract_characteristic.cpp
+++ b/src/karts/abstract_characteristic.cpp
@@ -513,6 +513,8 @@ std::string AbstractCharacteristic::getName(CharacteristicType type)
         return "SKID_REDUCE_TURN_MAX";
     case SKID_ENABLED:
         return "SKID_ENABLED";
+    case ENGINE_GENERIC_MAX_SPEED:
+        return "ENGINE_GENERIC_MAX_SPEED";
 
     /* <characteristics-end getName> */
     }   // switch (type)

--- a/src/karts/abstract_characteristic.hpp
+++ b/src/karts/abstract_characteristic.hpp
@@ -95,6 +95,7 @@ public:
         // Engine
         ENGINE_POWER,
         ENGINE_MAX_SPEED,
+        ENGINE_GENERIC_MAX_SPEED,
         ENGINE_BRAKE_FACTOR,
         ENGINE_BRAKE_TIME_INCREASE,
         ENGINE_MAX_SPEED_REVERSE_RATIO,
@@ -282,6 +283,7 @@ public:
 
     float getEnginePower() const;
     float getEngineMaxSpeed() const;
+    float getEngineGenericMaxSpeed() const;
     float getEngineBrakeFactor() const;
     float getEngineBrakeTimeIncrease() const;
     float getEngineMaxSpeedReverseRatio() const;

--- a/src/karts/abstract_kart.cpp
+++ b/src/karts/abstract_kart.cpp
@@ -59,7 +59,7 @@ AbstractKart::AbstractKart(const std::string& ident,
     // Technically the mesh in m_kart_model needs to be grab'ed and
     // released when the kart is deleted, but since the original
     // kart_model is stored in the kart_properties all the time,
-    // there is no risk of a mesh being deleted to early.
+    // there is no risk of a mesh being deleted too early.
     m_kart_model  = m_kart_properties->getKartModelCopy(ri);
     m_kart_width  = m_kart_model->getWidth();
     m_kart_height = m_kart_model->getHeight();

--- a/src/karts/kart_properties.cpp
+++ b/src/karts/kart_properties.cpp
@@ -680,6 +680,12 @@ float KartProperties::getEngineMaxSpeed() const
 }  // getEngineMaxSpeed
 
 // ----------------------------------------------------------------------------
+float KartProperties::getEngineGenericMaxSpeed() const
+{
+    return m_cached_characteristic->getEngineGenericMaxSpeed();
+}  // getEngineMaxSpeed
+
+// ----------------------------------------------------------------------------
 float KartProperties::getEngineBrakeFactor() const
 {
     return m_cached_characteristic->getEngineBrakeFactor();

--- a/src/karts/kart_properties.hpp
+++ b/src/karts/kart_properties.hpp
@@ -396,6 +396,7 @@ public:
 
     float getEnginePower() const;
     float getEngineMaxSpeed() const;
+    float getEngineGenericMaxSpeed() const;
     float getEngineBrakeFactor() const;
     float getEngineBrakeTimeIncrease() const;
     float getEngineMaxSpeedReverseRatio() const;

--- a/src/karts/xml_characteristic.cpp
+++ b/src/karts/xml_characteristic.cpp
@@ -365,6 +365,8 @@ void XmlCharacteristic::load(const XMLNode *node)
             &m_values[ENGINE_POWER]);
         sub_node->get("max-speed",
             &m_values[ENGINE_MAX_SPEED]);
+        sub_node->get("generic-max-speed",
+            &m_values[ENGINE_GENERIC_MAX_SPEED]);
         sub_node->get("brake-factor",
             &m_values[ENGINE_BRAKE_FACTOR]);
         sub_node->get("brake-time-increase",

--- a/src/network/protocols/client_lobby.cpp
+++ b/src/network/protocols/client_lobby.cpp
@@ -26,6 +26,7 @@
 #include "guiengine/screen_keyboard.hpp"
 #include "input/device_manager.hpp"
 #include "items/item_manager.hpp"
+#include "items/powerup_manager.hpp"
 #include "karts/kart_properties_manager.hpp"
 #include "modes/linear_world.hpp"
 #include "network/crypto.hpp"
@@ -816,6 +817,7 @@ void ClientLobby::startGame(Event* event)
 {
     World::getWorld()->setPhase(WorldStatus::SERVER_READY_PHASE);
     uint64_t start_time = event->data().getUInt64();
+    powerup_manager->setRandomSeed(start_time);
     joinStartGameThread();
     m_start_game_thread = std::thread([start_time, this]()
         {

--- a/src/network/protocols/server_lobby.cpp
+++ b/src/network/protocols/server_lobby.cpp
@@ -20,6 +20,7 @@
 
 #include "config/user_config.hpp"
 #include "items/item_manager.hpp"
+#include "items/powerup_manager.hpp"
 #include "karts/abstract_kart.hpp"
 #include "karts/controller/player_controller.hpp"
 #include "karts/kart_properties_manager.hpp"
@@ -2369,6 +2370,7 @@ void ServerLobby::configPeersStartTime()
     // Start up time will be after 2500ms, so even if this packet is sent late
     // (due to packet loss), the start time will still ahead of current time
     uint64_t start_time = STKHost::get()->getNetworkTimer() + (uint64_t)2500;
+    powerup_manager->setRandomSeed(start_time);
     NetworkString* ns = getNetworkString(10);
     ns->addUInt8(LE_START_RACE).addUInt64(start_time);
     sendMessageToPeers(ns, /*reliable*/true);

--- a/src/tracks/track.cpp
+++ b/src/tracks/track.cpp
@@ -53,6 +53,7 @@
 #include "items/item.hpp"
 #include "items/item_manager.hpp"
 #include "items/network_item_manager.hpp"
+#include "items/powerup_manager.hpp"
 #include "karts/abstract_kart.hpp"
 #include "karts/kart_properties.hpp"
 #include "modes/linear_world.hpp"
@@ -1855,8 +1856,10 @@ void Track::loadTrackModel(bool reverse_track, unsigned int mode_id)
     else
     {
         // Seed random engine locally
-        ItemManager::updateRandomSeed((uint32_t)StkTime::getTimeSinceEpoch());
+        uint32_t seed = (uint32_t)StkTime::getTimeSinceEpoch();
+        ItemManager::updateRandomSeed(seed);
         ItemManager::create();
+        powerup_manager->setRandomSeed(seed);
     }
 
     // Set the default start positions. Node that later the default


### PR DESCRIPTION
Most of the code is taken from #3179. The two main changes compared to this previous PR are some adaptations to work in the current codebase (like using ticks instead of dt) and using a target speed independent of kart type and handicap (but changing depending on difficulty, so the basket ball is not too fast in low difficulties or too slow in high difficulties).

Works as expected in local races ; the basket ball are much quicker to catch up, but as they slow down when close the player ahead keeps a fighting chance to outrun the ball long enough to find a bubble shield or to do a skillful destruction of the basket ball with another item.