### PR TITLE
Fix include path order

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -353,7 +353,7 @@ if(USE_SYSTEM_ANGELSCRIPT)
     endif()
 else()
     add_subdirectory("${PROJECT_SOURCE_DIR}/lib/angelscript/projects/cmake")
-    include_directories("${PROJECT_SOURCE_DIR}/lib/angelscript/include")
+    include_directories(BEFORE "${PROJECT_SOURCE_DIR}/lib/angelscript/include")
     set(Angelscript_LIBRARIES angelscript)
 endif()
 


### PR DESCRIPTION
...to avoid picking includes from system angelscript when bundled one is used

Fixes #4372

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
