### PR TITLE
Fix button spacing in grand_prix_lose.stkgui and grand_prix_win.stkgui

### DIFF
--- a/data/gui/screens/grand_prix_lose.stkgui
+++ b/data/gui/screens/grand_prix_lose.stkgui
@@ -2,8 +2,8 @@
 <stkgui>
     <div x="2%" y="2%" width="96%" height="96%" layout="vertical-row">
         <spacer proportion="1"/>
-        <button id="save"     width="450" align="center" text="Save Grand Prix"/>
+        <button id="save"     width="10f" align="center" text="Save Grand Prix"/>
         <spacer height="20"/>
-        <button id="continue" width="450" align="center" text="Continue"/>
+        <button id="continue" width="10f" align="center" text="Continue"/>
     </div>
 </stkgui>

--- a/data/gui/screens/grand_prix_win.stkgui
+++ b/data/gui/screens/grand_prix_win.stkgui
@@ -2,9 +2,9 @@
 <stkgui>
     <div x="2%" y="2%" width="96%" height="96%" layout="vertical-row">
         <spacer proportion="1"/>
-        <button id="save"     width="450" align="center" text="Save Grand Prix"/>
+        <button id="save"     width="10f" align="center" text="Save Grand Prix"/>
         <spacer height="20"/>
-        <button id="continue" width="450" align="center" text="Continue"/>
+        <button id="continue" width="10f" align="center" text="Continue"/>
     </div>
 </stkgui>
 


### PR DESCRIPTION
On HiDPI screens these buttons were too small.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
