### PR TITLE
Add options to control the number of red/blue AI in soccer mode

### DIFF
--- a/data/gui/screens/track_info.stkgui
+++ b/data/gui/screens/track_info.stkgui
@@ -57,15 +57,6 @@
                     <spacer width="1" height="1%"/>
                     <div width="100%" height="fit" layout="horizontal-row" >
                         <div proportion="1" height="fit" layout="horizontal-row">
-                            <spinner id="ai-mix-spinner" width="100%" min_value="1" max_value="20" align="center"
-                                     wrap_around="true" />
-                        </div>
-                        <spacer width="3%"/>
-                        <label id="ai-mix-text" proportion="3" I18N="In the track info screen" text="AI team distribution" text_align="left" align="center"/>
-                    </div>
-                    <spacer width="1" height="1%"/>
-                    <div width="100%" height="fit" layout="horizontal-row" >
-                        <div proportion="1" height="fit" layout="horizontal-row">
                             <spinner id="ai-spinner" width="100%" min_value="1" max_value="20" align="center"
                                      wrap_around="true" />
                         </div>

--- a/data/gui/screens/track_info.stkgui
+++ b/data/gui/screens/track_info.stkgui
@@ -64,7 +64,7 @@
                         <label id="ai-text" proportion="3" I18N="In the track info screen" text="Number of AI karts" text_align="left" align="center"/>
                     </div>
                     <spacer width="1" height="1%"/>
-                    <div width="100%" height="fit" layout="horizontal-row" >
+                    <div width="100%" height="fit" layout="horizontal-row" id="ai-blue-div">
                         <div proportion="1" height="fit" layout="horizontal-row">
                             <spinner id="ai-blue-spinner" width="100%" min_value="1" max_value="20" align="center"
                                      wrap_around="true" />

--- a/data/gui/screens/track_info.stkgui
+++ b/data/gui/screens/track_info.stkgui
@@ -57,11 +57,29 @@
                     <spacer width="1" height="1%"/>
                     <div width="100%" height="fit" layout="horizontal-row" >
                         <div proportion="1" height="fit" layout="horizontal-row">
+                            <spinner id="ai-mix-spinner" width="100%" min_value="1" max_value="20" align="center"
+                                     wrap_around="true" />
+                        </div>
+                        <spacer width="3%"/>
+                        <label id="ai-mix-text" proportion="3" I18N="In the track info screen" text="AI team distribution" text_align="left" align="center"/>
+                    </div>
+                    <spacer width="1" height="1%"/>
+                    <div width="100%" height="fit" layout="horizontal-row" >
+                        <div proportion="1" height="fit" layout="horizontal-row">
                             <spinner id="ai-spinner" width="100%" min_value="1" max_value="20" align="center"
                                      wrap_around="true" />
                         </div>
                         <spacer width="3%"/>
                         <label id="ai-text" proportion="3" I18N="In the track info screen" text="Number of AI karts" text_align="left" align="center"/>
+                    </div>
+                    <spacer width="1" height="1%"/>
+                    <div width="100%" height="fit" layout="horizontal-row" >
+                        <div proportion="1" height="fit" layout="horizontal-row">
+                            <spinner id="ai-blue-spinner" width="100%" min_value="1" max_value="20" align="center"
+                                     wrap_around="true" />
+                        </div>
+                        <spacer width="3%"/>
+                        <label id="ai-blue-text" proportion="3" I18N="In the track info screen" text="Number of blue team AI karts" text_align="left" align="center"/>
                     </div>
                     <spacer width="1" height="1%"/>
                     <div width="100%" height="fit" layout="horizontal-row" >

--- a/src/config/user_config.hpp
+++ b/src/config/user_config.hpp
@@ -449,6 +449,15 @@ namespace UserConfigParams
     PARAM_PREFIX StringUserConfigParam m_last_used_kart_group
             PARAM_DEFAULT( StringUserConfigParam("all", "last_kart_group",
                                                  "Last selected kart group") );
+    PARAM_PREFIX IntUserConfigParam          m_soccer_team_mix_balanced
+            PARAM_DEFAULT(  IntUserConfigParam(0, "m_soccer_team_mix_balanced",
+            &m_race_setup_group, "Options to control how to mix teams in soccer mode. 0=Balanced(default), 1=Custom") );
+    PARAM_PREFIX IntUserConfigParam          m_soccer_red_ai_num
+            PARAM_DEFAULT(  IntUserConfigParam(0, "m_soccer_red_ai_num",
+            &m_race_setup_group, "Number of red AI karts in soccer mode.") );
+    PARAM_PREFIX IntUserConfigParam          m_soccer_blue_ai_num
+            PARAM_DEFAULT(  IntUserConfigParam(0, "m_soccer_blue_ai_num",
+            &m_race_setup_group, "Number of blue AI karts in soccer mode.") );
 
     // ---- Wiimote data
     PARAM_PREFIX GroupUserConfigParam        m_wiimote_group

--- a/src/config/user_config.hpp
+++ b/src/config/user_config.hpp
@@ -449,9 +449,6 @@ namespace UserConfigParams
     PARAM_PREFIX StringUserConfigParam m_last_used_kart_group
             PARAM_DEFAULT( StringUserConfigParam("all", "last_kart_group",
                                                  "Last selected kart group") );
-    PARAM_PREFIX IntUserConfigParam          m_soccer_team_mix_balanced
-            PARAM_DEFAULT(  IntUserConfigParam(0, "m_soccer_team_mix_balanced",
-            &m_race_setup_group, "Options to control how to mix teams in soccer mode. 0=Balanced(default), 1=Custom") );
     PARAM_PREFIX IntUserConfigParam          m_soccer_red_ai_num
             PARAM_DEFAULT(  IntUserConfigParam(0, "m_soccer_red_ai_num",
             &m_race_setup_group, "Number of red AI karts in soccer mode.") );

--- a/src/modes/world.cpp
+++ b/src/modes/world.cpp
@@ -1555,31 +1555,39 @@ void World::setAITeam()
     // No AI
     if ((total_karts - total_players) == 0) return;
 
-    int red_players = 0;
-    int blue_players = 0;
-    for (int i = 0; i < total_players; i++)
+    if (UserConfigParams::m_soccer_team_mix_balanced == 0) // AI distribution: Balanced
     {
-        KartTeam team = race_manager->getKartInfo(i).getKartTeam();
-
-        // Happen in profiling mode
-        if (team == KART_TEAM_NONE)
+        int red_players = 0;
+        int blue_players = 0;
+        for (int i = 0; i < total_players; i++)
         {
-            race_manager->setKartTeam(i, KART_TEAM_BLUE);
-            team = KART_TEAM_BLUE;
-            continue; //FIXME, this is illogical
+            KartTeam team = race_manager->getKartInfo(i).getKartTeam();
+
+            // Happen in profiling mode
+            if (team == KART_TEAM_NONE)
+            {
+                race_manager->setKartTeam(i, KART_TEAM_BLUE);
+                team = KART_TEAM_BLUE;
+                continue; //FIXME, this is illogical
+            }
+
+            team == KART_TEAM_BLUE ? blue_players++ : red_players++;
         }
 
-        team == KART_TEAM_BLUE ? blue_players++ : red_players++;
+        int available_ai = total_karts - red_players - blue_players;
+        int additional_blue = red_players - blue_players;
+
+        m_blue_ai = (available_ai - additional_blue) / 2 + additional_blue;
+        m_red_ai  = (available_ai - additional_blue) / 2;
+
+        if ((available_ai + additional_blue)%2 == 1)
+            (additional_blue < 0) ? m_red_ai++ : m_blue_ai++;
     }
-
-    int available_ai = total_karts - red_players - blue_players;
-    int additional_blue = red_players - blue_players;
-
-    m_blue_ai = (available_ai - additional_blue) / 2 + additional_blue;
-    m_red_ai  = (available_ai - additional_blue) / 2;
-
-    if ((available_ai + additional_blue)%2 == 1)
-        (additional_blue < 0) ? m_red_ai++ : m_blue_ai++;
+    else // AI distribution: Custom
+    {
+        m_red_ai  = UserConfigParams::m_soccer_red_ai_num;
+        m_blue_ai = UserConfigParams::m_soccer_blue_ai_num;
+    }
 
     Log::debug("World", "Blue AI: %d red AI: %d", m_blue_ai, m_red_ai);
 

--- a/src/modes/world.cpp
+++ b/src/modes/world.cpp
@@ -1549,45 +1549,8 @@ KartTeam World::getKartTeam(unsigned int kart_id) const
 //-----------------------------------------------------------------------------
 void World::setAITeam()
 {
-    const int total_players = race_manager->getNumPlayers();
-    const int total_karts = race_manager->getNumberOfKarts();
-
-    // No AI
-    if ((total_karts - total_players) == 0) return;
-
-    if (UserConfigParams::m_soccer_team_mix_balanced == 0) // AI distribution: Balanced
-    {
-        int red_players = 0;
-        int blue_players = 0;
-        for (int i = 0; i < total_players; i++)
-        {
-            KartTeam team = race_manager->getKartInfo(i).getKartTeam();
-
-            // Happen in profiling mode
-            if (team == KART_TEAM_NONE)
-            {
-                race_manager->setKartTeam(i, KART_TEAM_BLUE);
-                team = KART_TEAM_BLUE;
-                continue; //FIXME, this is illogical
-            }
-
-            team == KART_TEAM_BLUE ? blue_players++ : red_players++;
-        }
-
-        int available_ai = total_karts - red_players - blue_players;
-        int additional_blue = red_players - blue_players;
-
-        m_blue_ai = (available_ai - additional_blue) / 2 + additional_blue;
-        m_red_ai  = (available_ai - additional_blue) / 2;
-
-        if ((available_ai + additional_blue)%2 == 1)
-            (additional_blue < 0) ? m_red_ai++ : m_blue_ai++;
-    }
-    else // AI distribution: Custom
-    {
-        m_red_ai  = UserConfigParams::m_soccer_red_ai_num;
-        m_blue_ai = UserConfigParams::m_soccer_blue_ai_num;
-    }
+    m_red_ai  = UserConfigParams::m_soccer_red_ai_num;
+    m_blue_ai = UserConfigParams::m_soccer_blue_ai_num;
 
     Log::debug("World", "Blue AI: %d red AI: %d", m_blue_ai, m_red_ai);
 

--- a/src/states_screens/track_info_screen.cpp
+++ b/src/states_screens/track_info_screen.cpp
@@ -283,24 +283,24 @@ void TrackInfoScreen::init()
             getRedBluePlayerNumber();
 
             int additional_blue = m_red_players - m_blue_players;
-            int m_blue_ai = (num_ai - additional_blue) / 2 + additional_blue;
-            int m_red_ai  = (num_ai - additional_blue) / 2;
+            int num_blue_ai = (num_ai - additional_blue) / 2 + additional_blue;
+            int num_red_ai  = (num_ai - additional_blue) / 2;
 
             if ((num_ai + additional_blue)%2 == 1)
-                (additional_blue < 0) ? m_red_ai++ : m_blue_ai++;
+                (additional_blue < 0) ? num_red_ai++ : num_blue_ai++;
 
-            UserConfigParams::m_soccer_red_ai_num  = m_red_ai;
-            UserConfigParams::m_soccer_blue_ai_num = m_blue_ai;
+            UserConfigParams::m_soccer_red_ai_num  = num_red_ai;
+            UserConfigParams::m_soccer_blue_ai_num = num_blue_ai;
 
-            int m_blue_lower = (m_blue_players > 0) ? 0 : 1;
-            int m_red_lower = (m_red_players > 0) ? 0 : 1;
-            int m_blue_upper_hard = max_arena_players - local_players - m_red_lower; // possible upper bound
-            int m_red_upper_hard  = max_arena_players - local_players - m_blue_lower;// possible upper bound
+            int num_blue_lower = (m_blue_players > 0) ? 0 : 1;
+            int num_red_lower = (m_red_players > 0) ? 0 : 1;
+            int num_blue_upper_hard = max_arena_players - local_players - num_red_lower; // possible upper bound
+            int num_red_upper_hard  = max_arena_players - local_players - num_blue_lower;// possible upper bound
 
-            m_ai_kart_spinner->setMin(m_red_lower);
-            m_ai_blue_spinner->setMin(m_blue_lower);
-            m_ai_kart_spinner->setMax(std::min( m_red_ai + (m_red_ai == m_red_lower ? 0 : 1), m_red_upper_hard )); // +1 to allow adding AI
-            m_ai_blue_spinner->setMax(std::min( m_blue_ai + (m_blue_ai == m_blue_lower ? 0 : 1), m_blue_upper_hard )); // +1 to allow adding AI
+            m_ai_kart_spinner->setMin(num_red_lower);
+            m_ai_blue_spinner->setMin(num_blue_lower);
+            m_ai_kart_spinner->setMax(std::min( num_red_ai + (num_red_ai == num_red_lower ? 0 : 1), num_red_upper_hard )); // +1 to allow adding AI
+            m_ai_blue_spinner->setMax(std::min( num_blue_ai + (num_blue_ai == num_blue_lower ? 0 : 1), num_blue_upper_hard )); // +1 to allow adding AI
 
             // Set the values
             m_ai_kart_spinner->setValue(UserConfigParams::m_soccer_red_ai_num);
@@ -691,36 +691,36 @@ void TrackInfoScreen::eventCallback(Widget* widget, const std::string& name,
             const int max_arena_players = m_track->getMaxArenaPlayers();
             const int local_players = race_manager->getNumLocalPlayers();
             const int num_ai = max_arena_players - local_players; // possible AI number
-            int m_red  = m_ai_kart_spinner->getValue();
-            int m_blue = m_ai_blue_spinner->getValue();
+            int num_red  = m_ai_kart_spinner->getValue();
+            int num_blue = m_ai_blue_spinner->getValue();
 
             getRedBluePlayerNumber();
 
-            int m_blue_lower = (m_blue_players > 0) ? 0 : 1;
-            int m_red_lower = (m_red_players > 0) ? 0 : 1;
-            int m_blue_upper      = num_ai - m_red;       // upper bound determined by the new m_red
-            int m_blue_upper_hard = num_ai - m_red_lower; // possible upper bound
-            int m_red_upper       = num_ai - m_blue;      // upper bound determined by the new m_blue
-            int m_red_upper_hard  = num_ai - m_blue_lower;// possible upper bound
+            int num_blue_lower = (m_blue_players > 0) ? 0 : 1;
+            int num_red_lower = (m_red_players > 0) ? 0 : 1;
+            int num_blue_upper      = num_ai - num_red;       // upper bound determined by the new num_red
+            int num_blue_upper_hard = num_ai - num_red_lower; // possible upper bound
+            int num_red_upper       = num_ai - num_blue;      // upper bound determined by the new num_blue
+            int num_red_upper_hard  = num_ai - num_blue_lower;// possible upper bound
 
             // Check if need to change blue in response to the red change
-            if (m_blue > m_blue_upper)
+            if (num_blue > num_blue_upper)
             {
-                m_blue = m_blue_upper; // change blue
-                m_red_upper = num_ai - m_blue; // recalculate the upper bound determined by the new m_blue
+                num_blue = num_blue_upper; // change blue
+                num_red_upper = num_ai - num_blue; // recalculate the upper bound determined by the new num_blue
             }
 
-            m_ai_kart_spinner->setMax(std::min( (m_red == m_red_lower ?  m_red_upper_hard : m_red_upper + 1), m_red_upper_hard )); // cannot be higher than the hard upper limit
-            m_ai_blue_spinner->setMax(std::min( (m_blue == m_blue_lower ? m_blue_upper_hard : m_blue_upper + 1), m_blue_upper_hard )); // cannot be higher than the hard upper limit
-            m_ai_kart_spinner->setMin(m_red_lower);
-            m_ai_blue_spinner->setMin(m_blue_lower);
-            m_ai_kart_spinner->setValue(m_red);
-            m_ai_blue_spinner->setValue(m_blue);
+            m_ai_kart_spinner->setMax(std::min( (num_red == num_red_lower ?  num_red_upper_hard : num_red_upper + 1), num_red_upper_hard )); // cannot be higher than the hard upper limit
+            m_ai_blue_spinner->setMax(std::min( (num_blue == num_blue_lower ? num_blue_upper_hard : num_blue_upper + 1), num_blue_upper_hard )); // cannot be higher than the hard upper limit
+            m_ai_kart_spinner->setMin(num_red_lower);
+            m_ai_blue_spinner->setMin(num_blue_lower);
+            m_ai_kart_spinner->setValue(num_red);
+            m_ai_blue_spinner->setValue(num_blue);
 
-            UserConfigParams::m_soccer_red_ai_num  = m_red;
-            UserConfigParams::m_soccer_blue_ai_num = m_blue;
+            UserConfigParams::m_soccer_red_ai_num  = num_red;
+            UserConfigParams::m_soccer_blue_ai_num = num_blue;
 
-            UserConfigParams::m_num_karts_per_gamemode[race_manager->getMinorMode()] = race_manager->getNumLocalPlayers() +  m_red + m_blue;
+            UserConfigParams::m_num_karts_per_gamemode[race_manager->getMinorMode()] = race_manager->getNumLocalPlayers() +  num_red + num_blue;
             //updateHighScores();
         }
         else // Other modes
@@ -737,36 +737,36 @@ void TrackInfoScreen::eventCallback(Widget* widget, const std::string& name,
             const int max_arena_players = m_track->getMaxArenaPlayers();
             const int local_players = race_manager->getNumLocalPlayers();
             const int num_ai = max_arena_players - local_players; // possible AI number
-            int m_red  = m_ai_kart_spinner->getValue();
-            int m_blue = m_ai_blue_spinner->getValue();
+            int num_red  = m_ai_kart_spinner->getValue();
+            int num_blue = m_ai_blue_spinner->getValue();
 
             getRedBluePlayerNumber();
 
-            int m_blue_lower = (m_blue_players > 0) ? 0 : 1;
-            int m_red_lower = (m_red_players > 0) ? 0 : 1;
-            int m_blue_upper      = num_ai - m_red;       // upper bound determined by the new m_red
-            int m_blue_upper_hard = num_ai - m_red_lower; // possible upper bound
-            int m_red_upper       = num_ai - m_blue;      // upper bound determined by the new m_blue
-            int m_red_upper_hard  = num_ai - m_blue_lower;// possible upper bound
+            int num_blue_lower = (m_blue_players > 0) ? 0 : 1;
+            int num_red_lower = (m_red_players > 0) ? 0 : 1;
+            int num_blue_upper      = num_ai - num_red;       // upper bound determined by the new num_red
+            int num_blue_upper_hard = num_ai - num_red_lower; // possible upper bound
+            int num_red_upper       = num_ai - num_blue;      // upper bound determined by the new num_blue
+            int num_red_upper_hard  = num_ai - num_blue_lower;// possible upper bound
 
             // Check if need to change red in response to the blue change
-            if (m_red > m_red_upper)
+            if (num_red > num_red_upper)
             {
-                m_red = m_red_upper; // change red
-                m_blue_upper = num_ai - m_red; // recalculate the upper bound determined by the new m_red
+                num_red = num_red_upper; // change red
+                num_blue_upper = num_ai - num_red; // recalculate the upper bound determined by the new num_red
             }
 
-            m_ai_kart_spinner->setMax(std::min( (m_red == m_red_lower ? m_red_upper_hard : m_red_upper + 1), m_red_upper_hard )); // cannot be higher than the hard upper limit
-            m_ai_blue_spinner->setMax(std::min( (m_blue == m_blue_lower ? m_blue_upper_hard : m_blue_upper + 1), m_blue_upper_hard )); // cannot be higher than the hard upper limit
-            m_ai_kart_spinner->setMin(m_red_lower);
-            m_ai_blue_spinner->setMin(m_blue_lower);
-            m_ai_kart_spinner->setValue(m_red);
-            m_ai_blue_spinner->setValue(m_blue);
+            m_ai_kart_spinner->setMax(std::min( (num_red == num_red_lower ? num_red_upper_hard : num_red_upper + 1), num_red_upper_hard )); // cannot be higher than the hard upper limit
+            m_ai_blue_spinner->setMax(std::min( (num_blue == num_blue_lower ? num_blue_upper_hard : num_blue_upper + 1), num_blue_upper_hard )); // cannot be higher than the hard upper limit
+            m_ai_kart_spinner->setMin(num_red_lower);
+            m_ai_blue_spinner->setMin(num_blue_lower);
+            m_ai_kart_spinner->setValue(num_red);
+            m_ai_blue_spinner->setValue(num_blue);
 
-            UserConfigParams::m_soccer_red_ai_num  = m_red;
-            UserConfigParams::m_soccer_blue_ai_num = m_blue;
+            UserConfigParams::m_soccer_red_ai_num  = num_red;
+            UserConfigParams::m_soccer_blue_ai_num = num_blue;
 
-            UserConfigParams::m_num_karts_per_gamemode[race_manager->getMinorMode()] = race_manager->getNumLocalPlayers() + m_red + m_blue;
+            UserConfigParams::m_num_karts_per_gamemode[race_manager->getMinorMode()] = race_manager->getNumLocalPlayers() + num_red + num_blue;
             //updateHighScores();
         }
     }

--- a/src/states_screens/track_info_screen.cpp
+++ b/src/states_screens/track_info_screen.cpp
@@ -358,8 +358,8 @@ void TrackInfoScreen::init()
 
 	    m_ai_kart_spinner->setMin(m_red_lower);
 	    m_ai_blue_spinner->setMin(m_blue_lower);
-	    m_ai_kart_spinner->setMax(std::min( UserConfigParams::m_soccer_red_ai_num+1, m_red_upper_hard )); // +1 to allow adding AI
-	    m_ai_blue_spinner->setMax(std::min( UserConfigParams::m_soccer_blue_ai_num+1, m_blue_upper_hard )); // +1 to allow adding AI
+	    m_ai_kart_spinner->setMax(std::min( m_red_ai + (m_red_ai == m_red_lower ? 0 : 1), m_red_upper_hard )); // +1 to allow adding AI
+	    m_ai_blue_spinner->setMax(std::min( m_blue_ai + (m_blue_ai == m_blue_lower ? 0 : 1), m_blue_upper_hard )); // +1 to allow adding AI
 
 	    // Set the values
 	    m_ai_kart_spinner->setValue(UserConfigParams::m_soccer_red_ai_num);
@@ -782,8 +782,8 @@ void TrackInfoScreen::eventCallback(Widget* widget, const std::string& name,
                 m_blue_upper = num_ai - m_red; // recalculate the upper bound determined by the new m_red
             }
 
-            m_ai_kart_spinner->setMax(std::min( m_red_upper+1, m_red_upper_hard )); // cannot be higher than the hard upper limit
-            m_ai_blue_spinner->setMax(std::min( m_blue_upper+1, m_blue_upper_hard )); // cannot be higher than the hard upper limit
+            m_ai_kart_spinner->setMax(std::min( m_red_upper + (m_red == m_red_lower ? 0 : 1), m_red_upper_hard )); // cannot be higher than the hard upper limit
+            m_ai_blue_spinner->setMax(std::min( m_blue_upper + (m_blue == m_blue_lower ? 0 : 1), m_blue_upper_hard )); // cannot be higher than the hard upper limit
 	    m_ai_kart_spinner->setMin(m_red_lower);
 	    m_ai_blue_spinner->setMin(m_blue_lower);
             m_ai_kart_spinner->setValue(m_red);
@@ -870,8 +870,8 @@ void TrackInfoScreen::eventCallback(Widget* widget, const std::string& name,
                 m_red_upper = num_ai - m_blue; // recalculate the upper bound determined by the new m_blue
             }
 
-            m_ai_blue_spinner->setMax(std::min( m_blue_upper+1, m_blue_upper_hard )); // cannot be higher than the hard upper limit
-            m_ai_kart_spinner->setMax(std::min( m_red_upper+1, m_red_upper_hard )); // cannot be higher than the hard upper limit
+            m_ai_kart_spinner->setMax(std::min( m_red_upper + (m_red == m_red_lower ? 0 : 1), m_red_upper_hard )); // cannot be higher than the hard upper limit
+            m_ai_blue_spinner->setMax(std::min( m_blue_upper + (m_blue == m_blue_lower ? 0 : 1), m_blue_upper_hard )); // cannot be higher than the hard upper limit
 	    m_ai_kart_spinner->setMin(m_red_lower);
 	    m_ai_blue_spinner->setMin(m_blue_lower);
             m_ai_kart_spinner->setValue(m_red);

--- a/src/states_screens/track_info_screen.cpp
+++ b/src/states_screens/track_info_screen.cpp
@@ -105,6 +105,9 @@ void TrackInfoScreen::loadedFromFile()
 
     m_is_soccer = false;
     m_show_ffa_spinner = false;
+
+    m_red_players = 0;
+    m_blue_players = 0;
 }   // loadedFromFile
 
 
@@ -277,24 +280,9 @@ void TrackInfoScreen::init()
             int num_ai = max_arena_players - local_players; // For soccer, use all possible AI by default
 
             // Balanced distribution by default
-            int red_players = 0;
-            int blue_players = 0;
-            for (int i = 0; i < local_players; i++)
-            {
-                KartTeam team = race_manager->getKartInfo(i).getKartTeam();
+	    getRedBluePlayerNumber();
 
-                // Happen in profiling mode
-                if (team == KART_TEAM_NONE)
-                {
-                    race_manager->setKartTeam(i, KART_TEAM_BLUE);
-                    team = KART_TEAM_BLUE;
-                    continue; //FIXME, this is illogical
-                }
-
-                team == KART_TEAM_BLUE ? blue_players++ : red_players++;
-            }
-
-            int additional_blue = red_players - blue_players;
+            int additional_blue = m_red_players - m_blue_players;
             int m_blue_ai = (num_ai - additional_blue) / 2 + additional_blue;
             int m_red_ai  = (num_ai - additional_blue) / 2;
 
@@ -304,8 +292,8 @@ void TrackInfoScreen::init()
             UserConfigParams::m_soccer_red_ai_num  = m_red_ai;
             UserConfigParams::m_soccer_blue_ai_num = m_blue_ai;
 
-            int m_blue_lower = (blue_players > 0) ? 0 : 1;
-            int m_red_lower = (red_players > 0) ? 0 : 1;
+            int m_blue_lower = (m_blue_players > 0) ? 0 : 1;
+            int m_red_lower = (m_red_players > 0) ? 0 : 1;
             int m_blue_upper_hard = max_arena_players - local_players - m_red_lower; // possible upper bound
             int m_red_upper_hard  = max_arena_players - local_players - m_blue_lower;// possible upper bound
 
@@ -706,25 +694,10 @@ void TrackInfoScreen::eventCallback(Widget* widget, const std::string& name,
             int m_red  = m_ai_kart_spinner->getValue();
             int m_blue = m_ai_blue_spinner->getValue();
 
-            int red_players = 0;
-            int blue_players = 0;
-            for (int i = 0; i < local_players; i++)
-            {
-                KartTeam team = race_manager->getKartInfo(i).getKartTeam();
+	    getRedBluePlayerNumber();
 
-                // Happen in profiling mode
-                if (team == KART_TEAM_NONE)
-                {
-                    race_manager->setKartTeam(i, KART_TEAM_BLUE);
-                    team = KART_TEAM_BLUE;
-                    continue; //FIXME, this is illogical
-                }
-
-                team == KART_TEAM_BLUE ? blue_players++ : red_players++;
-            }
-
-            int m_blue_lower = (blue_players > 0) ? 0 : 1;
-            int m_red_lower = (red_players > 0) ? 0 : 1;
+            int m_blue_lower = (m_blue_players > 0) ? 0 : 1;
+            int m_red_lower = (m_red_players > 0) ? 0 : 1;
             int m_blue_upper      = num_ai - m_red;       // upper bound determined by the new m_red
             int m_blue_upper_hard = num_ai - m_red_lower; // possible upper bound
             int m_red_upper       = num_ai - m_blue;      // upper bound determined by the new m_blue
@@ -767,25 +740,10 @@ void TrackInfoScreen::eventCallback(Widget* widget, const std::string& name,
             int m_red  = m_ai_kart_spinner->getValue();
             int m_blue = m_ai_blue_spinner->getValue();
 
-            int red_players = 0;
-            int blue_players = 0;
-            for (int i = 0; i < local_players; i++)
-            {
-                KartTeam team = race_manager->getKartInfo(i).getKartTeam();
+	    getRedBluePlayerNumber();
 
-                // Happen in profiling mode
-                if (team == KART_TEAM_NONE)
-                {
-                    race_manager->setKartTeam(i, KART_TEAM_BLUE);
-                    team = KART_TEAM_BLUE;
-                    continue; //FIXME, this is illogical
-                }
-
-                team == KART_TEAM_BLUE ? blue_players++ : red_players++;
-            }
-
-            int m_blue_lower = (blue_players > 0) ? 0 : 1;
-            int m_red_lower = (red_players > 0) ? 0 : 1;
+            int m_blue_lower = (m_blue_players > 0) ? 0 : 1;
+            int m_red_lower = (m_red_players > 0) ? 0 : 1;
             int m_blue_upper      = num_ai - m_red;       // upper bound determined by the new m_red
             int m_blue_upper_hard = num_ai - m_red_lower; // possible upper bound
             int m_red_upper       = num_ai - m_blue;      // upper bound determined by the new m_blue
@@ -813,6 +771,30 @@ void TrackInfoScreen::eventCallback(Widget* widget, const std::string& name,
         }
     }
 }   // eventCallback
+
+// ----------------------------------------------------------------------------
+void TrackInfoScreen::getRedBluePlayerNumber()
+{
+    const int local_players = race_manager->getNumLocalPlayers();
+    int red_players = 0;
+    int blue_players = 0;
+    for (int i = 0; i < local_players; i++)
+    {
+	KartTeam team = race_manager->getKartInfo(i).getKartTeam();
+
+	// Happen in profiling mode
+	if (team == KART_TEAM_NONE)
+	{
+	    race_manager->setKartTeam(i, KART_TEAM_BLUE);
+	    team = KART_TEAM_BLUE;
+	    continue; //FIXME, this is illogical
+	}
+
+	team == KART_TEAM_BLUE ? blue_players++ : red_players++;
+    }
+    m_red_players = red_players;
+    m_blue_players = blue_players;
+} // getRedBluePlayerNumber
 
 // ----------------------------------------------------------------------------
 

--- a/src/states_screens/track_info_screen.cpp
+++ b/src/states_screens/track_info_screen.cpp
@@ -68,6 +68,7 @@ void TrackInfoScreen::loadedFromFile()
     m_target_type_label     = getWidget <LabelWidget>("target-type-text");
     m_ai_blue_spinner       = getWidget<SpinnerWidget>("ai-blue-spinner");
     m_ai_blue_label         = getWidget <LabelWidget>("ai-blue-text");
+    m_ai_blue_div           = getWidget<Widget>("ai-blue-div");
     m_target_type_div       = getWidget<Widget>("target-type-div");
     m_target_value_spinner  = getWidget<SpinnerWidget>("target-value-spinner");
     m_target_value_label    = getWidget<LabelWidget>("target-value-text");
@@ -118,6 +119,9 @@ void TrackInfoScreen::beforeAddingWidget()
         m_target_type_div->setCollapsed(false, this);
     else
         m_target_type_div->setCollapsed(true, this);
+
+    if (race_manager->getMinorMode() != RaceManager::MINOR_MODE_SOCCER) // if not soccer, hide 'Number of blue team AI karts'
+        m_ai_blue_div->setCollapsed(true, this);  // not show the 'blue team AI' if not soccer
 } // beforeAddingWidget
 
 // ----------------------------------------------------------------------------

--- a/src/states_screens/track_info_screen.cpp
+++ b/src/states_screens/track_info_screen.cpp
@@ -278,26 +278,33 @@ void TrackInfoScreen::init()
 
             const int max_arena_players = m_track->getMaxArenaPlayers();
             const int local_players = race_manager->getNumLocalPlayers();
+            const int num_ai = max_arena_players - local_players; // possible AI number
 
-            int num_ai = max_arena_players - local_players; // For soccer, use all possible AI by default
-
-            // Balanced distribution by default
             getRedBluePlayerNumber();
-
-            int additional_blue = m_red_players - m_blue_players;
-            int num_blue_ai = (num_ai - additional_blue) / 2 + additional_blue;
-            int num_red_ai  = (num_ai - additional_blue) / 2;
-
-            if ((num_ai + additional_blue)%2 == 1)
-                (additional_blue < 0) ? num_red_ai++ : num_blue_ai++;
-
-            UserConfigParams::m_soccer_red_ai_num  = num_red_ai;
-            UserConfigParams::m_soccer_blue_ai_num = num_blue_ai;
 
             int num_blue_lower = (m_blue_players > 0) ? 0 : 1;
             int num_red_lower = (m_red_players > 0) ? 0 : 1;
             int num_blue_upper_hard = max_arena_players - local_players - num_red_lower; // possible upper bound
             int num_red_upper_hard  = max_arena_players - local_players - num_blue_lower;// possible upper bound
+
+            int num_red_ai  = UserConfigParams::m_soccer_red_ai_num;
+            int num_blue_ai = UserConfigParams::m_soccer_blue_ai_num;
+
+            // Try the saved value, recalculate AI number (Balanced) if cannot use the saved values
+            if (!((num_red_ai  >= num_red_lower)  && (num_red_ai  <= num_red_upper_hard)  &&
+                  (num_blue_ai >= num_blue_lower) && (num_blue_ai <= num_blue_upper_hard) &&
+                  (num_red_ai + num_blue_ai <= num_ai)))
+            {
+                int additional_blue = m_red_players - m_blue_players;
+                num_blue_ai = (num_ai - additional_blue) / 2 + additional_blue;
+                num_red_ai  = (num_ai - additional_blue) / 2;
+
+                if ((num_ai + additional_blue)%2 == 1)
+                    (additional_blue < 0) ? num_red_ai++ : num_blue_ai++;
+
+                UserConfigParams::m_soccer_red_ai_num  = num_red_ai;
+                UserConfigParams::m_soccer_blue_ai_num = num_blue_ai;
+            }
 
             m_ai_kart_spinner->setMin(num_red_lower);
             m_ai_blue_spinner->setMin(num_blue_lower);

--- a/src/states_screens/track_info_screen.cpp
+++ b/src/states_screens/track_info_screen.cpp
@@ -733,8 +733,8 @@ void TrackInfoScreen::eventCallback(Widget* widget, const std::string& name,
                 m_red_upper = num_ai - m_blue; // recalculate the upper bound determined by the new m_blue
             }
 
-            m_ai_kart_spinner->setMax(std::min( m_red_upper + (m_red == m_red_lower ? 0 : 1), m_red_upper_hard )); // cannot be higher than the hard upper limit
-            m_ai_blue_spinner->setMax(std::min( m_blue_upper + (m_blue == m_blue_lower ? 0 : 1), m_blue_upper_hard )); // cannot be higher than the hard upper limit
+            m_ai_kart_spinner->setMax(std::min( (m_red == m_red_lower ?  m_red_upper_hard : m_red_upper + 1), m_red_upper_hard )); // cannot be higher than the hard upper limit
+            m_ai_blue_spinner->setMax(std::min( (m_blue == m_blue_lower ? m_blue_upper_hard : m_blue_upper + 1), m_blue_upper_hard )); // cannot be higher than the hard upper limit
             m_ai_kart_spinner->setMin(m_red_lower);
             m_ai_blue_spinner->setMin(m_blue_lower);
             m_ai_kart_spinner->setValue(m_red);
@@ -794,8 +794,8 @@ void TrackInfoScreen::eventCallback(Widget* widget, const std::string& name,
                 m_blue_upper = num_ai - m_red; // recalculate the upper bound determined by the new m_red
             }
 
-            m_ai_kart_spinner->setMax(std::min( m_red_upper + (m_red == m_red_lower ? 0 : 1), m_red_upper_hard )); // cannot be higher than the hard upper limit
-            m_ai_blue_spinner->setMax(std::min( m_blue_upper + (m_blue == m_blue_lower ? 0 : 1), m_blue_upper_hard )); // cannot be higher than the hard upper limit
+            m_ai_kart_spinner->setMax(std::min( (m_red == m_red_lower ? m_red_upper_hard : m_red_upper + 1), m_red_upper_hard )); // cannot be higher than the hard upper limit
+            m_ai_blue_spinner->setMax(std::min( (m_blue == m_blue_lower ? m_blue_upper_hard : m_blue_upper + 1), m_blue_upper_hard )); // cannot be higher than the hard upper limit
             m_ai_kart_spinner->setMin(m_red_lower);
             m_ai_blue_spinner->setMin(m_blue_lower);
             m_ai_kart_spinner->setValue(m_red);

--- a/src/states_screens/track_info_screen.cpp
+++ b/src/states_screens/track_info_screen.cpp
@@ -726,8 +726,8 @@ void TrackInfoScreen::eventCallback(Widget* widget, const std::string& name,
 
                 m_ai_kart_spinner->setMin(m_red_lower);
                 m_ai_blue_spinner->setMin(m_blue_lower);
-                m_ai_kart_spinner->setMax(std::min( UserConfigParams::m_soccer_red_ai_num+1, m_red_upper_hard )); // +1 to allow adding AI
-                m_ai_blue_spinner->setMax(std::min( UserConfigParams::m_soccer_blue_ai_num+1, m_blue_upper_hard )); // +1 to allow adding AI
+                m_ai_kart_spinner->setMax(std::min( UserConfigParams::m_soccer_red_ai_num + (UserConfigParams::m_soccer_red_ai_num == m_red_lower ? 0 : 1), m_red_upper_hard )); // +1 to allow adding AI
+                m_ai_blue_spinner->setMax(std::min( UserConfigParams::m_soccer_blue_ai_num + (UserConfigParams::m_soccer_blue_ai_num == m_blue_lower ? 0 : 1), m_blue_upper_hard )); // +1 to allow adding AI
 
                 // Set the values
                 m_ai_kart_spinner->setValue(UserConfigParams::m_soccer_red_ai_num);

--- a/src/states_screens/track_info_screen.cpp
+++ b/src/states_screens/track_info_screen.cpp
@@ -280,7 +280,7 @@ void TrackInfoScreen::init()
             int num_ai = max_arena_players - local_players; // For soccer, use all possible AI by default
 
             // Balanced distribution by default
-	    getRedBluePlayerNumber();
+            getRedBluePlayerNumber();
 
             int additional_blue = m_red_players - m_blue_players;
             int m_blue_ai = (num_ai - additional_blue) / 2 + additional_blue;
@@ -694,7 +694,7 @@ void TrackInfoScreen::eventCallback(Widget* widget, const std::string& name,
             int m_red  = m_ai_kart_spinner->getValue();
             int m_blue = m_ai_blue_spinner->getValue();
 
-	    getRedBluePlayerNumber();
+            getRedBluePlayerNumber();
 
             int m_blue_lower = (m_blue_players > 0) ? 0 : 1;
             int m_red_lower = (m_red_players > 0) ? 0 : 1;
@@ -740,7 +740,7 @@ void TrackInfoScreen::eventCallback(Widget* widget, const std::string& name,
             int m_red  = m_ai_kart_spinner->getValue();
             int m_blue = m_ai_blue_spinner->getValue();
 
-	    getRedBluePlayerNumber();
+            getRedBluePlayerNumber();
 
             int m_blue_lower = (m_blue_players > 0) ? 0 : 1;
             int m_red_lower = (m_red_players > 0) ? 0 : 1;
@@ -780,17 +780,17 @@ void TrackInfoScreen::getRedBluePlayerNumber()
     int blue_players = 0;
     for (int i = 0; i < local_players; i++)
     {
-	KartTeam team = race_manager->getKartInfo(i).getKartTeam();
+        KartTeam team = race_manager->getKartInfo(i).getKartTeam();
 
-	// Happen in profiling mode
-	if (team == KART_TEAM_NONE)
-	{
-	    race_manager->setKartTeam(i, KART_TEAM_BLUE);
-	    team = KART_TEAM_BLUE;
-	    continue; //FIXME, this is illogical
-	}
+        // Happen in profiling mode
+        if (team == KART_TEAM_NONE)
+        {
+            race_manager->setKartTeam(i, KART_TEAM_BLUE);
+            team = KART_TEAM_BLUE;
+            continue; //FIXME, this is illogical
+        }
 
-	team == KART_TEAM_BLUE ? blue_players++ : red_players++;
+        team == KART_TEAM_BLUE ? blue_players++ : red_players++;
     }
     m_red_players = red_players;
     m_blue_players = blue_players;

--- a/src/states_screens/track_info_screen.cpp
+++ b/src/states_screens/track_info_screen.cpp
@@ -123,8 +123,10 @@ void TrackInfoScreen::beforeAddingWidget()
     else
         m_target_type_div->setCollapsed(true, this);
 
-    if (race_manager->getMinorMode() != RaceManager::MINOR_MODE_SOCCER) // if not soccer, hide 'Number of blue team AI karts'
-        m_ai_blue_div->setCollapsed(true, this);  // not show the 'blue team AI' if not soccer
+    if (race_manager->getMinorMode() == RaceManager::MINOR_MODE_SOCCER) // show 'Number of blue team AI karts' if soccer
+        m_ai_blue_div->setCollapsed(false, this);
+    else
+        m_ai_blue_div->setCollapsed(true, this);
 } // beforeAddingWidget
 
 // ----------------------------------------------------------------------------

--- a/src/states_screens/track_info_screen.hpp
+++ b/src/states_screens/track_info_screen.hpp
@@ -66,6 +66,9 @@ class TrackInfoScreen : public GUIEngine::Screen,
     /** The label besides the blue AI karts spinner. */
     GUIEngine::LabelWidget* m_ai_blue_label;
 
+    /* The div that contains the blue ai spinner and label */
+    GUIEngine::Widget* m_ai_blue_div;
+
     /* The div that contains the target type spinner and label */
     GUIEngine::Widget* m_target_type_div;
 

--- a/src/states_screens/track_info_screen.hpp
+++ b/src/states_screens/track_info_screen.hpp
@@ -60,6 +60,18 @@ class TrackInfoScreen : public GUIEngine::Screen,
     /** The label besides the target types spinner. */
     GUIEngine::LabelWidget* m_target_type_label;
 
+    /** Spinner for AI team mix types. */
+    GUIEngine::SpinnerWidget* m_ai_mix_type_spinner;
+
+    /** The label besides the AI team mix spinner. */
+    GUIEngine::LabelWidget* m_ai_mix_type_label;
+
+    /** Spinner for number of blue AI karts. */
+    GUIEngine::SpinnerWidget* m_ai_blue_spinner;
+
+    /** The label besides the blue AI karts spinner. */
+    GUIEngine::LabelWidget* m_ai_blue_label;
+
     /* The div that contains the target type spinner and label */
     GUIEngine::Widget* m_target_type_div;
 

--- a/src/states_screens/track_info_screen.hpp
+++ b/src/states_screens/track_info_screen.hpp
@@ -60,12 +60,6 @@ class TrackInfoScreen : public GUIEngine::Screen,
     /** The label besides the target types spinner. */
     GUIEngine::LabelWidget* m_target_type_label;
 
-    /** Spinner for AI team mix types. */
-    GUIEngine::SpinnerWidget* m_ai_mix_type_spinner;
-
-    /** The label besides the AI team mix spinner. */
-    GUIEngine::LabelWidget* m_ai_mix_type_label;
-
     /** Spinner for number of blue AI karts. */
     GUIEngine::SpinnerWidget* m_ai_blue_spinner;
 

--- a/src/states_screens/track_info_screen.hpp
+++ b/src/states_screens/track_info_screen.hpp
@@ -100,7 +100,13 @@ class TrackInfoScreen : public GUIEngine::Screen,
     
     int m_icon_unknown_kart;
 
+    /* The number of red and blue players */
+    int m_red_players;
+    int m_blue_players;
+
     void updateHighScores();
+
+    void getRedBluePlayerNumber();
 
 public:
     TrackInfoScreen();


### PR DESCRIPTION
Hi, 
This is an improved version compared to the previous PR (#4061). Now we can set the number of Red/Blue AI separately. It also works for split-screen. Having 8 split-screen will disable the spinners related to the AI. If increasing the number of red AI to num_red_ai+num_blue_ai>max_ai, the blue AI number will decrease by 1 automatically. The upper bound of each spinner is also taken care of.

I still added the spinner with two options: Balanced and Custom. This simplifies the implementation.

The spinner does not scale properly on low resolutions. I believe it can be solved with maosen's code.

The code may need to be cleaned a bit.

<img width="1712" alt="Screen Shot 2019-09-17 at 4 56 40 PM" src="https://user-images.githubusercontent.com/4726939/65082871-a20d8080-d96c-11e9-8c8c-1e1ce115e40e.png">

<img width="1712" alt="Screen Shot 2019-09-17 at 5 02 08 PM" src="https://user-images.githubusercontent.com/4726939/65082973-e9940c80-d96c-11e9-97db-3883e9609628.png">

## Agreement
```
By creating a pull request in stk-code, you hearby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
