### PR TITLE
Feature/raytracer reflexion

### DIFF
--- a/data/shaders/IBL.frag
+++ b/data/shaders/IBL.frag
@@ -87,8 +87,8 @@ vec3 RayCast(vec3 dir, inout vec3 hitCoord, out float dDepth, in sampler2D Depth
             if ((projectedCoord.x > 0.0 && projectedCoord.x < 1.0) && (projectedCoord.y > 0.0 && projectedCoord.y < 1.0))
             {
                 // Mix with fallback (black area should be dark anyway)
-                //vec3 finalColor = textureLod(albedo, projectedCoord.xy, 1.0).rgb;
-                vec3 finalColor = fastBlur(projectedCoord.xy, spread);
+                vec3 finalColor = textureLod(albedo, projectedCoord.xy, 1.0).rgb;
+                //vec3 finalColor = fastBlur(projectedCoord.xy, spread);
                 if ((finalColor.r + finalColor.g + finalColor.b) > 0.)
                 {
                     vec2 inside = (gl_FragCoord.xy / u_screen) - 0.5;

--- a/data/shaders/IBL.frag
+++ b/data/shaders/IBL.frag
@@ -63,7 +63,6 @@ vec3 RayCast(vec3 dir, inout vec3 hitCoord, out float dDepth, in sampler2D Depth
 
         if(dDepth < 0.0)
         {
-            //return vec3(1.0, 0.0, 0.0);
             if ((projectedCoord.x > 0.0 && projectedCoord.x < 1.0) && (projectedCoord.y > 0.0 && projectedCoord.y < 1.0))
             {
                 // Mix with fallback (black area should be dark anyway)

--- a/data/shaders/IBL.frag
+++ b/data/shaders/IBL.frag
@@ -142,6 +142,9 @@ void main(void)
     int x = int(gl_FragCoord.x), y = int(gl_FragCoord.y);
     vec3 FragPos = getXcYcZc(x, y, lineardepth);
 
+    // Fallback
+    vec3 fallback = .25 * SpecularIBL(normal, eyedir, specval);
+
     // Better implementation: :::::::::::::::::::::::::::::::::::
 
     float View_Depth            = makeLinear(1000.0, 0.001, lineardepth);
@@ -161,8 +164,7 @@ void main(void)
     vec3 hitPos                 = View_Pos.xyz;
     float dDepth;
     float minRayStep            = 100.0f;
-    // Fallback
-    vec3 fallback = .25 * SpecularIBL(normal, eyedir, specval);
+    
     vec3 outColor = RayCast(reflected * max(minRayStep, -View_Pos.z), hitPos, dDepth, dtex, fallback, 0.001);
     vec3 outColor2 = RayCast(reflected2 * max(minRayStep, -View_Pos.z), hitPos, dDepth, dtex, fallback, 0.001);
     outColor = mix(outColor, outColor2, 1.0 - specval);

--- a/data/shaders/IBL.frag
+++ b/data/shaders/IBL.frag
@@ -62,6 +62,11 @@ vec3 CalcViewPositionFromDepth(in vec2 TexCoord, in sampler2D DepthMap)
     return                          ViewPosition.xyz / ViewPosition.w;
 }
 
+float rand(vec2 co)
+{
+   return fract(sin(dot(co.xy,vec2(12.9898,78.233))) * 43758.5453);
+}
+
 
 vec3 RayCast(vec3 dir, inout vec3 hitCoord, out float dDepth, in sampler2D DepthMap, in vec3 fallback, float spread)
 {
@@ -82,8 +87,8 @@ vec3 RayCast(vec3 dir, inout vec3 hitCoord, out float dDepth, in sampler2D Depth
             if ((projectedCoord.x > 0.0 && projectedCoord.x < 1.0) && (projectedCoord.y > 0.0 && projectedCoord.y < 1.0))
             {
                 // Mix with fallback (black area should be dark anyway)
-                vec3 finalColor = textureLod(albedo, projectedCoord.xy, 1.0).rgb;
-                finalColor = fastBlur(projectedCoord.xy, spread);
+                //vec3 finalColor = textureLod(albedo, projectedCoord.xy, 1.0).rgb;
+                vec3 finalColor = fastBlur(projectedCoord.xy, spread);
                 if ((finalColor.r + finalColor.g + finalColor.b) > 0.)
                 {
                     vec2 inside = (gl_FragCoord.xy / u_screen) - 0.5;
@@ -104,13 +109,6 @@ vec3 RayCast(vec3 dir, inout vec3 hitCoord, out float dDepth, in sampler2D Depth
     }
 
     return fallback;
-}
-
-
-
-float rand(vec2 co)
-{
-   return fract(sin(dot(co.xy,vec2(12.9898,78.233))) * 43758.5453);
 }
 
 float rand2(vec2 co)
@@ -164,11 +162,9 @@ void main(void)
     vec3 hitPos                 = View_Pos.xyz;
     float dDepth;
     float minRayStep            = 100.0f;
-    
-    vec3 outColor = RayCast(reflected * max(minRayStep, -View_Pos.z), hitPos, dDepth, dtex, fallback, 0.001);
-    vec3 outColor2 = RayCast(reflected2 * max(minRayStep, -View_Pos.z), hitPos, dDepth, dtex, fallback, 0.001);
-    outColor = mix(outColor, outColor2, 1.0 - specval);
 
+    vec3 outColor = RayCast(mix(reflected, reflected2, 1.0 - specval) * max(minRayStep, -View_Pos.z),
+                            hitPos, dDepth, dtex, fallback, mix(0.001, 0.01, 1.0 - specval));
 
     Spec = vec4(outColor.rgb, 1.0);
 

--- a/data/shaders/IBL.frag
+++ b/data/shaders/IBL.frag
@@ -88,6 +88,7 @@ vec3 RayCast(vec3 dir, inout vec3 hitCoord, out float dDepth, in sampler2D Depth
             {
                 // Mix with fallback (black area should be dark anyway)
                 vec3 finalColor = textureLod(albedo, projectedCoord.xy, 1.0).rgb;
+                // FIXME, this is heavy, needs to be an option in the settings
                 //vec3 finalColor = fastBlur(projectedCoord.xy, spread);
                 if ((finalColor.r + finalColor.g + finalColor.b) > 0.)
                 {
@@ -132,8 +133,9 @@ void main(void)
     // Extract roughness
     float specval = texture(ntex, uv).z;
 
+#ifdef GL_ES
     Spec = vec4(.25 * SpecularIBL(normal, eyedir, specval), 1.);
-
+#else
     // Compute Space Screen Reflection =========================================================
 
     float lineardepth = textureLod(dtex, uv, 0.).x;
@@ -167,5 +169,6 @@ void main(void)
                             hitPos, dDepth, dtex, fallback, mix(0.001, 0.01, 1.0 - specval));
 
     Spec = vec4(outColor.rgb, 1.0);
+#endif
 
 }

--- a/data/shaders/IBL.frag
+++ b/data/shaders/IBL.frag
@@ -132,6 +132,10 @@ void main(void)
 
     vec3 outColor = RayCast(reflected * max(minRayStep, -View_Pos.z),
                             hitPos, dDepth, dtex, fallback, 0.0);
+    
+    // TODO temporary measure the lack of mipmaping for RTT albedo
+    // Implement it in proper way
+    outColor = mix(fallback, outColor, specval);
     Spec = vec4(outColor.rgb, 1.0);
 #endif
 

--- a/data/shaders/IBL.frag
+++ b/data/shaders/IBL.frag
@@ -1,6 +1,6 @@
 uniform sampler2D ntex;
 uniform sampler2D dtex;
-uniform sampler2D colorBuffer;
+uniform sampler2D albedo;
 
 #ifdef GL_ES
 layout (location = 0) out vec4 Diff;
@@ -26,7 +26,7 @@ vec3 getXcYcZc(int x, int y, float zC)
 
 float makeLinear(float f, float n, float z)
 {
-    return pow(z, 10);//(2 * n) / (f + n - z * (f - n));
+    return (2 * n) / (f + n - z * (f - n));
 }
 
 
@@ -66,7 +66,7 @@ vec3 RayCast(vec3 dir, inout vec3 hitCoord, out float dDepth, in sampler2D Depth
             if ((projectedCoord.x > 0.0 && projectedCoord.x < 1.0) && (projectedCoord.y > 0.0 && projectedCoord.y < 1.0))
             {
                 // Mix with fallback (black area should be dark anyway)
-                vec3 finalColor = textureLod(ntex, projectedCoord.xy, 1.0).rgb;
+                vec3 finalColor = textureLod(albedo, projectedCoord.xy, 1.0).rgb;
                 if ((finalColor.r + finalColor.g + finalColor.b) > 0.)
                 {
                     return finalColor;

--- a/data/shaders/IBL.frag
+++ b/data/shaders/IBL.frag
@@ -134,7 +134,7 @@ void main(void)
     float dDepth;
     float minRayStep            = 100.0f;
     // Fallback
-    vec3 fallback = .25 * SpecularIBL(normal, eyedir, 1.);
+    vec3 fallback = .25 * SpecularIBL(normal, eyedir, specval);
     vec3 outColor = RayCast(reflected * max(minRayStep, -View_Pos.z), hitPos, dDepth, dtex, fallback);
 
     // float lodval = 7. * (1 - specval);

--- a/data/shaders/IBL.frag
+++ b/data/shaders/IBL.frag
@@ -1,5 +1,6 @@
 uniform sampler2D ntex;
 uniform sampler2D dtex;
+uniform sampler2D colorBuffer;
 
 #ifdef GL_ES
 layout (location = 0) out vec4 Diff;
@@ -14,6 +15,87 @@ out vec4 Spec;
 #stk_include "utils/DiffuseIBL.frag"
 #stk_include "utils/SpecularIBL.frag"
 
+
+vec3 getXcYcZc(int x, int y, float zC)
+{
+    // We use perspective symetric projection matrix hence P(0,2) = P(1, 2) = 0
+    float xC= (2. * (float(x)) / u_screen.x - 1.) * zC / u_projection_matrix[0][0];
+    float yC= (2. * (float(y)) / u_screen.y - 1.) * zC / u_projection_matrix[1][1];
+    return vec3(xC, yC, zC);
+}
+
+float makeLinear(float f, float n, float z)
+{
+    return pow(z, 10);//(2 * n) / (f + n - z * (f - n));
+}
+
+
+vec3 CalcViewPositionFromDepth(in vec2 TexCoord, in sampler2D DepthMap)
+{
+    // Combine UV & depth into XY & Z (NDC)
+    float z = makeLinear(1000.0, 0.01, textureLod(DepthMap, TexCoord, 0.).x);
+    vec3 rawPosition                = vec3(TexCoord, z);
+
+    // Convert from (0, 1) range to (-1, 1)
+    vec4 ScreenSpacePosition        = vec4( rawPosition * 2 - 1, 1);
+
+    // Undo Perspective transformation to bring into view space
+    vec4 ViewPosition               = u_inverse_projection_matrix * ScreenSpacePosition;
+
+    // Perform perspective divide and return
+    return                          ViewPosition.xyz / ViewPosition.w;
+}
+
+
+vec3 RayCast(vec3 dir, inout vec3 hitCoord, out float dDepth, in sampler2D DepthMap, in vec3 fallback)
+{
+    dir *= 0.25f;
+
+    for(int i = 0; i < 10; ++i) {
+        hitCoord               += dir;
+
+        vec4 projectedCoord     = u_projection_matrix * vec4(hitCoord, 1.0);
+        projectedCoord.xy      /= projectedCoord.w;
+        projectedCoord.xy       = projectedCoord.xy * 0.5 + 0.5;
+
+        float depth             = CalcViewPositionFromDepth(projectedCoord.xy, DepthMap).z;
+        dDepth                  = hitCoord.z - depth;
+
+        if(dDepth < 0.0)
+        {
+            //return vec3(1.0, 0.0, 0.0);
+            if ((projectedCoord.x > 0.0 && projectedCoord.x < 1.0) && (projectedCoord.y > 0.0 && projectedCoord.y < 1.0))
+            {
+                // Mix with fallback (black area should be dark anyway)
+                vec3 finalColor = textureLod(ntex, projectedCoord.xy, 1.0).rgb;
+                if ((finalColor.r + finalColor.g + finalColor.b) > 0.)
+                {
+                    return finalColor;
+                }
+                else
+                {
+                    return fallback;
+                }
+            }
+            else
+            {
+                return fallback;
+            }
+            //return textureLod(ntex, vec2(clamp(projectedCoord.x, 0.1, 0.9), clamp(projectedCoord.y, 0.1, 0.9)), 1.0).rgb;
+            // return projectedCoord.xy;
+        }
+    }
+
+    return fallback;
+}
+
+
+
+
+
+
+// Main ===================================================================
+
 void main(void)
 {
     vec2 uv = gl_FragCoord.xy / u_screen;
@@ -25,7 +107,59 @@ void main(void)
 
     vec4 xpos = getPosFromUVDepth(vec3(uv, z), u_inverse_projection_matrix);
     vec3 eyedir = -normalize(xpos.xyz);
+    // Extract roughness
     float specval = texture(ntex, uv).z;
 
     Spec = vec4(.25 * SpecularIBL(normal, eyedir, specval), 1.);
+
+    // Compute Space Screen Reflection =========================================================
+
+    float lineardepth = textureLod(dtex, uv, 0.).x;
+    int x = int(gl_FragCoord.x), y = int(gl_FragCoord.y);
+    vec3 FragPos = getXcYcZc(x, y, lineardepth);
+
+    // Better implementation: :::::::::::::::::::::::::::::::::::
+
+    vec3 View_Normal            = normal;
+    float View_Depth            = makeLinear(1000.0, 0.01, lineardepth);
+    vec3 ScreenPos              = xpos.xyz;
+    vec4 View_Pos               = u_inverse_projection_matrix * vec4(ScreenPos, 1.0f);
+         View_Pos              /= View_Pos.w;
+
+    // Reflection vector
+    vec3 reflected              = normalize(reflect(eyedir, normal)); // normalize(reflect(normalize(View_Pos.xyz), normalize(View_Normal)));
+
+    // Ray cast
+    vec3 hitPos                 = View_Pos.xyz;
+    float dDepth;
+    float minRayStep            = 100.0f;
+    // Fallback
+    vec3 fallback = .25 * SpecularIBL(normal, eyedir, 1.);
+    vec3 outColor = RayCast(reflected * max(minRayStep, -View_Pos.z), hitPos, dDepth, dtex, fallback);
+
+    // float lodval = 7. * (1 - specval);
+    //vec4 finalColor = textureLod(ntex, coords, lodval);
+
+
+    vec2 inside = uv - 0.5;
+    float vignette = 1. - dot(inside, inside) * 3;
+    vignette = clamp(pow(vignette, 0.8), 0., 1.);
+
+
+    Spec = vec4(outColor.rgb, 1.0);
+
+    // Normal vis
+
+    vec3 reflection = reflect(eyedir, normal);
+
+    float red = 0.5+0.5*reflection.r;
+    float green = 0.5+0.5*reflection.g;
+    float blue = 0.5+0.5*reflection.b;
+
+
+
+    //Diff = vec4(red, green, blue, 1.0);
+
+    //Diff = vec4(reflection.rgb, 1.0);
+
 }

--- a/data/shaders/combine_diffuse_color.frag
+++ b/data/shaders/combine_diffuse_color.frag
@@ -28,12 +28,11 @@ void main()
     vec3 SpecularComponent = texture(specular_map, tc).xyz;
 
     vec3 diffuse_color_for_mix = diffuseMatColor.xyz * 4.0;
-    vec3 metallicMatColor = mix(vec3(0.5), diffuse_color_for_mix, metallicMapValue);
+    vec3 metallicMatColor = mix(vec3(0.04), diffuse_color_for_mix, metallicMapValue);
     vec3 tmp = DiffuseComponent * mix(diffuseMatColor.xyz, vec3(0.0), metallicMapValue) + (metallicMatColor * SpecularComponent);
 
     vec3 emitCol = diffuseMatColor.xyz + (diffuseMatColor.xyz * diffuseMatColor.xyz * emitMapValue * emitMapValue * 10.0);
     vec4 color_1 = vec4(tmp * ao + (emitMapValue * emitCol), 1.0);
-    //color_1 = vec4(tmp, 1.);
 
     // Fog
     float depth = texture(depth_stencil, tc).x;
@@ -59,5 +58,5 @@ void main()
     color_2.g = ls.g + color_1.g * (1.0 - ls.a);
     color_2.b = ls.b + color_1.b * (1.0 - ls.a);
     color_2.a = ls.a + color_1.a * (1.0 - ls.a);
-    o_final_color = vec4(color_2.rgb, 1.0);
+    o_final_color = color_2;
 }

--- a/data/shaders/combine_diffuse_color.frag
+++ b/data/shaders/combine_diffuse_color.frag
@@ -58,5 +58,5 @@ void main()
     color_2.g = ls.g + color_1.g * (1.0 - ls.a);
     color_2.b = ls.b + color_1.b * (1.0 - ls.a);
     color_2.a = ls.a + color_1.a * (1.0 - ls.a);
-    o_final_color = color_2;
+    o_final_color = vec4(SpecularComponent, 1.0);
 }

--- a/data/shaders/combine_diffuse_color.frag
+++ b/data/shaders/combine_diffuse_color.frag
@@ -21,6 +21,7 @@ void main()
     // Metallic map is stored in normal color framebuffer .w
     // Emit map is stored in diffuse color framebuffer.w
     float metallicMapValue = texture(normal_color, tc).w;
+    float specMapValue = texture(normal_color, tc).z;
     float emitMapValue = diffuseMatColor.w;
 
     float ao = texture(ssao_tex, tc).x;
@@ -28,7 +29,7 @@ void main()
     vec3 SpecularComponent = texture(specular_map, tc).xyz;
 
     vec3 diffuse_color_for_mix = diffuseMatColor.xyz * 4.0;
-    vec3 metallicMatColor = mix(vec3(0.5), diffuse_color_for_mix, metallicMapValue);
+    vec3 metallicMatColor = mix(vec3(specMapValue), diffuse_color_for_mix, metallicMapValue);
     vec3 tmp = DiffuseComponent * mix(diffuseMatColor.xyz, vec3(0.0), metallicMapValue) + (metallicMatColor * SpecularComponent);
 
     vec3 emitCol = diffuseMatColor.xyz + (diffuseMatColor.xyz * diffuseMatColor.xyz * emitMapValue * emitMapValue * 10.0);

--- a/data/shaders/combine_diffuse_color.frag
+++ b/data/shaders/combine_diffuse_color.frag
@@ -28,7 +28,7 @@ void main()
     vec3 SpecularComponent = texture(specular_map, tc).xyz;
 
     vec3 diffuse_color_for_mix = diffuseMatColor.xyz * 4.0;
-    vec3 metallicMatColor = mix(vec3(0.04), diffuse_color_for_mix, metallicMapValue);
+    vec3 metallicMatColor = mix(vec3(0.5), diffuse_color_for_mix, metallicMapValue);
     vec3 tmp = DiffuseComponent * mix(diffuseMatColor.xyz, vec3(0.0), metallicMapValue) + (metallicMatColor * SpecularComponent);
 
     vec3 emitCol = diffuseMatColor.xyz + (diffuseMatColor.xyz * diffuseMatColor.xyz * emitMapValue * emitMapValue * 10.0);

--- a/data/shaders/combine_diffuse_color.frag
+++ b/data/shaders/combine_diffuse_color.frag
@@ -20,7 +20,7 @@ void main()
     // Polish map is stored in normal color framebuffer .z
     // Metallic map is stored in normal color framebuffer .w
     // Emit map is stored in diffuse color framebuffer.w
-    float metallicMapValue = texture(normal_color, tc).w;
+    float metallicMapValue = 0.0; //texture(normal_color, tc).w;
     float emitMapValue = diffuseMatColor.w;
 
     float ao = texture(ssao_tex, tc).x;
@@ -28,11 +28,12 @@ void main()
     vec3 SpecularComponent = texture(specular_map, tc).xyz;
 
     vec3 diffuse_color_for_mix = diffuseMatColor.xyz * 4.0;
-    vec3 metallicMatColor = mix(vec3(0.04), diffuse_color_for_mix, metallicMapValue);
+    vec3 metallicMatColor = mix(vec3(0.5), diffuse_color_for_mix, metallicMapValue);
     vec3 tmp = DiffuseComponent * mix(diffuseMatColor.xyz, vec3(0.0), metallicMapValue) + (metallicMatColor * SpecularComponent);
 
     vec3 emitCol = diffuseMatColor.xyz + (diffuseMatColor.xyz * diffuseMatColor.xyz * emitMapValue * emitMapValue * 10.0);
     vec4 color_1 = vec4(tmp * ao + (emitMapValue * emitCol), 1.0);
+    //color_1 = vec4(tmp, 1.);
 
     // Fog
     float depth = texture(depth_stencil, tc).x;
@@ -58,5 +59,5 @@ void main()
     color_2.g = ls.g + color_1.g * (1.0 - ls.a);
     color_2.b = ls.b + color_1.b * (1.0 - ls.a);
     color_2.a = ls.a + color_1.a * (1.0 - ls.a);
-    o_final_color = vec4(SpecularComponent, 1.0);
+    o_final_color = vec4(color_2.rgb, 1.0);
 }

--- a/data/shaders/combine_diffuse_color.frag
+++ b/data/shaders/combine_diffuse_color.frag
@@ -20,7 +20,7 @@ void main()
     // Polish map is stored in normal color framebuffer .z
     // Metallic map is stored in normal color framebuffer .w
     // Emit map is stored in diffuse color framebuffer.w
-    float metallicMapValue = 0.0; //texture(normal_color, tc).w;
+    float metallicMapValue = texture(normal_color, tc).w;
     float emitMapValue = diffuseMatColor.w;
 
     float ao = texture(ssao_tex, tc).x;
@@ -28,7 +28,7 @@ void main()
     vec3 SpecularComponent = texture(specular_map, tc).xyz;
 
     vec3 diffuse_color_for_mix = diffuseMatColor.xyz * 4.0;
-    vec3 metallicMatColor = mix(vec3(0.5), diffuse_color_for_mix, metallicMapValue);
+    vec3 metallicMatColor = mix(vec3(0.2), diffuse_color_for_mix, metallicMapValue);
     vec3 tmp = DiffuseComponent * mix(diffuseMatColor.xyz, vec3(0.0), metallicMapValue) + (metallicMatColor * SpecularComponent);
 
     vec3 emitCol = diffuseMatColor.xyz + (diffuseMatColor.xyz * diffuseMatColor.xyz * emitMapValue * emitMapValue * 10.0);

--- a/data/shaders/combine_diffuse_color.frag
+++ b/data/shaders/combine_diffuse_color.frag
@@ -28,7 +28,7 @@ void main()
     vec3 SpecularComponent = texture(specular_map, tc).xyz;
 
     vec3 diffuse_color_for_mix = diffuseMatColor.xyz * 4.0;
-    vec3 metallicMatColor = mix(vec3(0.2), diffuse_color_for_mix, metallicMapValue);
+    vec3 metallicMatColor = mix(vec3(0.5), diffuse_color_for_mix, metallicMapValue);
     vec3 tmp = DiffuseComponent * mix(diffuseMatColor.xyz, vec3(0.0), metallicMapValue) + (metallicMatColor * SpecularComponent);
 
     vec3 emitCol = diffuseMatColor.xyz + (diffuseMatColor.xyz * diffuseMatColor.xyz * emitMapValue * emitMapValue * 10.0);

--- a/data/shaders/combine_diffuse_color.frag
+++ b/data/shaders/combine_diffuse_color.frag
@@ -29,7 +29,12 @@ void main()
     vec3 SpecularComponent = texture(specular_map, tc).xyz;
 
     vec3 diffuse_color_for_mix = diffuseMatColor.xyz * 4.0;
-    vec3 metallicMatColor = mix(vec3(specMapValue), diffuse_color_for_mix, metallicMapValue);
+
+    // FIXME enable this once the fallback shader is properly done!!!
+    //vec3 metallicMatColor = mix(vec3(specMapValue), diffuse_color_for_mix, metallicMapValue);
+    vec3 metallicMatColor = mix(vec3(0.04), diffuse_color_for_mix, metallicMapValue);
+    // END FIXME
+    
     vec3 tmp = DiffuseComponent * mix(diffuseMatColor.xyz, vec3(0.0), metallicMapValue) + (metallicMatColor * SpecularComponent);
 
     vec3 emitCol = diffuseMatColor.xyz + (diffuseMatColor.xyz * diffuseMatColor.xyz * emitMapValue * emitMapValue * 10.0);

--- a/data/shaders/degraded_ibl.frag
+++ b/data/shaders/degraded_ibl.frag
@@ -19,5 +19,5 @@ void main(void)
     vec3 normal = normalize(DecodeNormal(2. * texture(ntex, uv).xy - 1.));
 
     Diff = vec4(0.25 * DiffuseIBL(normal), 1.);
-    Spec = vec4(0., 0., 0., 1.);
+    Spec = vec4(0.031, 0.106, 0.173, 1.);
 }

--- a/data/shaders/sp_solid.frag
+++ b/data/shaders/sp_solid.frag
@@ -39,7 +39,7 @@ void main(void)
 
     o_normal_color.xy = 0.5 * EncodeNormal(normalize(normal)) + 0.5;
     o_normal_color.zw = layer_2.xy;
-    o_normal_color.z = 0.1;
+    //o_normal_color.z = 0;
 #else
     o_diffuse_color = vec4(final_color, 1.0);
 #endif

--- a/data/shaders/sp_solid.frag
+++ b/data/shaders/sp_solid.frag
@@ -39,6 +39,7 @@ void main(void)
 
     o_normal_color.xy = 0.5 * EncodeNormal(normalize(normal)) + 0.5;
     o_normal_color.zw = layer_2.xy;
+    o_normal_color.z = 1.0;
 #else
     o_diffuse_color = vec4(final_color, 1.0);
 #endif

--- a/data/shaders/sp_solid.frag
+++ b/data/shaders/sp_solid.frag
@@ -39,7 +39,6 @@ void main(void)
 
     o_normal_color.xy = 0.5 * EncodeNormal(normalize(normal)) + 0.5;
     o_normal_color.zw = layer_2.xy;
-    o_normal_color.z = 0.5;
 #else
     o_diffuse_color = vec4(final_color, 1.0);
 #endif

--- a/data/shaders/sp_solid.frag
+++ b/data/shaders/sp_solid.frag
@@ -39,7 +39,7 @@ void main(void)
 
     o_normal_color.xy = 0.5 * EncodeNormal(normalize(normal)) + 0.5;
     o_normal_color.zw = layer_2.xy;
-    //o_normal_color.z = 0;
+    o_normal_color.z = 0.5;
 #else
     o_diffuse_color = vec4(final_color, 1.0);
 #endif

--- a/data/shaders/sp_solid.frag
+++ b/data/shaders/sp_solid.frag
@@ -39,7 +39,7 @@ void main(void)
 
     o_normal_color.xy = 0.5 * EncodeNormal(normalize(normal)) + 0.5;
     o_normal_color.zw = layer_2.xy;
-    o_normal_color.z = 1.0;
+    o_normal_color.z = 0.1;
 #else
     o_diffuse_color = vec4(final_color, 1.0);
 #endif

--- a/src/graphics/lighting_passes.cpp
+++ b/src/graphics/lighting_passes.cpp
@@ -168,7 +168,7 @@ public:
 };
 
 // ============================================================================
-class IBLShader : public TextureShader<IBLShader, 3>
+class IBLShader : public TextureShader<IBLShader, 4>
 {
 public:
     IBLShader()
@@ -178,7 +178,8 @@ public:
         assignUniforms();
         assignSamplerNames(0, "ntex",  ST_NEAREST_FILTERED,
                            1, "dtex",  ST_NEAREST_FILTERED,
-                           2, "probe", ST_TRILINEAR_CUBEMAP);
+                           2, "probe", ST_TRILINEAR_CUBEMAP,
+                           3, "albedo",ST_NEAREST_FILTERED);
     }   // IBLShader
 };   // IBLShader
 
@@ -293,7 +294,8 @@ static void renderPointLights(unsigned count,
 // ----------------------------------------------------------------------------
 void LightingPasses::renderEnvMap(GLuint normal_depth_texture,
                                   GLuint depth_stencil_texture,
-                                  GLuint specular_probe)
+                                  GLuint specular_probe,
+                                  GLuint albedo_buffer)
 {
     glDisable(GL_DEPTH_TEST);
     glEnable(GL_BLEND);
@@ -317,7 +319,8 @@ void LightingPasses::renderEnvMap(GLuint normal_depth_texture,
         IBLShader::getInstance()->setTextureUnits(
             normal_depth_texture,
             depth_stencil_texture,
-            specular_probe);
+            specular_probe,
+            albedo_buffer);
         IBLShader::getInstance()->setUniforms();
     }
 
@@ -426,6 +429,7 @@ void LightingPasses::updateLightsInfo(scene::ICameraSceneNode * const camnode,
 void LightingPasses::renderLights(  bool has_shadow,
                                     GLuint normal_depth_texture,
                                     GLuint depth_stencil_texture,
+                                    GLuint albedo_texture,
                                     const FrameBuffer* shadow_framebuffer,
                                     GLuint specular_probe)
 {
@@ -433,7 +437,8 @@ void LightingPasses::renderLights(  bool has_shadow,
         ScopedGPUTimer timer(irr_driver->getGPUTimer(Q_ENVMAP));
         renderEnvMap(normal_depth_texture,
                      depth_stencil_texture,
-                     specular_probe);
+                     specular_probe,
+                     albedo_texture);
     }
 
     // Render sunlight if and only if track supports shadow

--- a/src/graphics/lighting_passes.hpp
+++ b/src/graphics/lighting_passes.hpp
@@ -34,7 +34,8 @@ private:
 
     void renderEnvMap(GLuint normal_depth_texture,
                       GLuint depth_stencil_texture,
-                      GLuint specular_probe);
+                      GLuint specular_probe,
+                      GLuint albedo_buffer);
 
     /** Generate diffuse and specular map */
     void         renderSunlight(const core::vector3df &direction,
@@ -50,6 +51,7 @@ public:
     void renderLights(  bool has_shadow,
                         GLuint normal_depth_texture,
                         GLuint depth_stencil_texture,
+                        GLuint albedo_texture,
                         const FrameBuffer* shadow_framebuffer,
                         GLuint specular_probe);
     void renderLightsScatter(GLuint depth_stencil_texture,

--- a/src/graphics/shader_based_renderer.cpp
+++ b/src/graphics/shader_based_renderer.cpp
@@ -275,11 +275,10 @@ void ShaderBasedRenderer::renderSceneDeferred(scene::ICameraSceneNode * const ca
         {
             specular_probe = m_skybox->getSpecularProbe();
         }
-
         m_lighting_passes.renderLights( hasShadow,
                                         m_rtts->getRenderTarget(RTT_NORMAL_AND_DEPTH),
                                         m_rtts->getDepthStencilTexture(),
-                                        m_rtts->getRenderTarget(RTT_SP_DIFF_COLOR),
+                                        m_rtts->getRenderTarget(RTT_COLOR),
                                         m_rtts->getShadowFrameBuffer(),
                                         specular_probe);
         PROFILER_POP_CPU_MARKER();

--- a/src/graphics/shader_based_renderer.cpp
+++ b/src/graphics/shader_based_renderer.cpp
@@ -279,6 +279,7 @@ void ShaderBasedRenderer::renderSceneDeferred(scene::ICameraSceneNode * const ca
         m_lighting_passes.renderLights( hasShadow,
                                         m_rtts->getRenderTarget(RTT_NORMAL_AND_DEPTH),
                                         m_rtts->getDepthStencilTexture(),
+                                        m_rtts->getRenderTarget(RTT_SP_DIFF_COLOR),
                                         m_rtts->getShadowFrameBuffer(),
                                         specular_probe);
         PROFILER_POP_CPU_MARKER();


### PR DESCRIPTION
The feature add realtime space screen raycasted reflexion. It basically uses the normal + depth buffer to raycast in the screen and lookup the previous frame of the game to compute reflections.

The technique isn't perfect but it gives the illusion of reflecting the surrounding. If the ray doesn't find an intersection it will simply fallback to the skybox.

https://docs.unrealengine.com/en-us/Engine/Rendering/PostProcessEffects/ScreenSpaceReflection

* It's fully integrated with the current pipeline and nothing needs to be changed for assets to work with. As soon as you add a pbr roughness map it will use it.
* Sadly currently many of the ground textures aren't using roughness, so the only part where it's visible is the space ship.
* Many karts will benefit from this and reflect their environment, since they use the roughness/pbr shader

Performance wise it's a bit heavy (because of the ray tracing). Probably I would like to have it as an option so users can turn it off.

Feedback is welcome (especially on the shader side, I feel the quality could be improved).
![reflective_kart](https://user-images.githubusercontent.com/6406045/54161647-1a8e0480-4453-11e9-809a-6c7feb54d978.jpg)
