### PR TITLE
Skinable kart icons

### DIFF
--- a/src/guiengine/skin.cpp
+++ b/src/guiengine/skin.cpp
@@ -2897,7 +2897,8 @@ std::string Skin::getThemedIcon(const std::string& relative_path) const
     {
         std::string relative_path2 = path_no_extension + s;
         if (!SkinConfig::m_icon_theme ||
-            relative_path2.find("gui/icons/") == std::string::npos)
+            (relative_path2.find("karts/") == std::string::npos &&
+             relative_path2.find("gui/icons/") == std::string::npos))
         {
             std::string tmp_path = file_manager->getAsset(relative_path2);
             if (file_manager->fileExists(tmp_path))

--- a/src/karts/kart_properties.cpp
+++ b/src/karts/kart_properties.cpp
@@ -265,7 +265,16 @@ void KartProperties::load(const std::string &filename, const std::string &node)
     // addShared makes sure that these textures/material infos stay in memory
     material_manager->addSharedMaterial(materials_file);
 
-    m_icon_file = m_root+m_icon_file;
+    // load the kart icon file
+    if(Addon::isAddon(filename))
+    {   // load the icon directly if addon karts
+        m_icon_file = m_root+m_icon_file;
+    }
+    else
+    {   // check the skin folder for icons first if official karts
+        m_icon_file = GUIEngine::getSkin()->getThemedIcon(std::string("karts/")
+                                                          +m_ident+"/"+m_icon_file);
+    }
 
     // Make permanent is important, since otherwise icons can get deleted
     // (e.g. when freeing temp. materials from a track, the last icon
@@ -277,8 +286,17 @@ void KartProperties::load(const std::string &filename, const std::string &node)
                                                     /*strip_path*/false);
     if (m_minimap_icon_file!="")
     {
-        m_minimap_icon = STKTexManager::getInstance()
-            ->getTexture(m_root+m_minimap_icon_file);
+        // check if there is an icon in the skin folder first
+        if(Addon::isAddon(filename))
+        {
+            m_minimap_icon_file = m_root+m_minimap_icon_file;
+        }
+        else
+        {
+            m_minimap_icon_file = GUIEngine::getSkin()->getThemedIcon(std::string("karts/")
+                                                                      +m_ident+"/"+m_minimap_icon_file);
+        }
+        m_minimap_icon = STKTexManager::getInstance()->getTexture(m_minimap_icon_file);
     }
     else
         m_minimap_icon = NULL;


### PR DESCRIPTION
Hi, I made it possible to load official karts' icons from the skin folder (svg icon is also supported). If an icon is not found in the skin folder, then the default one will be loaded.
The folder structure is like:
data/skins/xxx/data/karts/adiumy/xxx.png
Here is what jymis's icons look in game:
![Screenshot (70)](https://user-images.githubusercontent.com/4726939/94326513-e4976f00-ff69-11ea-8414-430c1e2e9fa2.png)
Hope you like it.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
