### PR TITLE
add option to substitute look back camera by soccer ball camera

### DIFF
--- a/src/config/user_config.hpp
+++ b/src/config/user_config.hpp
@@ -976,6 +976,11 @@ namespace UserConfigParams
             PARAM_DEFAULT(  FloatUserConfigParam(40.0, "camera-angle", &m_spectator,
                                                   "Angle between ground, kart and camera.") );
 
+    // ---- Special settings for soccer mode
+    PARAM_PREFIX BoolUserConfigParam       m_reverse_look_use_soccer_cam
+            PARAM_DEFAULT(  BoolUserConfigParam(false, "reverse-look-use-soccer-cam",
+                            "Use ball camera in soccer mode, instead of reverse") );
+
     // ---- Handicap
     PARAM_PREFIX GroupUserConfigParam       m_handicap
             PARAM_DEFAULT( GroupUserConfigParam("Handicap",

--- a/src/graphics/camera_normal.cpp
+++ b/src/graphics/camera_normal.cpp
@@ -354,7 +354,10 @@ void CameraNormal::positionCamera(float dt, float above_kart, float cam_angle,
 
     float tan_up = tanf(cam_angle);
 
-    switch(getMode())
+    Camera::Mode mode = getMode();
+    if (UserConfigParams::m_reverse_look_use_soccer_cam && getMode() == CM_REVERSE) mode=CM_SPECTATOR_SOCCER;
+
+    switch(mode)
     {
     case CM_SPECTATOR_SOCCER:
         {
@@ -363,7 +366,7 @@ void CameraNormal::positionCamera(float dt, float above_kart, float cam_angle,
             {
                 Vec3 ball_pos = soccer_world->getBallPosition();
                 Vec3 to_target=(ball_pos-wanted_target);
-                wanted_position = wanted_target + Vec3(0,  fabsf(distance)*tan_up+above_kart, 0) + (to_target.normalize() * distance);
+                wanted_position = wanted_target + Vec3(0,  fabsf(distance)*tan_up+above_kart, 0) + (to_target.normalize() * distance * (getMode() == CM_REVERSE ? -1:1));
                 m_camera->setPosition(wanted_position.toIrrVector());
                 m_camera->setTarget(wanted_target.toIrrVector());
                 return;


### PR DESCRIPTION
In user config, add a bool option `reverse-look-use-soccer-cam` to use almost the same camera than spectator camera soccer except angle and distance are the ones of reverse camera mode.

To use it : set the option to "true"; start a soccer game; use rear view mirror that is no more rear view mirror in this mode, but a camera that follows the ball.

On apply to soccer mode, not completely useful (given the minimap make the job), but :
- completely stylish :laughing: 
- familiar to Rocket League users

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
## Possible future, but that's not the subject here
In order to be used by non advanced users, this parameter would be located in a section that allows to set all about camera view with presets. (future PR from me ? probably, but i know it will raise some debates about complexity of parameters)  
