### PR TITLE
Limit sscanf %s fields to prevent possible crash.

### DIFF
--- a/src/replay/replay_play.cpp
+++ b/src/replay/replay_play.cpp
@@ -142,7 +142,7 @@ bool ReplayPlay::addReplayFile(const std::string& fn, bool custom_replay, int ca
     if (version >= 4)
     {
         fgets(s, 1023, fd);
-        if(sscanf(s, "stk_version: %s", s1) != 1)
+        if(sscanf(s, "stk_version: %1023s", s1) != 1)
         {
             Log::warn("Replay", "No STK release version found in replay file, '%s'.", fn.c_str());
             fclose(fd);
@@ -162,7 +162,7 @@ bool ReplayPlay::addReplayFile(const std::string& fn, bool custom_replay, int ca
         char s1[1024];
         char display_name_encoded[1024];
 
-        int scanned = sscanf(s,"kart: %s %[^\n]", s1, display_name_encoded);
+        int scanned = sscanf(s,"kart: %1023s %1023[^\n]", s1, display_name_encoded);
         if (scanned < 1)
         {
             Log::warn("Replay", "Could not read ghost karts info!");
@@ -224,7 +224,7 @@ bool ReplayPlay::addReplayFile(const std::string& fn, bool custom_replay, int ca
     if (version >= 4)
     {
         fgets(s, 1023, fd);
-        if (sscanf(s, "mode: %s", s1) != 1)
+        if (sscanf(s, "mode: %1023s", s1) != 1)
         {
             Log::warn("Replay", "Replay mode not found in replay file, '%s'.", fn.c_str());
             fclose(fd);
@@ -238,7 +238,7 @@ bool ReplayPlay::addReplayFile(const std::string& fn, bool custom_replay, int ca
 
 
     fgets(s, 1023, fd);
-    if (sscanf(s, "track: %s", s1) != 1)
+    if (sscanf(s, "track: %1023s", s1) != 1)
     {
         Log::warn("Replay", "Track info not found in replay file, '%s'.", fn.c_str());
         fclose(fd);


### PR DESCRIPTION
[Cppcheck 1.88](https://github.com/danmar/cppcheck) gives the following warnings about the `sscanf()` calls in the method `ReplayPlay::addReplayFile()`. I changed the sscanf calls from `%s` to `%1023s` because `s1` is a 1024 byte buffer and Cppcheck recommends to make the field width limit for `%s` one less than the buffer size to leave space for the null byte which ends a string. Without the field width limits in the format strings, STK probably won't crash unless the replay files are corrupted somehow (e.g. with `zzuf` or `afl` fuzzers).

Cppcheck warnings:
```
[replay\replay_play.cpp:145]: (warning) sscanf() without field width limits can crash with huge input data.
[replay\replay_play.cpp:165]: (warning) sscanf() without field width limits can crash with huge input data.
[replay\replay_play.cpp:227]: (warning) sscanf() without field width limits can crash with huge input data.
[replay\replay_play.cpp:241]: (warning) sscanf() without field width limits can crash with huge input data.
```
