### PR TITLE
add xcode_build to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 bld*/
 build*/
 cmake_build*/
+xcode_build*/
 dependencies*/
 CMakeFiles/
 stk-editor/


### PR DESCRIPTION
Hi, since it is in the official document, I suggest adding xcode_build to the ignore file.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
