### PR TITLE
Feature/material based for blender2.8 compatibility

### DIFF
--- a/src/graphics/material.cpp
+++ b/src/graphics/material.cpp
@@ -60,11 +60,23 @@ Material::Material(const XMLNode *node, bool deprecated)
     m_installed = false;
 
     m_sampler_path[0] = "unicolor_white";
-    node->get("name",      &m_texname);
+    node->get("name",      &m_matname);
+    if (m_matname=="")
+    {
+        throw std::runtime_error("[Material] No material name specified "
+                                 "in file\n");
+    }
+
+    node->get("tex-layer-0",      &m_texname);
     if (m_texname=="")
     {
-        throw std::runtime_error("[Material] No texture name specified "
-                                 "in file\n");
+        // We fallback to using the name as the slot 0 texture
+        node->get("name",      &m_texname);
+        if (m_texname=="")
+        {
+            throw std::runtime_error("[Material] No material name specified "
+                                     "in file\n");
+        }
     }
 
     const std::string& relative_path = file_manager->searchTexture(m_texname);

--- a/src/graphics/material.cpp
+++ b/src/graphics/material.cpp
@@ -79,6 +79,9 @@ Material::Material(const XMLNode *node, bool deprecated)
         }
     }
 
+    Log::warn("Material", "debug name: =========== %s",
+    m_matname.c_str());
+
     const std::string& relative_path = file_manager->searchTexture(m_texname);
     if (relative_path.empty())
     {

--- a/src/graphics/material.hpp
+++ b/src/graphics/material.hpp
@@ -277,6 +277,10 @@ public:
           getTexFullPath     () const { return m_full_path;          }
 
     // ------------------------------------------------------------------------
+    const std::string&
+        getMatName           () const { return m_matname;            }
+
+    // ------------------------------------------------------------------------
     bool  isTransparent      () const
     {
         return m_shader_name == "additive" || m_shader_name == "alphablend" ||

--- a/src/graphics/material.hpp
+++ b/src/graphics/material.hpp
@@ -67,6 +67,9 @@ private:
     /** Pointer to the texture. */
     video::ITexture *m_texture;
 
+    /** Name of the material */
+    std::string      m_matname;
+
     /** Name of the texture. */
     std::string      m_texname;
 

--- a/src/graphics/material_manager.cpp
+++ b/src/graphics/material_manager.cpp
@@ -86,6 +86,24 @@ Material* MaterialManager::getMaterialFor(video::ITexture* t,
 }
 
 //-----------------------------------------------------------------------------
+Material* MaterialManager::getMaterialSPMByName(std::string mat_name)
+{
+    // Search backward so that temporary (track) textures are found first
+    for (int i = (int)m_materials.size() - 1; i >= 0; i--)
+    {
+        Log::info("SPM material name", m_materials[i]->getMatName().c_str());
+        if (m_materials[i]->getMatName() == mat_name)
+        {
+            return m_materials[i];
+        }
+
+        printf("We use the default material -\n\n");
+        // If no material is found we use a default texture
+        return getMaterialSPM("stk_missingmat.png", "");
+    }
+}
+
+//-----------------------------------------------------------------------------
 Material* MaterialManager::getMaterialSPM(std::string lay_one_tex_lc,
                                           std::string lay_two_tex_lc,
                                           const std::string& def_shader_name)

--- a/src/graphics/material_manager.cpp
+++ b/src/graphics/material_manager.cpp
@@ -91,16 +91,13 @@ Material* MaterialManager::getMaterialSPMByName(std::string mat_name)
     // Search backward so that temporary (track) textures are found first
     for (int i = (int)m_materials.size() - 1; i >= 0; i--)
     {
-        Log::info("SPM material name", m_materials[i]->getMatName().c_str());
         if (m_materials[i]->getMatName() == mat_name)
         {
             return m_materials[i];
         }
-
-        printf("We use the default material -\n\n");
-        // If no material is found we use a default texture
-        return getMaterialSPM("stk_missingmat.png", "");
     }
+    // If no material is found we use a default texture
+    return getMaterialSPM("stk_missingmat.png", "");
 }
 
 //-----------------------------------------------------------------------------

--- a/src/graphics/material_manager.hpp
+++ b/src/graphics/material_manager.hpp
@@ -61,6 +61,7 @@ public:
     Material* getMaterialFor(video::ITexture* t,
                              video::E_MATERIAL_TYPE material_type);
     Material* getMaterialFor(video::ITexture* t);
+    Material* getMaterialSPMByName(std::string mat_name);
     Material* getMaterialSPM(std::string lay_one_tex_lc,
                              std::string lay_two_tex_lc,
                              const std::string& def_shader_name = "solid");

--- a/src/graphics/sp_mesh_loader.cpp
+++ b/src/graphics/sp_mesh_loader.cpp
@@ -131,10 +131,23 @@ scene::IAnimatedMesh* SPMeshLoader::createMesh(io::IReadFile* f)
                     tex_name_1 = full_path;
                 }
             }
-            sp_mat_map[id] =
-                std::make_tuple(
-                material_manager->getMaterialSPM(tex_name_1, tex_name_2),
-                !tex_name_1.empty(), !tex_name_2.empty());
+
+			// If we detect a material we look for the name rather than the texture
+            if (tex_name_1.find(".mat") != -1)
+            {
+                Log::info("SPM material found", tex_name_1.c_str());
+				sp_mat_map[id] =
+				std::make_tuple(
+					material_manager->getMaterialSPMByName(tex_name_1),
+					!tex_name_1.empty(), !tex_name_2.empty());
+            }
+			else
+			{
+				sp_mat_map[id] =
+				std::make_tuple(
+					material_manager->getMaterialSPM(tex_name_1, tex_name_2),
+					!tex_name_1.empty(), !tex_name_2.empty());
+			}
         }
         else
         {


### PR DESCRIPTION
Add support for materials directly from blender, it's done for two major reasons:

* First we need this to be compatible with Blender 2.8 since this upcoming version will remove the ability to add textures without using a material first
* Then it allows more flexibility to have different type of material using the same texture (thus using less  VRAM and less disk space).
* It's also fully compatible backward

How to use it?

In the materials.xml, you can set the name of the material. You need to use the extension .mat
`<material name="sand.mat" tex-layer-0="hd_palmTreeLeaf_a_Albedo.png" normal-map="hd_palmTreeBark_a_Normal.png"/>`
And then you can set the texture for the layer-0
