### PR TITLE
Added 2 seconds of immunity after getting rescued

### DIFF
--- a/src/karts/rescue_animation.cpp
+++ b/src/karts/rescue_animation.cpp
@@ -148,6 +148,7 @@ RescueAnimation::~RescueAnimation()
 {
     m_kart->getBody()->setLinearVelocity(btVector3(0, 0, 0));
     m_kart->getBody()->setAngularVelocity(btVector3(0, 0, 0));
+    m_kart->setInvulnerableTicks(stk_config->time2Ticks(2));
     if (m_referee && m_kart->getNode())
     {
         m_kart->getNode()->removeChild(m_referee->getSceneNode());

--- a/src/karts/rescue_animation.cpp
+++ b/src/karts/rescue_animation.cpp
@@ -149,6 +149,7 @@ RescueAnimation::~RescueAnimation()
     m_kart->getBody()->setLinearVelocity(btVector3(0, 0, 0));
     m_kart->getBody()->setAngularVelocity(btVector3(0, 0, 0));
     m_kart->setInvulnerableTicks(stk_config->time2Ticks(2));
+
     if (m_referee && m_kart->getNode())
     {
         m_kart->getNode()->removeChild(m_referee->getSceneNode());


### PR DESCRIPTION
## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```

This solves the problem of the rescue occasionally dropping the player in front of the banana, as described in #3779. As was suggested in the first comment of the issue; I went with providing immunity to the player for 2 seconds instead of changing the rescue placement, since that also contributes to fixing further issues such as immediately getting hit by another player.

2 seconds is arbitrary, but I think it hits a nice balance between not being able to drive away, and not making it advantageous to trigger a rescue.