### PR TITLE
Define VALIST as va_list rather than char* on non-glibc systems

### DIFF
--- a/src/utils/log.hpp
+++ b/src/utils/log.hpp
@@ -30,10 +30,10 @@
 #include <vector>
 
 
-#ifdef __GNUC__
+#if defined(__GLIBC__)
 #  define VALIST __gnuc_va_list
 #else
-#  define VALIST char*
+#  define VALIST va_list
 #endif
 
 #if defined(_WIN32) && defined(_MSC_VER) && _MSC_VER < 1800


### PR DESCRIPTION
## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
The `__GNUC__` check didn't actually work on Musl and it still got activated, even though it should've went for the else condition instead. Changing it to `__GLIBC__` worked and is the recommended way of doing it.

Then defining `VALIST` as `va_list` rather than `char*` made it compile successfully.

This fixes #4173.