### PR TITLE
Remove separate menu FPS throttling

### DIFF
--- a/src/guiengine/screen.cpp
+++ b/src/guiengine/screen.cpp
@@ -54,7 +54,6 @@ Screen::Screen(const char* file, bool pause_race)
     m_magic_number   = 0xCAFEC001;
 
     m_filename       = file;
-    m_throttle_FPS   = true;
     m_render_3d      = false;
     m_loaded         = false;
     m_pause_race     = pause_race;

--- a/src/guiengine/screen.hpp
+++ b/src/guiengine/screen.hpp
@@ -99,8 +99,6 @@ protected:
         /** True if this screen is resizable
          */
         bool m_resizable;
-
-        bool m_throttle_FPS;
     private:
         /** True if the race (if it is running) should be paused when this
          *  screen is shown. The RaceResultGUI uses this to leave the race
@@ -164,8 +162,6 @@ protected:
 
         /** \return whether this screen is currently loaded */
         bool isLoaded() const { return m_loaded; }
-
-        bool throttleFPS() const { return m_throttle_FPS; }
 
         void addWidgets();
 
@@ -350,7 +346,6 @@ protected:
         CutsceneScreen(const char* name) : Screen(name, false)
         {
             setNeeds3D(true);
-            m_throttle_FPS = false;
         }
 
         virtual void onCutsceneEnd() = 0;

--- a/src/main_loop.cpp
+++ b/src/main_loop.cpp
@@ -296,10 +296,8 @@ float MainLoop::getLimitedDt()
 #else
         const int max_fps = (irr_driver->isRecording() &&
                              UserConfigParams::m_limit_game_fps )
-                          ? UserConfigParams::m_record_fps 
-                          : ( StateManager::get()->throttleFPS() 
-                              ? 60 
-                              : UserConfigParams::m_max_fps     );
+                           ? UserConfigParams::m_record_fps 
+                           : UserConfigParams::m_max_fps;
 #endif
         const int current_fps = (int)(1000.0f / dt);
         if (!m_throttle_fps || current_fps <= max_fps ||

--- a/src/states_screens/credits.cpp
+++ b/src/states_screens/credits.cpp
@@ -119,8 +119,6 @@ void CreditsScreen::loadedFromFile()
 {
     reset();
 
-    m_throttle_FPS = false;
-
     std::string creditsfile = file_manager->getAsset("CREDITS");
 
     std::ifstream file(

--- a/src/states_screens/state_manager.cpp
+++ b/src/states_screens/state_manager.cpp
@@ -153,23 +153,6 @@ void StateManager::resetActivePlayers()
 
 // ----------------------------------------------------------------------------
 
-#if 0
-#pragma mark -
-#pragma mark misc stuff
-#endif
-
-bool StateManager::throttleFPS()
-{
-#ifndef SERVER_ONLY
-    return m_game_mode != GUIEngine::GAME && GUIEngine::getCurrentScreen() &&
-        GUIEngine::getCurrentScreen()->throttleFPS();
-#else
-    return true;
-#endif
-}   // throttleFPS
-
-// ----------------------------------------------------------------------------
-
 void StateManager::escapePressed()
 {
     // in input sensing mode

--- a/src/states_screens/state_manager.hpp
+++ b/src/states_screens/state_manager.hpp
@@ -188,13 +188,6 @@ public:
     unsigned int activePlayerCount();
     void resetActivePlayers();
 
-    /** \return whether to reduce FPS at the moment
-      * \note   this can be useful to avoid being too CPU/GPU intensive in
-      *         parts of the game that don't require high framerates, like
-      *         menus
-      */
-    bool throttleFPS();
-
     /** \brief implementing callback from base class AbstractStateManager */
     void escapePressed();
 


### PR DESCRIPTION
We should let VSync/m_max_fps (which defaults to 120) do their job.  If a monitor has a refresh rate even slightly higher than 60FPS (e.g. 60.0007FPS), throttling will introduce stutters, even more so at modern high refresh rates (75, 90, 120, etc.)

This also cleans up the code, e.g. the var name `m_throttle_fps` was also being used in `main_loop.[c/h]pp` for a different function, despite having the same var name.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
