### PR TITLE
Speed up loops by using prefix increment instead of postfix.

### DIFF
--- a/src/achievements/achievements_status.cpp
+++ b/src/achievements/achievements_status.cpp
@@ -296,7 +296,7 @@ void AchievementsStatus::save(UTFWriter &out)
 {
     out << "      <achievements online=\"" << m_online << "\"> \n";
     std::map<uint32_t, Achievement*>::const_iterator i;
-    for(i = m_achievements.begin(); i != m_achievements.end();  i++)
+    for(i = m_achievements.begin(); i != m_achievements.end();  ++i)
     {
         if (i->second != NULL)
             i->second->saveProgress(out);
@@ -356,7 +356,7 @@ void AchievementsStatus::sync(const std::vector<uint32_t> & achieved_ids)
     // String to collect all local ids that are not synched
     // to the online account
     std::string ids;
-    for(i=m_achievements.begin(); i!=m_achievements.end(); i++)
+    for(i=m_achievements.begin(); i!=m_achievements.end(); ++i)
     {
         unsigned int id = i->second->getID();
         if(i->second->isAchieved() && (id>=done.size() || !done[id]) )
@@ -482,7 +482,7 @@ void AchievementsStatus::updateAchievementsProgress(UpdateType type, unsigned in
     // Now that we know what string to look for, call an Achievement function
     // which will look throughout the progress goalTree to update it
     std::map<uint32_t, Achievement*>::const_iterator i;
-    for(i=m_achievements.begin(); i!=m_achievements.end(); i++)
+    for(i=m_achievements.begin(); i!=m_achievements.end(); ++i)
     {
         // Don't bother checking again already completed achievements
         if (i->second->isAchieved())

--- a/src/audio/music_manager.cpp
+++ b/src/audio/music_manager.cpp
@@ -97,7 +97,7 @@ MusicManager::MusicManager()
 MusicManager::~MusicManager()
 {
     for(std::map<std::string,MusicInformation*>::iterator
-        i=m_all_music.begin(); i!=m_all_music.end(); i++)
+        i=m_all_music.begin(); i!=m_all_music.end(); ++i)
     {
         delete i->second;
         i->second = NULL;
@@ -124,7 +124,7 @@ void MusicManager::loadMusicInformation()
     // SUPERTUXKART_MUSIC_PATH
     std::vector<std::string> allMusicDirs=file_manager->getMusicDirs();
     for(std::vector<std::string>::iterator dir=allMusicDirs.begin();
-                                           dir!=allMusicDirs.end(); dir++)
+                                           dir!=allMusicDirs.end(); ++dir)
     {
         loadMusicFromOneDir(*dir);
     }   // for dir
@@ -150,7 +150,7 @@ void MusicManager::loadMusicFromOneDir(const std::string& dir)
 void MusicManager::addMusicToTracks()
 {
     for(std::map<std::string,MusicInformation*>::iterator
-        i=m_all_music.begin(); i!=m_all_music.end(); i++)
+        i=m_all_music.begin(); i!=m_all_music.end(); ++i)
     {
         if(!i->second)
         {

--- a/src/audio/sfx_manager.cpp
+++ b/src/audio/sfx_manager.cpp
@@ -163,7 +163,7 @@ SFXManager::~SFXManager()
     // ---- clear m_quick_sounds
     {
         std::map<std::string, SFXBase*>::iterator i = m_quick_sounds.getData().begin();
-        for (; i != m_quick_sounds.getData().end(); i++)
+        for (; i != m_quick_sounds.getData().end(); ++i)
         {
             SFXBase* snd = (*i).second;
             delete snd;
@@ -175,7 +175,7 @@ SFXManager::~SFXManager()
     // ---- clear m_all_sfx_types
     {
         std::map<std::string, SFXBuffer*>::iterator i = m_all_sfx_types.begin();
-        for (; i != m_all_sfx_types.end(); i++)
+        for (; i != m_all_sfx_types.end(); ++i)
         {
             SFXBuffer* buffer = (*i).second;
             buffer->unload();
@@ -515,7 +515,7 @@ void SFXManager::toggleSound(const bool on)
     if (on)
     {
         std::map<std::string, SFXBuffer*>::iterator i = m_all_sfx_types.begin();
-        for (; i != m_all_sfx_types.end(); i++)
+        for (; i != m_all_sfx_types.end(); ++i)
         {
             SFXBuffer* buffer = (*i).second;
             buffer->load();
@@ -599,7 +599,7 @@ void SFXManager::loadSfx()
     i = 0;
 
     for (std::map<std::string, SFXBuffer*>::iterator it = m_all_sfx_types.begin();
-         it != m_all_sfx_types.end(); it++)
+         it != m_all_sfx_types.end(); ++it)
     {
         SFXBuffer* const buffer = (*it).second;
         array[i++] = buffer;
@@ -851,7 +851,7 @@ void SFXManager::reallyUpdateNow(SFXCommand *current)
         music_manager->getCurrentMusic()->update(dt);
     m_all_sfx.lock();
     for (std::vector<SFXBase*>::iterator i =  m_all_sfx.getData().begin();
-                                         i != m_all_sfx.getData().end(); i++)
+                                         i != m_all_sfx.getData().end(); ++i)
     {
         if((*i)->getStatus()==SFXBase::SFX_PLAYING)
             (*i)->updatePlayingSFX(dt);
@@ -862,7 +862,7 @@ void SFXManager::reallyUpdateNow(SFXCommand *current)
     // quick sounds by another thread could invalidate the iterator.
     m_quick_sounds.lock();
     std::map<std::string, SFXBase*>::iterator i = m_quick_sounds.getData().begin();
-    for (; i != m_quick_sounds.getData().end(); i++)
+    for (; i != m_quick_sounds.getData().end(); ++i)
     {
         if (i->second->getStatus() == SFXBase::SFX_PLAYING)
             i->second->updatePlayingSFX(dt);
@@ -922,7 +922,7 @@ void SFXManager::reallyPauseAllNow()
 {
     m_all_sfx.lock();
     for (std::vector<SFXBase*>::iterator i= m_all_sfx.getData().begin();
-                                         i!=m_all_sfx.getData().end(); i++)
+                                         i!=m_all_sfx.getData().end(); ++i)
     {
         (*i)->reallyPauseNow();
     }   // for i in m_all_sfx
@@ -946,7 +946,7 @@ void SFXManager::reallyResumeAllNow()
 {
     m_all_sfx.lock();
     for (std::vector<SFXBase*>::iterator i =m_all_sfx.getData().begin();
-                                         i!=m_all_sfx.getData().end(); i++)
+                                         i!=m_all_sfx.getData().end(); ++i)
     {
         (*i)->reallyResumeNow();
     }   // for i in m_all_sfx
@@ -993,7 +993,7 @@ void SFXManager::setMasterSFXVolume(float gain)
     {
         m_all_sfx.lock();
         for (std::vector<SFXBase*>::iterator i =m_all_sfx.getData().begin();
-                                             i!=m_all_sfx.getData().end(); i++)
+                                             i!=m_all_sfx.getData().end(); ++i)
         {
             (*i)->setMasterVolume(m_master_gain);
         }   // for i in m_all_sfx
@@ -1004,7 +1004,7 @@ void SFXManager::setMasterSFXVolume(float gain)
     {
         m_quick_sounds.lock();
         std::map<std::string, SFXBase*>::iterator i = m_quick_sounds.getData().begin();
-        for (; i != m_quick_sounds.getData().end(); i++)
+        for (; i != m_quick_sounds.getData().end(); ++i)
         {
             (*i).second->setMasterVolume(m_master_gain);
         }

--- a/src/challenges/story_mode_status.cpp
+++ b/src/challenges/story_mode_status.cpp
@@ -51,7 +51,7 @@ StoryModeStatus::StoryModeStatus(const XMLNode *node)
 StoryModeStatus::~StoryModeStatus()
 {
     std::map<std::string, ChallengeStatus*>::iterator it;
-    for (it = m_challenges_state.begin();it != m_challenges_state.end();it++)
+    for (it = m_challenges_state.begin();it != m_challenges_state.end();++it)
     {
         delete it->second;
     }
@@ -91,7 +91,7 @@ void StoryModeStatus::computeActive(bool first_call)
 
     std::map<std::string, ChallengeStatus*>::const_iterator i;
     for(i = m_challenges_state.begin();
-        i != m_challenges_state.end();  i++)
+        i != m_challenges_state.end();  ++i)
     {
         // Lock features from unsolved challenges
         if(!(i->second)->isSolvedAtAnyDifficulty())
@@ -151,7 +151,7 @@ void StoryModeStatus::computeActive(bool first_call)
     unlockFeatureByList();
 
     //Actually lock the tracks
-    for (i = m_challenges_state.begin(); i != m_challenges_state.end();  i++)
+    for (i = m_challenges_state.begin(); i != m_challenges_state.end();  ++i)
     {
         if (m_points < i->second->getData()->getNumTrophies())
         {
@@ -175,7 +175,7 @@ void StoryModeStatus::unlockFeatureByList()
     // test if we have unlocked a feature requiring a certain number of points
     std::map<std::string, ChallengeStatus*>::const_iterator i;
     for(i = m_challenges_state.begin();
-        i != m_challenges_state.end();  i++)
+        i != m_challenges_state.end();  ++i)
     {
         if (i->second->isUnlockList())
         {
@@ -322,7 +322,7 @@ void StoryModeStatus::save(UTFWriter &out)
     out << "      <story-mode first-time=\"" << m_first_time  << L"\">\n";
     std::map<std::string, ChallengeStatus*>::const_iterator i;
     for(i = m_challenges_state.begin();
-        i != m_challenges_state.end();  i++)
+        i != m_challenges_state.end();  ++i)
     {
         if (i->second != NULL)
             i->second->save(out);

--- a/src/challenges/unlock_manager.cpp
+++ b/src/challenges/unlock_manager.cpp
@@ -60,7 +60,7 @@ UnlockManager::UnlockManager()
     std::string challenge_dir = file_manager->getAsset(FileManager::CHALLENGE, "");
     file_manager->listFiles(result, challenge_dir);
     for(std::set<std::string>::iterator i  = result.begin();
-                                        i != result.end()  ; i++)
+                                        i != result.end()  ; ++i)
     {
         if (StringUtils::hasSuffix(*i, ".challenge"))
             addChallenge(file_manager->getAsset("challenges/"+*i));
@@ -86,7 +86,7 @@ UnlockManager::UnlockManager()
 UnlockManager::~UnlockManager()
 {
     for(AllChallengesType::iterator i =m_all_challenges.begin();
-        i!=m_all_challenges.end();  i++)
+        i!=m_all_challenges.end();  ++i)
     {
         delete i->second;
     }
@@ -98,13 +98,13 @@ UnlockManager::~UnlockManager()
 void UnlockManager::readAllChallengesInDirs(const std::vector<std::string>* all_dirs)
 {
     for(std::vector<std::string>::const_iterator dir = all_dirs->begin();
-        dir != all_dirs->end(); dir++)
+        dir != all_dirs->end(); ++dir)
     {
         std::set<std::string> all_files;
         file_manager->listFiles(all_files, *dir);
 
         for(std::set<std::string>::iterator file = all_files.begin();
-            file != all_files.end(); file++)
+            file != all_files.end(); ++file)
         {
             if (!StringUtils::hasSuffix(*file,".challenge")) continue;
 
@@ -214,7 +214,7 @@ StoryModeStatus* UnlockManager::createStoryModeStatus(const XMLNode *node)
     StoryModeStatus *status = new StoryModeStatus(node);
 
     for(AllChallengesType::iterator i = m_all_challenges.begin();
-                                    i!=m_all_challenges.end();  i++)
+                                    i!=m_all_challenges.end();  ++i)
     {
         ChallengeData* cd = i->second;
         ChallengeStatus *challenge_status = new ChallengeStatus(cd);
@@ -260,7 +260,7 @@ void UnlockManager::findWhatWasUnlocked(int points_before, int points_now,
     ChallengeData* c = NULL;
 
     for (AllChallengesType::iterator it = m_all_challenges.begin();
-         it != m_all_challenges.end(); it++)
+         it != m_all_challenges.end(); ++it)
     {
         c = it->second;
         if (c->getNumTrophies() > points_before &&

--- a/src/config/hardware_stats.cpp
+++ b/src/config/hardware_stats.cpp
@@ -172,7 +172,7 @@ void determineOSVersion()
     std::set<std::string> file_list;
     file_manager->listFiles(file_list, "./", true);
     for(std::set<std::string>::iterator i  = file_list.begin();
-                                        i != file_list.end(); i++)
+                                        i != file_list.end(); ++i)
     {
         // Only try reading /etc/*-release files
         if(StringUtils::hasSuffix(*i, "-release"))

--- a/src/graphics/graphics_restrictions.cpp
+++ b/src/graphics/graphics_restrictions.cpp
@@ -640,7 +640,7 @@ void init(const std::string &driver_version,
         {
             std::vector<std::string> restrictions = rule.getRestrictions();
             std::vector<std::string>::iterator p;
-            for (p = restrictions.begin(); p != restrictions.end(); p++)
+            for (p = restrictions.begin(); p != restrictions.end(); ++p)
             {
                 GraphicsRestrictionsType t = getTypeForName(*p);
                 if (t != GR_COUNT)

--- a/src/graphics/graphics_restrictions.cpp
+++ b/src/graphics/graphics_restrictions.cpp
@@ -114,7 +114,7 @@ private:
         std::string s = version;
         std::string::iterator p = s.begin();
         while( (p !=s.end()) && ((*p<'0') || (*p>'9')) )
-            p++;
+            ++p;
         s.erase(s.begin(), p);
         m_version = StringUtils::splitToUInt(s, '.');
     }   // convertVersionString

--- a/src/graphics/material_manager.cpp
+++ b/src/graphics/material_manager.cpp
@@ -70,7 +70,7 @@ MaterialManager::~MaterialManager()
 
     for (std::map<std::string, Material*> ::iterator it =
          m_default_sp_materials.begin(); it != m_default_sp_materials.end();
-         it++)
+         ++it)
     {
         delete it->second;
     }

--- a/src/graphics/particle_kind_manager.cpp
+++ b/src/graphics/particle_kind_manager.cpp
@@ -53,7 +53,7 @@ void ParticleKindManager::cleanup()
     cleanUpTrackSpecificGfx();
 
     std::map<std::string, ParticleKind*>::iterator it;
-    for (it = m_kinds.begin(); it != m_kinds.end(); it++)
+    for (it = m_kinds.begin(); it != m_kinds.end(); ++it)
     {
         delete it->second;
     }
@@ -65,7 +65,7 @@ void ParticleKindManager::cleanup()
 void ParticleKindManager::cleanUpTrackSpecificGfx()
 {
     std::map<std::string, ParticleKind*>::iterator it;
-    for (it = m_per_track_kinds.begin(); it != m_per_track_kinds.end(); it++)
+    for (it = m_per_track_kinds.begin(); it != m_per_track_kinds.end(); ++it)
     {
         delete it->second;
     }

--- a/src/graphics/shader_based_renderer.cpp
+++ b/src/graphics/shader_based_renderer.cpp
@@ -517,7 +517,7 @@ void ShaderBasedRenderer::debugPhysics()
             line->use();
             line->bindVertexArray();
             line->bindBuffer();
-            for (it = lines.begin(); it != lines.end(); it++)
+            for (it = lines.begin(); it != lines.end(); ++it)
             {
                 line->setUniforms(it->first);
                 const std::vector<float> &vertex = it->second;

--- a/src/guiengine/engine.cpp
+++ b/src/guiengine/engine.cpp
@@ -1298,7 +1298,7 @@ namespace GUIEngine
                                           true /* hcenter */,
                                           true /* vcenter */);
                     count++;
-                    it++;
+                    ++it;
                 }
                 else
                 {

--- a/src/io/file_manager.cpp
+++ b/src/io/file_manager.cpp
@@ -373,7 +373,7 @@ FileManager::~FileManager()
     std::string tmp=getAddonsFile("tmp");
     listFiles(allfiles, tmp);
     for(std::set<std::string>::iterator i=allfiles.begin();
-        i!=allfiles.end(); i++)
+        i!=allfiles.end(); ++i)
     {
         if((*i)=="." || (*i)=="..") continue;
         // For now there should be only zip files or .part files

--- a/src/items/item_manager.cpp
+++ b/src/items/item_manager.cpp
@@ -202,7 +202,7 @@ ItemManager::~ItemManager()
     if(m_items_in_quads)
         delete m_items_in_quads;
     for(AllItemTypes::iterator i =m_all_items.begin();
-                               i!=m_all_items.end();  i++)
+                               i!=m_all_items.end();  ++i)
     {
         if(*i)
             delete *i;
@@ -391,7 +391,7 @@ void  ItemManager::checkItemHit(AbstractKart* kart)
     if ( dynamic_cast<SpareTireAI*>(kart->getController()) ) return;
 
     for(AllItemTypes::iterator i =m_all_items.begin();
-                               i!=m_all_items.end();  i++)
+                               i!=m_all_items.end();  ++i)
     {
         // Ignore items that have been collected or are not available atm
         if ((!*i) || !(*i)->isAvailable() || (*i)->isUsedUp()) continue;
@@ -424,7 +424,7 @@ void ItemManager::reset()
     if(m_switch_ticks>=0)
     {
         for(AllItemTypes::iterator i =m_all_items.begin();
-                                   i!=m_all_items.end(); i++)
+                                   i!=m_all_items.end(); ++i)
         {
             if(*i) (*i)->switchBack();
         }
@@ -472,7 +472,7 @@ void ItemManager::update(int ticks)
         if(m_switch_ticks<0)
         {
             for(AllItemTypes::iterator i = m_all_items.begin();
-                                       i!= m_all_items.end();  i++)
+                                       i!= m_all_items.end();  ++i)
             {
                 if(*i) (*i)->switchBack();
             }   // for m_all_items
@@ -480,7 +480,7 @@ void ItemManager::update(int ticks)
     }   // m_switch_ticks>=0
 
     for(AllItemTypes::iterator i =m_all_items.begin();
-        i!=m_all_items.end();  i++)
+        i!=m_all_items.end();  ++i)
     {
         if(*i)
         {
@@ -500,7 +500,7 @@ void ItemManager::update(int ticks)
 void ItemManager::updateGraphics(float dt)
 {
     for (AllItemTypes::iterator i  = m_all_items.begin();
-                                i != m_all_items.end();  i++)
+                                i != m_all_items.end();  ++i)
     {
         if (*i) (*i)->updateGraphics(dt);
     }   // for m_all_items
@@ -556,7 +556,7 @@ void ItemManager::switchItems()
 void ItemManager::switchItemsInternal(std::vector<ItemState*> &all_items)
 {
     for(AllItemTypes::iterator i  = all_items.begin();
-                               i != all_items.end();  i++)
+                               i != all_items.end();  ++i)
     {
         if(!*i) continue;
 

--- a/src/items/item_manager.cpp
+++ b/src/items/item_manager.cpp
@@ -440,18 +440,18 @@ void ItemManager::reset()
     {
         if(!*i)
         {
-            i++;
+            ++i;
             continue;
         }
         if((*i)->canBeUsedUp() || (*i)->getType()==ItemState::ITEM_BUBBLEGUM)
         {
             deleteItem( *i );
-            i++;
+            ++i;
         }
         else
         {
             (*i)->reset();
-            i++;
+            ++i;
         }
     }  // whilem_all_items.end() i
 

--- a/src/items/projectile_manager.cpp
+++ b/src/items/projectile_manager.cpp
@@ -99,7 +99,7 @@ void ProjectileManager::update(int ticks)
             he = next;
         }   // if hit effect finished
         else  // hit effect not finished, go to next one.
-            he++;
+            ++he;
     }   // while hit effect != end
 }   // update
 

--- a/src/karts/kart_properties_manager.cpp
+++ b/src/karts/kart_properties_manager.cpp
@@ -126,7 +126,7 @@ void KartPropertiesManager::removeKart(const std::string &ident)
     // greater than index were moved one position further to the beginning
     std::map<std::string, std::vector<int> >::iterator it_gr;
     for(it_gr=m_groups_2_indices.begin(); it_gr != m_groups_2_indices.end();
-        it_gr++)
+        ++it_gr)
     {
         for(unsigned int i=0; i<(*it_gr).second.size(); i++)
         {
@@ -149,7 +149,7 @@ void KartPropertiesManager::loadAllKarts(bool loading_icon)
 {
     m_all_kart_dirs.clear();
     std::vector<std::string>::const_iterator dir;
-    for(dir = m_kart_search_path.begin(); dir!=m_kart_search_path.end(); dir++)
+    for(dir = m_kart_search_path.begin(); dir!=m_kart_search_path.end(); ++dir)
     {
         // First check if there is a kart in the current directory
         // -------------------------------------------------------
@@ -160,7 +160,7 @@ void KartPropertiesManager::loadAllKarts(bool loading_icon)
         std::set<std::string> result;
         file_manager->listFiles(result, *dir);
         for(std::set<std::string>::const_iterator subdir=result.begin();
-            subdir!=result.end(); subdir++)
+            subdir!=result.end(); ++subdir)
         {
             const bool loaded = loadKart(*dir+*subdir);
 
@@ -451,7 +451,7 @@ bool KartPropertiesManager::kartAvailable(int kartid)
     if(kartid<0 || kartid>=(int)m_kart_available.size()) return false;
     if(!m_kart_available[kartid]) return false;
     std::vector<int>::iterator it;
-    for (it = m_selected_karts.begin(); it < m_selected_karts.end(); it++)
+    for (it = m_selected_karts.begin(); it < m_selected_karts.end(); ++it)
     {
         if ( kartid == *it) return false;
     }

--- a/src/karts/xml_characteristic.cpp
+++ b/src/karts/xml_characteristic.cpp
@@ -85,7 +85,7 @@ void XmlCharacteristic::process(CharacteristicType type, Value value,
                         value.fv->clear();
                         break;
                     }
-                    fit++;
+                    ++fit;
                 }
             }
         }
@@ -108,7 +108,7 @@ void XmlCharacteristic::process(CharacteristicType type, Value value,
                     value.fv->clear();
                     break;
                 }
-                fit++;
+                ++fit;
             }
         }
         break;

--- a/src/modes/cutscene_world.cpp
+++ b/src/modes/cutscene_world.cpp
@@ -350,7 +350,7 @@ void CutsceneWorld::update(int ticks)
         }
         else
         {
-            it++;
+            ++it;
         }
      }
 
@@ -368,7 +368,7 @@ void CutsceneWorld::update(int ticks)
         }
         else
         {
-            it++;
+            ++it;
         }
      }
 
@@ -385,7 +385,7 @@ void CutsceneWorld::update(int ticks)
         }
         else
         {
-            it++;
+            ++it;
         }
     }
 

--- a/src/modes/profile_world.cpp
+++ b/src/modes/profile_world.cpp
@@ -263,7 +263,7 @@ void ProfileWorld::enterRaceOverState()
     // Determine maximum length of group name
     unsigned int max_len=4;   // for 'name' heading
     for(std::set<std::string>::iterator it = all_groups.begin();
-        it !=all_groups.end(); it++)
+        it !=all_groups.end(); ++it)
     {
         if(it->size()>max_len) max_len = (unsigned int) it->size();
     }
@@ -275,7 +275,7 @@ void ProfileWorld::enterRaceOverState()
        << "Strt End  Time    AvSp  Top   Skid  Resc Rsc Brake Expl Exp Itm Ban SNitLNit Bub Off Energy";
     Log::verbose("profile", ss.str().c_str());
     for(std::set<std::string>::iterator it = all_groups.begin();
-        it !=all_groups.end(); it++)
+        it !=all_groups.end(); ++it)
     {
         int   count         = 0,    position_gain   = 0,    rescue_count = 0;
         int   brake_count   = 0,    bonus_count     = 0,    banana_count = 0;

--- a/src/modes/world.cpp
+++ b/src/modes/world.cpp
@@ -766,7 +766,7 @@ void World::resetAllKarts()
 
     //Project karts onto track from above. This will lower each kart so
     //that at least one of its wheel will be on the surface of the track
-    for ( KartList::iterator i=m_karts.begin(); i!=m_karts.end(); i++)
+    for ( KartList::iterator i=m_karts.begin(); i!=m_karts.end(); ++i)
     {
         if ((*i)->isGhostKart()) continue;
         Vec3 xyz = (*i)->getXYZ();
@@ -798,7 +798,7 @@ void World::resetAllKarts()
     // Do a longer initial simulation, which should be long enough for all
     // karts to be firmly on ground.
     float g = Track::getCurrentTrack()->getGravity();
-    for (KartList::iterator i = m_karts.begin(); i != m_karts.end(); i++)
+    for (KartList::iterator i = m_karts.begin(); i != m_karts.end(); ++i)
     {
         if ((*i)->isGhostKart()) continue;
         (*i)->getBody()->setGravity(
@@ -808,7 +808,7 @@ void World::resetAllKarts()
     for(int i=0; i<stk_config->getPhysicsFPS(); i++) 
         Physics::getInstance()->update(1);
 
-    for ( KartList::iterator i=m_karts.begin(); i!=m_karts.end(); i++)
+    for ( KartList::iterator i=m_karts.begin(); i!=m_karts.end(); ++i)
     {
         (*i)->kartIsInRestNow();
     }

--- a/src/network/protocols/server_lobby.cpp
+++ b/src/network/protocols/server_lobby.cpp
@@ -2009,7 +2009,7 @@ void ServerLobby::startSelection(const Event *event)
             it = official_tracks.erase(it);
         }
         else
-            it++;
+            ++it;
     }
     if (official_tracks.empty())
     {

--- a/src/network/rewind_queue.cpp
+++ b/src/network/rewind_queue.cpp
@@ -99,7 +99,7 @@ void RewindQueue::insertRewindInfo(RewindInfo *ri)
     while (i != m_all_rewind_info.begin())
     {
         AllRewindInfo::iterator i_prev = i;
-        i_prev--;
+        --i_prev;
         // Now test if 'ri' needs to be inserted after the
         // previous element, i.e. before the current element:
         if ((*i_prev)->getTicks() < ri->getTicks()) break;
@@ -224,7 +224,7 @@ void RewindQueue::mergeNetworkData(int world_ticks, bool *needs_rewind,
         // time step is world_ticks.
         if ((*i)->getTicks() > world_ticks)
         {
-            i++;
+            ++i;
             continue;
         }
         // Any state of event that is received before the latest confirmed
@@ -444,7 +444,7 @@ void RewindQueue::unitTesting()
     assert(q0.m_all_rewind_info.size() == 2);
     AllRewindInfo::iterator rii = q0.m_all_rewind_info.begin();
     assert((*rii)->isState());
-    rii++;
+    ++rii;
     assert((*rii)->isEvent());
 
     // Another state must be sorted before the event:
@@ -454,9 +454,9 @@ void RewindQueue::unitTesting()
     assert(q0.m_all_rewind_info.size() == 3);
     rii = q0.m_all_rewind_info.begin();
     assert((*rii)->isState());
-    rii++;
+    ++rii;
     assert((*rii)->isState());
-    rii++;
+    ++rii;
     assert((*rii)->isEvent());
 
     // Test time base comparisons: adding an event to the end
@@ -465,9 +465,9 @@ void RewindQueue::unitTesting()
     q0.addLocalEvent(dummy_rewinder.get(), NULL, false, 1);
     // rii points to the 3rd element, the ones added just now
     // should be elements4 and 5:
-    rii++;
+    ++rii;
     assert((*rii)->getTicks()==1);
-    rii++;
+    ++rii;
     assert((*rii)->getTicks()==4);
 
     // Now test inserting an event first, then the state
@@ -476,7 +476,7 @@ void RewindQueue::unitTesting()
     q1.addLocalState(NULL, true, 5);
     rii = q1.m_all_rewind_info.begin();
     assert((*rii)->isState());
-    rii++;
+    ++rii;
     assert((*rii)->isEvent());
 
     // Bugs seen before

--- a/src/online/profile_manager.cpp
+++ b/src/online/profile_manager.cpp
@@ -177,7 +177,7 @@ void ProfileManager::updateFriendFlagsInCache(const ProfilesMap &cache,
                                               uint32_t profile_id)
 {
     ProfilesMap::const_iterator i;
-    for(i=cache.begin(); i!=cache.end(); i++)
+    for(i=cache.begin(); i!=cache.end(); ++i)
     {
         // Profile has no friends fetched, no need to test
         if(!(*i).second->hasFetchedFriends()) continue;

--- a/src/physics/irr_debug_drawer.cpp
+++ b/src/physics/irr_debug_drawer.cpp
@@ -79,7 +79,7 @@ void IrrDebugDrawer::drawLine(const btVector3& from, const btVector3& to,
 
 void IrrDebugDrawer::beginNextFrame()
 {
-    for (std::map<video::SColor, std::vector<float> >::iterator it = m_lines.begin(); it != m_lines.end(); it++)
+    for (std::map<video::SColor, std::vector<float> >::iterator it = m_lines.begin(); it != m_lines.end(); ++it)
     {
         it->second.clear();
     }

--- a/src/race/grand_prix_manager.cpp
+++ b/src/race/grand_prix_manager.cpp
@@ -73,7 +73,7 @@ void GrandPrixManager::loadDir(const std::string& dir, enum GrandPrixData::GPGro
     // Find out which grand prix are available and load them
     std::set<std::string> result;
     file_manager->listFiles(result, dir);
-    for(std::set<std::string>::iterator i = result.begin(); i != result.end(); i++)
+    for(std::set<std::string>::iterator i = result.begin(); i != result.end(); ++i)
     {
         if (StringUtils::hasSuffix(*i, SUFFIX))
             load(dir + *i, group);

--- a/src/race/highscore_manager.cpp
+++ b/src/race/highscore_manager.cpp
@@ -45,7 +45,7 @@ HighscoreManager::~HighscoreManager()
 {
     saveHighscores();
     for(type_all_scores::iterator i  = m_all_scores.begin();
-                                  i != m_all_scores.end();  i++)
+                                  i != m_all_scores.end();  ++i)
         delete *i;
 }   // ~HighscoreManager
 
@@ -187,7 +187,7 @@ Highscores* HighscoreManager::getHighscores(const Highscores::HighscoreType &hig
 
     // See if we already have a record for this type
     for(type_all_scores::iterator i  = m_all_scores.begin();
-                                  i != m_all_scores.end();  i++)
+                                  i != m_all_scores.end();  ++i)
     {
         if((*i)->matches(highscore_type, num_karts, difficulty, trackName,
                          number_of_laps, reverse) )

--- a/src/states_screens/options/options_screen_input.cpp
+++ b/src/states_screens/options/options_screen_input.cpp
@@ -357,7 +357,7 @@ void OptionsScreenInput::onUpdate(float dt)
         }
         else
         {
-            it++;
+            ++it;
         }
     }
     //m_highlights[internal_name]

--- a/src/states_screens/options/options_screen_ui.cpp
+++ b/src/states_screens/options/options_screen_ui.cpp
@@ -82,7 +82,7 @@ void OptionsScreenUI::loadedFromFile()
     file_manager->listFiles(skinFiles /* out */, file_manager->getAsset(FileManager::SKIN,""),
                             true /* make full path */ );
 
-    for (std::set<std::string>::iterator it = skinFiles.begin(); it != skinFiles.end(); it++)
+    for (std::set<std::string>::iterator it = skinFiles.begin(); it != skinFiles.end(); ++it)
     {
         if(StringUtils::getExtension(*it)=="stkskin")
         {

--- a/src/states_screens/options/options_screen_video.cpp
+++ b/src/states_screens/options/options_screen_video.cpp
@@ -296,7 +296,7 @@ void OptionsScreenVideo::init()
 
         // Add resolutions list
         for(std::vector<Resolution>::iterator it = m_resolutions.begin();
-            it != m_resolutions.end(); it++)
+            it != m_resolutions.end(); ++it)
         {
             const float ratio = it->getRatio();
             char name[32];

--- a/src/tracks/check_manager.cpp
+++ b/src/tracks/check_manager.cpp
@@ -85,7 +85,7 @@ void CheckManager::load(const XMLNode &node)
             check_node->get("other-id", &check_structures_to_change_state);
         std::vector<int>::iterator it;
         for(it=check_structures_to_change_state.begin();
-            it != check_structures_to_change_state.end(); it++)
+            it != check_structures_to_change_state.end(); ++it)
         {
             if(DriveGraph::get()->isReverse())
                 m_all_checks[*it]->addSuccessor(i);
@@ -115,7 +115,7 @@ CheckManager::~CheckManager()
 void CheckManager::reset(const Track &track)
 {
     std::vector<CheckStructure*>::iterator i;
-    for(i=m_all_checks.begin(); i!=m_all_checks.end(); i++)
+    for(i=m_all_checks.begin(); i!=m_all_checks.end(); ++i)
         (*i)->reset(track);
 }   // reset
 
@@ -128,7 +128,7 @@ void CheckManager::reset(const Track &track)
 void CheckManager::resetAfterKartMove(AbstractKart *kart)
 {
     std::vector<CheckStructure*>::iterator i;
-    for (i = m_all_checks.begin(); i != m_all_checks.end(); i++)
+    for (i = m_all_checks.begin(); i != m_all_checks.end(); ++i)
         (*i)->resetAfterKartMove(kart->getWorldKartId());
 }   // resetAfterKartMove
 
@@ -184,7 +184,7 @@ void CheckManager::removeFlyableFromCannons(Flyable *flyable)
 void CheckManager::update(float dt)
 {
     std::vector<CheckStructure*>::iterator i;
-    for(i=m_all_checks.begin(); i!=m_all_checks.end(); i++)
+    for(i=m_all_checks.begin(); i!=m_all_checks.end(); ++i)
         (*i)->update(dt);
 }   // update
 

--- a/src/tracks/model_definition_loader.cpp
+++ b/src/tracks/model_definition_loader.cpp
@@ -185,7 +185,7 @@ scene::IMesh* ModelDefinitionLoader::getFirstMeshFor(const std::string& name)
 void ModelDefinitionLoader::cleanLibraryNodesAfterLoad()
 {
     for (std::map<std::string, XMLNode*>::iterator it = m_library_nodes.begin();
-        it != m_library_nodes.end(); it++)
+        it != m_library_nodes.end(); ++it)
     {
         delete it->second;
 

--- a/src/tracks/track_manager.cpp
+++ b/src/tracks/track_manager.cpp
@@ -159,7 +159,7 @@ void TrackManager::loadTrackList()
         std::set<std::string> dirs;
         file_manager->listFiles(dirs, dir);
         for(std::set<std::string>::iterator subdir = dirs.begin();
-            subdir != dirs.end(); subdir++)
+            subdir != dirs.end(); ++subdir)
         {
             if(*subdir=="." || *subdir=="..") continue;
             loadTrack(dir+*subdir+"/");
@@ -277,7 +277,7 @@ void TrackManager::removeTrack(const std::string &ident)
                                (i==1 ? m_arena_groups :
                                  m_track_groups));
         Group2Indices::iterator j;
-        for(j=g2i.begin(); j!=g2i.end(); j++)
+        for(j=g2i.begin(); j!=g2i.end(); ++j)
         {
             for(unsigned int i=0; i<(*j).second.size(); i++)
                 if((*j).second[i]>index) (*j).second[i]--;

--- a/src/utils/command_line.cpp
+++ b/src/utils/command_line.cpp
@@ -68,7 +68,7 @@ void CommandLine::addArgsFromUserConfig()
 bool CommandLine::has(const std::string &option)
 {
     std::vector<std::string>::iterator i;
-    for(i=m_argv.begin(); i!=m_argv.end(); i++)
+    for(i=m_argv.begin(); i!=m_argv.end(); ++i)
     {
         if(*i==option)
         {


### PR DESCRIPTION
According to Cppcheck, using pre-increment can be "more efficient." This pull request fixes most of the warnings except for a couple in the `src/tinygettext/` directory.

Problem details in Cppcheck:
```
Prefix ++/-- operators should be preferred for non-primitive types. Pre-increment/decrement can
be more efficient than post-increment/decrement. Post-increment/decrement usually involves
keeping a copy of the previous value around and adds a little extra code.
```

Here's where Cppcheck detected post-increment on a non-primitive type:
```
[physics\irr_debug_drawer.cpp:82]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[race\grand_prix_manager.cpp:76]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[achievements\achievements_status.cpp:299]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[achievements\achievements_status.cpp:359]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[achievements\achievements_status.cpp:485]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[audio\music_manager.cpp:100]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[audio\music_manager.cpp:127]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[audio\music_manager.cpp:153]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[audio\sfx_manager.cpp:166]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[audio\sfx_manager.cpp:178]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[audio\sfx_manager.cpp:518]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[audio\sfx_manager.cpp:602]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[audio\sfx_manager.cpp:925]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[audio\sfx_manager.cpp:949]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[audio\sfx_manager.cpp:996]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[audio\sfx_manager.cpp:1007]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[audio\sfx_manager.cpp:854]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[audio\sfx_manager.cpp:865]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[challenges\story_mode_status.cpp:54]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[challenges\story_mode_status.cpp:94]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[challenges\story_mode_status.cpp:154]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[challenges\story_mode_status.cpp:178]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[challenges\story_mode_status.cpp:325]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[challenges\unlock_manager.cpp:63]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[challenges\unlock_manager.cpp:89]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[challenges\unlock_manager.cpp:101]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[challenges\unlock_manager.cpp:107]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[challenges\unlock_manager.cpp:217]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[challenges\unlock_manager.cpp:263]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[config\hardware_stats.cpp:175]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[graphics\graphics_restrictions.cpp:117]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[graphics\graphics_restrictions.cpp:643]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[graphics\material_manager.cpp:73]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[graphics\particle_kind_manager.cpp:56]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[graphics\particle_kind_manager.cpp:68]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[graphics\shader_based_renderer.cpp:520]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[guiengine\engine.cpp:1301]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[io\file_manager.cpp:367]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[items\item_manager.cpp:205]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[items\item_manager.cpp:394]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[items\item_manager.cpp:427]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[items\item_manager.cpp:443]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[items\item_manager.cpp:449]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[items\item_manager.cpp:454]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[items\item_manager.cpp:475]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[items\item_manager.cpp:483]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[items\item_manager.cpp:503]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[items\item_manager.cpp:559]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[items\projectile_manager.cpp:102]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[karts\kart_properties_manager.cpp:129]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[karts\kart_properties_manager.cpp:152]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[karts\kart_properties_manager.cpp:163]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[karts\kart_properties_manager.cpp:454]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[karts\xml_characteristic.cpp:88]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[karts\xml_characteristic.cpp:111]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[modes\cutscene_world.cpp:353]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[modes\cutscene_world.cpp:371]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[modes\cutscene_world.cpp:388]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[modes\profile_world.cpp:266]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[modes\profile_world.cpp:278]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[modes\world.cpp:769]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[modes\world.cpp:801]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[modes\world.cpp:811]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[network\rewind_queue.cpp:102]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[network\rewind_queue.cpp:227]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[network\rewind_queue.cpp:447]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[network\rewind_queue.cpp:457]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[network\rewind_queue.cpp:459]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[network\rewind_queue.cpp:468]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[network\rewind_queue.cpp:470]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[network\rewind_queue.cpp:479]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[network\protocols\server_lobby.cpp:2012]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[online\profile_manager.cpp:180]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[race\highscore_manager.cpp:48]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[race\highscore_manager.cpp:190]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[states_screens\options\options_screen_input.cpp:360]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[states_screens\options\options_screen_ui.cpp:85]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[states_screens\options\options_screen_video.cpp:299]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[tinygettext\dictionary_manager.cpp:130]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[tinygettext\stk_file_system.cpp:43]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[tracks\check_manager.cpp:88]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[tracks\check_manager.cpp:118]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[tracks\check_manager.cpp:131]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[tracks\check_manager.cpp:187]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[tracks\model_definition_loader.cpp:188]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[tracks\track_manager.cpp:162]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[tracks\track_manager.cpp:280]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[utils\command_line.cpp:71]: (performance) Prefer prefix ++/-- operators for non-primitive types.
```

