### PR TITLE
Make achievement goal string consistent

### DIFF
--- a/src/states_screens/dialogs/achievement_progress_dialog.cpp
+++ b/src/states_screens/dialogs/achievement_progress_dialog.cpp
@@ -207,9 +207,9 @@ core::stringw AchievementProgressDialog::niceGoalName(std::string internal_name)
     // I18N: A goal for achievements. If this text is in (), it's a precision added to multiple different goals.
     if(internal_name=="ftl-finished") nice_name = _("Follow-the-Leader races finished");
     // I18N: A goal for achievements. If this text is in (), it's a precision added to multiple different goals.
-    if(internal_name=="three-strikes-started") nice_name = _("3 Strikes battle started");
+    if(internal_name=="three-strikes-started") nice_name = _("3 Strikes battles started");
     // I18N: A goal for achievements. If this text is in (), it's a precision added to multiple different goals.
-    if(internal_name=="three-strikes-finished") nice_name = _("3 Strikes battle finished");
+    if(internal_name=="three-strikes-finished") nice_name = _("3 Strikes battles finished");
     // I18N: A goal for achievements. If this text is in (), it's a precision added to multiple different goals.
     if(internal_name=="soccer-started") nice_name = _("Soccer matches started");
     // I18N: A goal for achievements. If this text is in (), it's a precision added to multiple different goals.


### PR DESCRIPTION
The singular form of `battle` here is inconsistent with the other achievement goal strings. Just look at the surrounding code.

This resolves two Transifex issues.