### PR TITLE
Fix build when SDL2 is built with DirectFB support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,6 +304,12 @@ if (NOT SERVER_ONLY)
         include_directories("${SDL2_INCLUDEDIR}")
         MESSAGE(STATUS "Use system SDL2: ${SDL2_LIBRARY}")
     endif()
+    # DirectFB. Necessary if system SDL2 is built with DirectFB support.
+    find_path(DIRECTFB_INCLUDEDIR NAMES directfb.h directfb++.h PATH_SUFFIXES directfb include/directfb include PATHS)
+    if (DIRECTFB_INCLUDEDIR)
+        include_directories("${DIRECTFB_INCLUDEDIR}")
+        message(STATUS "Adding DirectFB include directories for DirectFB support in SDL2")
+    endif()
 endif()
 
 # Build the irrlicht library


### PR DESCRIPTION
## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```

Currently, if SDL2 is built with DirectFB support, build will fail as SDL2 cannot find some DirectFB headers. This patch intends to fix that while still allowing SuperTuxKart to be built without DirectFB if your build of SDL2 does not support it.

As is right now in Alpine Linux we have a downstream patch for this, but it'd be nice to be able to get rid of that with the next release of SuperTuxKart: https://gitlab.alpinelinux.org/alpine/aports/-/blob/master/community/supertuxkart/find-directfb-include.patch