### PR TITLE
Fix fire before start

### DIFF
--- a/src/karts/controller/player_controller.cpp
+++ b/src/karts/controller/player_controller.cpp
@@ -329,8 +329,7 @@ void PlayerController::update(int ticks)
     if (World::getWorld()->isStartPhase())
     {
         if ((m_controls->getAccel() || m_controls->getBrake()||
-            m_controls->getFire() || m_controls->getNitro()) &&
-            !NetworkConfig::get()->isNetworking())
+            m_controls->getNitro()) && !NetworkConfig::get()->isNetworking())
         {
             // Only give penalty time in READY_PHASE.
             // Penalty time check makes sure it doesn't get rendered on every

--- a/src/karts/kart.cpp
+++ b/src/karts/kart.cpp
@@ -1576,7 +1576,13 @@ void Kart::update(int ticks)
         }
         // use() needs to be called even if there currently is no collecteable
         // since use() can test if something needs to be switched on/off.
-        m_powerup->use() ;
+        if (!World::getWorld()->isStartPhase())
+            m_powerup->use();
+        else
+        {
+            if(!getKartAnimation())
+                beep();
+        }
         World::getWorld()->onFirePressed(getController());
         m_fire_clicked = 1;
     }


### PR DESCRIPTION
It was possible to fire items before the race started. This is an issue for Time Trial races, where you could waste your boosters during startup.

This pull request fixes this problem. Also, pushing the fire button no longer induces the Penalty Time, there is no reason to penalize here.