### PR TITLE
add a camera mode to spectate soccer in large view that follows the ball

### DIFF
--- a/src/graphics/camera.cpp
+++ b/src/graphics/camera.cpp
@@ -190,6 +190,7 @@ void Camera::setupCamera()
  */
 void Camera::setMode(Mode mode)
 {
+    if (mode == m_mode) return;
     // If we switch from reverse view, move the camera immediately to the
     // correct position.
     if( (m_mode==CM_REVERSE && mode==CM_NORMAL) || 
@@ -204,6 +205,7 @@ void Camera::setMode(Mode mode)
         m_camera->setTarget(target_position.toIrrVector());
     }
 
+    m_previous_mode = m_mode;
     m_mode = mode;
 }   // setMode
 
@@ -213,6 +215,14 @@ void Camera::setMode(Mode mode)
 Camera::Mode Camera::getMode()
 {
     return m_mode;
+}   // getMode
+
+// ----------------------------------------------------------------------------
+/** Returns the last kwown mode of the camera.
+ */
+Camera::Mode Camera::getPreviousMode()
+{
+    return m_previous_mode;
 }   // getMode
 
 //-----------------------------------------------------------------------------

--- a/src/graphics/camera.hpp
+++ b/src/graphics/camera.hpp
@@ -64,6 +64,7 @@ public:
         CM_CLOSEUP,           //!< Closer to kart
         CM_REVERSE,           //!< Looking backwards
         CM_LEADER_MODE,       //!< for deleted player karts in follow the leader
+        CM_SPECTATOR_SOCCER,  //!< for spectator (in soccer mode)
         CM_SIMPLE_REPLAY,
         CM_FALLING
     };   // Mode
@@ -77,6 +78,7 @@ private:
 
     /** Camera's mode. */
     Mode            m_mode;
+    Mode            m_previous_mode;
 
     /** The type of the camera. */
     CameraType      m_type;
@@ -173,6 +175,7 @@ public:
 
     void setMode(Mode mode);    /** Set the camera to the given mode */
     Mode getMode();
+    Mode getPreviousMode();
     void setKart(AbstractKart *new_kart);
     virtual void setInitialTransform();
     virtual void activate(bool alsoActivateInIrrlicht=true);

--- a/src/network/protocols/client_lobby.cpp
+++ b/src/network/protocols/client_lobby.cpp
@@ -1441,9 +1441,17 @@ void ClientLobby::changeSpectateTarget(PlayerAction action, int value,
     if (action == PA_LOOK_BACK)
     {
         if (cam->getMode() == Camera::CM_REVERSE)
-            cam->setMode(Camera::CM_NORMAL);
+            cam->setMode(cam->getPreviousMode());
         else
             cam->setMode(Camera::CM_REVERSE);
+        return;
+    }
+    if (action == PA_ACCEL)
+    {
+        if (cam->getMode() == Camera::CM_SPECTATOR_SOCCER)
+            cam->setMode(cam->getPreviousMode());
+        else 
+            cam->setMode(Camera::CM_SPECTATOR_SOCCER);
         return;
     }
 
@@ -1513,11 +1521,12 @@ void ClientLobby::addSpectateHelperMessage() const
     core::stringw left = dc->getBindingAsString(PA_STEER_LEFT);
     core::stringw right = dc->getBindingAsString(PA_STEER_RIGHT);
     core::stringw back = dc->getBindingAsString(PA_LOOK_BACK);
+    core::stringw accel = dc->getBindingAsString(PA_ACCEL);
 
     // I18N: Message shown in game to tell the player it's possible to change
     // the camera target in spectate mode of network
-    core::stringw msg = _("Press <%s> or <%s> to change the targeted player "
-        "or <%s> for the camera position.", left, right, back);
+    core::stringw msg = _("Press <%s> or <%s> to change the targeted player, "
+        "<%s> or <%s> for the camera position.", left, right, back, accel);
     MessageQueue::add(MessageQueue::MT_GENERIC, msg);
 }   // addSpectateHelperMessage
 


### PR DESCRIPTION
This PR, add a camera mode to spectate soccer in large isometric view  that follow the ball (switchable with accel/brake keys).

Related to issue: https://github.com/supertuxkart/stk-code/issues/4238 (no need to check the issue, it is just a technical question with some thougths about UI — a mirror like in _crazyracing kartrider_ —).


## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
