### PR TITLE
CMake: Add option to use system Squish library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,8 @@ CMAKE_DEPENDENT_OPTION(BUILD_RECORDER "Build opengl recorder" ON
     "NOT SERVER_ONLY;NOT APPLE" OFF)
 CMAKE_DEPENDENT_OPTION(USE_FRIBIDI "Support for right-to-left languages" ON
     "NOT SERVER_ONLY" OFF)
+CMAKE_DEPENDENT_OPTION(USE_SYSTEM_SQUISH "Use system Squish library instead of the built-in version, when available." ON
+    "NOT SERVER_ONLY" OFF)
 CMAKE_DEPENDENT_OPTION(USE_WIIUSE "Support for wiimote input devices" ON
     "NOT SERVER_ONLY;NOT MINGW;NOT CYGWIN" OFF)
 
@@ -247,8 +249,10 @@ if(NOT SERVER_ONLY)
 endif()
 
 if(NOT SERVER_ONLY)
-    find_library(SQUISH_LIBRARY NAMES squish libsquish)
-    find_path(SQUISH_INCLUDEDIR NAMES squish.h PATHS)
+    if(USE_SYSTEM_SQUISH)
+        find_library(SQUISH_LIBRARY NAMES squish libsquish)
+        find_path(SQUISH_INCLUDEDIR NAMES squish.h PATHS)
+    endif()
     if (NOT SQUISH_LIBRARY OR NOT SQUISH_INCLUDEDIR)
         add_subdirectory("${PROJECT_SOURCE_DIR}/lib/libsquish")
         include_directories("${PROJECT_SOURCE_DIR}/lib/libsquish")


### PR DESCRIPTION
The system version was preferred before but it wasn't possible to explicitly disable it, making its use 
automagic, which is bad for packaging.