### PR TITLE
add message freguency limit in chat #3893

### DIFF
--- a/src/network/protocols/server_lobby.cpp
+++ b/src/network/protocols/server_lobby.cpp
@@ -698,6 +698,20 @@ void ServerLobby::handleChat(Event* event)
     // Update so that the peer is not kicked
     event->getPeer()->updateLastActivity();
     const bool sender_in_game = event->getPeer()->isWaitingForGame();
+
+    int last_message = event->getPeer()->getLastMessage();
+    int elipsed_time = StkTime::getMonoTimeMs() - last_message;
+
+    // Increment consecutive_messages if last message is less than 5s ago
+    if (elipsed_time < 5000)
+        event->getPeer()->updateConsecutiveMessages(true);
+    else
+        event->getPeer()->updateConsecutiveMessages(false);
+
+    // Ignore message if there is already 3 consecutive messages
+    if (event->getPeer()->getConsecutiveMessages() >= 3)
+        return;
+    
     core::stringw message;
     event->data().decodeString16(&message, 360/*max_len*/);
     if (message.size() > 0)
@@ -718,6 +732,7 @@ void ServerLobby::handleChat(Event* event)
                 }
                 return true;
             }, chat);
+            event->getPeer()->updateLastMessage();
         delete chat;
     }
 }   // handleChat

--- a/src/network/stk_peer.cpp
+++ b/src/network/stk_peer.cpp
@@ -52,6 +52,8 @@ STKPeer::STKPeer(ENetPeer *enet_peer, STKHost* host, uint32_t host_id)
     m_disconnected.store(false);
     m_warned_for_high_ping.store(false);
     m_last_activity.store((int64_t)StkTime::getMonoTimeMs());
+    m_last_message.store(0);
+    m_consecutive_messages = 0;
 }   // STKPeer
 
 //-----------------------------------------------------------------------------

--- a/src/network/stk_peer.hpp
+++ b/src/network/stk_peer.hpp
@@ -97,6 +97,10 @@ protected:
 
     std::atomic<int64_t> m_last_activity;
 
+    std::atomic<int64_t> m_last_message;
+
+    int m_consecutive_messages;
+
     /** Available karts and tracks from this peer */
     std::pair<std::set<std::string>, std::set<std::string> > m_available_kts;
 
@@ -273,6 +277,23 @@ public:
     // ------------------------------------------------------------------------
     void setAddonsScores(const std::array<int, AS_TOTAL>& scores)
                                                   { m_addons_scores = scores; }
+    // ------------------------------------------------------------------------
+    void updateLastMessage()
+                   { m_last_message.store((int64_t)StkTime::getMonoTimeMs()); }
+    // ------------------------------------------------------------------------
+    int getLastMessage()
+                                                     { return m_last_message; }
+    // ------------------------------------------------------------------------
+    void updateConsecutiveMessages(bool tooFast)
+    {
+        if (tooFast)
+            m_consecutive_messages++;
+        else
+            m_consecutive_messages = 0;
+    }
+    // ------------------------------------------------------------------------
+    int getConsecutiveMessages()
+                                             { return m_consecutive_messages; }
 };   // STKPeer
 
 #endif // STK_PEER_HPP


### PR DESCRIPTION
## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```

In chat, ensure that for a person writing more than 3 consecutive messages (less than 5s between 2 messages) prevents display an other message from him while the next 5 seconds.