### PR TITLE
Fixes thunder sounds playing during paused game

### DIFF
--- a/src/graphics/weather.cpp
+++ b/src/graphics/weather.cpp
@@ -74,7 +74,8 @@ void Weather::update(float dt)
     {
         startLightning();
 
-        if (m_thunder_sound)
+        if (m_thunder_sound &&
+            World::getWorld()->getPhase() != WorldStatus::IN_GAME_MENU_PHASE)
         {
             m_thunder_sound->play();
         }


### PR DESCRIPTION
## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```

Fixes #4354 

It used to be that thunder sounds would still play after pausing the game since the sounds were a part of Weather::update which gets called every frame by World::updateGraphics. This was solved with a check in Weather::update to examine wether the game is paused or not, however I guess another solution would be to separate the updating of weather graphics and sound since World::updateGraphics probably shouldn't cause any sounds.