### PR TITLE
network_config: use ns_name_uncompress

### DIFF
--- a/src/network/network_config.cpp
+++ b/src/network/network_config.cpp
@@ -587,7 +587,7 @@ void NetworkConfig::fillStunList(std::vector<std::pair<std::string, int> >* l,
         for (unsigned i = 0; i < srv.size(); i++)
         {
             char server_name[512] = {};
-            if (ns_name_ntop(srv[i] + SRV_SERVER, server_name, 512) < 0)
+            if (ns_name_uncompress(response, response + response_len, srv[i] + SRV_SERVER, server_name, 512) < 0)
                 continue;
             uint16_t port = ns_get16(srv[i] + SRV_PORT);
             uint16_t weight = ns_get16(srv[i] + SRV_WEIGHT);


### PR DESCRIPTION
## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```

This allows the game to build for distros using musl libc, such as Void and Alpine, since musl does not implement `ns_name_ntop`. Does this patch keep the intended behavior for that code? I am opening this PR since it isn't clear whether this function will be added to musl, and it would be best if such changes were discussed with upstream.