### PR TITLE
add top view for spectating & rm gui item view for this camera mode

### DIFF
--- a/src/config/user_config.hpp
+++ b/src/config/user_config.hpp
@@ -964,6 +964,18 @@ namespace UserConfigParams
         PARAM_DEFAULT(IntUserConfigParam(0, "minimap_display",
                       "Minimap: 0 bottom-left, 1 middle-right, 2 hidden, 3 center"));
 
+    // ---- Settings for spectator camera
+    PARAM_PREFIX GroupUserConfigParam       m_spectator
+            PARAM_DEFAULT( GroupUserConfigParam("Spectator",
+                                          "Everything related to spectator mode.") );
+
+    PARAM_PREFIX FloatUserConfigParam        m_spectator_camera_distance
+            PARAM_DEFAULT(  FloatUserConfigParam(6.75, "camera-distance", &m_spectator,
+                                                  "Distance between kart and camera.") );
+    PARAM_PREFIX FloatUserConfigParam        m_spectator_camera_angle
+            PARAM_DEFAULT(  FloatUserConfigParam(40.0, "camera-angle", &m_spectator,
+                                                  "Angle between ground, kart and camera.") );
+
     // ---- Handicap
     PARAM_PREFIX GroupUserConfigParam       m_handicap
             PARAM_DEFAULT( GroupUserConfigParam("Handicap",

--- a/src/graphics/camera.cpp
+++ b/src/graphics/camera.cpp
@@ -223,7 +223,25 @@ Camera::Mode Camera::getMode()
 Camera::Mode Camera::getPreviousMode()
 {
     return m_previous_mode;
-}   // getMode
+}   // getPreviousMode
+
+// ----------------------------------------------------------------------------
+/** Returns true if camera is a spectator camera
+ */
+bool Camera::isSpectatorMode()
+{
+    return ((m_mode == CM_SPECTATOR_TOP_VIEW) || (m_mode == CM_SPECTATOR_SOCCER));
+}   // isSpectatorMode
+
+// ----------------------------------------------------------------------------
+/** Switch to next spectator mode  (a -> soccer -> top view -> a)
+ */
+void Camera::setNextSpectatorMode()
+{
+    if (m_mode == CM_SPECTATOR_SOCCER) m_mode = CM_SPECTATOR_TOP_VIEW;
+    else if (m_mode == CM_SPECTATOR_TOP_VIEW) m_mode = m_previous_mode;
+    else setMode(CM_SPECTATOR_SOCCER);
+}   // setNextSpectatorMode
 
 //-----------------------------------------------------------------------------
 /** Reset is called when a new race starts. Make sure that the camera

--- a/src/graphics/camera.hpp
+++ b/src/graphics/camera.hpp
@@ -64,7 +64,8 @@ public:
         CM_CLOSEUP,           //!< Closer to kart
         CM_REVERSE,           //!< Looking backwards
         CM_LEADER_MODE,       //!< for deleted player karts in follow the leader
-        CM_SPECTATOR_SOCCER,  //!< for spectator (in soccer mode)
+        CM_SPECTATOR_SOCCER,   //!< for spectator (in soccer mode)
+        CM_SPECTATOR_TOP_VIEW, //!< for spectator (top view on ball if soccer or top view on kart)
         CM_SIMPLE_REPLAY,
         CM_FALLING
     };   // Mode
@@ -176,6 +177,8 @@ public:
     void setMode(Mode mode);    /** Set the camera to the given mode */
     Mode getMode();
     Mode getPreviousMode();
+    bool isSpectatorMode();
+    void setNextSpectatorMode();
     void setKart(AbstractKart *new_kart);
     virtual void setInitialTransform();
     virtual void activate(bool alsoActivateInIrrlicht=true);

--- a/src/network/protocols/client_lobby.cpp
+++ b/src/network/protocols/client_lobby.cpp
@@ -1454,10 +1454,7 @@ void ClientLobby::changeSpectateTarget(PlayerAction action, int value,
     }
     if (action == PA_ACCEL)
     {
-        if (cam->getMode() == Camera::CM_SPECTATOR_SOCCER)
-            cam->setMode(cam->getPreviousMode());
-        else 
-            cam->setMode(Camera::CM_SPECTATOR_SOCCER);
+        cam->setNextSpectatorMode();
         return;
     }
 

--- a/src/states_screens/race_gui.cpp
+++ b/src/states_screens/race_gui.cpp
@@ -357,8 +357,10 @@ void RaceGUI::renderPlayerView(const Camera *camera, float dt)
     core::vector2df scaling = camera->getScaling();
     const AbstractKart *kart = camera->getKart();
     if(!kart) return;
-    
-    drawPlungerInFace(camera, dt);
+
+    bool isSpectatorCam = Camera::getActiveCamera()->isSpectatorMode();
+
+    if (!isSpectatorCam) drawPlungerInFace(camera, dt);
 
     if (viewport.getWidth() != (int)irr_driver->getActualScreenSize().Width)
     {
@@ -373,10 +375,13 @@ void RaceGUI::renderPlayerView(const Camera *camera, float dt)
 
     if(!World::getWorld()->isRacePhase()) return;
 
-    if (m_multitouch_gui == NULL || m_multitouch_gui->isSpectatorMode())
+    if (!isSpectatorCam) 
     {
-        drawPowerupIcons(kart, viewport, scaling);
-        drawSpeedEnergyRank(kart, viewport, scaling, dt);
+        if (m_multitouch_gui == NULL || m_multitouch_gui->isSpectatorMode())
+        {
+            drawPowerupIcons(kart, viewport, scaling);
+            drawSpeedEnergyRank(kart, viewport, scaling, dt);
+        }
     }
 
     if (!m_is_tutorial)


### PR DESCRIPTION
Hello,  
  following the addition of parameters camera distance and angle in `kart_characteristics.xml` , i observed that soccer camera for spectator mode was too much far. Too, in context of recording video, kim notified a view was missing.

Therefore, the changes are the following :
- add in `user_config.xml`, settings for spectator camera angle and distance 
- add a new camera mode for to have a top view that look the ball in soccer mode,  and look the kart else
- in order to have a full view of the situation, remove the appearance of the player item and speed information when choosing a spectator camera mode

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
