### PR TITLE
Close program when Wayland connection hangs up

### DIFF
--- a/lib/irrlicht/source/Irrlicht/CIrrDeviceWayland.cpp
+++ b/lib/irrlicht/source/Irrlicht/CIrrDeviceWayland.cpp
@@ -1283,7 +1283,10 @@ bool CIrrDeviceWayland::run()
 {
     os::Timer::tick();
 
-    wl_display_dispatch_pending(m_display);
+    if (wl_display_dispatch_pending(m_display) == -1)
+    {
+	closeDevice();
+    }
 
     for (unsigned int i = 0; i < m_events.size(); i++)
     {


### PR DESCRIPTION
> This change ensures that SuperTuxKart will not keep running in the background when the compositor crashes and doesn't close the STK main window.

Errors with Wayland are always fatal and prohibit further actions with Wayland connection, so if the return value for  `wl_display_dispatch_pending` is ever `-1`, then the connection will have closed.  See also the documentation for [`wl_display_dispatch_pending`](https://wayland.freedesktop.org/docs/html/apb.html#Client-classwl__display_1ac4b6b5ad31932bc3830ff362d2938560). 

This change can be tested by running a Wayland compositor (say, `weston`, nested under something; then inside a child terminal, orphaning the STK process with `supertuxkart & disown` so that it isn't automatically cleaned up when Weston exists, and then running `killall weston`.)