### PR TITLE
Expose getDifficulty() to scripting

### DIFF
--- a/src/scriptengine/script_track.cpp
+++ b/src/scriptengine/script_track.cpp
@@ -179,6 +179,15 @@ namespace Scripting
         {
             return RaceManager::get()->getReverseTrack();
         }
+        
+        /**
+          * Gets the difficulty setting for this race.
+          * @return A Difficulty enum as defined in race_manager.hpp, implicitly casted to an int
+          */
+        int getDifficulty()
+        {
+            return RaceManager::get()->getDifficulty();
+        }
 
         int getMajorRaceMode()
         {
@@ -570,6 +579,10 @@ namespace Scripting
                                                
             r = engine->RegisterGlobalFunction("bool isReverse()", 
                                                mp ? WRAP_FN(isTrackReverse) : asFUNCTION(isTrackReverse), 
+                                               call_conv); assert(r >= 0);
+            
+            r = engine->RegisterGlobalFunction("int getDifficulty()", 
+                                               mp ? WRAP_FN(getDifficulty) : asFUNCTION(getDifficulty), 
                                                call_conv); assert(r >= 0);
                                                
             r = engine->RegisterGlobalFunction("int getMajorRaceMode()", 


### PR DESCRIPTION
## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
**Note: due to an issue with my setup, I haven't been able to compile and test this patch.** However it is very basic and I am willing to test a compiled version (either Win or Lin).

This feature was requested by three users in [this forum thread](https://forum.freegamedev.net/viewtopic.php?f=18&t=13078#p91399). Potential uses include:
* assisting AI and slow drivers over gaps or jumps on low difficulty settings
* tailoring jump landings and other track features to work better for each difficulty speed
* adding or removing obstacles based on difficulty (e.g. add falling rocks on expert/supertux but not on novice/intermediate)