### PR TITLE
Make red team color also configurable

### DIFF
--- a/data/skins/coal/stkskin.xml
+++ b/data/skins/coal/stkskin.xml
@@ -291,9 +291,11 @@ when the border that intersect at this corner are enabled.
 <color type="emphasis_text" state="neutral" r="230" g="210" b="50" />
 <color type="emphasis_text" state="focused" r="255" g="226" b="56" />
 
-<!-- Color used for blue items in list (e.g. player team color in networking) -->
+<!-- Color used for red/blue items in list (e.g. player team color in networking) -->
 <color type="list_blue" state="neutral" r="0" g="0" b="180" />
 <color type="list_blue" state="focused" r="0" g="0" b="255" />
+<color type="list_red" state="neutral" r="255" g="0" b="0" />
+<color type="list_red" state="focused" r="255" g="0" b="0" />
 
 <!-- Color used to fade out background when a dialog is shown -->
 <color type="dialog_background" state="neutral" a="120" r="0" g="0" b="0" />

--- a/data/skins/forest/stkskin.xml
+++ b/data/skins/forest/stkskin.xml
@@ -291,9 +291,11 @@ when the border that intersect at this corner are enabled.
 <color type="emphasis_text" state="neutral" r="0" g="0" b="180" />
 <color type="emphasis_text" state="focused" r="0" g="0" b="160" />
 
-<!-- Color used for blue items in list (e.g. player team color in networking) -->
+<!-- Color used for red/blue items in list (e.g. player team color in networking) -->
 <color type="list_blue" state="neutral" r="0" g="0" b="255" />
 <color type="list_blue" state="focused" r="0" g="0" b="255" />
+<color type="list_red" state="neutral" r="255" g="0" b="0" />
+<color type="list_red" state="focused" r="255" g="0" b="0" />
 
 <!-- Color used to fade out background when a dialog is shown -->
 <color type="dialog_background" state="neutral" a="120" r="0" g="0" b="0" />

--- a/data/skins/modern/stkskin.xml
+++ b/data/skins/modern/stkskin.xml
@@ -313,9 +313,11 @@ all types of ttf.
 <color type="emphasis_text" state="neutral" r="0" g="0" b="180" />
 <color type="emphasis_text" state="focused" r="0" g="0" b="160" />
 
-<!-- Color used for blue items in list (e.g. player team color in networking) -->
+<!-- Color used for red/blue items in list (e.g. player team color in networking) -->
 <color type="list_blue" state="neutral" r="0" g="0" b="255" />
 <color type="list_blue" state="focused" r="0" g="0" b="255" />
+<color type="list_red" state="neutral" r="255" g="0" b="0" />
+<color type="list_red" state="focused" r="255" g="0" b="0" />
 
 <!-- Color used to fade out background when a dialog is shown -->
 <color type="dialog_background" state="neutral" a="120" r="0" g="0" b="0" />

--- a/data/skins/ocean/stkskin.xml
+++ b/data/skins/ocean/stkskin.xml
@@ -290,9 +290,11 @@ when the border that intersect at this corner are enabled.
 <color type="emphasis_text" state="neutral" r="0" g="0" b="180" />
 <color type="emphasis_text" state="focused" r="0" g="0" b="160" />
 
-<!-- Color used for blue items in list (e.g. player team color in networking) -->
+<!-- Color used for red/blue items in list (e.g. player team color in networking) -->
 <color type="list_blue" state="neutral" r="0" g="0" b="255" />
 <color type="list_blue" state="focused" r="0" g="0" b="255" />
+<color type="list_red" state="neutral" r="255" g="0" b="0" />
+<color type="list_red" state="focused" r="255" g="0" b="0" />
 
 <!-- Color used to fade out background when a dialog is shown -->
 <color type="dialog_background" state="neutral" a="120" r="0" g="0" b="0" />

--- a/data/skins/peach/stkskin.xml
+++ b/data/skins/peach/stkskin.xml
@@ -308,9 +308,11 @@ all types of ttf.
 <color type="emphasis_text" state="neutral" r="0" g="0" b="180" />
 <color type="emphasis_text" state="focused" r="0" g="0" b="160" />
 
-<!-- Color used for blue items in list (e.g. player team color in networking) -->
+<!-- Color used for red/blue items in list (e.g. player team color in networking) -->
 <color type="list_blue" state="neutral" r="0" g="0" b="255" />
 <color type="list_blue" state="focused" r="0" g="0" b="255" />
+<color type="list_red" state="neutral" r="255" g="0" b="0" />
+<color type="list_red" state="focused" r="255" g="0" b="0" />
 
 <!-- Color used to fade out background when a dialog is shown -->
 <color type="dialog_background" state="neutral" a="120" r="0" g="0" b="0" />

--- a/data/skins/ruby/stkskin.xml
+++ b/data/skins/ruby/stkskin.xml
@@ -289,9 +289,11 @@ when the border that intersect at this corner are enabled.
 <color type="emphasis_text" state="neutral" r="0" g="0" b="180" />
 <color type="emphasis_text" state="focused" r="0" g="0" b="160" />
 
-<!-- Color used for blue items in list (e.g. player team color in networking) -->
+<!-- Color used for red/blue items in list (e.g. player team color in networking) -->
 <color type="list_blue" state="neutral" r="0" g="0" b="255" />
 <color type="list_blue" state="focused" r="0" g="0" b="255" />
+<color type="list_red" state="neutral" r="255" g="0" b="0" />
+<color type="list_red" state="focused" r="255" g="0" b="0" />
 
 <!-- Color used to fade out background when a dialog is shown -->
 <color type="dialog_background" state="neutral" a="120" r="0" g="0" b="0" />

--- a/src/guiengine/widgets/list_widget.cpp
+++ b/src/guiengine/widgets/list_widget.cpp
@@ -456,8 +456,8 @@ void ListWidget::markItemRed(const int id, bool red)
 
     if (red)
     {
-        irritem->setItemOverrideColor( id, EGUI_LBC_TEXT,           video::SColor(255,255,0,0) );
-        irritem->setItemOverrideColor( id, EGUI_LBC_TEXT_HIGHLIGHT, video::SColor(255,255,0,0) );
+        irritem->setItemOverrideColor( id, EGUI_LBC_TEXT,           GUIEngine::getSkin()->getColor("list_red::neutral"));
+        irritem->setItemOverrideColor( id, EGUI_LBC_TEXT_HIGHLIGHT, GUIEngine::getSkin()->getColor("list_red::focused"));
     }
     else
     {


### PR DESCRIPTION
Hi, I made the red team color in the player list also configurable in the skin. This can provide more flexibility for skin design.
## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
