### PR TITLE
removing compilation warning explicitly showing enum origin

### DIFF
--- a/lib/irrlicht/source/Irrlicht/CGUIListBox.cpp
+++ b/lib/irrlicht/source/Irrlicht/CGUIListBox.cpp
@@ -443,7 +443,7 @@ bool CGUIListBox::OnEvent(const SEvent& event)
 		case EET_LOG_TEXT_EVENT:
 		case EET_USER_EVENT:
 		case EET_JOYSTICK_INPUT_EVENT:
-		case EGUIET_FORCE_32_BIT:
+		case EEVENT_TYPE::EGUIET_FORCE_32_BIT:
 			break;
 		default:
 			break;

--- a/src/config/hardware_stats.cpp
+++ b/src/config/hardware_stats.cpp
@@ -311,6 +311,9 @@ void reportHardwareStats()
 #if defined(__linux__) && !defined(ANDROID)
     json.add("os_linux", 1);
     json.add("os_unix", 1);
+#elif defined(__FreeBSD__)
+    json.add("os_freebsd", 1);
+    json.add("os_unix", 1);
 #else
     json.add("os_linux", 0);
     json.add("os_unix", 0);

--- a/src/guiengine/widgets/CGUISTKListBox.cpp
+++ b/src/guiengine/widgets/CGUISTKListBox.cpp
@@ -409,7 +409,7 @@ bool CGUISTKListBox::OnEvent(const SEvent& event)
         case EET_LOG_TEXT_EVENT:
         case EET_USER_EVENT:
         case EET_JOYSTICK_INPUT_EVENT:
-        case EGUIET_FORCE_32_BIT:
+        case EEVENT_TYPE::EGUIET_FORCE_32_BIT:
             break;
         default:
             break;


### PR DESCRIPTION
to avoid confusions even though they have same values.
FreeBSD recognised as os in stats point of view.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
