### PR TITLE
Use unsigned int with %x format string

### DIFF
--- a/src/utils/string_utils.cpp
+++ b/src/utils/string_utils.cpp
@@ -800,9 +800,9 @@ namespace StringUtils
                     }
                     else if (input[n] == ';')
                     {
-                        int c;
+                        unsigned int c;
 
-                        const char* format = (isHex ? "%x" : "%i");
+                        const char* format = (isHex ? "%x" : "%u");
                         if (sscanf(entity.c_str(), format, &c) == 1)
                         {
                             output += char32_t(c);


### PR DESCRIPTION
This is a small change to fix a Cppcheck warning.

```[utils\string_utils.cpp:806]: (warning) %x in format string (no. 1) requires 'unsigned int *' but the argument type is 'signed int *'.  ```
## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
