### PR TITLE
use /listaddon in network lobby

### DIFF
--- a/src/network/protocols/client_lobby.cpp
+++ b/src/network/protocols/client_lobby.cpp
@@ -1543,17 +1543,19 @@ void ClientLobby::handleClientCommand(const std::string& cmd)
 	    const Addon & addon = addons_manager->getAddon(i);
 	    core::stringw name = core::stringw(addon.getName().c_str());
 	    core::stringw findstr = core::stringw(argv[1].c_str());
+	    core::stringw id = core::stringw(addon.getId().c_str());
+	    id.trim("addon_"); // remove addon_
 
 	    if(addon.getType()!="track") continue; // only show tracks
 
 	    if (argv.size() == 2 && name.make_lower().find(findstr.make_lower().c_str()) == -1) continue;// if not find it
 
 	    if (addon.isInstalled())
-		name += L" (y)";
+		id += L" (y)";
 	    else
-		name += L" (n)";
+		id += L" (n)";
 
-	    namelist += name;
+	    namelist += id;
 	    namelist += L", ";
 	}
 	printf("%ls\n",namelist.c_str());

--- a/src/network/protocols/client_lobby.cpp
+++ b/src/network/protocols/client_lobby.cpp
@@ -1537,8 +1537,8 @@ void ClientLobby::handleClientCommand(const std::string& cmd)
     else if (argv[0] == "listaddons" && argv.size() <= 2)
     {
 	// Usage: /listaddons or /listaddons string
-	core::stringw namelist;
-	for(unsigned int i=0; i<addons_manager->getNumAddons(); i++)
+        core::stringw namelist;
+        for(unsigned int i=0; i<addons_manager->getNumAddons(); i++)
 	{
 	    const Addon & addon = addons_manager->getAddon(i);
 	    core::stringw name = core::stringw(addon.getName().c_str());

--- a/src/network/protocols/client_lobby.cpp
+++ b/src/network/protocols/client_lobby.cpp
@@ -63,6 +63,7 @@
 #include "utils/log.hpp"
 #include "utils/string_utils.hpp"
 #include "utils/translation.hpp"
+#include "addons/addons_manager.hpp"
 
 #include <cstdlib>
 
@@ -1532,6 +1533,30 @@ void ClientLobby::handleClientCommand(const std::string& cmd)
         }
         else
             music_manager->setMasterMusicVolume((float)vol / 10);
+    }
+    else if (argv[0] == "listaddons" && argv.size() <= 2)
+    {
+	// Usage: /listaddons or /listaddons string
+	core::stringw namelist;
+	for(unsigned int i=0; i<addons_manager->getNumAddons(); i++)
+	{
+	    const Addon & addon = addons_manager->getAddon(i);
+	    core::stringw name = core::stringw(addon.getName().c_str());
+	    core::stringw findstr = core::stringw(argv[1].c_str());
+
+	    if(addon.getType()!="track") continue; // only show tracks
+
+	    if (argv.size() == 2 && name.make_lower().find(findstr.make_lower().c_str()) == -1) continue;// if not find it
+
+	    if (addon.isInstalled())
+		name += L" (y)";
+	    else
+		name += L" (n)";
+
+	    namelist += name;
+	    namelist += L", ";
+	}
+	printf("%ls\n",namelist.c_str());
     }
     else
     {


### PR DESCRIPTION
Hi, I add a function /listaddons in the network lobby to list all (local) addons' id (installed and non-installed). The player can further install addons with /installaddon id
/listaddons will list all addons
/listaddons str will list addons whose name matches str

For example: /listaddons island will give results:
kapman-island-resort (n), mystery-island_1 (n), mystic-isl (n), supertux-island-resort (n), the-isl (y), the-old-isl (n), volcan-isl (n), the-old-island_2 (y),
Here, (n) means this addon is not installed, (y) means this addon is installed.

Currently I output the result to the terminal. I am thinking to change it to the text box above the chat box. But I am not sure if it is a good idea (possible spam).

<img width="1392" alt="Screen Shot 2019-12-02 at 7 00 11 PM" src="https://user-images.githubusercontent.com/4726939/70012783-236fba80-153b-11ea-8f6e-6b4e59d7bdd4.png">


## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
