### PR TITLE
Remove StringUtils::notEmpty

### DIFF
--- a/src/utils/string_utils.cpp
+++ b/src/utils/string_utils.cpp
@@ -122,24 +122,6 @@ namespace StringUtils
     }   // getExtension
 
     //-------------------------------------------------------------------------
-    /** Checks if the input string is not empty. ( = has characters different
-     *  from a space).
-     */
-    bool notEmpty(const irr::core::stringw& input)
-    {
-        const int size = input.size();
-        int nonEmptyChars = 0;
-        for (int n=0; n<size; n++)
-        {
-            if (input[n] != L' ')
-            {
-                nonEmptyChars++;
-            }
-        }
-        return (nonEmptyChars > 0);
-    }   // getExtension
-
-    //-------------------------------------------------------------------------
     /** Returns a string converted to upper case.
      */
     std::string toUpperCase(const std::string& str)

--- a/src/utils/string_utils.hpp
+++ b/src/utils/string_utils.hpp
@@ -47,7 +47,6 @@ namespace StringUtils
     std::string removeExtension(const std::string& filename);
     std::string getExtension(const std::string& filename);
 
-    bool notEmpty(const irr::core::stringw& input);
     std::string ticksTimeToString(int time);
     std::string timeToString(float time, unsigned int precision=2,
                              bool display_minutes_if_zero = true, bool display_hours = false);


### PR DESCRIPTION
The function is rather bad because it doesn't exit the loop early and doesn't check for whitespace that is not exactly " ", such as \t, \n. Since the function is unused, it can simply be removed instead of improving it.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
