### PR TITLE
Add support for Haiku operating system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,14 +177,12 @@ endif()
 add_subdirectory("${PROJECT_SOURCE_DIR}/lib/bullet")
 include_directories("${PROJECT_SOURCE_DIR}/lib/bullet/src")
 
-if(WIN32)
+if(WIN32 OR CMAKE_SYSTEM_NAME MATCHES "BSD")
     set(LIBRESOLV_LIBRARY)
+elseif (HAIKU)
+    find_library(LIBRESOLV_LIBRARY NAMES network socket)
 else()
-    if (NOT CMAKE_SYSTEM_NAME MATCHES "BSD")
-        find_library(LIBRESOLV_LIBRARY NAMES resolv libresolv)
-    else()
-        set(LIBRESOLV_LIBRARY)
-    endif()
+   find_library(LIBRESOLV_LIBRARY NAMES resolv libresolv)
 endif()
 
 # Find system ENet library or build it if missing
@@ -317,7 +315,7 @@ include_directories("${PROJECT_SOURCE_DIR}/lib/irrlicht/include")
 # of the added include directory.
 if(USE_WIIUSE)
     # Find system WiiUse library or build it if missing
-    if((UNIX AND NOT APPLE) AND USE_SYSTEM_WIIUSE)
+    if((UNIX AND NOT (APPLE OR HAIKU)) AND USE_SYSTEM_WIIUSE)
         find_package(WiiUse)
     endif()
 

--- a/lib/angelscript/source/as_config.h
+++ b/lib/angelscript/source/as_config.h
@@ -1085,23 +1085,26 @@
 	// Haiku OS
 	#elif __HAIKU__
 		#define AS_HAIKU
-		// Only x86-32 is currently supported by Haiku, but they do plan to support
-		// x86-64 and PowerPC in the future, so should go ahead and check the platform
-		// for future compatibility
 		#if (defined(i386) || defined(__i386) || defined(__i386__)) && !defined(__LP64__)
 			#define AS_X86
 			#define THISCALL_PASS_OBJECT_POINTER_ON_THE_STACK
 			#define THISCALL_RETURN_SIMPLE_IN_MEMORY
 			#define CDECL_RETURN_SIMPLE_IN_MEMORY
 			#define STDCALL_RETURN_SIMPLE_IN_MEMORY
-		#else
-			#define AS_MAX_PORTABILITY
-		#endif
-
-		#define AS_POSIX_THREADS
-		#if !( ( (__GNUC__ == 4) && (__GNUC_MINOR__ >= 1) || __GNUC__ > 4) )
-			// Only with GCC 4.1 was the atomic instructions available
-			#define AS_NO_ATOMIC
+                #elif defined(__x86_64__)
+                        #define AS_X64_GCC
+                        #define HAS_128_BIT_PRIMITIVES
+                        #define SPLIT_OBJS_BY_MEMBER_TYPES
+                        #undef COMPLEX_MASK
+                        #define COMPLEX_MASK (asOBJ_APP_CLASS_DESTRUCTOR | asOBJ_APP_CLASS_COPY_CONSTRUCTOR | asOBJ_APP_ARRAY)
+                        #undef COMPLEX_RETURN_MASK
+                        #define COMPLEX_RETURN_MASK (asOBJ_APP_CLASS_DESTRUCTOR | asOBJ_APP_CLASS_COPY_CONSTRUCTOR | asOBJ_APP_ARRAY)
+                        #define AS_LARGE_OBJS_PASSED_BY_REF
+                        #define AS_LARGE_OBJ_MIN_SIZE 5
+                        #undef STDCALL
+                        #define STDCALL
+                #else
+                        #define AS_MAX_PORTABILITY
 		#endif
 
 	// Illumos

--- a/lib/irrlicht/include/IrrCompileConfig.h
+++ b/lib/irrlicht/include/IrrCompileConfig.h
@@ -22,6 +22,7 @@
 //! _IRR_WINDOWS_CE_PLATFORM_ for Windows CE
 //! _IRR_WINDOWS_API_ for Windows or XBox
 //! _IRR_LINUX_PLATFORM_ for Linux (it is defined here if no other os is defined)
+//! _IRR_HAIKU_PLATFORM_ for Haiku
 //! _IRR_SOLARIS_PLATFORM_ for Solaris
 //! _IRR_OSX_PLATFORM_ for Apple systems running OSX
 //! _IRR_IOS_PLATFORM_ for Apple devices running iOS
@@ -88,6 +89,15 @@
 #endif
 #endif
 
+#if defined(HAIKU)
+#define _IRR_HAIKU_PLATFORM_
+#endif
+
+#if defined(_IRR_HAIKU_PLATFORM_)
+#define _IRR_COMPILE_WITH_SDL_DEVICE_
+#define _IRR_COMPILE_WITH_OPENGL_
+#endif
+
 #if defined(ANDROID)
 #define _IRR_ANDROID_PLATFORM_
 #define _IRR_POSIX_API_
@@ -99,7 +109,7 @@
 #define _IRR_COMPILE_ANDROID_ASSET_READER_
 #endif
 
-#if !defined(_IRR_WINDOWS_API_) && !defined(_IRR_OSX_PLATFORM_) && !defined(_IRR_ANDROID_PLATFORM_)
+#if !defined(_IRR_WINDOWS_API_) && !defined(_IRR_OSX_PLATFORM_) && !defined(_IRR_ANDROID_PLATFORM_) && !defined(_IRR_HAIKU_PLATFORM_)
 #ifndef _IRR_SOLARIS_PLATFORM_
 #define _IRR_LINUX_PLATFORM_
 #endif

--- a/lib/irrlicht/source/Irrlicht/CFileSystem.cpp
+++ b/lib/irrlicht/source/Irrlicht/CFileSystem.cpp
@@ -874,7 +874,7 @@ IFileList* CFileSystem::createFileList(const io::path& directory)
 					size = buf.st_size;
 					isDirectory = S_ISDIR(buf.st_mode);
 				}
-				#if !defined(_IRR_SOLARIS_PLATFORM_) && !defined(__CYGWIN__)
+				#if !defined(_IRR_SOLARIS_PLATFORM_) && !defined(__CYGWIN__) && !defined(__HAIKU__)
 				// only available on some systems
 				else
 				{

--- a/lib/irrlicht/source/Irrlicht/COSOperator.cpp
+++ b/lib/irrlicht/source/Irrlicht/COSOperator.cpp
@@ -11,7 +11,7 @@
 #else
 #include <string.h>
 #include <unistd.h>
-#if !defined(_IRR_SOLARIS_PLATFORM_) && !defined(__CYGWIN__)
+#if !defined(_IRR_SOLARIS_PLATFORM_) && !defined(__CYGWIN__) && !defined(__HAIKU__)
 #include <sys/param.h>
 #include <sys/types.h>
 #if defined(ANDROID) || (defined(__linux__) && !defined(__GLIBC__))

--- a/src/network/socket_address.hpp
+++ b/src/network/socket_address.hpp
@@ -46,10 +46,7 @@
 class SocketAddress
 {
 private:
-    // We need to have a biggest size to hold all type of sockaddr
-    static_assert(sizeof(sockaddr_in6) > sizeof(sockaddr_in),
-        "Invalid sockaddr size");
-    std::array<char, sizeof(sockaddr_in6)> m_sockaddr;
+    std::array<char, sizeof(sockaddr_storage)> m_sockaddr;
 
     short m_family;
 public:

--- a/src/utils/string_utils.cpp
+++ b/src/utils/string_utils.cpp
@@ -1388,6 +1388,8 @@ namespace StringUtils
         uagent += (std::string)" (Macintosh)";
 #elif defined(__FreeBSD__)
         uagent += (std::string)" (FreeBSD)";
+#elif defined(__HAIKU__)
+        uagent += (std::string)" (Haiku)";
 #elif defined(ANDROID)
         uagent += (std::string)" (Android)";
 #elif defined(linux)


### PR DESCRIPTION
## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```

So, this took a while. This pull request is meant to add support for the POSIX-compatible Haiku operating system and exists largely because of @Benau and @PulkoMandy.

Multiplayer works, after a few small modifications to the socket code. The game runs under SDL (which is supported under Haiku) and OpenGL.

I only managed to try it in a KVM virtual machine (aka. it runs under the llvmpipeline) and not bare metal/physical hardware. The performance was a bit lackluster, but it still ran alright, despite the circumstances.

I also had to make some patches to the Irrlicht engine, as well as modify the Angelscript source code in order to add support for the 64-bit versions of Haiku (largely thanks to the *BSD code that was also available). The changes are not a part of the upstream yet, but I've e-mailed the developer of AngelScript to ask about it.

You can find out more about the Haiku operating system [here](https://haiku-os.org).