### PR TITLE
Add Render resolution (scale_rtts) slider with auto-mode 

### DIFF
--- a/data/gui/screens/options_video.stkgui
+++ b/data/gui/screens/options_video.stkgui
@@ -34,7 +34,7 @@
                 <!-- ************ GRAPHICAL EFFECTS SETTINGS ************ -->
                 <div width="100%" height="fit" layout="horizontal-row">
                     <spacer width="3%" height="100%" />
-                    <div layout="vertical-row" width="8f" height="fit">
+                    <div layout="vertical-row" width="10f" height="fit">
                         <gauge id="gfx_level" min_value="1" max_value="8" width="100%" align="center" />
                     </div>
                     <div layout="vertical-row" proportion="1" height="100%">
@@ -46,7 +46,25 @@
 
                 <div width="100%" height="fit" layout="horizontal-row">
                     <spacer width="3%" height="100%" />
-                    <div layout="vertical-row" width="8f" height="fit">
+                    <div layout="vertical-row" width="10f" height="fit">
+                        <gauge id="scale_rtts" min_value="0" max_value="7" width="100%" align="center" />
+                    </div>
+                    <div layout="vertical-row" proportion="1" height="100%">
+                        <label id="scale_rtts_label" height="100%" I18N="In the video settings" text="Render resolution" align="left"/>
+                    </div>
+                    <div proportion="1" layout="horizontal-row" height="fit">
+                        <spacer width="5%" height="100%" />
+                        <checkbox id="scale_rtts_custom"/>
+                        <spacer width="2%" height="100%" />
+                        <label id="scale_rtts_custom_label" height="100%" I18N="In the video settings" text="Custom"/>
+                    </div>
+                </div>
+
+                <spacer width="5" height="1%"/>
+
+                <div width="100%" height="fit" layout="horizontal-row">
+                    <spacer width="3%" height="100%" />
+                    <div layout="vertical-row" width="10f" height="fit">
                         <gauge id="blur_level" min_value="0" max_value="2" width="100%" align="center" />
                     </div>
                     <div layout="vertical-row" proportion="1" height="100%">
@@ -59,7 +77,7 @@
                 <!-- ************ VSYNC ************ -->
                 <div width="100%" height="fit" layout="horizontal-row" id="outer_box" >
                     <spacer width="3%" height="100%" />
-                    <div layout="vertical-row" width="8f" height="fit" id="inner_box">
+                    <div layout="vertical-row" width="10f" height="fit" id="inner_box">
                         <spinner id="vsync" width="100%" align="center" />
                     </div>
                     <div layout="vertical-row" proportion="1" height="100%">

--- a/lib/irrlicht/include/IrrlichtDevice.h
+++ b/lib/irrlicht/include/IrrlichtDevice.h
@@ -248,6 +248,10 @@ namespace irr
 		/** \return true if success */
 		virtual bool getWindowPosition(int* x, int* y) = 0;
 
+		//! Get DPI of current display.
+		/** \return true if success */
+		virtual bool getDisplayDPI(float* ddpi, float* hdpi, float* vdpi) = 0;
+
 
 		//! Activate any joysticks, and generate events for them.
 		/** Irrlicht contains support for joysticks, but does not generate joystick events by default,

--- a/lib/irrlicht/source/Irrlicht/CIrrDeviceSDL.cpp
+++ b/lib/irrlicht/source/Irrlicht/CIrrDeviceSDL.cpp
@@ -1006,6 +1006,18 @@ bool CIrrDeviceSDL::getWindowPosition(int* x, int* y)
 }
 
 
+//! Get DPI of current display.
+bool CIrrDeviceSDL::getDisplayDPI(float* ddpi, float* hdpi, float* vdpi)
+{
+	if (Window)
+	{
+        SDL_GetDisplayDPI(SDL_GetWindowDisplayIndex(Window), ddpi, hdpi, vdpi);
+		return true;
+	}
+	return false;
+}
+
+
 //! returns if window is active. if not, nothing need to be drawn
 bool CIrrDeviceSDL::isWindowActive() const
 {

--- a/lib/irrlicht/source/Irrlicht/CIrrDeviceSDL.h
+++ b/lib/irrlicht/source/Irrlicht/CIrrDeviceSDL.h
@@ -90,6 +90,9 @@ namespace irr
 		//! Get current window position.
 		virtual bool getWindowPosition(int* x, int* y);
 
+		//! Get DPI of current display.
+		virtual bool getDisplayDPI(float* ddpi, float* hdpi, float* vdpi);
+
 		//! Activate any joysticks, and generate events for them.
 		virtual bool activateJoysticks(core::array<SJoystickInfo> & joystickInfo);
 

--- a/lib/irrlicht/source/Irrlicht/CIrrDeviceStub.h
+++ b/lib/irrlicht/source/Irrlicht/CIrrDeviceStub.h
@@ -113,6 +113,9 @@ namespace irr
 		//! Checks if the window is running in fullscreen mode.
 		virtual bool isFullscreen() const;
 
+        //! Gets the DPI of the display currently used
+        virtual bool getDisplayDPI(float* ddpi, float* hdpi, float* vdpi) {return false;}
+
 		//! get color format of the current window
 		virtual video::ECOLOR_FORMAT getColorFormat() const;
 

--- a/src/config/user_config.hpp
+++ b/src/config/user_config.hpp
@@ -674,10 +674,18 @@ namespace UserConfigParams
     PARAM_PREFIX BoolUserConfigParam        m_old_driver_popup
         PARAM_DEFAULT(BoolUserConfigParam(true, "old_driver_popup",
         &m_video_group, "Determines if popup message about too old drivers should be displayed."));
+    PARAM_PREFIX IntUserConfigParam         m_scale_rtts_mode
+        PARAM_DEFAULT(IntUserConfigParam(5, "scale_rtts_mode",
+        &m_video_group, "Allows one to increase performance by setting lower RTTs "
+                        "resolution. 0 = Max performance, 1 = Performance, "
+                        "2 = Balanced, 3 = Quality, 4 = High Quality, 5 = Always Full"));
+    PARAM_PREFIX BoolUserConfigParam        m_scale_rtts_custom
+        PARAM_DEFAULT(BoolUserConfigParam(false, "scale_rtts_custom",
+        &m_video_group, "Determines if custom value for RTTs resolution is used."));
     PARAM_PREFIX FloatUserConfigParam       m_scale_rtts_factor
         PARAM_DEFAULT(FloatUserConfigParam(1.0f, "scale_rtts_factor",
-        &m_video_group, "Allows one to increase performance by setting lower RTTs "
-                        "resolution. Value should be smaller or equal to 1.0"));
+        &m_video_group, "Custom value for RTTs resolution. "
+                        "Value should be smaller or equal to 1.0"));
     PARAM_PREFIX IntUserConfigParam         m_max_texture_size
         PARAM_DEFAULT(IntUserConfigParam(512, "max_texture_size",
         &m_video_group, "Max texture size when high definition textures are "
@@ -689,7 +697,7 @@ namespace UserConfigParams
                         "high quality method with SSE"));
     PARAM_PREFIX FloatUserConfigParam         m_font_size
         PARAM_DEFAULT(  FloatUserConfigParam(3, "font_size",
-        &m_video_group,"The size of fonts. 0 is the smallest and 6 is the biggest") );
+        &m_video_group, "The size of fonts. 0 is the smallest and 6 is the biggest") );
 
     // ---- Recording
     PARAM_PREFIX GroupUserConfigParam        m_recording_group

--- a/src/graphics/shader_based_renderer.cpp
+++ b/src/graphics/shader_based_renderer.cpp
@@ -625,6 +625,56 @@ void ShaderBasedRenderer::onLoadWorld()
     const core::recti &viewport = Camera::getCamera(0)->getViewport();
     unsigned int width = viewport.LowerRightCorner.X - viewport.UpperLeftCorner.X;
     unsigned int height = viewport.LowerRightCorner.Y - viewport.UpperLeftCorner.Y;
+
+	float ddpi = 0.f;
+    float hdpi = 0.f;
+    float vdpi = 0.f;
+
+    if (!UserConfigParams::m_scale_rtts_custom) // Calculate scale factor
+    {
+        if (!irr_driver->getDevice()->getDisplayDPI(&ddpi, &hdpi, &vdpi))
+        {
+            Log::warn("Renderer", "Failed to get display DPI, falling back to 100% render scaling.");
+            UserConfigParams::m_scale_rtts_factor = 1.0f;
+        }
+        else
+        {
+            switch (UserConfigParams::m_scale_rtts_mode)
+            {
+                case 0: // Max Performance
+                    UserConfigParams::m_scale_rtts_factor = 72.f / ddpi;
+                    break;
+                case 1: // Performance
+                    UserConfigParams::m_scale_rtts_factor = 96.f / ddpi;
+                    break;
+                case 2: // Balanced
+                    UserConfigParams::m_scale_rtts_factor = 120.f / ddpi;
+                    break;
+                case 3: // Quality
+                    UserConfigParams::m_scale_rtts_factor = 160.f / ddpi;
+                    break;
+                case 4: // High Quality
+                    UserConfigParams::m_scale_rtts_factor = 210.f / ddpi;
+                    break;
+                case 5: // Always Full
+                    UserConfigParams::m_scale_rtts_factor = 1.0f;
+                    break;
+            }
+            
+            // Round to nearest 5%
+            UserConfigParams::m_scale_rtts_factor = (float)((((int)(UserConfigParams::m_scale_rtts_factor*100.f)+2)/5)*5) / 100.f;
+
+            // Round up to 100% if at 90% or more; also make sure scale is at least 30%
+            if (UserConfigParams::m_scale_rtts_factor >= 0.9f)
+                UserConfigParams::m_scale_rtts_factor = 1.0f;
+            if (UserConfigParams::m_scale_rtts_factor < 0.3f)
+                UserConfigParams::m_scale_rtts_factor = 0.3f;
+
+            Log::info("Renderer", "Display DPI: %f", ddpi);
+            Log::info("Renderer", "Render scale: %f", (float)UserConfigParams::m_scale_rtts_factor);
+        }
+    }
+
     RTT* rtts = new RTT(width, height, CVS->isDeferredEnabled() ?
                         UserConfigParams::m_scale_rtts_factor : 1.0f,
                         !CVS->isDeferredEnabled());

--- a/src/states_screens/options/options_screen_video.cpp
+++ b/src/states_screens/options/options_screen_video.cpp
@@ -112,6 +112,22 @@ void OptionsScreenVideo::initPresets()
         true  /* motionblur */, true  /* depth of field */
     });
 
+    m_scale_rtts_custom_presets.push_back({ 0.3f });
+    m_scale_rtts_custom_presets.push_back({ 0.35f });
+    m_scale_rtts_custom_presets.push_back({ 0.4f });
+    m_scale_rtts_custom_presets.push_back({ 0.45f });
+    m_scale_rtts_custom_presets.push_back({ 0.5f });
+    m_scale_rtts_custom_presets.push_back({ 0.55f });
+    m_scale_rtts_custom_presets.push_back({ 0.6f });
+    m_scale_rtts_custom_presets.push_back({ 0.65f });
+    m_scale_rtts_custom_presets.push_back({ 0.7f });
+    m_scale_rtts_custom_presets.push_back({ 0.75f });
+    m_scale_rtts_custom_presets.push_back({ 0.8f });
+    m_scale_rtts_custom_presets.push_back({ 0.85f });
+    m_scale_rtts_custom_presets.push_back({ 0.9f });
+    m_scale_rtts_custom_presets.push_back({ 0.95f });
+    m_scale_rtts_custom_presets.push_back({ 1.0f });
+
 }   // initPresets
 
 // --------------------------------------------------------------------------------------------
@@ -240,6 +256,31 @@ void OptionsScreenVideo::init()
 
     vsync->setTooltip(vsync_tooltip);
 #endif
+
+    // Setup Render Resolution (scale_rtts) spinner
+    GUIEngine::SpinnerWidget* scale_rtts = getWidget<GUIEngine::SpinnerWidget>("scale_rtts");
+    assert( scale_rtts != NULL );
+
+    scale_rtts->clearLabels();
+    scale_rtts->addLabel(_("30%%"));
+    scale_rtts->addLabel(_("35%%"));
+    scale_rtts->addLabel(_("40%%"));
+    scale_rtts->addLabel(_("45%%"));
+    scale_rtts->addLabel(_("50%%"));
+    scale_rtts->addLabel(_("55%%"));
+    scale_rtts->addLabel(_("60%%"));
+    scale_rtts->addLabel(_("65%%"));
+    scale_rtts->addLabel(_("70%%"));
+    scale_rtts->addLabel(_("75%%"));
+    scale_rtts->addLabel(_("80%%"));
+    scale_rtts->addLabel(_("85%%"));
+    scale_rtts->addLabel(_("90%%"));
+    scale_rtts->addLabel(_("95%%"));
+    scale_rtts->addLabel(_("100%%"));
+
+    CheckBoxWidget* scale_rtts_custom = getWidget<CheckBoxWidget>("scale_rtts_custom");
+    assert( scale_rtts_custom != NULL );
+    scale_rtts_custom->setState( UserConfigParams::m_scale_rtts_custom );
 
     // ---- video modes
     DynamicRibbonWidget* res = getWidget<DynamicRibbonWidget>("resolutions");
@@ -395,6 +436,7 @@ void OptionsScreenVideo::init()
     // --- set gfx settings values
     updateGfxSlider();
     updateBlurSlider();
+    updateScaleRTTsSlider();
 
     // ---- forbid changing resolution or animation settings from in-game
     // (we need to disable them last because some items can't be edited when
@@ -406,6 +448,8 @@ void OptionsScreenVideo::init()
     applyBtn->setActive(!in_game);
     gfx->setActive(!in_game);
     getWidget<ButtonWidget>("custom")->setActive(!in_game);
+    getWidget<SpinnerWidget>("scale_rtts")->setActive(!in_game);
+    getWidget<CheckBoxWidget>("scale_rtts_custom")->setActive(!in_game);
     
 #if defined(MOBILE_STK)
     applyBtn->setVisible(false);
@@ -492,6 +536,12 @@ void OptionsScreenVideo::updateGfxSlider()
     // Enable the blur slider if the modern renderer is used
     getWidget<GUIEngine::SpinnerWidget>("blur_level")->
         setActive(UserConfigParams::m_dynamic_lights);
+    // Same with Render resolution slider
+    getWidget<GUIEngine::SpinnerWidget>("scale_rtts")->
+        setActive(UserConfigParams::m_dynamic_lights);
+    getWidget<GUIEngine::CheckBoxWidget>("scale_rtts_custom")->
+        setActive(UserConfigParams::m_dynamic_lights);
+
     updateTooltip();
 } // updateGfxSlider
 
@@ -522,6 +572,64 @@ void OptionsScreenVideo::updateBlurSlider()
 
     updateBlurTooltip();
 } // updateBlurSlider
+
+// --------------------------------------------------------------------------------------------
+
+void OptionsScreenVideo::updateScaleRTTsSlider()
+{
+    GUIEngine::SpinnerWidget* scale_rtts_level = 
+        getWidget<GUIEngine::SpinnerWidget>("scale_rtts");
+    assert( scale_rtts_level != NULL );
+
+    if (UserConfigParams::m_scale_rtts_custom)
+    {
+        scale_rtts_level->clearLabels();
+        scale_rtts_level->addLabel(_("30%%"));
+        scale_rtts_level->addLabel(_("35%%"));
+        scale_rtts_level->addLabel(_("40%%"));
+        scale_rtts_level->addLabel(_("45%%"));
+        scale_rtts_level->addLabel(_("50%%"));
+        scale_rtts_level->addLabel(_("55%%"));
+        scale_rtts_level->addLabel(_("60%%"));
+        scale_rtts_level->addLabel(_("65%%"));
+        scale_rtts_level->addLabel(_("70%%"));
+        scale_rtts_level->addLabel(_("75%%"));
+        scale_rtts_level->addLabel(_("80%%"));
+        scale_rtts_level->addLabel(_("85%%"));
+        scale_rtts_level->addLabel(_("90%%"));
+        scale_rtts_level->addLabel(_("95%%"));
+        scale_rtts_level->addLabel(_("100%%"));
+
+        bool found = false;
+        for (unsigned int l = 0; l < m_scale_rtts_custom_presets.size(); l++)
+        {
+            if (m_scale_rtts_custom_presets[l].value == UserConfigParams::m_scale_rtts_factor)
+            {
+                scale_rtts_level->setValue(l);
+                found = true;
+                break;
+            }
+        }
+
+        if (!found)
+        {
+            //I18N: custom video settings
+            scale_rtts_level->setCustomText( _("Custom") );
+        }
+    }
+    else
+    {
+        scale_rtts_level->clearLabels();
+        scale_rtts_level->addLabel(_("Max Performance"));
+        scale_rtts_level->addLabel(_("Performance"));
+        scale_rtts_level->addLabel(_("Balanced"));
+        scale_rtts_level->addLabel(_("Quality"));
+        scale_rtts_level->addLabel(_("High Quality"));
+        scale_rtts_level->addLabel(_("Always Full"));
+
+        scale_rtts_level->setValue(UserConfigParams::m_scale_rtts_mode);
+    }
+} // updateScaleRTTsSlider
 
 // --------------------------------------------------------------------------------------------
 
@@ -698,6 +806,12 @@ void OptionsScreenVideo::eventCallback(Widget* widget, const std::string& name,
         // Enable the blur spinner only if the new renderer is on
         getWidget<GUIEngine::SpinnerWidget>("blur_level")->setActive(level >= 2);
 
+        // Same with Render resolution slider
+        getWidget<GUIEngine::SpinnerWidget>("scale_rtts")->
+            setActive(UserConfigParams::m_dynamic_lights);
+        getWidget<GUIEngine::CheckBoxWidget>("scale_rtts_custom")->
+            setActive(UserConfigParams::m_dynamic_lights);
+
         UserConfigParams::m_animated_characters = m_presets[level].animatedCharacters;
         UserConfigParams::m_particles_effects = m_presets[level].particles;
         setImageQuality(m_presets[level].image_quality);
@@ -737,6 +851,31 @@ void OptionsScreenVideo::eventCallback(Widget* widget, const std::string& name,
 #if !defined(SERVER_ONLY) && defined(_IRR_COMPILE_WITH_SDL_DEVICE_)
         update_swap_interval(UserConfigParams::m_swap_interval);
 #endif
+    }
+    else if (name == "scale_rtts")
+    {
+        GUIEngine::SpinnerWidget* scale_rtts_level =
+            getWidget<GUIEngine::SpinnerWidget>("scale_rtts");
+        assert( scale_rtts_level != NULL );
+
+        const int level = scale_rtts_level->getValue();
+
+        if (UserConfigParams::m_scale_rtts_custom)
+            UserConfigParams::m_scale_rtts_factor = m_scale_rtts_custom_presets[level].value;
+        else
+            UserConfigParams::m_scale_rtts_mode = level;
+
+        updateScaleRTTsSlider();
+    }
+    else if (name == "scale_rtts_custom")
+    {
+        GUIEngine::CheckBoxWidget* scale_rtts_custom =
+            getWidget<GUIEngine::CheckBoxWidget>("scale_rtts_custom");
+        assert( scale_rtts_custom != NULL );
+
+        UserConfigParams::m_scale_rtts_custom = scale_rtts_custom->getState();
+
+        updateScaleRTTsSlider();
     }
     else if (name == "rememberWinpos")
     {

--- a/src/states_screens/options/options_screen_video.hpp
+++ b/src/states_screens/options/options_screen_video.hpp
@@ -48,6 +48,16 @@ struct BlurPreset
     bool dof;
 };
 
+struct ScaleRttsCustomPreset
+{
+    float value;
+};
+
+struct ScaleRttsAutoPreset
+{
+    int preset;
+};
+
 struct Resolution
 {
     int width; 
@@ -90,6 +100,8 @@ private:
     bool m_inited;
     std::vector<GFXPreset> m_presets;
     std::vector<BlurPreset> m_blur_presets;
+    std::vector<ScaleRttsCustomPreset> m_scale_rtts_custom_presets;
+    std::vector<ScaleRttsAutoPreset>   m_scale_rtts_auto_presets;
     std::vector<Resolution> m_resolutions;
 
     void updateTooltip();
@@ -118,6 +130,7 @@ public:
 
     void         updateGfxSlider();
     void         updateBlurSlider();
+    void         updateScaleRTTsSlider();
     static int getImageQuality();
     static void setImageQuality(int quality);
 };


### PR DESCRIPTION
[UPDATED]

Auto mode adjusts based on your display's DPI in order to hit a target DPI.  Currently it will default to Always Full for render resolution, but High Quality or even Quality might make a good default, community testing is needed.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
