### PR TITLE
Rename "Global networking" to "Internet" to be more straightforward

### DIFF
--- a/data/gui/screens/help7.stkgui
+++ b/data/gui/screens/help7.stkgui
@@ -33,7 +33,7 @@
                     <spacer width="3%" height="100%"/>
                     <bubble proportion="1" height="100%"
                             I18N="In the help menu"
-                            text="First, select the 'online' icon in the main menu. Choose either local networking, or global networking (requires internet to be enabled in the options). Then, you can either create your own server with custom options, or search among a list of existing servers to join. Some of them are recommended servers with optionally ranked races."/>
+                            text="First, select the 'online' icon in the main menu. Choose either the local network or Internet (requires Internet to be enabled in the options). Then, you can either create your own server with custom options, or search among a list of existing servers to join. Some of them are recommended servers with optionally ranked races."/>
                 </div>
 
                 <div width="100%" proportion="2" layout="horizontal-row">

--- a/data/gui/screens/online/online.stkgui
+++ b/data/gui/screens/online/online.stkgui
@@ -21,16 +21,16 @@
         <buttonbar id="menu_toprow" proportion="3" width="90%" align="center">
             <icon-button id="lan" width="128" height="128"
                          icon="gui/icons/menu_multi.png" focus_icon="gui/icons/menu_multi_focus.png"
-                         I18N="Networking menu button" text="Local networking" word_wrap="true"/>
+                         I18N="Networking menu button" text="Local Network" word_wrap="true"/>
             <icon-button id="wan" width="128" height="128"
                          icon="gui/icons/menu_online.png" focus_icon="gui/icons/menu_online_focus.png"
-                         I18N="Networking menu button" text="Global networking" word_wrap="true"/>
+                         I18N="Networking menu button" text="Internet" word_wrap="true"/>
             <icon-button id="enter-address" width="128" height="128"
                          icon="gui/icons/online/menu_quick_play.png" focus_icon="gui/icons/online/menu_quick_play_hover.png"
-                         I18N="Networking menu button" text="Enter server address" word_wrap="true"/>
+                         I18N="Networking menu button" text="Direct Connect" word_wrap="true"/>
             <icon-button id="online" width="128" height="128"
                          icon="gui/icons/menu_online.png" focus_icon="gui/icons/menu_online_focus.png"
-                         I18N="Networking menu button" text="Your profile" word_wrap="true"/>
+                         I18N="Networking menu button" text="Your Profile" word_wrap="true"/>
         </buttonbar>
 
         <spacer height="5%" width="10"/>

--- a/data/gui/screens/online/profile_servers.stkgui
+++ b/data/gui/screens/online/profile_servers.stkgui
@@ -3,7 +3,7 @@
     <icon-button id="back" x="1%" y="0" height="9%" icon="gui/icons/back.png"/>
 
     <div x="1%" y="1%" width="98%" height="98%" layout="vertical-row" >
-        <header id="title" text_align="center" height="8%" width="80%" align="center" text="Global Networking"/>
+        <header id="title" text_align="center" height="8%" width="80%" align="center" text="Internet"/>
         <spacer height="1%" width="10"/>
 
         <spacer height="5%" width="10"/>


### PR DESCRIPTION
I've always found "Global networking" kind of confusing, which made me take several seconds to actually decide on an option when I want to play online. "Enter server address" has also been renamed to "Direct Connect" for concision.

This also tweaks menu option casing to match the rest of the menus.

**Don't merge yet** as this currently lacks translation changes. Should I update the source strings in all translatrions or just in the POT file? Is there a tool to do so, or does it have to be done manually?

Speaking of which, I also noticed casing inconsistencies in track names. We should probably settle on a single style (either `Like This` or `Like this`). My vote goes for the former, as the rest of the UI seems to follow that style.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```