### PR TITLE
Include linux/sysctl.h rather than sys/sysctl.h on non-glibc systems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,9 @@
 sudo: false
 language: cpp
 os:
-  - osx
+  - linux
 compiler:
+  - gcc
   - clang
 
 matrix:
@@ -15,6 +16,8 @@ matrix:
 
 env:
   matrix:
+    - BUILD_TYPE="Debug" SERVER_ONLY="OFF"
+    - BUILD_TYPE="Debug" SERVER_ONLY="ON"
     - BUILD_TYPE="Release" SERVER_ONLY="OFF"
     - BUILD_TYPE="Release" SERVER_ONLY="ON"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,8 @@
 sudo: false
 language: cpp
 os:
-  - linux
+  - osx
 compiler:
-  - gcc
   - clang
 
 matrix:
@@ -16,8 +15,6 @@ matrix:
 
 env:
   matrix:
-    - BUILD_TYPE="Debug" SERVER_ONLY="OFF"
-    - BUILD_TYPE="Debug" SERVER_ONLY="ON"
     - BUILD_TYPE="Release" SERVER_ONLY="OFF"
     - BUILD_TYPE="Release" SERVER_ONLY="ON"
 

--- a/lib/irrlicht/source/Irrlicht/COSOperator.cpp
+++ b/lib/irrlicht/source/Irrlicht/COSOperator.cpp
@@ -14,7 +14,7 @@
 #if !defined(_IRR_SOLARIS_PLATFORM_) && !defined(__CYGWIN__)
 #include <sys/param.h>
 #include <sys/types.h>
-#ifdef ANDROID
+#if defined(ANDROID) || (defined(__linux__) && !defined(__GLIBC__))
 #include <linux/sysctl.h>
 #else
 #include <sys/sysctl.h>

--- a/src/network/protocols/lobby_protocol.hpp
+++ b/src/network/protocols/lobby_protocol.hpp
@@ -32,6 +32,7 @@ class Track;
 #include <map>
 #include <memory>
 #include <mutex>
+#include <string>
 #include <thread>
 #include <vector>
 


### PR DESCRIPTION
## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
I'm not sure if SuperTuxKart is supported on non-Linux and macOS *nix platforms like BSD, as this might break it.

Anyways, this fixes #4172.