### PR TITLE
Expose getKartType(int kartId) to scripting

### DIFF
--- a/src/scriptengine/script_track.cpp
+++ b/src/scriptengine/script_track.cpp
@@ -165,7 +165,16 @@ namespace Scripting
         {
             return race_manager->getNumLocalPlayers();
         }
-
+        
+        /**
+          * Gets the kart type, such as local player, networked player, AI, etc.
+          * @return A KartType enum as defined in race_manager.hpp, implicitly casted to an int
+          */
+        int getKartType(int kartId)
+        {
+            return race_manager->getKartType(kartId);
+        }
+        
         bool isTrackReverse()
         {
             return race_manager->getReverseTrack();
@@ -553,6 +562,10 @@ namespace Scripting
                                                
             r = engine->RegisterGlobalFunction("int getNumLocalPlayers()", 
                                                mp ? WRAP_FN(getNumLocalPlayers) : asFUNCTION(getNumLocalPlayers), 
+                                               call_conv); assert(r >= 0);
+            
+            r = engine->RegisterGlobalFunction("int getKartType(int kartId)", 
+                                               mp ? WRAP_FN(getKartType) : asFUNCTION(getKartType), 
                                                call_conv); assert(r >= 0);
                                                
             r = engine->RegisterGlobalFunction("bool isReverse()", 


### PR DESCRIPTION
This change attempts to expose the KartType (local player, networked player, AI, etc.) to scripting.
This is useful if a track creator wants an action to only occur if triggered by a real player, or only if triggered by a non-networked player (e.g. alternate route music in Frozen Drive unofficial add-on).

I have rushed this in to try and get it added in STK 1.1 and I have not yet been able to configure and build STK from source, **so this change is currently untested!** If there is still time before 1.1, I can try building myself but otherwise I may not be able to.

I have placed this function in the Track section because it uses the race manager. Please let me know if the Kart section is more appropriate.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
