### PR TITLE
Prevent early explosive items

### DIFF
--- a/src/items/powerup_manager.cpp
+++ b/src/items/powerup_manager.cpp
@@ -602,6 +602,13 @@ PowerupManager::PowerupType PowerupManager::getRandomPowerup(unsigned int pos,
     }
     else
         *n=1;
+
+    // Prevents early explosive items
+    if (stk_config->ticks2Time(World::getWorld()->getTicksSinceStart()) < 15.)
+    {
+        if (powerup == POWERUP_CAKE || powerup == POWERUP_RUBBERBALL)
+            powerup = POWERUP_BOWLING;
+    }
     return (PowerupType)powerup;
 }   // getRandomPowerup
 


### PR DESCRIPTION
There are complaints of people getting too much often caked by AIs very early in a race. As everyone is packed during the first ~10 s, explosive homing items tend to create a lot of mess and frustration in this situation.

In this pull request, I propose a simple patch that disables the rubber ball and the cake during the first 15 s by replacing them by bowling balls.

As this is my first pull request here, I hope that I did this right.