### PR TITLE
Show everyone's items with the left characters icons

### DIFF
--- a/src/states_screens/race_gui_base.cpp
+++ b/src/states_screens/race_gui_base.cpp
@@ -1069,6 +1069,27 @@ void RaceGUIBase::drawPlayerIcon(AbstractKart *kart, int x, int y, int w,
         draw2DImage(icon, pos4, rect4, NULL, NULL, true);
     }
 
+    // Current item(s) and how many if > 1
+    const Powerup* powerup = kart->getPowerup();
+    if (powerup->getType() != PowerupManager::POWERUP_NOTHING && !kart->hasFinishedRace())
+    {
+        int numberItems = kart->getPowerup()->getNum();
+        video::ITexture *iconItem = powerup->getIcon()->getTexture();
+        assert(iconItem);
+
+        const core::rect<s32> rect(core::position2d<s32>(0,0), iconItem->getSize());
+        const core::rect<s32> posItem(x + w/2, y + w/2, x + 5*w/4, y + 5*w/4);
+        draw2DImage(iconItem, posItem, rect, NULL, NULL, true);
+
+        if (numberItems > 1)
+        {
+            gui::ScalableFont* font = GUIEngine::getHighresDigitFont();
+            const core::rect<s32> posNumber(x + w, y + w/4, x + 7*w/4, y + w);
+            font->setScale(3.f*((float) w)/(4.f*(float)font->getDimension(L"X").Height));
+            font->draw(StringUtils::toWString(numberItems), posNumber, video::SColor(255, 255, 255, 255));
+        }
+    }
+
     //Plunger
     if (kart->getBlockedByPlungerTicks()>0)
     {


### PR DESCRIPTION
Feature that shows the items of every player in the icons at left, similar to some Mario Karts.

Personally, I really liked that feature, and maybe others Stk players might too. It would also make races a bit more exciting and strategic by having a way to anticipate the others' actions. And I can finally see who is sending me all these Basket Balls Lol.

More importantly, this is currently a way to cheat by having this feature while others don't, and I don't see any real cons to see what items others have (other than "items should be secret", but again, as we can cheat easily...).

Sorry, I can't test this online for now so hopefully that works for it too, but I don't see why it should not work.
Should work in all modes, though there is no icons at left in Soccer, but I think that this feature does not have much point here anyway and would not help a cheater much.
The icons should properly scale depending on the number of players and the resolution.

![ShowEveryonesItems1](https://user-images.githubusercontent.com/42526046/62166436-0d4db580-b321-11e9-924e-603f677feb7c.png)
![ShowEveryonesItems2](https://user-images.githubusercontent.com/42526046/62166437-0d4db580-b321-11e9-9c4e-d0cfd7bc50ff.png)
![ShowEveryonesItems3](https://user-images.githubusercontent.com/42526046/62166438-0d4db580-b321-11e9-8ab5-644c03fcf163.png)


