### PR TITLE
Fix for #3444

### DIFF
--- a/src/states_screens/dialogs/press_a_key_dialog.cpp
+++ b/src/states_screens/dialogs/press_a_key_dialog.cpp
@@ -28,10 +28,15 @@ using namespace irr::gui;
 
 // ------------------------------------------------------------------------------------------------------
 
-PressAKeyDialog::PressAKeyDialog(const float w, const float h) :
+PressAKeyDialog::PressAKeyDialog(const float w, const float h, const bool isKeyboardFlag) :
         ModalDialog(w, h)
 {
     loadFromFile("press_a_key_dialog.stkgui");
+    if(isKeyboardFlag)
+    {
+        Widget* title = getWidget("title");
+        title->setText("Press any key...");
+    }
 }
 
 // ------------------------------------------------------------------------------------------------------

--- a/src/states_screens/dialogs/press_a_key_dialog.hpp
+++ b/src/states_screens/dialogs/press_a_key_dialog.hpp
@@ -31,7 +31,7 @@ public:
     /**
      * Creates a modal dialog with given percentage of screen width and height
      */
-    PressAKeyDialog(const float percentWidth, const float percentHeight);
+    PressAKeyDialog(const float percentWidth, const float percentHeight, const bool isKeyboardFlag);
     GUIEngine::EventPropagation processEvent(const std::string& eventSource);
 };
 

--- a/src/states_screens/options/options_screen_device.cpp
+++ b/src/states_screens/options/options_screen_device.cpp
@@ -588,7 +588,7 @@ void OptionsScreenDevice::eventCallback(Widget* widget,
 
                 binding_to_set = (PlayerAction)n;
 
-                new PressAKeyDialog(0.5f, 0.4f);
+                new PressAKeyDialog(0.5f, 0.4f, m_config->isKeyboard());
 
                 if (m_config->isKeyboard())
                 {


### PR DESCRIPTION
* Added a check for the keyboard input device and changed the text of the "title" widget using **Widget->setText("id")** method
* Have hard coded the string **"Press any key..."** in **src/states_screens/dialogs/press_a_key_dialog.cpp** 

****
## Agreement
```
By creating a pull request in stk-code, you hearby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
