### PR TITLE
Always show times in ms

### DIFF
--- a/src/race/race_manager.hpp
+++ b/src/race/race_manager.hpp
@@ -741,10 +741,7 @@ public:
      /** \brief Returns the number of second's decimals to display */
     int currentModeTimePrecision() const
     {
-        if (isEggHuntMode() || isTimeTrialMode())
-            return 3;//display milliseconds
-
-        return 2;//display centiseconds
+        return 3; // display milliseconds
     }   // currentModeTimePrecision
     // ----------------------------------------------------------------------------------------
     /** \brief Returns true if the current mode has laps. */

--- a/src/states_screens/dialogs/ghost_replay_info_dialog.cpp
+++ b/src/states_screens/dialogs/ghost_replay_info_dialog.cpp
@@ -205,7 +205,7 @@ void GhostReplayInfoDialog::updateReplayDisplayedInfo()
             row.push_back(GUIEngine::ListWidget::ListCell
                 (StringUtils::toWString(rd.m_laps), -1, 3, true));
         row.push_back(GUIEngine::ListWidget::ListCell
-            (StringUtils::toWString(rd.m_min_time) + L"s", -1, 3, true));
+            (StringUtils::toWString(StringUtils::timeToString(rd.m_min_time)), -1, 3, true));
         row.push_back(GUIEngine::ListWidget::ListCell
             ("", icon, 1, true));
         row.push_back(GUIEngine::ListWidget::ListCell

--- a/src/states_screens/ghost_replay_selection.cpp
+++ b/src/states_screens/ghost_replay_selection.cpp
@@ -403,7 +403,7 @@ void GhostReplaySelection::loadList()
             row.push_back(GUIEngine::ListWidget::ListCell
                 (StringUtils::toWString(rd.m_laps), -1, 3, true));
         row.push_back(GUIEngine::ListWidget::ListCell
-            (StringUtils::toWString(rd.m_min_time) + L"s", -1, 4, true));
+            (StringUtils::toWString(StringUtils::timeToString(rd.m_min_time)), -1, 4, true));
         row.push_back(GUIEngine::ListWidget::ListCell
             ("", icon, 1, true));
         row.push_back(GUIEngine::ListWidget::ListCell

--- a/src/states_screens/race_gui.cpp
+++ b/src/states_screens/race_gui.cpp
@@ -73,7 +73,7 @@ RaceGUI::RaceGUI()
     // Determine maximum length of the rank/lap text, in order to
     // align those texts properly on the right side of the viewport.
     gui::ScalableFont* font = GUIEngine::getHighresDigitFont();
-    core::dimension2du area = font->getDimension(L"99:99.99");
+    core::dimension2du area = font->getDimension(L"99:99.999");
     m_timer_width = area.Width;
     m_font_height = area.Height;
 

--- a/src/utils/string_utils.hpp
+++ b/src/utils/string_utils.hpp
@@ -49,7 +49,7 @@ namespace StringUtils
 
     bool notEmpty(const irr::core::stringw& input);
     std::string ticksTimeToString(int time);
-    std::string timeToString(float time, unsigned int precision=2,
+    std::string timeToString(float time, unsigned int precision = 3,
                              bool display_minutes_if_zero = true, bool display_hours = false);
     irr::core::stringw loadingDots(float interval = 0.5f, int max_dots = 3);
     irr::core::stringw loadingDots(const irr::core::stringw& s);


### PR DESCRIPTION
There is no reason to have centiseconds here and milliseconds there...

The only drawback is that most of the time, the time in the finish screen is different of a few ms from the one shown at the left icon due to the fact that one is based on an interpolation and the other on the Tick number (or sometimes due to a bug, https://www.youtube.com/watch?v=MMbPQWepM8k ).
But that is an issue that should be fixed, and we should eventually have consistent times and precision everywhere anyway...

The Pull Request also changes the time string in the Ghosts List/Dialog to have something like "1:12:346" rather than "72.3456s", or "1:23.000" rather than "83s".

![Pr1](https://user-images.githubusercontent.com/42526046/71391185-718c5100-2603-11ea-94cc-855dc35758e2.png)
![Pr2](https://user-images.githubusercontent.com/42526046/71391186-718c5100-2603-11ea-8ab7-17b41282080f.png)
![Pr0](https://user-images.githubusercontent.com/42526046/71391184-718c5100-2603-11ea-8a14-090779b11b5b.png)
![Pr3](https://user-images.githubusercontent.com/42526046/71391187-718c5100-2603-11ea-94c5-f0eec801026e.png)

There should be a fixed width font for times...

## Agreement
Well if I could I would release my Pull Requests to the Public Domain... ![68747470733a2f2f6c69686b672e636f6d2f6173736574732f66616365732f7069672f64616e63652e676966](https://user-images.githubusercontent.com/42526046/71391143-3db12b80-2603-11ea-990f-1a938d72b096.gif)![68747470733a2f2f6c69686b672e636f6d2f6173736574732f66616365732f706967786d2f64616e63652e676966](https://user-images.githubusercontent.com/42526046/71391060-f62a9f80-2602-11ea-8de6-81376dd1678c.gif)![68747470733a2f2f6c69686b672e636f6d2f6173736574732f66616365732f7069672f64616e63652e676966](https://user-images.githubusercontent.com/42526046/71391143-3db12b80-2603-11ea-990f-1a938d72b096.gif)![68747470733a2f2f6c69686b672e636f6d2f6173736574732f66616365732f706967786d2f64616e63652e676966](https://user-images.githubusercontent.com/42526046/71391060-f62a9f80-2602-11ea-8de6-81376dd1678c.gif)![68747470733a2f2f6c69686b672e636f6d2f6173736574732f66616365732f7069672f64616e63652e676966](https://user-images.githubusercontent.com/42526046/71391143-3db12b80-2603-11ea-990f-1a938d72b096.gif)![68747470733a2f2f6c69686b672e636f6d2f6173736574732f66616365732f706967786d2f64616e63652e676966](https://user-images.githubusercontent.com/42526046/71391060-f62a9f80-2602-11ea-8de6-81376dd1678c.gif)
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```

