### PR TITLE
Fix CMD flags in main.cpp

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -764,11 +764,11 @@ int handleCmdLinePreliminary()
         UserConfigParams::m_verbosity |= UserConfigParams::LOG_MEMORY;
     if(CommandLine::has("--debug=addons"))
         UserConfigParams::m_verbosity |= UserConfigParams::LOG_ADDONS;
-    if(CommandLine::has("--debug=mgui"))
+    if(CommandLine::has("--debug=gui"))
         UserConfigParams::m_verbosity |= UserConfigParams::LOG_GUI;
     if(CommandLine::has("--debug=flyable"))
         UserConfigParams::m_verbosity |= UserConfigParams::LOG_FLYABLE;
-    if(CommandLine::has("--debug=mist"))
+    if(CommandLine::has("--debug=misc"))
         UserConfigParams::m_verbosity |= UserConfigParams::LOG_MISC;
     if(CommandLine::has("--debug=all") )
         UserConfigParams::m_verbosity |= UserConfigParams::LOG_ALL;


### PR DESCRIPTION
Came across these when working in my branch.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
