### PR TITLE
Collapsing widget function

### DIFF
--- a/src/guiengine/widget.cpp
+++ b/src/guiengine/widget.cpp
@@ -344,6 +344,27 @@ void Widget::setVisible(bool visible)
 
 // -----------------------------------------------------------------------------
 
+void Widget::setCollapsed(bool collapsed, Screen* calling_screen)
+{
+    if (m_h != 0)
+        m_uncollapsed_height = m_h;
+
+    setVisible(!collapsed);
+
+    if (collapsed)
+    {
+        m_properties[GUIEngine::PROP_HEIGHT] = "0";
+    }
+    else
+    {
+        m_properties[GUIEngine::PROP_HEIGHT] = StringUtils::toString(m_uncollapsed_height);
+    }
+
+    calling_screen->calculateLayout();
+}
+
+// -----------------------------------------------------------------------------
+
 void Widget::moveIrrlichtElement()
 {
     if (m_element != NULL)

--- a/src/guiengine/widget.cpp
+++ b/src/guiengine/widget.cpp
@@ -346,21 +346,29 @@ void Widget::setVisible(bool visible)
 
 void Widget::setCollapsed(bool collapsed, Screen* calling_screen)
 {
-    if (m_h != 0)
+    // check for height > 0 to not loose height of widget in uncollapsed state
+    // if widget is set to collapse twice.
+    if (collapsed && m_h > 0)
         m_uncollapsed_height = m_h;
+
+    setCollapsed(collapsed, m_uncollapsed_height, calling_screen);
+}
+
+// -----------------------------------------------------------------------------
+
+void Widget::setCollapsed(bool collapsed, int uncollapsed_height, Screen* calling_screen)
+{
+    m_uncollapsed_height = uncollapsed_height;
 
     setVisible(!collapsed);
 
     if (collapsed)
-    {
         m_properties[GUIEngine::PROP_HEIGHT] = "0";
-    }
     else
-    {
         m_properties[GUIEngine::PROP_HEIGHT] = StringUtils::toString(m_uncollapsed_height);
-    }
 
-    calling_screen->calculateLayout();
+    if (calling_screen != NULL)
+        calling_screen->calculateLayout();
 }
 
 // -----------------------------------------------------------------------------

--- a/src/guiengine/widget.hpp
+++ b/src/guiengine/widget.hpp
@@ -358,7 +358,17 @@ namespace GUIEngine
          * it visible implicitely calls setActive(true). If you mix visiblity and (de)activated calls,
          * undefined behavior may ensue (like invisible but clickable buttons).
          */
-        virtual void setCollapsed(bool collapsed, Screen* calling_screen);
+        virtual void setCollapsed(bool collapsed, Screen* calling_screen = NULL);
+
+        /**
+         * \brief Sets the widget (and its children, if any) collapsed or not.
+         * !!! Note: this has to be called inside beforeAddingWidget() !!!
+         * This will also set the widget invisible depending of collapsed state.
+         * Note that setting a widget invisible implicitely calls setDeactivated(), and setting
+         * it visible implicitely calls setActive(true). If you mix visiblity and (de)activated calls,
+         * undefined behavior may ensue (like invisible but clickable buttons).
+         */
+        virtual void setCollapsed(bool collapsed, int uncollapsed_height, Screen* calling_screen = NULL);
 
         /** Returns if the element is visible. */
         bool isVisible() const;

--- a/src/guiengine/widget.hpp
+++ b/src/guiengine/widget.hpp
@@ -275,6 +275,10 @@ namespace GUIEngine
         bool m_has_tooltip;
         irr::core::stringw m_tooltip_text;
 
+
+        /** height of the widget before it was collapsed (only set if widget got collapsed) */
+        int m_uncollapsed_height;
+
     public:
 
         /**
@@ -345,6 +349,16 @@ namespace GUIEngine
          * undefined behavior may ensue (like invisible but clickable buttons).
          */
         virtual void setVisible(bool visible);
+
+        /**
+         * \brief Sets the widget (and its children, if any) collapsed or not.
+         * !!! Note: this has to be called inside beforeAddingWidget() !!!
+         * This will also set the widget invisible depending of collapsed state.
+         * Note that setting a widget invisible implicitely calls setDeactivated(), and setting
+         * it visible implicitely calls setActive(true). If you mix visiblity and (de)activated calls,
+         * undefined behavior may ensue (like invisible but clickable buttons).
+         */
+        virtual void setCollapsed(bool collapsed, Screen* calling_screen);
 
         /** Returns if the element is visible. */
         bool isVisible() const;

--- a/src/states_screens/online/tracks_screen.cpp
+++ b/src/states_screens/online/tracks_screen.cpp
@@ -225,8 +225,7 @@ void TracksScreen::beforeAddingWidget()
     m_track_icons->clear();
     if (m_network_tracks)
     {
-        rect_box->setVisible(true);
-        rect_box->m_properties[GUIEngine::PROP_HEIGHT] = StringUtils::toString(m_bottom_box_height);
+        rect_box->setCollapsed(false, m_bottom_box_height);
         getWidget("lap-text")->setVisible(true);
         m_laps = getWidget<SpinnerWidget>("lap-spinner");
         assert(m_laps != NULL);
@@ -317,8 +316,7 @@ void TracksScreen::beforeAddingWidget()
     else
     {
         m_timer->setVisible(false);
-        rect_box->setVisible(false);
-        rect_box->m_properties[GUIEngine::PROP_HEIGHT] = "0";
+        rect_box->setCollapsed(true);
         m_laps = NULL;
         m_reversed = NULL;
         getWidget("lap-text")->setVisible(false);


### PR DESCRIPTION
This pull request simplifies the collapsing of widgets.
for example this code:
```
static int target_type_div_height = m_target_type_div->m_h;
 
const bool is_soccer = race_manager->getMinorMode() == RaceManager::MINOR_MODE_SOCCER;
if (is_soccer)
{
    m_target_type_div->setVisible(true);
    m_target_type_div->m_properties[GUIEngine::PROP_HEIGHT] = StringUtils::toString(target_type_div_height);
}
else
{
    m_target_type_div->setVisible(false);
    m_target_type_div->m_properties[GUIEngine::PROP_HEIGHT] = "0";
}
calculateLayout();
```

could be simplified to this:
```
const bool is_soccer = race_manager->getMinorMode() == RaceManager::MINOR_MODE_SOCCER;
m_target_type_div->setCollapsed(isSoccer, this);
```

It also still supports storing the uncollapsed height outside the function.
For another usage example see how I applied it to the online track screen