### PR TITLE
Add option to disable light scattering

### DIFF
--- a/src/config/user_config.hpp
+++ b/src/config/user_config.hpp
@@ -851,6 +851,10 @@ namespace UserConfigParams
             PARAM_DEFAULT(BoolUserConfigParam(false,
                            "ssao", &m_graphics_quality,
                            "Enable Screen Space Ambient Occlusion") );
+    PARAM_PREFIX BoolUserConfigParam         m_light_scatter
+            PARAM_DEFAULT(BoolUserConfigParam(true,
+                           "light_scatter", &m_graphics_quality,
+                           "Enable light scattering shaders") );
     PARAM_PREFIX IntUserConfigParam          m_shadows_resolution
             PARAM_DEFAULT( IntUserConfigParam(0,
                            "shadows_resolution", &m_graphics_quality,

--- a/src/graphics/shader_based_renderer.cpp
+++ b/src/graphics/shader_based_renderer.cpp
@@ -297,7 +297,7 @@ void ShaderBasedRenderer::renderSceneDeferred(scene::ICameraSceneNode * const ca
     // Render discrete lights scattering
     if (track && track->isFogEnabled())
     {
-        PROFILER_PUSH_CPU_MARKER("- PointLight Scatter", 0xFF, 0x00, 0x00);
+        PROFILER_PUSH_CPU_MARKER("- Light Scatter", 0xFF, 0x00, 0x00);
         ScopedGPUTimer Timer(irr_driver->getGPUTimer(Q_LIGHTSCATTER));
         m_lighting_passes.renderLightsScatter(m_rtts->getDepthStencilTexture(),
                                               m_rtts->getFBO(FBO_HALF1),

--- a/src/graphics/shader_based_renderer.cpp
+++ b/src/graphics/shader_based_renderer.cpp
@@ -295,7 +295,7 @@ void ShaderBasedRenderer::renderSceneDeferred(scene::ICameraSceneNode * const ca
 
     const Track * const track = Track::getCurrentTrack();
     // Render discrete lights scattering
-    if (track && track->isFogEnabled())
+    if (UserConfigParams::m_light_scatter && track && track->isFogEnabled())
     {
         PROFILER_PUSH_CPU_MARKER("- Light Scatter", 0xFF, 0x00, 0x00);
         ScopedGPUTimer Timer(irr_driver->getGPUTimer(Q_LIGHTSCATTER));

--- a/src/modes/world.cpp
+++ b/src/modes/world.cpp
@@ -970,7 +970,7 @@ void World::scheduleTutorial()
 //-----------------------------------------------------------------------------
 /** This updates all only graphical elements. It is only called once per
  *  rendered frame, not once per time step.
- *  float dt Time since last rame.
+ *  float dt Time since last frame.
  */
 void World::updateGraphics(float dt)
 {


### PR DESCRIPTION
On old (circa 2011) graphics hardware, I have the sad option of either using fast but ugly graphics with the old pipeline (graphics level 2) or nice-looking but very, very slow (a second in game takes 3 real seconds with very poor control response) render on some maps like Cocoa Temple.

For some context, on my hardware, the solid render at Cocoa Temple takes 15 ms. In the room with the spinning gear, light scatter takes up to 48 ms. That makes for a really crappy experience.

This option, currently not visible in-game, preserving existing behavior by default, adds a configuration setting that disables the light scattering shader in the pipeline. This means that you get the new pipeline, with the new point light sources, only without the later light scattering stage. This means that users running hardware like the stuff I run don't have to pick either old pipeline or unplayable graphics.