### PR TITLE
Move soccer options to track info screen

### DIFF
--- a/data/gui/screens/soccer_setup.stkgui
+++ b/data/gui/screens/soccer_setup.stkgui
@@ -11,27 +11,6 @@
 
         <spacer height="1%" width="25"/>
 
-        <div layout="horizontal-row" width="100%" height="fit" align="left">
-            <bright width="fit" height="100%"
-                    I18N="In soccer setup screen" text="Soccer game type" text_align="left" />
-            <spacer width="2%" height="25"/>
-            <spinner id="time_enabled" width="30%" wrap_around="true"/>
-        </div>
-
-        <div layout="horizontal-row" width="100%" height="fit" align="left">
-            <bright width="fit" height="100%"
-                    I18N="In soccer setup screen" text="Number of goals to win" text_align="left" />
-            <spacer width="2%" height="25"/>
-            <spinner id="goalamount" width="15%" min_value="1" max_value="10"/>
-        </div>
-
-        <div layout="horizontal-row" width="100%" height="fit" align="left">
-            <bright width="fit" height="100%"
-                    I18N="In soccer setup screen" text="Maximum time (min.)" text_align="left" />
-            <spacer width="2%" height="25"/>
-            <spinner id="timeamount" width="15%" min_value="1" max_value="15"/>
-        </div>
-
         <spacer height="1%" width="25"/>
 
         <bubble height="fit" width="100%" id="lblLeftRight" I18N="In soccer setup screen" text="Use left/right to choose your team and press fire" word_wrap="true" text_align="center"/>

--- a/data/gui/screens/track_info.stkgui
+++ b/data/gui/screens/track_info.stkgui
@@ -74,8 +74,7 @@
 
                 <spacer width="1" height="2%"/>
                 <!-- Race options box -->
-                <box width="100%" height="43%" layout="vertical-row">
-                
+                <box width="100%" height="43%" layout="vertical-row">            
                     <div width="100%" height="fit" layout="horizontal-row" >
                         <div proportion="1" height="fit" layout="horizontal-row">
                             <spinner id="target-type-spinner" width="100%" min_value="1" max_value="10" align="center"

--- a/data/gui/screens/track_info.stkgui
+++ b/data/gui/screens/track_info.stkgui
@@ -75,16 +75,16 @@
                 <spacer width="1" height="2%"/>
                 <!-- Race options box -->
                 <box width="100%" height="43%" layout="vertical-row">
-				
-					<div width="100%" height="fit" layout="horizontal-row" >
-						<div proportion="1" height="fit" layout="horizontal-row">
+                
+                    <div width="100%" height="fit" layout="horizontal-row" >
+                        <div proportion="1" height="fit" layout="horizontal-row">
                             <spinner id="target-type-spinner" width="100%" min_value="1" max_value="10" align="center"
                                      wrap_around="true" />
                         </div>
-						<spacer width="3%"/>
-						<label id="target-type-text" proportion="3" I18N="In the track info screen" text="Soccer game type" text_align="left" />
-					</div>
-					<spacer width="1" height="2%"/>
+                        <spacer width="3%"/>
+                        <label id="target-type-text" proportion="3" I18N="In the track info screen" text="Soccer game type" text_align="left" />
+                    </div>
+                    <spacer width="1" height="2%"/>
                     <div width="100%" height="fit" layout="horizontal-row" >
                         <div proportion="1" height="fit" layout="horizontal-row">
                             <spinner id="target-value-spinner" width="100%" min_value="1" max_value="20" align="center"

--- a/data/gui/screens/track_info.stkgui
+++ b/data/gui/screens/track_info.stkgui
@@ -75,6 +75,28 @@
                 <spacer width="1" height="2%"/>
                 <!-- Race options box -->
                 <box width="100%" height="43%" layout="vertical-row">
+				
+					<div id="targetoptionsdiv" layout="horizontal-row" width="100%" height="fit" align="left">
+						<label width="fit" height="100%"
+								I18N="In the track info screen" text="Soccer game type" text_align="left" />
+						<spacer width="2%" height="25"/>
+						<spinner id="targetoptions" width="30%" wrap_around="true"/>
+					</div>
+
+					<div id="pointamountdiv" layout="horizontal-row" width="100%" height="fit" align="left">
+						<label width="fit" height="100%"
+								I18N="In the track info screen" text="Number of goals to win" text_align="left" />
+						<spacer width="2%" height="25"/>
+						<spinner id="pointamount" width="15%" min_value="1" max_value="10"/>
+					</div>
+
+					<div id="timeamountdiv" layout="horizontal-row" width="100%" height="fit" align="left">
+						<label width="fit" height="100%"
+								I18N="In the track info screen" text="Maximum time (min.)" text_align="left" />
+						<spacer width="2%" height="25"/>
+						<spinner id="timeamount" width="15%" min_value="1" max_value="15"/>
+					</div>
+				
                     <div width="100%" height="fit" layout="horizontal-row" >
                         <div proportion="1" height="fit" layout="horizontal-row">
                             <spinner id="lap-spinner" width="100%" min_value="1" max_value="20" align="center"

--- a/data/gui/screens/track_info.stkgui
+++ b/data/gui/screens/track_info.stkgui
@@ -76,31 +76,22 @@
                 <!-- Race options box -->
                 <box width="100%" height="43%" layout="vertical-row">
 				
-					<div id="targetoptionsdiv" width="100%" height="fit" layout="horizontal-row" >
+					<div width="100%" height="fit" layout="horizontal-row" >
 						<div proportion="1" height="fit" layout="horizontal-row">
-                            <spinner id="targetoptions" width="100%" min_value="1" max_value="10" align="center"
+                            <spinner id="target-type-spinner" width="100%" min_value="1" max_value="10" align="center"
                                      wrap_around="true" />
                         </div>
 						<spacer width="3%"/>
-						<label proportion="3" I18N="In the track info screen" text="Soccer game type" text_align="left" />
-					</div>
-					<spacer width="1" height="2%"/>
-					<div id="pointamountdiv" width="100%" height="fit" layout="horizontal-row" >
-						<div proportion="1" height="fit" layout="horizontal-row">
-                            <spinner id="pointamount" width="100%" min_value="1" max_value="10" align="center"
-                                     wrap_around="true" />
-                        </div>
-						<spacer width="3%"/>
-						<label id="pointamountlabel" proportion="3" I18N="In the track info screen" text="Number of goals to win" text_align="left" />
+						<label id="target-type-text" proportion="3" I18N="In the track info screen" text="Soccer game type" text_align="left" />
 					</div>
 					<spacer width="1" height="2%"/>
                     <div width="100%" height="fit" layout="horizontal-row" >
                         <div proportion="1" height="fit" layout="horizontal-row">
-                            <spinner id="lap-spinner" width="100%" min_value="1" max_value="20" align="center"
+                            <spinner id="target-value-spinner" width="100%" min_value="1" max_value="20" align="center"
                                      wrap_around="true" />
                         </div>
                         <spacer width="3%"/>
-                        <label id="lap-text" proportion="3" I18N="In the track info screen" text="Number of laps" text_align="left"/>
+                        <label id="target-value-text" proportion="3" I18N="In the track info screen" text="Number of laps" text_align="left"/>
                     </div>
                     <spacer width="1" height="2%"/>
                     <div width="100%" height="fit" layout="horizontal-row" >

--- a/data/gui/screens/track_info.stkgui
+++ b/data/gui/screens/track_info.stkgui
@@ -76,27 +76,24 @@
                 <!-- Race options box -->
                 <box width="100%" height="43%" layout="vertical-row">
 				
-					<div id="targetoptionsdiv" layout="horizontal-row" width="100%" height="fit" align="left">
-						<label width="fit" height="100%"
-								I18N="In the track info screen" text="Soccer game type" text_align="left" />
-						<spacer width="2%" height="25"/>
-						<spinner id="targetoptions" width="30%" wrap_around="true"/>
+					<div id="targetoptionsdiv" width="100%" height="fit" layout="horizontal-row" >
+						<div proportion="1" height="fit" layout="horizontal-row">
+                            <spinner id="targetoptions" width="100%" min_value="1" max_value="10" align="center"
+                                     wrap_around="true" />
+                        </div>
+						<spacer width="3%"/>
+						<label proportion="3" I18N="In the track info screen" text="Soccer game type" text_align="left" />
 					</div>
-
-					<div id="pointamountdiv" layout="horizontal-row" width="100%" height="fit" align="left">
-						<label width="fit" height="100%"
-								I18N="In the track info screen" text="Number of goals to win" text_align="left" />
-						<spacer width="2%" height="25"/>
-						<spinner id="pointamount" width="15%" min_value="1" max_value="10"/>
+					<spacer width="1" height="2%"/>
+					<div id="pointamountdiv" width="100%" height="fit" layout="horizontal-row" >
+						<div proportion="1" height="fit" layout="horizontal-row">
+                            <spinner id="pointamount" width="100%" min_value="1" max_value="10" align="center"
+                                     wrap_around="true" />
+                        </div>
+						<spacer width="3%"/>
+						<label id="pointamountlabel" proportion="3" I18N="In the track info screen" text="Number of goals to win" text_align="left" />
 					</div>
-
-					<div id="timeamountdiv" layout="horizontal-row" width="100%" height="fit" align="left">
-						<label width="fit" height="100%"
-								I18N="In the track info screen" text="Maximum time (min.)" text_align="left" />
-						<spacer width="2%" height="25"/>
-						<spinner id="timeamount" width="15%" min_value="1" max_value="15"/>
-					</div>
-				
+					<spacer width="1" height="2%"/>
                     <div width="100%" height="fit" layout="horizontal-row" >
                         <div proportion="1" height="fit" layout="horizontal-row">
                             <spinner id="lap-spinner" width="100%" min_value="1" max_value="20" align="center"

--- a/src/states_screens/soccer_setup_screen.cpp
+++ b/src/states_screens/soccer_setup_screen.cpp
@@ -87,14 +87,6 @@ void SoccerSetupScreen::eventCallback(Widget* widget, const std::string& name,
     {
         StateManager::get()->escapePressed();
     }
-    else if(name == "time_enabled")
-    {
-        SpinnerWidget* timeEnabled = dynamic_cast<SpinnerWidget*>(widget);
-        bool timed = timeEnabled->getValue() == 0;
-        UserConfigParams::m_soccer_use_time_limit = timed;
-        getWidget<SpinnerWidget>("goalamount")->setActive(!timed);
-        getWidget<SpinnerWidget>("timeamount")->setActive(timed);
-    }
     else if (name == "red_team")
     {
         if (m_kart_view_info.size() == 1)
@@ -211,26 +203,6 @@ void SoccerSetupScreen::init()
 
     Screen::init();
 
-    if (UserConfigParams::m_num_goals <= 0)
-        UserConfigParams::m_num_goals = 3;
-
-    if (UserConfigParams::m_soccer_time_limit <= 0)
-        UserConfigParams::m_soccer_time_limit = 3;
-
-    SpinnerWidget*  goalamount = getWidget<SpinnerWidget>("goalamount");
-    goalamount->setValue(UserConfigParams::m_num_goals);
-    goalamount->setActive(!UserConfigParams::m_soccer_use_time_limit);
-
-    SpinnerWidget* timeAmount = getWidget<SpinnerWidget>("timeamount");
-    timeAmount->setValue(UserConfigParams::m_soccer_time_limit);
-    timeAmount->setActive(UserConfigParams::m_soccer_use_time_limit);
-
-    SpinnerWidget* timeEnabled = getWidget<SpinnerWidget>("time_enabled");
-    timeEnabled->clearLabels();
-    timeEnabled->addLabel(_("Time limit"));
-    timeEnabled->addLabel(_("Goals limit"));
-    timeEnabled->setValue(UserConfigParams::m_soccer_use_time_limit ? 0 : 1);
-
     // Set focus on "continue"
     ButtonWidget* bt_continue = getWidget<ButtonWidget>("continue");
     bt_continue->setFocusForPlayer(PLAYER_ID_GAME_MASTER);
@@ -251,9 +223,6 @@ void SoccerSetupScreen::tearDown()
 
     // Reset the 'map fire to select' option of the device manager
     input_manager->getDeviceManager()->mapFireToSelect(false);
-
-    UserConfigParams::m_num_goals = getWidget<SpinnerWidget>("goalamount")->getValue();
-    UserConfigParams::m_soccer_time_limit = getWidget<SpinnerWidget>("timeamount")->getValue();
 
     // Remove all ModelViewWidgets we created manually
     PtrVector<Widget>&  children = central_div->getChildren();
@@ -520,10 +489,5 @@ bool SoccerSetupScreen::onEscapePressed()
 // -----------------------------------------------------------------------------
 void SoccerSetupScreen::prepareGame()
 {
-    if (getWidget<SpinnerWidget>("goalamount")->isActivated())
-        race_manager->setMaxGoal(getWidget<SpinnerWidget>("goalamount")->getValue());
-    else
-        race_manager->setTimeTarget((float)getWidget<SpinnerWidget>("timeamount")->getValue() * 60);
-
     input_manager->setMasterPlayerOnly(true);
 }   // prepareGame

--- a/src/states_screens/track_info_screen.cpp
+++ b/src/states_screens/track_info_screen.cpp
@@ -454,16 +454,38 @@ void TrackInfoScreen::eventCallback(Widget* widget, const std::string& name,
 
         if (timed)
         {
-            UserConfigParams::m_num_goals = m_target_value_spinner->getValue();
             m_target_value_label->setText(_("Maximum time (min.)"), false);
             m_target_value_spinner->setValue(UserConfigParams::m_soccer_time_limit);
         }
         else
         {
-            UserConfigParams::m_soccer_time_limit = m_target_value_spinner->getValue();
             m_target_value_label->setText(_("Number of goals to win"), false);
             m_target_value_spinner->setValue(UserConfigParams::m_num_goals);
 
+        }
+    }
+    else if (name == "target-value-spinner")
+    {
+        bool is_soccer = race_manager->getMinorMode() == RaceManager::MINOR_MODE_SOCCER;
+        if (is_soccer)
+        {
+            bool timed = m_target_type_spinner->getValue() == 0;
+            if (timed)
+            {
+                UserConfigParams::m_soccer_time_limit = m_target_value_spinner->getValue();
+            }
+            else
+            {
+                UserConfigParams::m_num_goals = m_target_value_spinner->getValue();
+            }
+        }
+        else
+        {
+            assert(race_manager->modeHasLaps());
+            const int num_laps = m_target_value_spinner->getValue();
+            race_manager->setNumLaps(num_laps);
+            UserConfigParams::m_num_laps = num_laps;
+            updateHighScores();
         }
     }
     else if (name == "option")
@@ -495,18 +517,6 @@ void TrackInfoScreen::eventCallback(Widget* widget, const std::string& name,
         else
         {
             m_ai_kart_spinner->setActive(true);
-        }
-    }
-    else if (name == "target-value-spinner")
-    {
-        bool is_soccer = race_manager->getMinorMode() == RaceManager::MINOR_MODE_SOCCER;
-        if (!is_soccer)
-        {
-            assert(race_manager->modeHasLaps());
-            const int num_laps = m_target_value_spinner->getValue();
-            race_manager->setNumLaps(num_laps);
-            UserConfigParams::m_num_laps = num_laps;
-            updateHighScores();
         }
     }
     else if (name=="ai-spinner")

--- a/src/states_screens/track_info_screen.cpp
+++ b/src/states_screens/track_info_screen.cpp
@@ -65,8 +65,8 @@ void TrackInfoScreen::loadedFromFile()
 {
     m_target_type_spinner   = getWidget<SpinnerWidget>("target-type-spinner");
     m_target_type_label     = getWidget <LabelWidget>("target-type-text");
-    m_target_value_spinner           = getWidget<SpinnerWidget>("target-value-spinner");
-    m_target_value_label             = getWidget<LabelWidget>("target-value-text");
+    m_target_value_spinner  = getWidget<SpinnerWidget>("target-value-spinner");
+    m_target_value_label    = getWidget<LabelWidget>("target-value-text");
     m_ai_kart_spinner       = getWidget<SpinnerWidget>("ai-spinner");
     m_option                = getWidget<CheckBoxWidget>("option");
     m_record_race           = getWidget<CheckBoxWidget>("record");
@@ -138,12 +138,51 @@ void TrackInfoScreen::init()
     if (image != NULL)
         screenshot->setImage(image);
 
+    m_target_type_spinner->setVisible(false);
+    m_target_type_label->setVisible(false);
+    m_target_value_spinner->setVisible(false);
+    m_target_value_label->setVisible(false);
+
+    // Soccer options
+    // -------------
+    const bool is_soccer = race_manager->getMinorMode() == RaceManager::MINOR_MODE_SOCCER;
+    if (is_soccer)
+    {
+        m_target_type_spinner->setVisible(true);
+        m_target_type_label->setVisible(true);
+        m_target_value_spinner->setVisible(true);
+        m_target_value_label->setVisible(true);
+
+        if (UserConfigParams::m_num_goals <= 0)
+            UserConfigParams::m_num_goals = UserConfigParams::m_num_goals.getDefaultValue();
+
+        if (UserConfigParams::m_soccer_time_limit <= 0)
+            UserConfigParams::m_soccer_time_limit = UserConfigParams::m_soccer_time_limit.getDefaultValue();
+
+        m_target_type_spinner->clearLabels();
+        m_target_type_spinner->addLabel(_("Time limit"));
+        m_target_type_spinner->addLabel(_("Goals limit"));
+        m_target_type_spinner->setValue(UserConfigParams::m_soccer_use_time_limit ? 0 : 1);
+
+        if (UserConfigParams::m_soccer_use_time_limit)
+        {
+            m_target_value_label->setText(_("Maximum time (min.)"), false);
+            m_target_value_spinner->setValue(UserConfigParams::m_soccer_time_limit);
+        }
+        else
+        {
+            m_target_value_label->setText(_("Number of goals to win"), false);
+            m_target_value_spinner->setValue(UserConfigParams::m_num_goals);
+        }
+    }
+
     // Lap count m_lap_spinner
     // -----------------------
-    m_target_value_spinner->setVisible(has_laps);
-    m_target_value_label->setVisible(has_laps);
     if (has_laps)
     {
+        m_target_value_spinner->setVisible(true);
+        m_target_value_label->setVisible(true);
+
         if (UserConfigParams::m_artist_debug_mode)
             m_target_value_spinner->setMin(0);
         else
@@ -257,37 +296,6 @@ void TrackInfoScreen::init()
     {
         m_record_race->setActive(true);
         m_record_race->setState(false);
-    }
-
-    bool is_soccer = race_manager->getMinorMode() == RaceManager::MINOR_MODE_SOCCER;
-    m_target_type_spinner->setVisible(is_soccer);
-    m_target_type_label->setVisible(is_soccer);
-    if (is_soccer)
-    {
-        if (UserConfigParams::m_num_goals <= 0)
-            UserConfigParams::m_num_goals = UserConfigParams::m_num_goals.getDefaultValue();
-
-        if (UserConfigParams::m_soccer_time_limit <= 0)
-            UserConfigParams::m_soccer_time_limit = UserConfigParams::m_soccer_time_limit.getDefaultValue();
-
-        m_target_type_spinner->clearLabels();
-        m_target_type_spinner->addLabel(_("Time limit"));
-        m_target_type_spinner->addLabel(_("Goals limit"));
-        m_target_type_spinner->setValue(UserConfigParams::m_soccer_use_time_limit ? 0 : 1);
-
-        m_target_value_spinner->setVisible(true);
-        m_target_value_label->setVisible(true);
-
-        if (UserConfigParams::m_soccer_use_time_limit)
-        {
-            m_target_value_label->setText(_("Maximum time (min.)"), false);
-            m_target_value_spinner->setValue(UserConfigParams::m_soccer_time_limit);
-        }
-        else
-        {
-            m_target_value_label->setText(_("Number of goals to win"), false);
-            m_target_value_spinner->setValue(UserConfigParams::m_num_goals);
-        }
     }
 
     // ---- High Scores
@@ -449,7 +457,7 @@ void TrackInfoScreen::eventCallback(Widget* widget, const std::string& name,
     }
     else if (name == "target-type-spinner")
     {
-        bool timed = m_target_type_spinner->getValue() == 0;
+        const bool timed = m_target_type_spinner->getValue() == 0;
         UserConfigParams::m_soccer_use_time_limit = timed;
 
         if (timed)
@@ -466,18 +474,14 @@ void TrackInfoScreen::eventCallback(Widget* widget, const std::string& name,
     }
     else if (name == "target-value-spinner")
     {
-        bool is_soccer = race_manager->getMinorMode() == RaceManager::MINOR_MODE_SOCCER;
+        const bool is_soccer = race_manager->getMinorMode() == RaceManager::MINOR_MODE_SOCCER;
         if (is_soccer)
         {
-            bool timed = m_target_type_spinner->getValue() == 0;
+            const bool timed = m_target_type_spinner->getValue() == 0;
             if (timed)
-            {
                 UserConfigParams::m_soccer_time_limit = m_target_value_spinner->getValue();
-            }
             else
-            {
                 UserConfigParams::m_num_goals = m_target_value_spinner->getValue();
-            }
         }
         else
         {

--- a/src/states_screens/track_info_screen.cpp
+++ b/src/states_screens/track_info_screen.cpp
@@ -71,8 +71,7 @@ void TrackInfoScreen::loadedFromFile()
     m_targetoptions_spinner = getWidget<SpinnerWidget>("targetoptions");
     m_pointamount_div = getWidget<Widget>("pointamountdiv");
     m_pointamount_spinner = getWidget<SpinnerWidget>("pointamount");
-    m_timeamount_div = getWidget<Widget>("timeamountdiv");
-    m_timeamount_spinner = getWidget<SpinnerWidget>("timeamount");
+    m_pointamount_label = getWidget<LabelWidget>("pointamountlabel");
     m_option->setState(false);
     m_record_race->setState(false);
 
@@ -273,16 +272,22 @@ void TrackInfoScreen::init()
         m_targetoptions_spinner->addLabel(_("Time limit"));
         m_targetoptions_spinner->addLabel(_("Goals limit"));
         m_targetoptions_spinner->setValue(UserConfigParams::m_soccer_use_time_limit ? 0 : 1);
-        m_pointamount_spinner->setActive(!UserConfigParams::m_soccer_use_time_limit);
-        m_pointamount_spinner->setValue(UserConfigParams::m_num_goals);
-        m_timeamount_spinner->setActive(UserConfigParams::m_soccer_use_time_limit);
-        m_timeamount_spinner->setValue(UserConfigParams::m_soccer_time_limit);
+
+        if (UserConfigParams::m_soccer_use_time_limit)
+        {
+            m_pointamount_label->setText(_("Maximum time (min.)"), false);
+            m_pointamount_spinner->setValue(UserConfigParams::m_soccer_time_limit);
+        }
+        else
+        {
+            m_pointamount_label->setText(_("Number of goals to win"), false);
+            m_pointamount_spinner->setValue(UserConfigParams::m_num_goals);
+        }
     }
     else
     {
-        m_targetoptions_div->setVisible(true);
+        m_targetoptions_div->setVisible(false);
         m_pointamount_div->setVisible(false);
-        m_timeamount_div->setVisible(false);
     }
 
     // ---- High Scores
@@ -414,7 +419,7 @@ void TrackInfoScreen::onEnterPressedInternal()
 
     int selected_targetoption = m_targetoptions_spinner->getValue();
     if (selected_targetoption == 0)
-        race_manager->setTimeTarget((float)m_timeamount_spinner->getValue() * 60);
+        race_manager->setTimeTarget((float)m_pointamount_spinner->getValue() * 60);
     else
         race_manager->setMaxGoal(m_pointamount_spinner->getValue());
 
@@ -445,11 +450,20 @@ void TrackInfoScreen::eventCallback(Widget* widget, const std::string& name,
     {
         bool timed = m_targetoptions_spinner->getValue() == 0;
         UserConfigParams::m_soccer_use_time_limit = timed;
-        m_pointamount_spinner->setActive(!timed);
-        m_timeamount_spinner->setActive(timed);
 
-        UserConfigParams::m_num_goals = m_pointamount_spinner->getValue();
-        UserConfigParams::m_soccer_time_limit = m_timeamount_spinner->getValue();
+        if (timed)
+        {
+            UserConfigParams::m_num_goals = m_pointamount_spinner->getValue();
+            m_pointamount_label->setText(_("Maximum time (min.)"), false);
+            m_pointamount_spinner->setValue(UserConfigParams::m_soccer_time_limit);
+        }
+        else
+        {
+            UserConfigParams::m_soccer_time_limit = m_pointamount_spinner->getValue();
+            m_pointamount_label->setText(_("Number of goals to win"), false);
+            m_pointamount_spinner->setValue(UserConfigParams::m_num_goals);
+
+        }
     }
     else if (name == "option")
     {

--- a/src/states_screens/track_info_screen.hpp
+++ b/src/states_screens/track_info_screen.hpp
@@ -48,8 +48,18 @@ class TrackInfoScreen : public GUIEngine::Screen,
 
     // When there is no need to tab through / click on images/labels, we can add directly
     // irrlicht labels (more complicated uses require the use of our widget set)
+        
+    /** Spinner for target types. */
+    GUIEngine::SpinnerWidget* m_target_type_spinner;
+
+    /** The label besides the target types spinner. */
+    GUIEngine::LabelWidget* m_target_type_label;
+
     /** Spinner for number of laps. */
-    GUIEngine::SpinnerWidget* m_lap_spinner;
+    GUIEngine::SpinnerWidget* m_target_value_spinner;
+
+    /** The label besides the lap spinner. */
+    GUIEngine::LabelWidget* m_target_value_label;
 
     /** Spinner for number of AI karts. */
     GUIEngine::SpinnerWidget* m_ai_kart_spinner;
@@ -62,19 +72,6 @@ class TrackInfoScreen : public GUIEngine::Screen,
 
     /** The label of the highscore list. */
     GUIEngine::LabelWidget* m_highscore_label;
-
-    GUIEngine::Widget* m_targetoptions_div;
-
-    /** Spinner for target options. */
-    GUIEngine::SpinnerWidget* m_targetoptions_spinner;
-
-    /** The actual highscore text values shown. */
-    GUIEngine::LabelWidget* m_pointamount_label;
-
-    GUIEngine::Widget* m_pointamount_div;
-
-    /** Spinner for number of laps. */
-    GUIEngine::SpinnerWidget* m_pointamount_spinner;
 
     /** The icons for the highscore list. */
     GUIEngine::IconButtonWidget* m_kart_icons[HIGHSCORE_COUNT];

--- a/src/states_screens/track_info_screen.hpp
+++ b/src/states_screens/track_info_screen.hpp
@@ -68,15 +68,13 @@ class TrackInfoScreen : public GUIEngine::Screen,
     /** Spinner for target options. */
     GUIEngine::SpinnerWidget* m_targetoptions_spinner;
 
+    /** The actual highscore text values shown. */
+    GUIEngine::LabelWidget* m_pointamount_label;
+
     GUIEngine::Widget* m_pointamount_div;
 
     /** Spinner for number of laps. */
     GUIEngine::SpinnerWidget* m_pointamount_spinner;
-
-    GUIEngine::Widget* m_timeamount_div;
-
-    /** Spinner for number of laps. */
-    GUIEngine::SpinnerWidget* m_timeamount_spinner;
 
     /** The icons for the highscore list. */
     GUIEngine::IconButtonWidget* m_kart_icons[HIGHSCORE_COUNT];

--- a/src/states_screens/track_info_screen.hpp
+++ b/src/states_screens/track_info_screen.hpp
@@ -63,6 +63,21 @@ class TrackInfoScreen : public GUIEngine::Screen,
     /** The label of the highscore list. */
     GUIEngine::LabelWidget* m_highscore_label;
 
+    GUIEngine::Widget* m_targetoptions_div;
+
+    /** Spinner for target options. */
+    GUIEngine::SpinnerWidget* m_targetoptions_spinner;
+
+    GUIEngine::Widget* m_pointamount_div;
+
+    /** Spinner for number of laps. */
+    GUIEngine::SpinnerWidget* m_pointamount_spinner;
+
+    GUIEngine::Widget* m_timeamount_div;
+
+    /** Spinner for number of laps. */
+    GUIEngine::SpinnerWidget* m_timeamount_spinner;
+
     /** The icons for the highscore list. */
     GUIEngine::IconButtonWidget* m_kart_icons[HIGHSCORE_COUNT];
 

--- a/src/states_screens/track_info_screen.hpp
+++ b/src/states_screens/track_info_screen.hpp
@@ -55,10 +55,10 @@ class TrackInfoScreen : public GUIEngine::Screen,
     /** The label besides the target types spinner. */
     GUIEngine::LabelWidget* m_target_type_label;
 
-    /** Spinner for number of laps. */
+    /** Spinner for target value e.g. number of laps or goals to score. */
     GUIEngine::SpinnerWidget* m_target_value_spinner;
 
-    /** The label besides the lap spinner. */
+    /** The label besides the target value spinner. */
     GUIEngine::LabelWidget* m_target_value_label;
 
     /** Spinner for number of AI karts. */


### PR DESCRIPTION
What this pull request does:
It moves the options for setting up a soccer game (goal/time targets) from the screen where you can select your team to the track info screen.

Why?
Because it makes much more sense to have all options on the same place. Right now the settings how many AI players or random item location are on another place like the goal/time targets.

Additional info:
For this the time-enabled spinner is moved to the track info screen, formatted to fit in and renamed to target-type-spinnner, the lap-spinner is reused for both goal and time target and renamed to target-value-spinner.
As a consequence of this they share the same max value of 20 (that was the highest of the three spinners and the one from the lap spinner). Max value could also be set in the code dependent of the spinner, but it does not hurt to share the value (goal target max increases from 15 goals and time target max from 10 minutes; I could apply these again if whished).
When changing the target type the spinner below it changes it's text and value according to the selection, no inactive spinners like before.
Because there was one spinner added all the other widgets move one spot down, but there is still enough space in all the other game modes.

Here is a screenshot:
![menu-2018 12 01_15 17 14](https://user-images.githubusercontent.com/33566379/49329416-dd29f900-f57e-11e8-9dac-6dfa851a0b5c.png)
