### PR TITLE
Link against libatomic if required

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -513,6 +513,21 @@ else()
     target_link_libraries(supertuxkart ${PTHREAD_LIBRARY})
 endif()
 
+# check if linking against libatomic is required
+include(CheckCXXSourceCompiles)
+check_cxx_source_compiles("
+#include <atomic>
+#include <cstdint>
+int main() {
+  std::atomic<uint64_t> x{0};
+  x.load();
+  return 0;
+}
+" NO_LIBATOMIC_NEEDED)
+if (NOT NO_LIBATOMIC_NEEDED)
+    target_link_libraries(supertuxkart atomic)
+endif()
+
 # CURL and OpenSSL or Nettle
 # 1.0.1d for compatible AES GCM handling
 SET(OPENSSL_MINIMUM_VERSION "1.0.1d")


### PR DESCRIPTION
On some architectures it is required to explicitely link against
libatomic to use e.g. 8 byte atomics.
Check during configuration if it compiles without libatomic. If not,
add it to target_link_libraries.

Noticed on Debian build servers: https://bugs.debian.org/934799

## Agreement
```
By creating a pull request in stk-code, you hearby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
