### PR TITLE
Use floating trigonometric functions

### DIFF
--- a/src/graphics/camera.cpp
+++ b/src/graphics/camera.cpp
@@ -273,7 +273,7 @@ void Camera::update(float dt)
 
     if (race_manager->getNumLocalPlayers() < 2)
     {
-        Vec3 heading(sin(m_kart->getHeading()), 0.0f, cos(m_kart->getHeading()));
+        Vec3 heading(sinf(m_kart->getHeading()), 0.0f, cosf(m_kart->getHeading()));
         SFXManager::get()->positionListener(m_kart->getSmoothedXYZ(),
                                             heading,
                                             Vec3(0, 1, 0));

--- a/src/graphics/camera_normal.cpp
+++ b/src/graphics/camera_normal.cpp
@@ -82,9 +82,9 @@ void CameraNormal::moveCamera(float dt, bool smooth)
     Kart *kart = dynamic_cast<Kart*>(m_kart);
     if (kart->isFlying())
     {
-        Vec3 vec3 = m_kart->getSmoothedXYZ() + Vec3(sin(m_kart->getHeading()) * -4.0f,
+        Vec3 vec3 = m_kart->getSmoothedXYZ() + Vec3(sinf(m_kart->getHeading()) * -4.0f,
             0.5f,
-            cos(m_kart->getHeading()) * -4.0f);
+            cosf(m_kart->getHeading()) * -4.0f);
         m_camera->setTarget(m_kart->getSmoothedXYZ().toIrrVector());
         m_camera->setPosition(vec3.toIrrVector());
         return;
@@ -99,7 +99,7 @@ void CameraNormal::moveCamera(float dt, bool smooth)
     const Skidding *ks = m_kart->getSkidding();
     float skid_factor = ks->getVisualSkidRotation();
 
-    float skid_angle = asin(skid_factor);
+    float skid_angle = asinf(skid_factor);
     float ratio = current_speed / max_speed_without_zipper;
 
     ratio = ratio > -0.12f ? ratio : -0.12f;
@@ -109,9 +109,9 @@ void CameraNormal::moveCamera(float dt, bool smooth)
     if (camera_distance > -2.0f) camera_distance = -2.0f; // don't get too close to the kart
 
     // Defines how far camera should be from player kart.
-    Vec3 wanted_camera_offset(camera_distance * sin(skid_angle / 2),
+    Vec3 wanted_camera_offset(camera_distance * sinf(skid_angle / 2),
         (0.85f + ratio / 2.5f),
-        camera_distance * cos(skid_angle / 2));
+        camera_distance * cosf(skid_angle / 2));
 
     float delta = 1;
     float delta2 = 1;
@@ -325,7 +325,7 @@ void CameraNormal::positionCamera(float dt, float above_kart, float cam_angle,
     Vec3 wanted_position;
     Vec3 wanted_target = m_kart->getSmoothedTrans()(Vec3(0, above_kart, 0));
 
-    float tan_up = tan(cam_angle);
+    float tan_up = tanf(cam_angle);
     Vec3 relative_position(side_way,
                            fabsf(distance)*tan_up+above_kart,
                            distance);

--- a/src/graphics/show_curve.cpp
+++ b/src/graphics/show_curve.cpp
@@ -127,7 +127,7 @@ void ShowCurve::makeCircle(const Vec3 &center, float radius)
     float dx = 2.0f*M_PI/num_segs;
     for(float x = 0; x <=2.0f*M_PI; x+=dx)
     {
-        Vec3 xyz(radius*sin(x), 0.2f, radius*cos(x));
+        Vec3 xyz(radius*sinf(x), 0.2f, radius*cosf(x));
         addPoint(xyz+center);
     }
 }   // makeCircle

--- a/src/graphics/slip_stream.cpp
+++ b/src/graphics/slip_stream.cpp
@@ -320,8 +320,8 @@ SP::SPMesh* SlipStream::createMesh(Material* material, bool bonus_mesh)
             video::S3DVertexSkinnedMesh v;
             // Offset every 2nd circle by one half segment to increase
             // the number of planes so it looks better.
-            v.m_position.X =  sin((i+(j%2)*0.5f)*f)*radius[j];
-            v.m_position.Y = -cos((i+(j%2)*0.5f)*f)*radius[j];
+            v.m_position.X =  sinf((i+(j%2)*0.5f)*f)*radius[j];
+            v.m_position.Y = -cosf((i+(j%2)*0.5f)*f)*radius[j];
             v.m_position.Z = distance[j];
             // Enable texture matrix and dummy normal for visualization
             v.m_normal = 0x1FF << 10 | 1 << 30;

--- a/src/guiengine/skin.cpp
+++ b/src/guiengine/skin.cpp
@@ -722,7 +722,7 @@ void Skin::drawButton(Widget* w, const core::recti &rect,
         core::recti sized_rect = rect;
         core::position2d<u32> center =
             core::position2d<u32>(irr_driver->getFrameSize()/2);
-        const float texture_size = sin(m_dialog_size*M_PI*0.5f);
+        const float texture_size = sinf(m_dialog_size*M_PI*0.5f);
 
         sized_rect.UpperLeftCorner.X  =
             center.X + (int)(((int)rect.UpperLeftCorner.X
@@ -794,7 +794,7 @@ void Skin::drawProgress(Widget* w, const core::recti &rect,
     {
         core::position2d<u32> center =
             core::position2d<u32>(irr_driver->getFrameSize()/2);
-        const float texture_size = sin(m_dialog_size*M_PI*0.5f);
+        const float texture_size = sinf(m_dialog_size*M_PI*0.5f);
 
         sized_rect.UpperLeftCorner.X  =
             center.X + (int)(((int)rect.UpperLeftCorner.X
@@ -1151,7 +1151,7 @@ void Skin::drawRibbonChild(const core::recti &rect, Widget* widget,
                 const float dt = GUIEngine::getLatestDt();
                 glow_effect += dt * 3;
                 if (glow_effect > 6.2832f /* 2*PI */) glow_effect -= 6.2832f;
-                grow = (int)(45 + 10 * sin(glow_effect));
+                grow = (int)(45 + 10 * sinf(glow_effect));
 
 
 
@@ -1372,7 +1372,7 @@ void Skin::drawSpinnerBody(const core::recti &rect, Widget* widget,
         widget->m_parent->getType() == gui::EGUIET_WINDOW)
     {
         core::position2d<u32> center(irr_driver->getFrameSize()/2);
-        const float texture_size = sin(m_dialog_size*M_PI*0.5f);
+        const float texture_size = sinf(m_dialog_size*M_PI*0.5f);
         sized_rect.UpperLeftCorner.X  =
             center.X + (int)(((int)rect.UpperLeftCorner.X
                             - (int)center.X)*texture_size);
@@ -1503,7 +1503,7 @@ void Skin::drawIconButton(const core::recti &rect, Widget* widget,
         const float dt = GUIEngine::getLatestDt();
         glow_effect += dt*3;
         if (glow_effect > 6.2832f /* 2*PI */) glow_effect -= 6.2832f;
-        grow = (int)(45 + 10*sin(glow_effect));
+        grow = (int)(45 + 10*sinf(glow_effect));
 
         const int glow_center_x = rect.UpperLeftCorner.X+rect.getWidth()/2;
         const int glow_center_y = rect.LowerRightCorner.Y;
@@ -1532,7 +1532,7 @@ void Skin::drawIconButton(const core::recti &rect, Widget* widget,
         widget->m_parent->getType() == gui::EGUIET_WINDOW)
     {
         core::position2d<u32> center(irr_driver->getFrameSize()/2);
-        const float texture_size = sin(m_dialog_size*M_PI*0.5f);
+        const float texture_size = sinf(m_dialog_size*M_PI*0.5f);
         sized_rect.UpperLeftCorner.X  =
             center.X + (int)(((int)rect.UpperLeftCorner.X
                             - (int)center.X)*texture_size);
@@ -2248,7 +2248,7 @@ void Skin::draw3DSunkenPane (IGUIElement *element, video::SColor bgcolor,
             widget->m_parent->getType() == gui::EGUIET_WINDOW)
         {
             core::position2d<u32> center(irr_driver->getFrameSize()/2);
-            const float texture_size = sin(m_dialog_size*M_PI*0.5f);
+            const float texture_size = sinf(m_dialog_size*M_PI*0.5f);
 
             borderArea.UpperLeftCorner.X  =
                 center.X + (int)(((int)rect.UpperLeftCorner.X
@@ -2377,7 +2377,7 @@ core::recti Skin::draw3DWindowBackground(IGUIElement *element,
             core::position2d<s32> center = sized_rect.getCenter();
             const int w = sized_rect.getWidth();
             const int h = sized_rect.getHeight();
-            const float tex_size = sin(m_dialog_size*M_PI*0.5f);
+            const float tex_size = sinf(m_dialog_size*M_PI*0.5f);
             sized_rect.UpperLeftCorner.X  = (int)(center.X -(w/2.0f)*tex_size);
             sized_rect.UpperLeftCorner.Y  = (int)(center.Y -(h/2.0f)*tex_size);
             sized_rect.LowerRightCorner.X = (int)(center.X +(w/2.0f)*tex_size);

--- a/src/input/input_manager.cpp
+++ b/src/input/input_manager.cpp
@@ -964,11 +964,11 @@ EventPropagation InputManager::input(const SEvent& event)
             // *0.017453925f is to convert degrees to radians
             dispatchInput(Input::IT_STICKMOTION, event.JoystickEvent.Joystick,
                           Input::HAT_H_ID, Input::AD_NEUTRAL,
-                          (int)(cos(event.JoystickEvent.POV*0.017453925f/100.0f)
+                          (int)(cosf(event.JoystickEvent.POV*0.017453925f/100.0f)
                                 *Input::MAX_VALUE));
             dispatchInput(Input::IT_STICKMOTION, event.JoystickEvent.Joystick,
                           Input::HAT_V_ID, Input::AD_NEUTRAL,
-                          (int)(sin(event.JoystickEvent.POV*0.017453925f/100.0f)
+                          (int)(sinf(event.JoystickEvent.POV*0.017453925f/100.0f)
                                 *Input::MAX_VALUE));
         }
 

--- a/src/input/wiimote.cpp
+++ b/src/input/wiimote.cpp
@@ -97,8 +97,8 @@ void Wiimote::update()
     const float sign = normalized_angle >= 0.0f ? 1.0f : -1.0f;
     const float normalized_angle_2 = w1 * normalized_angle
                                    + w2 * sign*normalized_angle*normalized_angle
-                                   + wa * asin(normalized_angle)*(2.0f/M_PI)
-                                   + ws * sin(normalized_angle*(M_PI/2.0f));
+                                   + wa * asinf(normalized_angle)*(2.0f/M_PI)
+                                   + ws * sinf(normalized_angle*(M_PI/2.0f));
 
     if(UserConfigParams::m_wiimote_debug)
     {

--- a/src/karts/controller/ai_base_controller.cpp
+++ b/src/karts/controller/ai_base_controller.cpp
@@ -138,7 +138,7 @@ float AIBaseController::steerToPoint(const Vec3 &point)
     if(sin_steer_angle >=  1.0f)
         return  m_kart->getMaxSteerAngle()
                *m_ai_properties->m_skidding_threshold+0.1f;
-    float steer_angle     = asin(sin_steer_angle);
+    float steer_angle     = asinf(sin_steer_angle);
 
     // After doing the exact computation, we now return an 'oversteered'
     // value. This actually helps in making tighter turns, and also in

--- a/src/karts/controller/soccer_ai.cpp
+++ b/src/karts/controller/soccer_ai.cpp
@@ -475,7 +475,7 @@ bool SoccerAI::determineOvertakePosition(const Vec3& ball_lc,
  */
 float SoccerAI::rotateSlope(float old_slope, bool rotate_up)
 {
-    const float theta = atan(old_slope) + (old_slope < 0 ? M_PI : 0);
+    const float theta = atanf(old_slope) + (old_slope < 0 ? M_PI : 0);
     float new_theta = theta + (rotate_up ? M_PI / 6 : -M_PI /6);
     if (new_theta > ((M_PI / 2) - 0.02f) && new_theta < ((M_PI / 2) + 0.02f))
     {
@@ -488,7 +488,7 @@ float SoccerAI::rotateSlope(float old_slope, bool rotate_up)
     else if (new_theta < 0)
         new_theta = 0.1f;
 
-    return tan(new_theta);
+    return tanf(new_theta);
 }   // rotateSlope
 
 //-----------------------------------------------------------------------------

--- a/src/karts/kart.cpp
+++ b/src/karts/kart.cpp
@@ -875,9 +875,9 @@ float Kart::getSpeedForTurnRadius(float radius) const
     InterpolationArray turn_angle_at_speed = m_kart_properties->getTurnRadius();
     // Convert the turn radius into turn angle
     for(int i = 0; i < (int)turn_angle_at_speed.size(); i++)
-        turn_angle_at_speed.setY(i, sin( 1.0f / turn_angle_at_speed.getY(i)));
+        turn_angle_at_speed.setY(i, sinf( 1.0f / turn_angle_at_speed.getY(i)));
 
-    float angle = sin(1.0f / radius);
+    float angle = sinf(1.0f / radius);
     return turn_angle_at_speed.getReverse(angle);
 }   // getSpeedForTurnRadius
 
@@ -894,7 +894,7 @@ float Kart::getMaxSteerAngle(float speed) const
     // across karts of different lengths sharing the same
     // turn radius properties
     for(int i = 0; i < (int)turn_angle_at_speed.size(); i++)
-        turn_angle_at_speed.setY(i, sin( 1.0f / turn_angle_at_speed.getY(i))
+        turn_angle_at_speed.setY(i, sinf( 1.0f / turn_angle_at_speed.getY(i))
                                     * m_kart_properties->getWheelBase());
 
     return turn_angle_at_speed.get(speed);
@@ -2891,8 +2891,8 @@ void Kart::updateFlying()
         if (velocity.length() < 25)
         {
             float orientation = getHeading();
-            m_body->applyCentralImpulse(btVector3(100.0f*sin(orientation), 0.0,
-                100.0f*cos(orientation)));
+            m_body->applyCentralImpulse(btVector3(100.0f*sinf(orientation), 0.0,
+                100.0f*cosf(orientation)));
         }
     }
     else if (m_controls.getBrake())
@@ -2901,8 +2901,8 @@ void Kart::updateFlying()
         if (velocity.length() > -15)
         {
             float orientation = getHeading();
-            m_body->applyCentralImpulse(btVector3(-100.0f*sin(orientation), 0.0,
-                -100.0f*cos(orientation)));
+            m_body->applyCentralImpulse(btVector3(-100.0f*sinf(orientation), 0.0,
+                -100.0f*cosf(orientation)));
         }
     }
 
@@ -3226,7 +3226,7 @@ void Kart::updateGraphics(float dt)
 
     // If the kart is leaning, part of the kart might end up 'in' the track.
     // To avoid this, raise the kart enough to offset the leaning.
-    float lean_height = tan(m_current_lean) * getKartWidth()*0.5f;
+    float lean_height = tanf(m_current_lean) * getKartWidth()*0.5f;
 
     Moveable::updateSmoothedGraphics(dt);
 

--- a/src/karts/skidding.cpp
+++ b/src/karts/skidding.cpp
@@ -470,7 +470,7 @@ void Skidding::update(int ticks, bool is_on_ground,
                         * fabsf(getSteeringFraction());
             //FIXME : what is this for ?
             float r = kp->getWheelBase()
-                    / asin(angle)*1.0f;
+                    / asinf(angle)*1.0f;
 
             const int num_steps = 50;
 

--- a/src/states_screens/feature_unlocked.cpp
+++ b/src/states_screens/feature_unlocked.cpp
@@ -492,14 +492,14 @@ void FeatureUnlockedCutScene::onUpdate(float dt)
         float progress_factor = (m_global_time - GIFT_EXIT_FROM) 
                               / (GIFT_EXIT_TO - GIFT_EXIT_FROM);
         float smoothed_progress_factor = 
-                                sin((progress_factor - 0.5f)*M_PI)/2.0f + 0.5f;
+                                sinf((progress_factor - 0.5f)*M_PI)/2.0f + 0.5f;
 
         for (int n=0; n<unlockedStuffCount; n++)
         {
             if (m_unlocked_stuff[n].m_root_gift_node == NULL) continue;
 
             core::vector3df pos = m_unlocked_stuff[n].m_root_gift_node->getPosition();
-            pos.Y = sin(smoothed_progress_factor*2.5f)*10.0f;
+            pos.Y = sinf(smoothed_progress_factor*2.5f)*10.0f;
 
             // when there are more than 1 unlocked items, make sure they each
             // have their own path when they move

--- a/src/states_screens/race_gui_base.cpp
+++ b/src/states_screens/race_gui_base.cpp
@@ -195,8 +195,8 @@ void RaceGUIBase::createRegularPolygon(unsigned int n, float radius,
     for (unsigned int i=0; i<n; i++)
     {
         float p = i*f;
-        core::vector2df X = center + core::vector2df( sin(p)*radius,
-                                                     -cos(p)*radius);
+        core::vector2df X = center + core::vector2df( sinf(p)*radius,
+                                                     -cosf(p)*radius);
         v[i].Pos.X = X.X;
         v[i].Pos.Y = X.Y;
         v[i].Color = color;
@@ -534,8 +534,8 @@ void RaceGUIBase::drawGlobalMusicDescription()
     float timeProgression = (float)(race_time) /
                             (float)(stk_config->m_music_credit_time - 2.0f);
 
-    const int x_pulse = (int)(sin(race_time*9.0f)*10.0f);
-    const int y_pulse = (int)(cos(race_time*9.0f)*10.0f);
+    const int x_pulse = (int)(sinf(race_time*9.0f)*10.0f);
+    const int y_pulse = (int)(cosf(race_time*9.0f)*10.0f);
 
     float resize = 1.0f;
     if (timeProgression < 0.1)
@@ -942,7 +942,7 @@ void RaceGUIBase::drawPlayerIcon(AbstractKart *kart, int x, int y, int w)
         {
             colors[i]=kart->getKartProperties()->getColor();
             colors[i].setAlpha(
-                               100+(int)(100*cos(M_PI/2*i+World::getWorld()->getTime()*2)));
+                               100+(int)(100*cosf(M_PI/2*i+World::getWorld()->getTime()*2)));
         }
         const core::rect<s32> rect(core::position2d<s32>(0,0),
                                    m_icons_frame->getSize());
@@ -963,7 +963,7 @@ void RaceGUIBase::drawPlayerIcon(AbstractKart *kart, int x, int y, int w)
     {
         //icon fades to the left
         float t = kart->getKartAnimation()->getAnimationTimer();
-        float t_anim=100*sin(0.5f*M_PI*t);
+        float t_anim=100*sinf(0.5f*M_PI*t);
         const core::rect<s32> rect1(core::position2d<s32>(0,0),
                                     icon->getSize());
         const core::rect<s32> pos1((int)(x-t_anim), y,
@@ -989,7 +989,7 @@ void RaceGUIBase::drawPlayerIcon(AbstractKart *kart, int x, int y, int w)
     {
         //exploses into 4 parts
         float t = kart->getKartAnimation()->getAnimationTimer();
-        float t_anim=50.0f*sin(0.5f*M_PI*t);
+        float t_anim=50.0f*sinf(0.5f*M_PI*t);
         u16 icon_size_x=icon->getSize().Width;
         u16 icon_size_y=icon->getSize().Height;
 

--- a/src/states_screens/race_result_gui.cpp
+++ b/src/states_screens/race_result_gui.cpp
@@ -1028,9 +1028,9 @@ void RaceResultGUI::displayCTFResults()
                 }
                 case RR_RESORT_TABLE:
                     x = ri->m_x_pos
-                        - ri->m_radius*sin(m_timer / m_time_rotation*M_PI);
+                        - ri->m_radius*sinf(m_timer / m_time_rotation*M_PI);
                     y = ri->m_centre_point
-                        + ri->m_radius*cos(m_timer / m_time_rotation*M_PI);
+                        + ri->m_radius*cosf(m_timer / m_time_rotation*M_PI);
                     break;
                 case RR_WAIT_TILL_END:
                     break;

--- a/src/tracks/terrain_info.cpp
+++ b/src/tracks/terrain_info.cpp
@@ -129,8 +129,8 @@ bool TerrainInfo::getSurfaceInfo(const Vec3 &from, Vec3 *position,
 float TerrainInfo::getTerrainPitch(float heading) const {
     if(!m_material) return 0.0f;
 
-    const float X = sin(heading);
-    const float Z = cos(heading);
+    const float X = sinf(heading);
+    const float Z = cosf(heading);
     // Compute the angle between the normal of the plane and the line to
     // (x,0,z).  (x,0,z) is normalised, so are the coordinates of the plane,
     // simplifying the computation of the scalar product.


### PR DESCRIPTION
Replace calls to double-precision trigonometric functions to their floating-point counterparts. Depending on this platform and standard math library, this can result in less computation.