### PR TITLE
Make formatting of song title translatable

### DIFF
--- a/src/states_screens/race_gui_base.cpp
+++ b/src/states_screens/race_gui_base.cpp
@@ -626,7 +626,8 @@ void RaceGUIBase::drawGlobalMusicDescription()
     const MusicInformation* mi = music_manager->getCurrentMusic();
     if (!mi) return;
 
-    core::stringw thetext = core::stringw(L"\"") + mi->getTitle() + L"\"";
+    // I18N: string used to show the song title (e.g. "Sunny Song")
+    core::stringw thetext = _("\"%s\"", mi->getTitle());
 
     core::dimension2d< u32 > textSize = font->getDimension(thetext.c_str());
     int textWidth = textSize.Width;


### PR DESCRIPTION
Different languages use different quotation marks and spacing
(e.g., « Song title » in French), so the formatting needs
to be translatable.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.
```
