### PR TITLE
fix a small bug in reusing previously saved AI number

### DIFF
--- a/src/states_screens/track_info_screen.cpp
+++ b/src/states_screens/track_info_screen.cpp
@@ -398,7 +398,7 @@ void TrackInfoScreen::setSoccerWidgets(bool has_AI)
         // Make sure each team has at least 1 (ai + player)
         bool reuse_ai = ((num_blue_players + UserConfigParams::m_soccer_blue_ai_num) > 0) &&
                         ((num_red_players  + UserConfigParams::m_soccer_red_ai_num ) > 0) &&
-                        ((UserConfigParams::m_soccer_red_ai_num + UserConfigParams::m_soccer_blue_ai_num) < max_num_ai);
+                        ((UserConfigParams::m_soccer_red_ai_num + UserConfigParams::m_soccer_blue_ai_num) <= max_num_ai);
 
         // Try the saved values.
         // If they can't be used, use default balanced values


### PR DESCRIPTION
Reuse the AI number for cases like: 1 red player + 0 red AI + 7 blue AI
## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
