### PR TITLE
Using a default music if specified music of track was not found

### DIFF
--- a/data/stk_config.xml
+++ b/data/stk_config.xml
@@ -132,7 +132,7 @@
            solver-mode=""/>
 
   <!-- The title music. -->
-  <music title="main_theme.music"/>
+  <music title="main_theme.music" default="kart_grand_prix.music"/>
 
   <!--  Replay related values, mostly concerned with saving less data
         and using interpolation instead.

--- a/data/stk_config.xml
+++ b/data/stk_config.xml
@@ -131,7 +131,7 @@
            solver-split-impulse-threshold="-0.00001"
            solver-mode=""/>
 
-  <!-- The title music. -->
+  <!-- The title and default musics. -->
   <music title="main_theme.music" default="kart_grand_prix.music"/>
 
   <!--  Replay related values, mostly concerned with saving less data

--- a/src/config/stk_config.cpp
+++ b/src/config/stk_config.cpp
@@ -48,6 +48,9 @@ STKConfig::~STKConfig()
     if(m_title_music)
         delete m_title_music;
 
+    if (m_default_music)
+        delete m_default_music;
+
     if(m_default_kart_properties)
         delete m_default_kart_properties;
 
@@ -210,6 +213,7 @@ void STKConfig::init_defaults()
     m_solver_reset_flags         = 0;
     m_network_steering_reduction = -100;
     m_title_music                = NULL;
+    m_default_music              = NULL;
     m_solver_split_impulse       = false;
     m_smooth_normals             = false;
     m_same_powerup_mode          = POWERUP_MODE_ONLY_IF_SAME;
@@ -377,6 +381,14 @@ void STKConfig::getAllData(const XMLNode * root)
         m_title_music = MusicInformation::create(title_music);
         if(!m_title_music)
             Log::error("StkConfig", "Cannot load title music : %s", title_music.c_str());
+
+        std::string default_music;
+        music_node->get("default", &default_music);
+        assert(default_music.size() > 0);
+        default_music = file_manager->getAsset(FileManager::MUSIC, default_music);
+        m_default_music = MusicInformation::create(default_music);
+        if (!m_default_music)
+            Log::error("StkConfig", "Cannot load default music : %s", default_music.c_str());
     }
 
     if(const XMLNode *skidmarks_node = root->getNode("skid-marks"))

--- a/src/config/stk_config.hpp
+++ b/src/config/stk_config.hpp
@@ -163,6 +163,9 @@ public:
     /** Filename of the title music to play.*/
     MusicInformation *m_title_music;
 
+    /** Filename of the music that is played when the track's music was not found */
+    MusicInformation *m_default_music;
+
     /** Maximum number of transform events of a replay. */
     int m_replay_max_frames;
 

--- a/src/tracks/track.cpp
+++ b/src/tracks/track.cpp
@@ -696,10 +696,13 @@ void Track::getMusicInformation(std::vector<std::string>&       filenames,
         if(mi)
             m_music.push_back(mi);
         else
-            Log::warn("track",
-                      "Music information file '%s' not found for track '%s' - ignored.\n",
-                      filenames[i].c_str(), m_name.c_str());
+        {
+            m_music.push_back(stk_config->m_default_music);
 
+            Log::warn("track",
+                "Music information file '%s' not found for track '%s' - replaced by default track.\n",
+                filenames[i].c_str(), m_name.c_str());
+        }
     }   // for i in filenames
 
 }   // getMusicInformation

--- a/src/tracks/track.cpp
+++ b/src/tracks/track.cpp
@@ -696,14 +696,20 @@ void Track::getMusicInformation(std::vector<std::string>&       filenames,
         if(mi)
             m_music.push_back(mi);
         else
-        {
-            m_music.push_back(stk_config->m_default_music);
-
             Log::warn("track",
-                "Music information file '%s' not found for track '%s' - replaced by default track.\n",
-                filenames[i].c_str(), m_name.c_str());
-        }
+                      "Music information file '%s' not found for track '%s' - ignored.\n",
+                      filenames[i].c_str(), m_name.c_str());
+
     }   // for i in filenames
+
+    if (m_music.empty())
+    {
+        m_music.push_back(stk_config->m_default_music);
+
+        Log::warn("track",
+            "Music information for track '%s' replaced by default music.\n",
+            m_name.c_str());
+    }
 
 }   // getMusicInformation
 


### PR DESCRIPTION
Some addon tracks have set a music in their track.xml that can't be found (either because it was removed from the game in the meantime or the author forgot to include that file). When playing these tracks no music is played at all, which just doesn't feel right.

With this pull request a default music will be played in such cases. The default music can be specified in the stk_config.xml where also the title music is specified.

I chose "kart_grand_prix.music" as default because it (at least for me) always felt like the standard song and I think it just fits almost every possible track well. But that can be easily changed.