### PR TITLE
For now rename 'official' servers to 'trusted'

### DIFF
--- a/src/network/server.cpp
+++ b/src/network/server.cpp
@@ -114,7 +114,6 @@ Server::Server(const XMLNode& server_info) : m_supports_encrytion(true)
         // not operated by us). #3691 will introduce the various states
         // required to properly distinguish between trusted, ranked,
         // and official servers.
-        // (currently) 'official' servers 'trusted', since we 
         m_server_owner_name = _("Trusted");
         m_server_owner_lower_case_name = "trusted";
         return;

--- a/src/network/server.cpp
+++ b/src/network/server.cpp
@@ -104,9 +104,19 @@ Server::Server(const XMLNode& server_info) : m_supports_encrytion(true)
     xml.get("official", &m_official);
     if (m_official)
     {
+        // TODO: I'll leave this string in so that we don't lose
+        // the translations already done, to be fixed as part of #3691
         // I18N: Official means this server is hosted by STK team
         m_server_owner_name = _("Official");
-        m_server_owner_lower_case_name = "Official";
+
+        // TODO: temporary work around for #3691: for now call all
+        // 'official' server 'trusted' (since most trusted servers are
+        // not operated by us). #3691 will introduce the various states
+        // required to properly distinguish between trusted, ranked,
+        // and official servers.
+        // (currently) 'official' servers 'trusted', since we 
+        m_server_owner_name = _("Trusted");
+        m_server_owner_lower_case_name = "trusted";
         return;
     }
 


### PR DESCRIPTION
... to make it more obvious what the STK team does not operate those servers.

This is a fix for #3691 good enough for the next release, when a proper solution can be implemented. 

Note that some strings modified in this pull request are temporary only (i.e. to make sure we keep already translated strings that we will need later). 

@Benau, can you check that I didn't break anything (especially I found it hard to understand that m_server_owner_lower_case_name was "Official" (capitalised), I used all lower case now, please check that I didn't break anything ;) ).