### PR TITLE
fix for widget collapsing

### DIFF
--- a/src/guiengine/widget.cpp
+++ b/src/guiengine/widget.cpp
@@ -348,10 +348,7 @@ void Widget::setVisible(bool visible)
 
 void Widget::setCollapsed(const bool collapsed, Screen* calling_screen)
 {
-    // check for height > 0 to not loose height of widget in uncollapsed state
-    // if widget is set to collapse twice.
-    // the check for m_is_collapsed allows to save a height of 0 if widget was not collapsed
-    if (collapsed && (m_h > 0 || !m_is_collapsed))
+    if (!m_is_collapsed)
         m_uncollapsed_height = m_h;
 
     setCollapsed(collapsed, m_uncollapsed_height, calling_screen);


### PR DESCRIPTION
with my PR for widget collapsing functions #3664, the widgets for soccer target type (goals or time), introduced in PR #3638, the widgets are not shown if the soccer track info screen is shown before a track info screen for another game mode. Sorry for that, this PR fixes the wrong behavior of the function setCollapsed.