### PR TITLE
Fix build with joystick on FreeBSD

### DIFF
--- a/lib/irrlicht/source/Irrlicht/CIrrDeviceWayland.cpp
+++ b/lib/irrlicht/source/Irrlicht/CIrrDeviceWayland.cpp
@@ -32,7 +32,11 @@
 #if defined _IRR_COMPILE_WITH_JOYSTICK_EVENTS_
 #include <fcntl.h>
 #include <sys/ioctl.h>
+#ifdef __FreeBSD__
+#include <sys/joystick.h>
+#else
 #include <linux/joystick.h>
+#endif
 #endif
 
 #include "CColorConverter.h"


### PR DESCRIPTION
FreeBSD doesn't have linux/joystick.h. Fix build on FreeBSD when joystick support is enabled (the default).