### PR TITLE
Music theming

### DIFF
--- a/data/stk_config.xml
+++ b/data/stk_config.xml
@@ -151,7 +151,8 @@
            solver-split-impulse-threshold="-0.00001"
            solver-mode=""/>
 
-  <!-- The title and default musics. -->
+  <!-- The title and track default musics.  Note that the title music can
+       be overridden by the skin. -->
   <music title="main_theme.music" default="kart_grand_prix.music"/>
 
   <!--  Replay related values, mostly concerned with saving less data

--- a/src/config/stk_config.cpp
+++ b/src/config/stk_config.cpp
@@ -564,6 +564,11 @@ void STKConfig::getAllData(const XMLNode * root)
     for (unsigned int i = 0; i < child_node->getNumNodes(); ++i)
     {
         const XMLNode* type = child_node->getNode(i);
+
+        // Avoid memory leak on re-load of stk_config
+        if (m_kart_properties[type->getName()])
+            delete m_kart_properties[type->getName()];
+
         m_kart_properties[type->getName()] = new KartProperties();
         m_kart_properties[type->getName()]->copyFrom(m_default_kart_properties);
         m_kart_properties[type->getName()]->getAllData(type);

--- a/src/config/stk_config.cpp
+++ b/src/config/stk_config.cpp
@@ -77,6 +77,8 @@ void STKConfig::load(const std::string &filename)
     if(m_has_been_loaded) return;
     m_has_been_loaded = true;
 
+    m_stk_config_file = filename;
+
     init_defaults();
 
     XMLNode *root = 0;

--- a/src/config/stk_config.cpp
+++ b/src/config/stk_config.cpp
@@ -575,6 +575,11 @@ void STKConfig::getAllData(const XMLNode * root)
  */
 void STKConfig::initMusicFiles()
 {
+    if (m_title_music)
+        delete m_title_music;
+    if (m_default_music)
+        delete m_title_music;
+
     m_title_music = MusicInformation::create(m_title_music_file);
     if (!m_title_music)
     {

--- a/src/config/stk_config.hpp
+++ b/src/config/stk_config.hpp
@@ -236,18 +236,21 @@ public:
      *  version. */
     std::set<std::string> m_network_capabilities;
 
-private:
     /** True if stk_config has been loaded. This is necessary if the
      *  --stk-config command line parameter has been specified to avoid
      *  that stk loads the default configuration after already having
      *  loaded a user specified config file. */
-    bool  m_has_been_loaded;
+    bool m_has_been_loaded;
 
+private:
     /** Default FPS rate for physics. */
     int m_physics_fps;
 
     std::string m_title_music_file;
     std::string m_default_music_file;
+    /** String of the currently loaded stk_config.xml */
+    std::string m_stk_config_file;
+
 public:
     STKConfig();
     ~STKConfig();
@@ -281,6 +284,9 @@ public:
     // ------------------------------------------------------------------------
     /** Returns the physics frame per seconds rate. */
     int getPhysicsFPS() const { return m_physics_fps; }
+    // ------------------------------------------------------------------------
+    /** Returns the path of the loaded stk_config. */
+    std::string getSTKConfigPath() const { return m_stk_config_file; }
 }
 ;   // STKConfig
 

--- a/src/config/stk_config.hpp
+++ b/src/config/stk_config.hpp
@@ -162,9 +162,11 @@ public:
     std::vector<int> m_score_increase;
 
     /** Filename of the title music to play.*/
+    std::string m_title_music_file;
     MusicInformation *m_title_music;
 
     /** Filename of the music that is played when the track's music was not found */
+    std::string m_default_music_file;
     MusicInformation *m_default_music;
 
     /** Maximum number of transform events of a replay. */
@@ -246,8 +248,6 @@ private:
     /** Default FPS rate for physics. */
     int m_physics_fps;
 
-    std::string m_title_music_file;
-    std::string m_default_music_file;
     /** String of the currently loaded stk_config.xml */
     std::string m_stk_config_file;
 

--- a/src/graphics/irr_driver.cpp
+++ b/src/graphics/irr_driver.cpp
@@ -998,6 +998,9 @@ void IrrDriver::applyResolutionSettings()
         SP::loadShaders();
 #endif
 
+    stk_config->m_has_been_loaded = false;
+    stk_config->load(stk_config->getSTKConfigPath());
+
     font_manager = new FontManager();
     font_manager->loadFonts();
     // Re-init GUI engine

--- a/src/graphics/irr_driver.cpp
+++ b/src/graphics/irr_driver.cpp
@@ -1006,6 +1006,9 @@ void IrrDriver::applyResolutionSettings()
     // Re-init GUI engine
     GUIEngine::init(m_device, m_video_driver, StateManager::get());
 
+    // Re-init music files
+    stk_config->initMusicFiles();
+
     setMaxTextureSize();
     //material_manager->reInit();
     material_manager = new MaterialManager();

--- a/src/guiengine/skin.cpp
+++ b/src/guiengine/skin.cpp
@@ -22,7 +22,9 @@
 #include <iostream>
 #include <algorithm>
 
+#include "audio/music_information.hpp"
 #include "config/user_config.hpp"
+#include "config/stk_config.hpp"
 #include "graphics/2dutils.hpp"
 #include "graphics/central_settings.hpp"
 #include "guiengine/engine.hpp"
@@ -173,6 +175,22 @@ namespace SkinConfig
             else if (node->getName() == "color")
             {
                 parseColor(node);
+            }
+            else if (node->getName() == "menumusic")
+            {                
+                std::string title_music_file;
+                node->get("name", &title_music_file);
+                assert(title_music_file.size() > 0);
+                title_music_file = file_manager->getAsset(FileManager::MUSIC, title_music_file);
+                if (title_music_file.size() <= 0)
+                {
+                    Log::error("Theming", "Cannot load theme-specific menu music: %s", title_music_file.c_str());
+                }
+                else
+                {
+                    stk_config->m_title_music_file = title_music_file;
+                    Log::info("Theming", "Theme-specific menu music loaded: %s", title_music_file.c_str());
+                }
             }
             else
             {

--- a/src/states_screens/options/options_screen_ui.cpp
+++ b/src/states_screens/options/options_screen_ui.cpp
@@ -195,6 +195,7 @@ void OptionsScreenUI::init()
     GUIEngine::SpinnerWidget* font_size = getWidget<GUIEngine::SpinnerWidget>("font_size");
     assert( font_size != NULL );
 
+    m_prev_title_music_file = stk_config->m_title_music_file;
     m_prev_font_size = UserConfigParams::m_font_size;
     int size_int = (int)roundf(UserConfigParams::m_font_size);
     if (size_int < 0 || size_int > 6)
@@ -320,7 +321,7 @@ void OptionsScreenUI::eventCallback(Widget* widget, const std::string& name, con
 
 void OptionsScreenUI::tearDown()
 {
-    if (m_prev_font_size != UserConfigParams::m_font_size)
+    if (m_prev_font_size != UserConfigParams::m_font_size || m_prev_title_music_file != stk_config->m_title_music_file)
     {
         irr_driver->sameRestart();
     }

--- a/src/states_screens/options/options_screen_ui.hpp
+++ b/src/states_screens/options/options_screen_ui.hpp
@@ -36,6 +36,7 @@ class OptionsScreenUI : public GUIEngine::Screen, public GUIEngine::ScreenSingle
     OptionsScreenUI();
     bool m_inited;
     float m_prev_font_size;
+    std::string m_prev_title_music_file;
 
     std::vector<std::string> m_skins;
 


### PR DESCRIPTION
## Agreement
```
By creating a pull request in stk-code, you hearby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
Upstreams the menu music theming support from my branch.

The first commit makes it so STK re-loads `stk_config` when re-initing, so any overridden values are reset.  Care was taken to ensure it handles reloading properly when alternative `stk_config.xml` files are set via the command-line flag.

The second commit actually adds the lines to load the alternative music, and to make sure it is reloaded upon re-init.