### PR TITLE
Use skin color for the kart name label on kart selection screen

### DIFF
--- a/src/states_screens/kart_selection.cpp
+++ b/src/states_screens/kart_selection.cpp
@@ -890,6 +890,9 @@ void KartSelectionScreen::updateKartWidgetModel(int widget_id,
     ModelViewWidget* w3 = m_kart_widgets[widget_id].m_model_view;
     assert( w3 != NULL );
 
+    // set the color of the name label
+    m_kart_widgets[widget_id].m_kart_name->setColor(GUIEngine::getSkin()->getColor("text::neutral"));
+
     if (selection == RANDOM_KART_ID)
     {
         // Random kart


### PR DESCRIPTION
On the kart selection screen, the kart name is shown using the default black color. This does not work well with a dark skin. Here I use the color provided in skin for it.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
