### PR TITLE
Condense checkboxes in video options

### DIFF
--- a/data/gui/screens/options_video.stkgui
+++ b/data/gui/screens/options_video.stkgui
@@ -27,7 +27,6 @@
             <spacer width="2%" height="100%"/>
 
             <box width="78%" height="100%" layout="vertical-row">
-                <spacer width="5" height="1%"/>
                 <label width="100%" I18N="In the video settings" text="Graphics"/>
 
                 <spacer width="5" height="1%"/>
@@ -88,29 +87,29 @@
 
                 <spacer width="5" height="1%"/>
 
-                <div width="75%" height="fit" layout="horizontal-row" >
-                    <spacer width="5%" height="100%" />
-                    <checkbox id="fullscreen"/>
-                    <spacer width="1%" height="100%" />
-                    <label id="fullscreenText" height="100%" I18N="In the video settings" text="Fullscreen"/>
+                <div layout="horizontal-row" width="100%" height="fit">
+                    <div proportion="2" height="fit" layout="horizontal-row" >
+                        <spacer width="5%" height="100%" />
+                        <checkbox id="fullscreen"/>
+                        <spacer width="2%" height="100%" />
+                        <label id="fullscreenText" height="100%" I18N="In the video settings" text="Fullscreen"/>
+                    </div>
+
+                    <div proportion="3" layout="horizontal-row" height="fit">
+                        <spacer width="5%" height="100%" />
+                        <checkbox id="rememberWinpos"/>
+                        <spacer width="2%" height="100%" />
+                        <label id="rememberWinposText" height="100%" I18N="In the video settings" text="Remember window location"/>
+                    </div>
                 </div>
 
-                <div width="75%" layout="horizontal-row" height="fit">
-                    <spacer width="5%" height="100%" />
-                    <checkbox id="rememberWinpos"/>
-                    <spacer width="1%" height="100%" />
-                    <label id="rememberWinposText" height="100%" I18N="In the video settings" text="Remember window location"/>
-                </div>
-
-                <spacer width="5" height="1%"/>
+                <spacer width="5" height="2%"/>
 
                 <div width="100%" height="fit" layout="horizontal-row" >
                     <spacer width="5%" height="100%" />
                     <button id="apply_resolution"
                         I18N="In the video settings" text="Apply new resolution" />
                 </div>
-
-                <spacer width="5" height="1%"/>
 
             </box>
         </div>


### PR DESCRIPTION
With the font size set to "Very Large" and the theme set to "Cartoon", the Apply button went slightly outside of the main box.  This fixes that by putting the two checkboxes on the same row, which saves a bit of valuable horizontal space.

![Screenshot from 2020-09-25 20-33-15](https://user-images.githubusercontent.com/13989090/94329309-c5e7a700-ff6e-11ea-850c-430e3922b67b.png)

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
