### PR TITLE
Revert "Define VALIST as va_list rather than char* on non-glibc systems"

### DIFF
--- a/src/utils/log.hpp
+++ b/src/utils/log.hpp
@@ -30,10 +30,10 @@
 #include <vector>
 
 
-#if defined(__GLIBC__)
+#ifdef __GNUC__
 #  define VALIST __gnuc_va_list
 #else
-#  define VALIST va_list
+#  define VALIST char*
 #endif
 
 #if defined(_WIN32) && defined(_MSC_VER) && _MSC_VER < 1800


### PR DESCRIPTION
Reverts supertuxkart/stk-code#4185