### PR TITLE
Gdpr compliance

### DIFF
--- a/src/config/user_config.hpp
+++ b/src/config/user_config.hpp
@@ -954,7 +954,7 @@ namespace UserConfigParams
                                                   "A random number to avoid duplicated reports.") );
 
     PARAM_PREFIX BoolUserConfigParam      m_hw_report_enable
-            PARAM_DEFAULT( BoolUserConfigParam(   true,
+            PARAM_DEFAULT( BoolUserConfigParam(   false,
                                                      "hw-report-enabled",
                                                      &m_hw_report_group,
                                                     "If HW reports are enabled."));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1814,7 +1814,7 @@ void askForInternetPermission()
         "Please read our privacy policy at http://privacy.supertuxkart.net. "
         "Would you like this feature to be enabled? (To change this setting "
         "at a later time, go to options, select tab "
-        "'User Interface', and edit \"Connect to the "
+        "'General', and edit \"Connect to the "
         "Internet\" and \"Send anonymous HW statistics\")."),
         MessageDialog::MESSAGE_DIALOG_YESNO,
         new ConfirmServer(), true, true, 0.7f, 0.7f);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1807,7 +1807,7 @@ void askForInternetPermission()
         }   // onCancel
     };   // ConfirmServer
 
-    GUIEngine::ModalDialog *dialog =
+    MessageDialog *dialog =
     new MessageDialog(_("SuperTuxKart may connect to a server "
         "to download add-ons and notify you of updates. We also collect "
         "anonymous hardware statistics to help with the development of STK. "
@@ -1818,6 +1818,10 @@ void askForInternetPermission()
         "Internet\" and \"Send anonymous HW statistics\")."),
         MessageDialog::MESSAGE_DIALOG_YESNO,
         new ConfirmServer(), true, true, 0.7f, 0.7f);
+
+    // Changes the default focus to be 'cancel', which is not
+    // GDPR compliant, see #3378
+    dialog->setFocusCancel();
     GUIEngine::DialogQueue::get()->pushDialog(dialog, false);
 }   // askForInternetPermission
 

--- a/src/states_screens/dialogs/message_dialog.cpp
+++ b/src/states_screens/dialogs/message_dialog.cpp
@@ -42,10 +42,11 @@ MessageDialog::MessageDialog(const irr::core::stringw &msg,
                              float width, float height)
              : ModalDialog(width, height)
 {
-    m_msg          = msg;
-    m_type         = type;
-    m_listener     = listener;
-    m_own_listener = own_listener;
+    m_msg             = msg;
+    m_type            = type;
+    m_listener        = listener;
+    m_own_listener    = own_listener;
+    m_focus_on_cancel = false;
     doInit(from_queue);
 }   // MessageDialog(stringw, type, listener, own_listener)
 
@@ -127,12 +128,17 @@ void MessageDialog::loadedFromFile()
     {
         IconButtonWidget* cancelbtn = getWidget<IconButtonWidget>("cancel");
         cancelbtn->setText(_("No"));
+        if(m_focus_on_cancel)
+            cancelbtn->setFocusForPlayer(PLAYER_ID_GAME_MASTER);
     }
     else if (m_type == MessageDialog::MESSAGE_DIALOG_OK_CANCEL)
     {
         // In case of a OK_CANCEL dialog, change the text from 'Yes' to 'Ok'
         IconButtonWidget* yesbtn = getWidget<IconButtonWidget>("confirm");
         yesbtn->setText(_("OK"));
+        IconButtonWidget* cancelbtn = getWidget<IconButtonWidget>("cancel");
+        if (m_focus_on_cancel)
+            cancelbtn->setFocusForPlayer(PLAYER_ID_GAME_MASTER);
     }
 }
 

--- a/src/states_screens/dialogs/message_dialog.hpp
+++ b/src/states_screens/dialogs/message_dialog.hpp
@@ -74,6 +74,10 @@ private:
     irr::core::stringw m_msg;
     void doInit(bool from_queue);
 
+    /** If set this will set the focus on 'cancel'/'no' 
+     *  instead of "yes"/"ok". */
+    bool m_focus_on_cancel;
+
 public:
 
     /**
@@ -101,6 +105,10 @@ public:
     GUIEngine::EventPropagation processEvent(const std::string& eventSource) OVERRIDE;
 
     virtual void loadedFromFile() OVERRIDE;
+
+    /** Calling this will make sure that the focus is set on the 'cancel' or
+     * 'no'. */
+    void setFocusCancel() {m_focus_on_cancel = true; }
 };
 
 

--- a/src/states_screens/options/options_screen_general.cpp
+++ b/src/states_screens/options/options_screen_general.cpp
@@ -177,7 +177,7 @@ void OptionsScreenGeneral::eventCallback(Widget* widget, const std::string& name
             stats_label->setVisible(true);
             stats->setState(UserConfigParams::m_hw_report_enable);
             chat->setVisible(true);
-            stats->setState(UserConfigParams::m_lobby_chat);
+            chat->setState(UserConfigParams::m_lobby_chat);
             chat_label->setVisible(true);
         }
         else

--- a/src/states_screens/options/options_screen_general.cpp
+++ b/src/states_screens/options/options_screen_general.cpp
@@ -81,29 +81,35 @@ void OptionsScreenGeneral::init()
     ribbon->setFocusForPlayer(PLAYER_ID_GAME_MASTER);
     ribbon->select( "tab_general", PLAYER_ID_GAME_MASTER );
 
-    CheckBoxWidget* news = getWidget<CheckBoxWidget>("enable-internet");
-    assert( news != NULL );
-    news->setState( UserConfigParams::m_internet_status
+    CheckBoxWidget* internet_enabled = getWidget<CheckBoxWidget>("enable-internet");
+    assert( internet_enabled != NULL );
+    internet_enabled->setState( UserConfigParams::m_internet_status
                                      ==RequestManager::IPERM_ALLOWED );
     CheckBoxWidget* stats = getWidget<CheckBoxWidget>("enable-hw-report");
     assert( stats != NULL );
     LabelWidget *stats_label = getWidget<LabelWidget>("label-hw-report");
     assert( stats_label );
-            stats->setState(UserConfigParams::m_hw_report_enable);
+    stats->setState(UserConfigParams::m_hw_report_enable);
 
-    getWidget<CheckBoxWidget>("enable-lobby-chat")
-        ->setState(UserConfigParams::m_lobby_chat);
+    
+    CheckBoxWidget* chat = getWidget<CheckBoxWidget>("enable-lobby-chat");
+    LabelWidget* chat_label = getWidget<LabelWidget>("label-lobby-chat");
 
-    if(news->getState())
+    if(internet_enabled->getState())
     {
         stats_label->setVisible(true);
         stats->setVisible(true);
         stats->setState(UserConfigParams::m_hw_report_enable);
+        chat_label->setVisible(true);
+        chat->setVisible(true);
+        chat->setState(UserConfigParams::m_lobby_chat);
     }
     else
     {
         stats_label->setVisible(false);
         stats->setVisible(false);
+        chat_label->setVisible(false);
+        chat->setVisible(false);
     }
     CheckBoxWidget* difficulty = getWidget<CheckBoxWidget>("perPlayerDifficulty");
     assert( difficulty != NULL );
@@ -186,6 +192,9 @@ void OptionsScreenGeneral::eventCallback(Widget* widget, const std::string& name
             chat_label->setVisible(false);
             stats->setVisible(false);
             stats_label->setVisible(false);
+            // Disable this, so that the user has to re-check this if
+            // enabled later (for GDPR compliance).
+            UserConfigParams::m_hw_report_enable = false;
             PlayerProfile* profile = PlayerManager::getCurrentPlayer();
             if (profile != NULL && profile->isLoggedIn())
                 profile->requestSignOut();


### PR DESCRIPTION
First fix for #3378: sending hardware stats is now opt-in (no default to send hardware stats anymore). Fixes also incorrect help message and incorrect status display if hw-stats are reported or not, and made the chat option (in)visible same as hw-stats.

Note that the order of entries in the 'internet' option is strange (the 'always show login' option is not strictly an internet-only option, since it also affects local-only accounts), but I am not sure why this order was chosen, so I left this unchanged.

Combining internet-access and hw-stats with just one option is bad now that stk is gdpr compliant, since it must now default to internet-off :( But I can't see an easy and convenient location - best option imho: remove the HW statistic, since we are actually not using the stats anymore.