### PR TITLE
CMake: Add option to use system WiiUse

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,8 +21,9 @@ endif()
 option(SERVER_ONLY "Create a server only (i.e. no graphics or sound)" OFF)
 option(CHECK_ASSETS "Check if assets are installed in ../stk-assets" ON)
 option(USE_SYSTEM_ANGELSCRIPT "Use system angelscript instead of built-in angelscript. If you enable this option, make sure to use a compatible version." OFF)
-option(USE_SYSTEM_ENET "Use system ENET instead of the built-in version, when available." ON)
+option(USE_SYSTEM_ENET "Use system ENet instead of the built-in version, when available." ON)
 option(USE_SYSTEM_GLEW "Use system GLEW instead of the built-in version, when available." ON)
+option(USE_SYSTEM_WIIUSE "Use system WiiUse instead of the built-in version, when available." OFF)
 
 option(USE_CRYPTO_OPENSSL "Use OpenSSL instead of Nettle for cryptography in STK." OFF)
 CMAKE_DEPENDENT_OPTION(BUILD_RECORDER "Build opengl recorder" ON
@@ -266,10 +267,21 @@ include_directories("${PROJECT_SOURCE_DIR}/lib/irrlicht/include")
 # (at least on VS) irrlicht will find wiiuse io.h file because
 # of the added include directory.
 if(USE_WIIUSE)
-    if(WIIUSE_BUILD)
-        add_subdirectory("${PROJECT_SOURCE_DIR}/lib/wiiuse")
+    # Find system WiiUse library or build it if missing
+    if((UNIX AND NOT APPLE) AND USE_SYSTEM_WIIUSE)
+        find_package(WiiUse)
     endif()
-    include_directories("${PROJECT_SOURCE_DIR}/lib/wiiuse/src")
+
+    if(WIIUSE_FOUND)
+        include_directories(${WIIUSE_INCLUDE_DIR})
+    else()
+        # Fallback to built-in version
+        if(WIIUSE_BUILD)
+            add_subdirectory("${PROJECT_SOURCE_DIR}/lib/wiiuse")
+        endif()
+        include_directories("${PROJECT_SOURCE_DIR}/lib/wiiuse/src")
+        set(WIIUSE_LIBRARIES "wiiuse bluetooth")
+    endif()
 endif()
 
 # Set include paths
@@ -566,7 +578,7 @@ if(USE_WIIUSE)
             target_link_libraries(supertuxkart ${PROJECT_SOURCE_DIR}/${DEPENDENCIES}/lib/wiiuse.lib)
         endif()
     else()
-        target_link_libraries(supertuxkart wiiuse bluetooth)
+        target_link_libraries(supertuxkart ${WIIUSE_LIBRARIES})
     endif()
     add_definitions(-DENABLE_WIIUSE)
 

--- a/cmake/FindWiiUse.cmake
+++ b/cmake/FindWiiUse.cmake
@@ -1,0 +1,99 @@
+# - try to find WiiUse library
+#
+# Cache Variables: (probably not for direct use in your scripts)
+#  WIIUSE_INCLUDE_DIR
+#  WIIUSE_LIBRARY
+#
+# Non-cache variables you might use in your CMakeLists.txt:
+#  WIIUSE_FOUND
+#  WIIUSE_INCLUDE_DIRS
+#  WIIUSE_LIBRARIES
+#  WIIUSE_RUNTIME_LIBRARIES - aka the dll for installing
+#  WIIUSE_RUNTIME_LIBRARY_DIRS
+#
+# Requires these CMake modules:
+#  FindPackageHandleStandardArgs (known included with CMake >=2.6.2)
+#
+# Original Author:
+# 2009-2010 Ryan Pavlik <rpavlik@iastate.edu> <abiryan@ryand.net>
+# http://academic.cleardefinition.com
+# Iowa State University HCI Graduate Program/VRAC
+#
+# Copyright Iowa State University 2009-2010.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+set(WIIUSE_ROOT_DIR
+	"${WIIUSE_ROOT_DIR}"
+	CACHE
+	PATH
+	"Directory to search for WiiUse")
+
+if(CMAKE_SIZEOF_VOID_P MATCHES "8")
+	set(_LIBSUFFIXES /lib64 /lib)
+else()
+	set(_LIBSUFFIXES /lib)
+endif()
+
+find_library(WIIUSE_LIBRARY
+	NAMES
+	wiiuse
+	PATHS
+	"${WIIUSE_ROOT_DIR}"
+	PATH_SUFFIXES
+	"${_LIBSUFFIXES}")
+
+get_filename_component(_libdir "${WIIUSE_LIBRARY}" PATH)
+
+find_path(WIIUSE_INCLUDE_DIR
+	NAMES
+	wiiuse.h
+	HINTS
+	"${_libdir}"
+	"${_libdir}/.."
+	PATHS
+	"${WIIUSE_ROOT_DIR}"
+	PATH_SUFFIXES
+	include/)
+
+set(_deps_check)
+if(WIN32)
+	find_file(WIIUSE_RUNTIME_LIBRARY
+		NAMES
+		wiiuse.dll
+		HINTS
+		"${_libdir}"
+		"${_libdir}/.."
+		PATH_SUFFIXES
+		bin)
+
+	set(WIIUSE_RUNTIME_LIBRARIES "${WIIUSE_RUNTIME_LIBRARY}")
+	get_filename_component(WIIUSE_RUNTIME_LIBRARY_DIRS
+		"${WIIUSE_RUNTIME_LIBRARY}"
+		PATH)
+	list(APPEND _deps_check WIIUSE_RUNTIME_LIBRARY)
+else()
+	set(WIIUSE_RUNTIME_LIBRARY "${WIIUSE_LIBRARY}")
+	set(WIIUSE_RUNTIME_LIBRARIES "${WIIUSE_RUNTIME_LIBRARY}")
+	get_filename_component(WIIUSE_RUNTIME_LIBRARY_DIRS
+		"${WIIUSE_LIBRARY}"
+		PATH)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(WiiUse
+	DEFAULT_MSG
+	WIIUSE_LIBRARY
+	WIIUSE_INCLUDE_DIR
+	${_deps_check})
+
+if(WIIUSE_FOUND)
+	set(WIIUSE_LIBRARIES "${WIIUSE_LIBRARY}")
+	set(WIIUSE_INCLUDE_DIRS "${WIIUSE_INCLUDE_DIR}")
+	mark_as_advanced(WIIUSE_ROOT_DIR)
+endif()
+
+mark_as_advanced(WIIUSE_INCLUDE_DIR
+	WIIUSE_LIBRARY
+	WIIUSE_RUNTIME_LIBRARY)


### PR DESCRIPTION
Adapted from Fedora patch by @ignatenkobrain:
https://src.fedoraproject.org/rpms/supertuxkart/blob/be85787d3485c477d23419b19c382b2186020016/f/0002-Unbundle-WiiUse.patch

Tested successfully on Mageia 7 with `-DUSE_SYSTEM_WIIUSE=ON`, currently building with `=OFF` to confirm that the original system still works as expected.