### PR TITLE
Fix build without _IRR_COMPILE_WITH_JOYSTICK_EVENTS_

### DIFF
--- a/lib/irrlicht/source/Irrlicht/CIrrDeviceWayland.cpp
+++ b/lib/irrlicht/source/Irrlicht/CIrrDeviceWayland.cpp
@@ -26,11 +26,11 @@
 #include <linux/input.h>
 #include <sys/mman.h>
 #include <sys/utsname.h>
+#include <unistd.h>
 #include <time.h>
 
 #if defined _IRR_COMPILE_WITH_JOYSTICK_EVENTS_
 #include <fcntl.h>
-#include <unistd.h>
 #include <sys/ioctl.h>
 #include <linux/joystick.h>
 #endif


### PR DESCRIPTION
This code calls *close*, which requires *unistd.h* which is currently only in the #if block. Fix build when _IRR_COMPILE_WITH_JOYSTICK_EVENTS_ is not set by moving the #include.