### PR TITLE
Show total karts in speedometer

### DIFF
--- a/data/gui/screens/options_ui.stkgui
+++ b/data/gui/screens/options_ui.stkgui
@@ -92,6 +92,9 @@
                     <checkbox id="speedometer_total_kart_gui"/>
                     <spacer width="1%" height="100%" />
                     <label height="100%" I18N="In the ui settings" text="Show total number of karts in speedometer" word_wrap="true"/>
+                </div>
+                    
+                <spacer width="5" height="2%"/>
 
                 <div layout="horizontal-row" width="100%" height="fit">
                     <checkbox id="story-mode-timer"/>

--- a/data/gui/screens/options_ui.stkgui
+++ b/data/gui/screens/options_ui.stkgui
@@ -87,6 +87,14 @@
                 </div>
 
                 <spacer width="5" height="2%"/>
+                
+                <div layout="horizontal-row" width="100%" height="fit">
+                    <checkbox id="speedometer_total_kart_gui"/>
+                    <spacer width="1%" height="100%" />
+                    <label height="100%" I18N="In the ui settings" text="Show total number of karts in speedometer" word_wrap="true"/>
+                </div>
+
+                <spacer width="5" height="2%"/>
             </box>
         </div>
     </div>

--- a/src/config/user_config.hpp
+++ b/src/config/user_config.hpp
@@ -458,6 +458,9 @@ namespace UserConfigParams
     PARAM_PREFIX BoolUserConfigParam          m_karts_powerup_gui
             PARAM_DEFAULT(  BoolUserConfigParam(false, "karts-powerup-gui",
             &m_race_setup_group, "Show other karts' held powerups in race gui.") );
+    PARAM_PREFIX BoolUserConfigParam          m_speedometer_total_kart_gui
+            PARAM_DEFAULT(  BoolUserConfigParam(false, "speedometer-total-kart-gui",
+            &m_race_setup_group, "Show total number of karts in speedometer in race gui.") );
 
     // ---- Wiimote data
     PARAM_PREFIX GroupUserConfigParam        m_wiimote_group

--- a/src/states_screens/options/options_screen_ui.cpp
+++ b/src/states_screens/options/options_screen_ui.cpp
@@ -234,6 +234,10 @@ void OptionsScreenUI::init()
     CheckBoxWidget* karts_powerup_gui = getWidget<CheckBoxWidget>("karts_powerup_gui");
     assert(karts_powerup_gui != NULL);
     karts_powerup_gui->setState(UserConfigParams::m_karts_powerup_gui);
+    
+    CheckBoxWidget* speedometer_total_kart_gui = getWidget<CheckBoxWidget>("speedometer_total_kart_gui");
+    assert(speedometer_total_kart_gui != NULL);
+    speedometer_total_kart_gui->setState(UserConfigParams::m_speedometer_total_kart_gui);
 
     //Forbid changing this setting in game
     splitscreen_method->setActive(!in_game);
@@ -396,6 +400,12 @@ void OptionsScreenUI::eventCallback(Widget* widget, const std::string& name, con
         CheckBoxWidget* karts_powerup_gui = getWidget<CheckBoxWidget>("karts_powerup_gui");
         assert(karts_powerup_gui != NULL);
         UserConfigParams::m_karts_powerup_gui = karts_powerup_gui->getState();
+    }
+    else if (name == "speedometer_total_kart_gui")
+    {
+        CheckBoxWidget* speedometer_total_kart_gui = getWidget<CheckBoxWidget>("speedometer_total_kart_gui");
+        assert(speedometer_total_kart_gui != NULL);
+        UserConfigParams::m_speedometer_total_kart_gui = speedometer_total_kart_gui->getState();
     }
     else if (name == "showfps")
     {

--- a/src/states_screens/race_gui.cpp
+++ b/src/states_screens/race_gui.cpp
@@ -882,23 +882,59 @@ void RaceGUI::drawRank(const AbstractKart *kart,
     }
 
     gui::ScalableFont* font = GUIEngine::getHighresDigitFont();
-    
     int font_height = font->getDimension(L"X").Height;
-    font->setScale((float)meter_height / font_height * 0.4f * scale);
     font->setShadow(video::SColor(255, 128, 0, 0));
-    std::ostringstream oss;
-    oss << rank; // the current font has no . :(   << ".";
+    
+    if(UserConfigParams::m_speedometer_total_kart_gui)
+    {
+        int num_karts = race_manager->getNumberOfKarts();
+        if(num_karts > 9)
+            scale *= 0.85f;
+        if(rank > 9)
+            scale *= 0.75f;
 
-    core::recti pos;
-    pos.LowerRightCorner = core::vector2di(int(offset.X + 0.64f*meter_width),
-                                           int(offset.Y - 0.49f*meter_height));
-    pos.UpperLeftCorner = core::vector2di(int(offset.X + 0.64f*meter_width),
-                                          int(offset.Y - 0.49f*meter_height));
+        font->setScale((float)meter_height / font_height * 0.4f * scale);
+        std::ostringstream oss;
+        oss << rank; // the current font has no . :(   << ".";
 
-    font->setBlackBorder(true);
-    font->draw(oss.str().c_str(), pos, color, true, true);
+        core::recti pos;
+        pos.LowerRightCorner = core::vector2di(int(offset.X + 0.53f*meter_width),
+                                               int(offset.Y - 0.49f*meter_height));
+        pos.UpperLeftCorner = core::vector2di(int(offset.X + 0.53f*meter_width),
+                                              int(offset.Y - 0.49f*meter_height));
+
+        font->setBlackBorder(true);
+        font->draw(oss.str().c_str(), pos, color, true, true);
+        font->setScale((float)meter_height / font_height * 0.2f * scale);
+        std::ostringstream oss2;
+        oss2 << "/" << num_karts; // the current font has no . :(   << ".";
+
+        core::recti num_karts_pos;
+        num_karts_pos.LowerRightCorner = core::vector2di(int(offset.X + 0.75f*meter_width),
+                                               int(offset.Y - 0.43f*meter_height));
+        num_karts_pos.UpperLeftCorner = core::vector2di(int(offset.X + 0.75f*meter_width),
+                                              int(offset.Y - 0.43f*meter_height));
+
+        font->draw(oss2.str().c_str(), num_karts_pos, color, true, true);
+    }
+    else
+    {
+        font->setScale((float)meter_height / font_height * 0.4f * scale);
+        std::ostringstream oss;
+        oss << rank; // the current font has no . :(   << ".";
+
+        core::recti pos;
+        pos.LowerRightCorner = core::vector2di(int(offset.X + 0.64f*meter_width),
+                                               int(offset.Y - 0.49f*meter_height));
+        pos.UpperLeftCorner = core::vector2di(int(offset.X + 0.64f*meter_width),
+                                              int(offset.Y - 0.49f*meter_height));
+
+        font->setBlackBorder(true);
+        font->draw(oss.str().c_str(), pos, color, true, true);
+    }
+
+    font->setScale(1.0f); // Reset scale
     font->setBlackBorder(false);
-    font->setScale(1.0f);
 }   // drawRank
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
![stk100](https://user-images.githubusercontent.com/35170687/67612025-9619a780-f7d1-11e9-8430-2f0ebcdea023.png)
![spedo2](https://user-images.githubusercontent.com/35170687/68526978-d07c5c00-031c-11ea-953c-f815c2071261.png)
![speedometer](https://user-images.githubusercontent.com/35170687/68526891-ad04e180-031b-11ea-9db0-64f819d414f9.png)
## Agreement
```
By creating a pull request in stk-code, you hearby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
Revamped from STK-helper/speedometer-show-total-rank
Allow showing the total kart number in speedometer. It can give the info clearly to users instead of counting those small icons in the left.
It's defaultly disabled.