### PR TITLE
Add rename config option

### DIFF
--- a/data/gui/screens/options_device.stkgui
+++ b/data/gui/screens/options_device.stkgui
@@ -53,6 +53,11 @@
 
                          <spacer width="50" height="2%" />
                      </div>
+
+                     <spacer width="2%" height="10" />
+                     
+                     <button id="rename_config" I18N="In the input configuration screen"  text="Rename Configuration"/>
+
                      <spacer width="2%" height="10" />
                      <label id="conflict" proportion="1" text="" word_wrap="true" align="center"/>
                  </div>

--- a/src/input/device_config.cpp
+++ b/src/input/device_config.cpp
@@ -74,7 +74,7 @@ DeviceConfig::DeviceConfig()
     m_name    = "";
     m_enabled = true;
     m_plugged = 0;
-    m_config_name= "";
+    m_config_name= L"";
 }   // DeviceConfig
 
 // ------------------------------------------------------------------------
@@ -295,7 +295,7 @@ void DeviceConfig::save (std::ofstream& stream)
     stream << "enabled=\""
         << (m_enabled ? "true\"" : "false\"") 
         << " configName=\"" 
-        << StringUtils::xmlEncode(StringUtils::utf8ToWide(m_config_name))
+        << StringUtils::xmlEncode(m_config_name)
         << "\">\n ";
 
     for(int n = 0; n < PA_COUNT; n++) // Start at 0?
@@ -317,10 +317,7 @@ bool DeviceConfig::load(const XMLNode *config)
 {
     config->get("name", &m_name);
     config->get("enabled", &m_enabled);
-    
-    irr::core::stringw wide_config_name;
-    config->getAndDecode("configName", &wide_config_name);
-    m_config_name = StringUtils::wideToUtf8(wide_config_name);
+    config->getAndDecode("configName", &m_config_name);
     bool error = false;
     for(unsigned int i=0; i<config->getNumNodes(); i++)
     {

--- a/src/input/device_config.cpp
+++ b/src/input/device_config.cpp
@@ -73,6 +73,7 @@ DeviceConfig::DeviceConfig()
     m_name    = "";
     m_enabled = true;
     m_plugged = 0;
+    m_config_name= "";
 }   // DeviceConfig
 
 // ------------------------------------------------------------------------
@@ -291,7 +292,10 @@ bool DeviceConfig::doGetAction(Input::InputType    type,
 void DeviceConfig::save (std::ofstream& stream)
 {
     stream << "enabled=\""
-        << (m_enabled ? "true\">\n" : "false\">\n");
+        << (m_enabled ? "true\"" : "false\"") 
+        << " configName=\"" 
+        << m_config_name
+        << "\">\n ";
 
     for(int n = 0; n < PA_COUNT; n++) // Start at 0?
     {
@@ -312,6 +316,7 @@ bool DeviceConfig::load(const XMLNode *config)
 {
     config->get("name", &m_name);
     config->get("enabled", &m_enabled);
+    config->get("configName", &m_config_name);
     bool error = false;
     for(unsigned int i=0; i<config->getNumNodes(); i++)
     {

--- a/src/input/device_config.cpp
+++ b/src/input/device_config.cpp
@@ -23,6 +23,7 @@
 #include "input/gamepad_android_config.hpp"
 #include "input/keyboard_config.hpp"
 #include "io/xml_node.hpp"
+#include "io/utf_writer.hpp"
 #include "utils/log.hpp"
 
 #include <SKeyMap.h>
@@ -294,7 +295,7 @@ void DeviceConfig::save (std::ofstream& stream)
     stream << "enabled=\""
         << (m_enabled ? "true\"" : "false\"") 
         << " configName=\"" 
-        << m_config_name
+        << StringUtils::xmlEncode(StringUtils::utf8ToWide(m_config_name))
         << "\">\n ";
 
     for(int n = 0; n < PA_COUNT; n++) // Start at 0?
@@ -316,7 +317,10 @@ bool DeviceConfig::load(const XMLNode *config)
 {
     config->get("name", &m_name);
     config->get("enabled", &m_enabled);
-    config->get("configName", &m_config_name);
+    
+    irr::core::stringw wide_config_name;
+    config->getAndDecode("configName", &wide_config_name);
+    m_config_name = StringUtils::wideToUtf8(wide_config_name);
     bool error = false;
     for(unsigned int i=0; i<config->getNumNodes(); i++)
     {

--- a/src/input/device_config.hpp
+++ b/src/input/device_config.hpp
@@ -49,8 +49,11 @@ private:
     /** How many devices connected to the system which uses this config? */
     int m_plugged; 
 
-    /** Name of this configuratiom. */
+    /** Internal name of this configuration. */
     std::string m_name;
+
+    /** Name of this configuration (given by the user). */
+    std::string m_config_name;
 
 protected:
 
@@ -126,11 +129,11 @@ public:
     }   // getNumberOfAxes
 
     // ------------------------------------------------------------------------
-    /** Sets the name of this device. */
+    /** Sets the internal name of this device. */
     void setName(const std::string &name) { m_name = name; }
 
     // ------------------------------------------------------------------------
-    /** Returns the name for this device configuration. */
+    /** Returns the internal name for this device configuration. */
     const std::string& getName() const { return m_name; };
 
     // ------------------------------------------------------------------------
@@ -156,6 +159,14 @@ public:
     // ------------------------------------------------------------------------
     /** Sets this config to be enabled or disabled. */
     void setEnabled(bool new_value) { m_enabled = new_value; }
+
+    // ------------------------------------------------------------------------
+    /** Sets the name of this device configuration */
+    std::string getConfigName() const { return m_config_name;  }
+
+    // ------------------------------------------------------------------------
+    /** Returns the name of this device configuration */
+    void setConfigName( std::string config_name ) { m_config_name = config_name; }
 };   // class DeviceConfig
 
 #endif

--- a/src/input/device_config.hpp
+++ b/src/input/device_config.hpp
@@ -53,7 +53,7 @@ private:
     std::string m_name;
 
     /** Name of this configuration (given by the user). */
-    std::string m_config_name;
+    irr::core::stringw m_config_name;
 
 protected:
 
@@ -162,11 +162,11 @@ public:
 
     // ------------------------------------------------------------------------
     /** Sets the name of this device configuration */
-    std::string getConfigName() const { return m_config_name;  }
+    irr::core::stringw getConfigName() const { return m_config_name;  }
 
     // ------------------------------------------------------------------------
     /** Returns the name of this device configuration */
-    void setConfigName( std::string config_name ) { m_config_name = config_name; }
+    void setConfigName( irr::core::stringw config_name ) { m_config_name = config_name; }
 };   // class DeviceConfig
 
 #endif

--- a/src/states_screens/options/options_screen_device.cpp
+++ b/src/states_screens/options/options_screen_device.cpp
@@ -24,6 +24,7 @@
 #include "guiengine/widget.hpp"
 #include "guiengine/widgets/button_widget.hpp"
 #include "guiengine/widgets/label_widget.hpp"
+#include "guiengine/widgets/text_box_widget.hpp"
 #include "guiengine/widgets/list_widget.hpp"
 #include "guiengine/widgets/ribbon_widget.hpp"
 #include "input/input_manager.hpp"
@@ -31,6 +32,7 @@
 #include "input/gamepad_device.hpp"
 #include "io/file_manager.hpp"
 #include "states_screens/dialogs/press_a_key_dialog.hpp"
+#include "states_screens/dialogs/general_text_field_dialog.hpp"
 #include "states_screens/options/options_screen_audio.hpp"
 #include "states_screens/options/options_screen_general.hpp"
 #include "states_screens/options/options_screen_input.hpp"
@@ -636,6 +638,24 @@ void OptionsScreenDevice::eventCallback(Widget* widget,
         }
 
         input_manager->getDeviceManager()->save();
+    }
+    else if (name == "rename_config")
+    {
+        core::stringw configName = StringUtils::utf8ToWide(m_config->getName());
+        DeviceConfig *the_config = m_config; //Can't give variable m_config directly
+
+        new GeneralTextFieldDialog(configName, [] (const irr::core::stringw& text) {},
+            [the_config] (GUIEngine::LabelWidget* lw,
+                GUIEngine::TextBoxWidget* tb)->bool
+            {
+                core::stringw info = tb->getText();
+                if (info.empty())
+                    return false;
+                
+                the_config->setConfigName(StringUtils::wideToUtf8(info.c_str()).c_str());
+                input_manager->getDeviceManager()->save();
+                return true;
+            });
     }
 
 }   // eventCallback

--- a/src/states_screens/options/options_screen_device.cpp
+++ b/src/states_screens/options/options_screen_device.cpp
@@ -652,7 +652,7 @@ void OptionsScreenDevice::eventCallback(Widget* widget,
                 if (info.empty())
                     return false;
                 
-                the_config->setConfigName(info.c_str());
+                the_config->setConfigName(info);
                 input_manager->getDeviceManager()->save();
                 return true;
             });

--- a/src/states_screens/options/options_screen_device.cpp
+++ b/src/states_screens/options/options_screen_device.cpp
@@ -652,7 +652,7 @@ void OptionsScreenDevice::eventCallback(Widget* widget,
                 if (info.empty())
                     return false;
                 
-                the_config->setConfigName(StringUtils::wideToUtf8(info.c_str()).c_str());
+                the_config->setConfigName(info.c_str());
                 input_manager->getDeviceManager()->save();
                 return true;
             });

--- a/src/states_screens/options/options_screen_input.cpp
+++ b/src/states_screens/options/options_screen_input.cpp
@@ -108,7 +108,7 @@ void OptionsScreenInput::buildDeviceList()
             const int icon = (config->isEnabled() ? 0 : 1);
 
             //Display the configName instead of default name if it exists
-            if (wcslen(config->getConfigName().c_str()) != 0)
+            if (!config->getConfigName().empty())
             {
                 // since irrLicht's list widget has the nasty tendency to put the
                 // icons very close to the text, I'm adding spaces to compensate.
@@ -135,7 +135,7 @@ void OptionsScreenInput::buildDeviceList()
             irr::core::stringw name;
 
             //Display the configName instead of default name if it exists
-            if (wcslen(config->getConfigName().c_str()) != 0)
+            if (!config->getConfigName().empty())
             {
                 // since irrLicht's list widget has the nasty tendency to put the
                 // icons very close to the text, I'm adding spaces to compensate.

--- a/src/states_screens/options/options_screen_input.cpp
+++ b/src/states_screens/options/options_screen_input.cpp
@@ -108,12 +108,12 @@ void OptionsScreenInput::buildDeviceList()
             const int icon = (config->isEnabled() ? 0 : 1);
 
             //Display the configName instead of default name if it exists
-            if (config->getConfigName().length() != 0)
+            if (wcslen(config->getConfigName().c_str()) != 0)
             {
                 // since irrLicht's list widget has the nasty tendency to put the
                 // icons very close to the text, I'm adding spaces to compensate.
                 devices->addItem(internal_name, (core::stringw("   ") + 
-                    StringUtils::utf8ToWide(config->getConfigName())), icon);
+                    config->getConfigName()), icon);
             }
             else
             {
@@ -135,12 +135,12 @@ void OptionsScreenInput::buildDeviceList()
             irr::core::stringw name;
 
             //Display the configName instead of default name if it exists
-            if (config->getConfigName().length() != 0)
+            if (wcslen(config->getConfigName().c_str()) != 0)
             {
                 // since irrLicht's list widget has the nasty tendency to put the
                 // icons very close to the text, I'm adding spaces to compensate.
                 name = (core::stringw("   ") + 
-                             StringUtils::utf8ToWide(config->getConfigName()));
+                             config->getConfigName());
             }
             else
             {

--- a/src/states_screens/options/options_screen_input.cpp
+++ b/src/states_screens/options/options_screen_input.cpp
@@ -107,10 +107,19 @@ void OptionsScreenInput::buildDeviceList()
         {
             const int icon = (config->isEnabled() ? 0 : 1);
 
-            // since irrLicht's list widget has the nasty tendency to put the
-            // icons very close to the text, I'm adding spaces to compensate.
-            devices->addItem(internal_name, (core::stringw("   ") + 
-                             _("Keyboard %i", i)).c_str(), icon);
+            //Display the configName instead of default name if it exists
+            if (config->getConfigName().length() != 0)
+            {
+                // since irrLicht's list widget has the nasty tendency to put the
+                // icons very close to the text, I'm adding spaces to compensate.
+                devices->addItem(internal_name, (core::stringw("   ") + 
+                    StringUtils::utf8ToWide(config->getConfigName())), icon);
+            }
+            else
+            {
+                devices->addItem(internal_name, (core::stringw("   ") + 
+                                _("Keyboard %i", i)).c_str(), icon);   
+            }
         }
     }
 
@@ -123,15 +132,26 @@ void OptionsScreenInput::buildDeviceList()
         // Don't display the configuration if a matching device is not available
         if (config->isPlugged())
         {
-            // since irrLicht's list widget has the nasty tendency to put the
-            // icons very close to the text, I'm adding spaces to compensate.
-            irr::core::stringw name = ("   " + config->getName()).c_str();
+            irr::core::stringw name;
 
-            if (config->getNumberOfDevices() > 1)
+            //Display the configName instead of default name if it exists
+            if (config->getConfigName().length() != 0)
             {
-                name += core::stringw(L" (x");
-                name += config->getNumberOfDevices();
-                name += core::stringw(L")");
+                // since irrLicht's list widget has the nasty tendency to put the
+                // icons very close to the text, I'm adding spaces to compensate.
+                name = (core::stringw("   ") + 
+                             StringUtils::utf8ToWide(config->getConfigName()));
+            }
+            else
+            {
+                name = ("   " + config->getName()).c_str();   
+
+                if (config->getNumberOfDevices() > 1)
+                {
+                    name += core::stringw(L" (x");
+                    name += config->getNumberOfDevices();
+                    name += core::stringw(L")");
+                }
             }
 
             std::ostringstream gpname;


### PR DESCRIPTION
Issue #3408
Add a button for rename a configuration.

![RenameConfigOption](https://user-images.githubusercontent.com/54895740/74642484-5b1df400-5173-11ea-83e2-6627fd736d10.png)


## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
