### PR TITLE
Add options to distribute AI in single-player soccer

### DIFF
--- a/data/gui/screens/track_info.stkgui
+++ b/data/gui/screens/track_info.stkgui
@@ -66,6 +66,15 @@
                     <spacer width="1" height="1%"/>
                     <div width="100%" height="fit" layout="horizontal-row" >
                         <div proportion="1" height="fit" layout="horizontal-row">
+                            <spinner id="ai-mix-spinner" width="100%" min_value="1" max_value="20" align="center"
+                                     wrap_around="true" />
+                        </div>
+                        <spacer width="3%"/>
+                        <label id="ai-mix-text" proportion="3" I18N="In the track info screen" text="AI team distribution" text_align="left" align="center"/>
+                    </div>
+                    <spacer width="1" height="1%"/>
+                    <div width="100%" height="fit" layout="horizontal-row" >
+                        <div proportion="1" height="fit" layout="horizontal-row">
                             <div width="100%" height="fit" text-align="center" layout="vertical-row" >
                                 <checkbox id="option" align="center"/>
                             </div>

--- a/src/config/user_config.hpp
+++ b/src/config/user_config.hpp
@@ -449,6 +449,9 @@ namespace UserConfigParams
     PARAM_PREFIX StringUserConfigParam m_last_used_kart_group
             PARAM_DEFAULT( StringUserConfigParam("all", "last_kart_group",
                                                  "Last selected kart group") );
+    PARAM_PREFIX IntUserConfigParam          m_soccer_team_mix
+            PARAM_DEFAULT(  IntUserConfigParam(0, "m_soccer_team_mix",
+            &m_race_setup_group, "Options to control how to mix teams in soccer mode. 0=balanced(default), 1=all AI blue, 2=all AI red") );
 
     // ---- Wiimote data
     PARAM_PREFIX GroupUserConfigParam        m_wiimote_group

--- a/src/modes/world.cpp
+++ b/src/modes/world.cpp
@@ -1575,7 +1575,8 @@ void World::setAITeam()
     int available_ai = total_karts - red_players - blue_players;
 
     // Distribute AI based on settings read from GUI
-    if (UserConfigParams::m_soccer_team_mix==0){ // balanced distribution
+    if (UserConfigParams::m_soccer_team_mix==0) // balanced distribution
+    {
         int additional_blue = red_players - blue_players;
 
         m_blue_ai = (available_ai - additional_blue) / 2 + additional_blue;
@@ -1583,16 +1584,26 @@ void World::setAITeam()
 
         if ((available_ai + additional_blue)%2 == 1)
             (additional_blue < 0) ? m_red_ai++ : m_blue_ai++;
-    }else if (UserConfigParams::m_soccer_team_mix==1){ // make all AI blue
+    }
+    else if (UserConfigParams::m_soccer_team_mix==1) // make all AI blue
+    {
         m_blue_ai = available_ai;
         m_red_ai = 0;
         // make sure there is at least one AI
-        if ( (m_red_ai + red_players)==0 ) {m_red_ai++; m_blue_ai--;}
-    }else if (UserConfigParams::m_soccer_team_mix==2){ // make all AI red
+        if ( (m_red_ai + red_players)==0 )
+	{
+	    m_red_ai++; m_blue_ai--;
+	}
+    }
+    else if (UserConfigParams::m_soccer_team_mix==2) // make all AI red
+    {
         m_blue_ai = 0;
 	m_red_ai = available_ai;
         // make sure there is at least one AI
-        if ( (m_blue_ai + blue_players)==0 ) {m_red_ai--; m_blue_ai++;}
+        if ( (m_blue_ai + blue_players)==0 )
+	{
+	    m_red_ai--; m_blue_ai++;
+	}
     }
 
     Log::debug("World", "Blue AI: %d red AI: %d", m_blue_ai, m_red_ai);

--- a/src/modes/world.cpp
+++ b/src/modes/world.cpp
@@ -1573,13 +1573,27 @@ void World::setAITeam()
     }
 
     int available_ai = total_karts - red_players - blue_players;
-    int additional_blue = red_players - blue_players;
 
-    m_blue_ai = (available_ai - additional_blue) / 2 + additional_blue;
-    m_red_ai  = (available_ai - additional_blue) / 2;
+    // Distribute AI based on settings read from GUI
+    if (UserConfigParams::m_soccer_team_mix==0){ // balanced distribution
+        int additional_blue = red_players - blue_players;
 
-    if ((available_ai + additional_blue)%2 == 1)
-        (additional_blue < 0) ? m_red_ai++ : m_blue_ai++;
+        m_blue_ai = (available_ai - additional_blue) / 2 + additional_blue;
+        m_red_ai  = (available_ai - additional_blue) / 2;
+
+        if ((available_ai + additional_blue)%2 == 1)
+            (additional_blue < 0) ? m_red_ai++ : m_blue_ai++;
+    }else if (UserConfigParams::m_soccer_team_mix==1){ // make all AI blue
+        m_blue_ai = available_ai;
+        m_red_ai = 0;
+        // make sure there is at least one AI
+        if ( (m_red_ai + red_players)==0 ) {m_red_ai++; m_blue_ai--;}
+    }else if (UserConfigParams::m_soccer_team_mix==2){ // make all AI red
+        m_blue_ai = 0;
+	m_red_ai = available_ai;
+        // make sure there is at least one AI
+        if ( (m_blue_ai + blue_players)==0 ) {m_red_ai--; m_blue_ai++;}
+    }
 
     Log::debug("World", "Blue AI: %d red AI: %d", m_blue_ai, m_red_ai);
 

--- a/src/modes/world.cpp
+++ b/src/modes/world.cpp
@@ -1590,7 +1590,7 @@ void World::setAITeam()
         m_blue_ai = available_ai;
         m_red_ai = 0;
         // make sure there is at least one AI
-        if ( (m_red_ai + red_players)==0 )
+        if ((m_red_ai + red_players) == 0)
 	{
 	    m_red_ai++; m_blue_ai--;
 	}
@@ -1600,7 +1600,7 @@ void World::setAITeam()
         m_blue_ai = 0;
 	m_red_ai = available_ai;
         // make sure there is at least one AI
-        if ( (m_blue_ai + blue_players)==0 )
+        if ((m_blue_ai + blue_players) == 0)
 	{
 	    m_red_ai--; m_blue_ai++;
 	}

--- a/src/states_screens/track_info_screen.cpp
+++ b/src/states_screens/track_info_screen.cpp
@@ -66,6 +66,8 @@ void TrackInfoScreen::loadedFromFile()
 {
     m_target_type_spinner   = getWidget<SpinnerWidget>("target-type-spinner");
     m_target_type_label     = getWidget <LabelWidget>("target-type-text");
+    m_ai_mix_type_spinner   = getWidget<SpinnerWidget>("ai-mix-spinner");
+    m_ai_mix_type_label     = getWidget <LabelWidget>("ai-mix-text");
     m_target_type_div       = getWidget<Widget>("target-type-div");
     m_target_value_spinner  = getWidget<SpinnerWidget>("target-value-spinner");
     m_target_value_label    = getWidget<LabelWidget>("target-value-text");
@@ -173,6 +175,9 @@ void TrackInfoScreen::init()
     m_target_value_spinner->setVisible(false);
     m_target_value_label->setVisible(false);
 
+    m_ai_mix_type_spinner->setVisible(false);
+    m_ai_mix_type_label->setVisible(false);
+
     // Soccer options
     // -------------
     if (m_is_soccer)
@@ -203,6 +208,15 @@ void TrackInfoScreen::init()
             m_target_value_label->setText(_("Number of goals to win"), false);
             m_target_value_spinner->setValue(UserConfigParams::m_num_goals);
         }
+
+        // Options to distribute AI in soccer
+        m_ai_mix_type_spinner->setVisible(true);
+        m_ai_mix_type_label->setVisible(true);
+        m_ai_mix_type_spinner->clearLabels();
+        m_ai_mix_type_spinner->addLabel(_("Balanced"));
+        m_ai_mix_type_spinner->addLabel(_("All AI blue"));
+        m_ai_mix_type_spinner->addLabel(_("All AI red"));
+        m_ai_mix_type_spinner->setValue(UserConfigParams::m_soccer_team_mix);
     }
 
     // options for free-for-all and three strikes battle
@@ -585,6 +599,13 @@ void TrackInfoScreen::eventCallback(Widget* widget, const std::string& name,
             race_manager->setNumLaps(num_laps);
             UserConfigParams::m_num_laps = num_laps;
             updateHighScores();
+        }
+    }
+    else if (name == "ai-mix-spinner")
+    {
+        if (m_is_soccer)
+        {
+            UserConfigParams::m_soccer_team_mix = m_ai_mix_type_spinner->getValue();
         }
     }
     else if (name == "option")

--- a/src/states_screens/track_info_screen.hpp
+++ b/src/states_screens/track_info_screen.hpp
@@ -60,6 +60,12 @@ class TrackInfoScreen : public GUIEngine::Screen,
     /** The label besides the target types spinner. */
     GUIEngine::LabelWidget* m_target_type_label;
 
+    /** Spinner for AI team mix types. */
+    GUIEngine::SpinnerWidget* m_ai_mix_type_spinner;
+
+    /** The label besides the AI team mix spinner. */
+    GUIEngine::LabelWidget* m_ai_mix_type_label;
+
     /* The div that contains the target type spinner and label */
     GUIEngine::Widget* m_target_type_div;
 


### PR DESCRIPTION
I add an option for single-player soccer mode, as shown below, to have additional flexibility to control the distribution of AI among teams. There are three options:
Balanced - this is what used in stk before
All AI blue - make all AI go to the blue team
All AI red - make all AI go to the red team

This will be useful for people who want to play against more AI karts or need more help from AI. I know not everyone needs this, but they can always play with the default option: balanced.

![Screenshot from 2019-09-15 16-54-50](https://user-images.githubusercontent.com/4726939/64928218-ad30a700-d7da-11e9-98e8-5855e6f87b09.png)
![Screenshot from 2019-09-15 16-55-11](https://user-images.githubusercontent.com/4726939/64928220-b28df180-d7da-11e9-9a4b-73b08ee8e7a6.png)


## Agreement
```
By creating a pull request in stk-code, you hearby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
