### PR TITLE
Add an option to lock accel key once the key is pressed

### DIFF
--- a/data/gui/screens/options_input.stkgui
+++ b/data/gui/screens/options_input.stkgui
@@ -44,6 +44,15 @@
 
                 <label id="help2" I18N="In the input configuration screen" text="* Which config to use will be inferred from which 'Select' key is pressed to join the game."
                        proportion="2" word_wrap="true"/>
+
+                <div layout="horizontal-row" width="100%" height="fit">
+                  <checkbox id="controller_autoaccel"/>
+                  <spacer width="1%" height="100%" />
+                  <label height="100%" I18N="In the input configuration screen" text="Add a chewing-gum under the accelerator pedal" word_wrap="true"/>
+                </div>
+
+                <spacer width="5" height="2%"/>
+
             </box>
         </div>
     </div>

--- a/src/config/user_config.hpp
+++ b/src/config/user_config.hpp
@@ -1063,6 +1063,11 @@ namespace UserConfigParams
             PARAM_DEFAULT(  BoolUserConfigParam(false, "reverse-look-use-soccer-cam",
                             "Use ball camera in soccer mode, instead of reverse") );
 
+    // ---- Auto accelerate once you pressed to accel key
+    PARAM_PREFIX BoolUserConfigParam       m_controller_autoaccel
+            PARAM_DEFAULT(  BoolUserConfigParam(false, "controller-autoaccel",
+                            "Add a chewing-gum under the accelerator pedal") );
+
     // ---- Handicap
     PARAM_PREFIX GroupUserConfigParam       m_handicap
             PARAM_DEFAULT( GroupUserConfigParam("Handicap",

--- a/src/karts/controller/local_player_controller.cpp
+++ b/src/karts/controller/local_player_controller.cpp
@@ -208,7 +208,18 @@ bool LocalPlayerController::action(PlayerAction action, int value,
                 m_steer_val_l, m_steer_val_r);
         }
     }
-    return PlayerController::action(action, value, /*dry_run*/false);
+    bool ret = PlayerController::action(action, value, /*dry_run*/false);
+
+    if (UserConfigParams::m_controller_autoaccel)
+    {
+      if (((action == PA_BRAKE || action == PA_ACCEL) && value == 0))
+      {
+        ret = LocalPlayerController::action(PA_ACCEL, 65535.0f, false);
+        action = PA_ACCEL;
+      }
+    }
+
+    return ret;
 }   // action
 
 //-----------------------------------------------------------------------------

--- a/src/states_screens/options/options_screen_input.cpp
+++ b/src/states_screens/options/options_screen_input.cpp
@@ -22,6 +22,7 @@
 #include "guiengine/CGUISpriteBank.hpp"
 #include "guiengine/screen.hpp"
 #include "guiengine/widget.hpp"
+#include "guiengine/widgets/check_box_widget.hpp"
 #include "guiengine/widgets/button_widget.hpp"
 #include "guiengine/widgets/list_widget.hpp"
 #include "guiengine/widgets/ribbon_widget.hpp"
@@ -210,6 +211,9 @@ void OptionsScreenInput::init()
         getWidget("help1")->setText(_("Press enter or double-click on a device to configure it"));
         getWidget("help2")->setVisible(true);
     }
+
+    getWidget<CheckBoxWidget>("controller_autoaccel")->setState(UserConfigParams::m_controller_autoaccel);
+
 }   // init
 
 // -----------------------------------------------------------------------------
@@ -318,6 +322,10 @@ void OptionsScreenInput::eventCallback(Widget* widget, const std::string& name, 
         {
             Log::error("OptionsScreenInput", "Cannot read internal input device ID: %s", selection.c_str());
         }
+    }
+    else if (name == "controller_autoaccel")
+    {
+        UserConfigParams::m_controller_autoaccel = getWidget<CheckBoxWidget>("controller_autoaccel")->getState();
     }
 
 }   // eventCallback


### PR DESCRIPTION
Related to issue https://github.com/supertuxkart/stk-code/issues/4432.

What does it change to use it :
On race starting, you still have to press on accel key (for activating the startup boost or just start to go forward).
Once you have pressed the accel key, STK will accelerate by default; you will have to brake to reduce speed or to be static.

Pros :
- for mobile users, ease the pression on accel key at max value, and relax the thumb
- for pc / keyboard users, reduce injury on middle finger due to constant pressure and (on the key pressed :p)

Cons:
- difficult to be static with this option activated
- add ~1 on linear complexity of the program ( a condition check + once you release forward or backward key, another key event is raised ) // in fact no real impact on perf

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
