### PR TITLE
replace split screen horizontal checkbox by a spinner 

### DIFF
--- a/data/gui/screens/options_ui.stkgui
+++ b/data/gui/screens/options_ui.stkgui
@@ -53,6 +53,17 @@
 
                 <spacer width="5" height="2%"/>
 
+                <div layout="horizontal-row" width="100%" height="fit">
+                    <div layout="vertical-row" width="10f" height="fit">
+                        <spinner id="splitscreen_method" width="100%" align="center" />
+                    </div>
+                    <div layout="vertical-row" proportion="1" height="100%">
+                        <label height="100%" I18N="In the ui settings" text="Multiplayer splits" align="left"/>
+                    </div>
+                </div>
+
+                <spacer width="5" height="2%"/>
+
                 <div width="100%" height="fit" layout="horizontal-row">
                     <div layout="vertical-row" width="10f" height="fit">
                         <gauge id="font_size" width="100%" align="center" />
@@ -68,14 +79,6 @@
                     <checkbox id="showfps"/>
                     <spacer width="1%" height="100%" />
                     <label height="100%" I18N="In the ui settings" text="Display FPS" word_wrap="true"/>
-                </div>
-
-                <spacer width="5" height="2%"/>
-
-                <div layout="horizontal-row" width="100%" height="fit">
-                    <checkbox id="split_screen_horizontally"/>
-                    <spacer width="1%" height="100%" />
-                    <label height="100%" I18N="In the ui settings" text="Multiplayer splits screen horizontally" word_wrap="true"/>
                 </div>
 
                 <spacer width="5" height="2%"/>

--- a/src/states_screens/options/options_screen_ui.cpp
+++ b/src/states_screens/options/options_screen_ui.cpp
@@ -103,6 +103,18 @@ void OptionsScreenUI::loadedFromFile()
     }
     minimap_options->m_properties[GUIEngine::PROP_MAX_VALUE] = "3";
 
+    // Setup splitscreen spinner
+    GUIEngine::SpinnerWidget* splitscreen_method = getWidget<GUIEngine::SpinnerWidget>("splitscreen_method");
+    splitscreen_method->m_properties[PROP_WRAP_AROUND] = "true";
+    splitscreen_method->clearLabels();
+    //I18N: In the UI options, splitscreen_method in the race UI
+    splitscreen_method->addLabel( core::stringw(_("Vertical")));
+    //I18N: In the UI options, splitscreen_method position in the race UI
+    splitscreen_method->addLabel( core::stringw(_("Horizontal")));
+    splitscreen_method->m_properties[GUIEngine::PROP_MIN_VALUE] = "0";
+    splitscreen_method->m_properties[GUIEngine::PROP_MAX_VALUE] = "1";
+
+    // Setup fontsize spinner
     GUIEngine::SpinnerWidget* font_size = getWidget<GUIEngine::SpinnerWidget>("font_size");
     assert( font_size != NULL );
 
@@ -228,16 +240,15 @@ void OptionsScreenUI::init()
     font_size->setActive(!in_game);
 
     // ---- video modes
-    CheckBoxWidget* splitscreen_method = getWidget<CheckBoxWidget>("split_screen_horizontally");
-    assert(splitscreen_method != NULL);
-    splitscreen_method->setState(UserConfigParams::split_screen_horizontally);
+    GUIEngine::SpinnerWidget* splitscreen_method = getWidget<GUIEngine::SpinnerWidget>("splitscreen_method");
+    assert( splitscreen_method != NULL );
+    if (UserConfigParams::split_screen_horizontally) splitscreen_method->setValue(1);
+    else splitscreen_method->setValue(0);
+    splitscreen_method->setActive(!in_game);
 
     CheckBoxWidget* karts_powerup_gui = getWidget<CheckBoxWidget>("karts_powerup_gui");
     assert(karts_powerup_gui != NULL);
     karts_powerup_gui->setState(UserConfigParams::m_karts_powerup_gui);
-
-    //Forbid changing this setting in game
-    splitscreen_method->setActive(!in_game);
 
     CheckBoxWidget* fps = getWidget<CheckBoxWidget>("showfps");
     assert( fps != NULL );
@@ -420,11 +431,11 @@ void OptionsScreenUI::eventCallback(Widget* widget, const std::string& name, con
         font_size->setFocusForPlayer(PLAYER_ID_GAME_MASTER);
         font_size->setSelectedButton(right);
     }
-    else if (name == "split_screen_horizontally")
+    else if (name == "splitscreen_method")
     {
-        CheckBoxWidget* split_screen_horizontally = getWidget<CheckBoxWidget>("split_screen_horizontally");
-        assert(split_screen_horizontally != NULL);
-        UserConfigParams::split_screen_horizontally = split_screen_horizontally->getState();
+        GUIEngine::SpinnerWidget* splitscreen_method = getWidget<GUIEngine::SpinnerWidget>("splitscreen_method");
+        assert( splitscreen_method != NULL );
+        UserConfigParams::split_screen_horizontally = (splitscreen_method->getValue() == 1);
     }
     else if (name == "karts_powerup_gui")
     {


### PR DESCRIPTION
Hello !

I propose to replace the checkbox that activate horizontal splits in multiplayer mode by a spinner.

The aim is to clarify this part of the interface, because (IMO) :
 -  the user need to knows explicitly which current split in multiplayer mode.
 -  activating horizontal split is a global rendering option, not an additionnal widget like "display FPS". Therefore this option shall be placed in same group that theming.

![Capture d’écran_2020-04-19_15-39-06](https://user-images.githubusercontent.com/9461518/79689670-9c578080-8256-11ea-8c85-699e1dfbb32d.png)

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
