### PR TITLE
Fix pull_from_transifex.sh due to Transifex changes

### DIFF
--- a/data/po/pull_from_transifex.sh
+++ b/data/po/pull_from_transifex.sh
@@ -12,8 +12,8 @@ else
     echo "==== Performing initial checkout ===="
     mkdir -p transifex
     cd transifex
-    tx init
-    tx set --auto-remote http://www.transifex.net/projects/p/supertuxkart/
+    tx init --skipsetup
+    tx config --auto-remote https://www.transifex.com/projects/p/supertuxkart/
 fi
 
 echo "==== Pulling all translations ===="


### PR DESCRIPTION
Currently (TX client 0.13.5 and obviously latest server) pull_from_transifex.sh initialization is broken. It wants me to manually set up file mappings. I do not remember having to do that in the past. Apparently `tx init` is running interactive `tx config`, but it can be disabled with `--skipsetup`. We do automatic configuration afterwards with `tx set --auto-remote`. Moreover, `tx set` is now deprecated in favor of `tx config`.

Also Transifex now complains it wants HTTPS and the domain changed from `.net` to `.com`.