### PR TITLE
Split the num of bots from human players in server selection

### DIFF
--- a/src/states_screens/online/server_selection.cpp
+++ b/src/states_screens/online/server_selection.cpp
@@ -245,7 +245,15 @@ void ServerSelection::loadList()
         if (t)
             icon = track_manager->getTrackIndexByIdent(t->getIdent()) + 2;
         core::stringw num_players;
-        num_players.append(StringUtils::toWString(server->getCurrentPlayers()));
+        int np = static_cast<int>(server->getPlayers().size()); // number of real players
+        int nc = server->getCurrentPlayers(); // number of current players (includes AI)
+        num_players.append(StringUtils::toWString(np));
+        // if there is AI player: use the format player+ai/max
+        if (nc-np > 0)
+        {
+            num_players.append("+");
+            num_players.append(StringUtils::toWString(nc-np));
+        }
         num_players.append("/");
         num_players.append(StringUtils::toWString(server->getMaxPlayers()));
         std::vector<GUIEngine::ListWidget::ListCell> row;


### PR DESCRIPTION
Hi, I sometimes find it is not straightforward to know if the number of players is Bot or human player by simply looking at the Players column on the Server Selection screen. The following figure shows what the code does. If a server supports Bots, the Players column will be: 
number of human players + number of bots / Max. player

Hope you like it :D

![Screenshot from 2020-07-08 10-09-20](https://user-images.githubusercontent.com/4726939/86937728-3667f000-c105-11ea-8ea7-b7c4fe5a0340.png)

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
