### PR TITLE
file_manager: Emit a compiler error when no asset dir is defined for mobile platform

### DIFF
--- a/src/io/file_manager.cpp
+++ b/src/io/file_manager.cpp
@@ -221,6 +221,8 @@ FileManager::FileManager()
     m_stk_assets_download_dir += "/Library/Application Support/SuperTuxKart/stk-assets/";
 #elif defined (ANDROID)
     m_stk_assets_download_dir += "/stk-assets/";
+#else
+#error You must set m_stk_assets_download_dir to appropriate place for your platform
 #endif
 
 #else


### PR DESCRIPTION
I'm playing with running various games on a mobile GNU/Linux device. It's often the case that when a game has existing mobile support (Android and/or iOS), it then relies on some preprocessor directives in order to adjust some of its UI, available options etc. to mobile devices - so when I've noticed `MOBILE_STK` across the SuperTuxKart's code, I decided to try compiling it with it to see whether it will bring some benefits. It compiled fine.

However, running it had some unforeseen consequences.

In `src/io/file_manager.cpp`:

```c
#ifdef MOBILE_STK
    m_stk_assets_download_dir = getenv("HOME");
#ifdef IOS_STK
    m_stk_assets_download_dir += "/Library/Application Support/SuperTuxKart/stk-assets/";
#elif defined (ANDROID)
    m_stk_assets_download_dir += "/stk-assets/";
#endif
#else
```

As I was running a mobile STK, but neither on iOS nor Android, the `m_stk_assets_download_dir` was left at `getenv("HOME");`...

**...and turns out `m_stk_assets_download_dir` is passed in a few places straight to `FileManager::removeDirectory`, which then happily removes everything recursively from that directory.**

Maybe this fail-save check will help save some `$HOME`s. Fortunately mine had a recent enough backup.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
