### PR TITLE
Add a function to use UTF-32 emojis

### DIFF
--- a/src/utils/string_utils.hpp
+++ b/src/utils/string_utils.hpp
@@ -276,6 +276,34 @@ namespace StringUtils
     }   // getCountryFlag
 
     // ------------------------------------------------------------------------
+    /** Return string for UTF32 emoji. */
+    inline irr::core::stringw getUtf32Emoji(const uint32_t code)
+    {
+        uint32_t emoji[2] =
+        {
+            code,
+            0
+        };
+        if (sizeof(wchar_t) == 4)
+        {
+            return (wchar_t*)emoji;
+        }
+        else if (sizeof(wchar_t) == 2)
+        {
+            emoji[0] -= 0x10000;
+            wchar_t u16[3] =
+            {
+                //make a surrogate pair
+                static_cast<wchar_t>((emoji[0] >> 10) + 0xd800),
+                static_cast<wchar_t>((emoji[0] & 0x3ff) + 0xdc00),
+                0
+            };
+            return u16;
+        }
+        return L"";
+    }   // getUtf32Emoji
+
+    // ------------------------------------------------------------------------
     irr::core::stringw utf8ToWide(const char* input);
     irr::core::stringw utf8ToWide(const std::string &input);
     std::u32string utf8ToUtf32(const std::string &input);


### PR DESCRIPTION
Add a function to use UTF-32 emojis, e.g. getUtf32Emoji(0x1f947).
I used this function to add the medal emoji for players that finished a race. As that may not be of interest to many players, let me just push this function right now. It can be used in many other places.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
