### PR TITLE
allow 0 player number if there is AI

### DIFF
--- a/src/states_screens/track_info_screen.cpp
+++ b/src/states_screens/track_info_screen.cpp
@@ -400,15 +400,14 @@ void TrackInfoScreen::setSoccerWidgets(bool has_AI)
         }
 
         const int max_num_ai = max_arena_players - local_players;
-        // Make sure each team has at least 1 ai if only all players join same team
-        bool reset_ai = ((num_blue_players == 0 || num_red_players == 0) &&
-            ((UserConfigParams::m_soccer_red_ai_num == 0 && UserConfigParams::m_soccer_blue_ai_num != 0) ||
-            (UserConfigParams::m_soccer_blue_ai_num == 0 && UserConfigParams::m_soccer_red_ai_num != 0)));
+        // Make sure each team has at least 1 (ai + player)
+        bool reuse_ai = ((num_blue_players + UserConfigParams::m_soccer_blue_ai_num) > 0) &&
+                       ((num_red_players  + UserConfigParams::m_soccer_red_ai_num ) > 0) &&
+                       ((UserConfigParams::m_soccer_red_ai_num + UserConfigParams::m_soccer_blue_ai_num) < max_num_ai);
 
         // Try the saved values.
         // If they can't be used, use default balanced values
-        if (UserConfigParams::m_soccer_red_ai_num + UserConfigParams::m_soccer_blue_ai_num > max_num_ai ||
-            reset_ai)
+        if (!reuse_ai)
         {
             const int additional_blue = num_red_players - num_blue_players;
             int num_blue_ai = (max_num_ai - additional_blue) / 2 + additional_blue;

--- a/src/states_screens/track_info_screen.cpp
+++ b/src/states_screens/track_info_screen.cpp
@@ -402,8 +402,8 @@ void TrackInfoScreen::setSoccerWidgets(bool has_AI)
         const int max_num_ai = max_arena_players - local_players;
         // Make sure each team has at least 1 (ai + player)
         bool reuse_ai = ((num_blue_players + UserConfigParams::m_soccer_blue_ai_num) > 0) &&
-                       ((num_red_players  + UserConfigParams::m_soccer_red_ai_num ) > 0) &&
-                       ((UserConfigParams::m_soccer_red_ai_num + UserConfigParams::m_soccer_blue_ai_num) < max_num_ai);
+                        ((num_red_players  + UserConfigParams::m_soccer_red_ai_num ) > 0) &&
+                        ((UserConfigParams::m_soccer_red_ai_num + UserConfigParams::m_soccer_blue_ai_num) < max_num_ai);
 
         // Try the saved values.
         // If they can't be used, use default balanced values


### PR DESCRIPTION
It is not necessary to restrict player number > 0. If there is at least one AI in the team, 0 player should be allowed. We only need to deal with the case of 0 player and 0 AI.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
