### PR TITLE
add polygon radar / optionnal in user_config

### DIFF
--- a/src/config/user_config.hpp
+++ b/src/config/user_config.hpp
@@ -941,6 +941,23 @@ namespace UserConfigParams
         PARAM_DEFAULT(IntUserConfigParam(0, "minimap_display",
                       "Minimap: 0 bottom-left, 1 middle-right, 2 hidden, 3 center"));
 
+    // ---- Radar
+    PARAM_PREFIX GroupUserConfigParam        m_radar
+            PARAM_DEFAULT( GroupUserConfigParam("radar_display",
+                                                "Radar settings") );
+
+    PARAM_PREFIX BoolUserConfigParam         m_radar_enabled
+        PARAM_DEFAULT(BoolUserConfigParam(false, "enable",  &m_radar,
+                      "Enable radar (show target in ctf and soccer modes)"));
+
+    PARAM_PREFIX FloatUserConfigParam         m_radar_offset_y
+        PARAM_DEFAULT(FloatUserConfigParam(1.0f, "offset",  &m_radar,
+                      "Radar offset above a the kart"));
+
+    PARAM_PREFIX FloatUserConfigParam         m_radar_size
+        PARAM_DEFAULT(FloatUserConfigParam(1.0f, "size",  &m_radar,
+                      "Radar size (default: 1.0)"));
+
     // ---- Handicap
     PARAM_PREFIX GroupUserConfigParam       m_handicap
             PARAM_DEFAULT( GroupUserConfigParam("Handicap",

--- a/src/config/user_config.hpp
+++ b/src/config/user_config.hpp
@@ -951,7 +951,7 @@ namespace UserConfigParams
                       "Enable radar (show target in ctf and soccer modes)"));
 
     PARAM_PREFIX FloatUserConfigParam         m_radar_offset_y
-        PARAM_DEFAULT(FloatUserConfigParam(1.0f, "offset",  &m_radar,
+        PARAM_DEFAULT(FloatUserConfigParam(0.2f, "offset",  &m_radar,
                       "Radar offset above a the kart"));
 
     PARAM_PREFIX FloatUserConfigParam         m_radar_size

--- a/src/modes/soccer_world.hpp
+++ b/src/modes/soccer_world.hpp
@@ -357,6 +357,8 @@ public:
     // ------------------------------------------------------------------------
     const Vec3& getBallPosition() const
         { return (Vec3&)m_ball_body->getCenterOfMassTransform().getOrigin(); }
+    const Vec3& getBallLinearVelocity() const
+        { return (Vec3&)m_ball_body->getLinearVelocity(); }
     // ------------------------------------------------------------------------
     bool ballNotMoving() const
     {

--- a/src/states_screens/race_gui.hpp
+++ b/src/states_screens/race_gui.hpp
@@ -129,6 +129,7 @@ private:
                                 const core::vector2df &offset,
                                 float min_ratio, int meter_width,
                                 int meter_height, float dt);
+    void drawRadar             (const AbstractKart *kart);
 
     /* Helper functions for drawing meters */
 


### PR DESCRIPTION
Hello, 
  This change add a 3D wireframe radar inspired by modern karting games (showing other karts position relative to the camera) with a simplistic design :
  - In all modes, it shows discretly the speed by showing the point reached in 3 ticks, and if you got a cake item, a square is drawn on the target.
  - In ctf mode, it broadly indicate were to go (were is the flag or the base if you already have the flag). 
  - In soccer mode, it shows where is the ball and how it move and the karts that are around the ball (with gradients to represents the distance).
       1. (KART) the **white arrow** (pyramid) shows approximately with distance **where is the ball**;
       2. (KART) around the white arrow there is a square to show with **color** (if red you touch the ball, if blue you miss it, if green it is a perfect alignement) **alignment between kart and ball** (basically saying if you can shoot);
       3. (KART) the **black arrow** (inside white one) shows **where move ball**;
       4. (KART) the **black square** (outside white one) represents **the future shock** - if you want to control the ball you need to keep it small;
       5. (BALL) a green vector shows the trajectory of the ball
       6. (BALL) work with ii. : if the ball is reachable (red or green), a square with same color is drawn on the ball

  The feature still experimental.
  To use it, edit user config.xml file :
```xml
    <!-- Enable radar (show target in ctf and soccer modes) -->
    <show_radar value="true" />
```
## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
