### PR TITLE
Rescale the time font if icon is small (solve issue #4089)

### DIFF
--- a/src/states_screens/race_gui_base.cpp
+++ b/src/states_screens/race_gui_base.cpp
@@ -889,7 +889,7 @@ void RaceGUIBase::drawGlobalPlayerIcons(int bottom_margin)
 
 	// If player number is large (small icon), rescale font size
 	int font_height = font->getDimension(L"X").Height;
-	if ((float)ICON_PLAYER_WIDTH*0.7f <= (float)font_height)
+	if ((float)ICON_PLAYER_WIDTH*0.7f < (float)font_height)
 	    font->setScale(0.7f*(float)ICON_PLAYER_WIDTH / (float)font_height);
 
         if (info.m_text.size() > 0)

--- a/src/states_screens/race_gui_base.cpp
+++ b/src/states_screens/race_gui_base.cpp
@@ -887,6 +887,11 @@ void RaceGUIBase::drawGlobalPlayerIcons(int bottom_margin)
             break;
         }
 
+	// If player number is large (small icon), rescale font size
+	int font_height = font->getDimension(L"X").Height;
+	if ((float)ICON_PLAYER_WIDTH*0.7f <= (float)font_height)
+	    font->setScale(0.7f*(float)ICON_PLAYER_WIDTH / (float)font_height);
+
         if (info.m_text.size() > 0)
         {
             core::dimension2du dim = font->getDimension(info.m_text.c_str());
@@ -924,6 +929,7 @@ void RaceGUIBase::drawGlobalPlayerIcons(int bottom_margin)
             font->setThinBorder(false);
             font->setBlackBorder(false);
         }
+	font->setScale(1.0f);
 
 
         AbstractKart* target_kart = NULL;


### PR DESCRIPTION
In addressing issue #4089, I make the font smaller based on the icon size, see below:
<img width="1392" alt="Screen Shot 2019-10-10 at 9 28 18 PM" src="https://user-images.githubusercontent.com/4726939/66620373-d6f4a800-eba5-11e9-86ef-67bd18cb1f3a.png">


## Agreement
```
By creating a pull request in stk-code, you hearby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
