### PR TITLE
camera parameter forward-smoothing  and restore use of forward-up-angle 

### DIFF
--- a/data/kart_characteristics.xml
+++ b/data/kart_characteristics.xml
@@ -180,11 +180,13 @@
             Distance between kart and camera.
             forward-up-angle: Angle between camera and plane of kart (pitch)
                 when the camera is pointing forward
+            forward-smoothing: if true, use smoothing (forward-up-angle become relative to speed) when pointing forward
             backward-up-angle: Angle between camera and plane of kart (pitch)
                 when the camera is pointing backwards. This is usually
                 larger than the forward-up-angle, since the kart itself
                 otherwise obstricts too much of the view. -->
-        <camera distance="1.0" forward-up-angle="15"
+        <camera distance="1.0"
+                forward-up-angle="0" forward-smoothing="true"
                 backward-up-angle="5" />
 
         <!-- Jump animation

--- a/src/graphics/camera_normal.hpp
+++ b/src/graphics/camera_normal.hpp
@@ -51,7 +51,7 @@ private:
 
     Vec3            m_camera_offset;
 
-    void moveCamera(float dt, bool smooth);
+    void moveCamera(float dt, bool smooth, float cam_angle, float distance);
     void handleEndCamera(float dt);
     void getCameraSettings(float *above_kart, float *cam_angle,
                            float *side_way, float *distance,

--- a/src/karts/abstract_characteristic.cpp
+++ b/src/karts/abstract_characteristic.cpp
@@ -111,6 +111,8 @@ AbstractCharacteristic::ValueType AbstractCharacteristic::getType(
         return TYPE_FLOAT;
     case CAMERA_FORWARD_UP_ANGLE:
         return TYPE_FLOAT;
+    case CAMERA_FORWARD_SMOOTHING:
+        return TYPE_BOOL;
     case CAMERA_BACKWARD_UP_ANGLE:
         return TYPE_FLOAT;
     case JUMP_ANIMATION_TIME:
@@ -862,6 +864,18 @@ float AbstractCharacteristic::getCameraForwardUpAngle() const
                     getName(CAMERA_FORWARD_UP_ANGLE).c_str());
     return result;
 }  // getCameraForwardUpAngle
+
+// ----------------------------------------------------------------------------
+bool AbstractCharacteristic::getCameraForwardSmoothing() const
+{
+    bool result;
+    bool is_set = false;
+    process(CAMERA_FORWARD_SMOOTHING, &result, &is_set);
+    if (!is_set)
+        Log::fatal("AbstractCharacteristic", "Can't get characteristic %s",
+                    getName(CAMERA_FORWARD_SMOOTHING).c_str());
+    return result;
+}  // getCameraForwardSmoothing (advanced option)
 
 // ----------------------------------------------------------------------------
 float AbstractCharacteristic::getCameraBackwardUpAngle() const

--- a/src/karts/abstract_characteristic.hpp
+++ b/src/karts/abstract_characteristic.hpp
@@ -114,6 +114,7 @@ public:
         // Camera
         CAMERA_DISTANCE,
         CAMERA_FORWARD_UP_ANGLE,
+        CAMERA_FORWARD_SMOOTHING,
         CAMERA_BACKWARD_UP_ANGLE,
 
         // Jump
@@ -298,6 +299,7 @@ public:
 
     float getCameraDistance() const;
     float getCameraForwardUpAngle() const;
+    bool getCameraForwardSmoothing() const;
     float getCameraBackwardUpAngle() const;
 
     float getJumpAnimationTime() const;

--- a/src/karts/kart_properties.cpp
+++ b/src/karts/kart_properties.cpp
@@ -785,6 +785,11 @@ float KartProperties::getCameraForwardUpAngle() const
     return m_cached_characteristic->getCameraForwardUpAngle();
 }  // getCameraForwardUpAngle
 
+bool KartProperties::getCameraForwardSmoothing() const
+{
+    return m_cached_characteristic->getCameraForwardSmoothing();
+}  // getCameraForwardSmoothing
+
 // ----------------------------------------------------------------------------
 float KartProperties::getCameraBackwardUpAngle() const
 {

--- a/src/karts/kart_properties.hpp
+++ b/src/karts/kart_properties.hpp
@@ -405,6 +405,7 @@ public:
 
     float getCameraDistance() const;
     float getCameraForwardUpAngle() const;
+    bool getCameraForwardSmoothing() const;
     float getCameraBackwardUpAngle() const;
 
     float getJumpAnimationTime() const;

--- a/src/karts/xml_characteristic.cpp
+++ b/src/karts/xml_characteristic.cpp
@@ -403,6 +403,8 @@ void XmlCharacteristic::load(const XMLNode *node)
             &m_values[CAMERA_DISTANCE]);
         sub_node->get("forward-up-angle",
             &m_values[CAMERA_FORWARD_UP_ANGLE]);
+        sub_node->get("forward-smoothing",
+            &m_values[CAMERA_FORWARD_SMOOTHING]);
         sub_node->get("backward-up-angle",
             &m_values[CAMERA_BACKWARD_UP_ANGLE]);
     }


### PR DESCRIPTION
This PR restore the usage of _forward-up-angle_ which was unused in code because of hardcoded smoothing. It is an attempt to reconcile the hard coded dynamic camera with xml settings. Default settings change nothing to the camera.

Additionnally, smoothing when camera is pointing forward can be disabled with new parameter _forward-smoothing_.

Related to : https://github.com/supertuxkart/stk-code/issues/4154

Impact `data/kart_characteristics.xml`.
```xml 
        <!-- Camera
            Distance between kart and camera.
            forward-up-angle: Angle between camera and plane of kart (pitch)
                when the camera is pointing forward
            forward-smoothing: if true, use smoothing (forward-up-angle become relative to speed) when pointing forward
            backward-up-angle: Angle between camera and plane of kart (pitch)
                when the camera is pointing backwards. This is usually
                larger than the forward-up-angle, since the kart itself
                otherwise obstricts too much of the view. -->
        <camera distance="1.0"
                forward-up-angle="0" forward-smoothing="true"
                backward-up-angle="5" />
```

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
