### PR TITLE
Fix access out of bounds warning with Cppcheck 2.2

### DIFF
--- a/src/utils/translation.cpp
+++ b/src/utils/translation.cpp
@@ -262,8 +262,10 @@ Translations::Translations() //: m_dictionary_manager("UTF-16")
                 while (!StringUtils::safeGetline(in, line).eof())
                 {
                     const std::u32string& u32line = StringUtils::utf8ToUtf32(line);
+                    if (u32line.empty())
+                        continue;
                     char32_t thai = u32line[0];
-                    if (u32line.empty() || !isThaiCP(thai))
+                    if (!isThaiCP(thai))
                         continue;
                     if (g_thai_dict.find(thai) == g_thai_dict.end())
                     {


### PR DESCRIPTION
This pull request fixes a potential access out of bounds found with Cppcheck when reading thaidict.txt. If `u32line` is empty, the program tries to access the zeroth element of `u32line` which is out of bounds when the string is empty.

The fix is simple: just move the `.empty()` check before accessing `u32line[0]`.

Currently thaidict.txt doesn't have any empty lines so no out of bounds access will actually occur.

Cppcheck warnings for translation.cpp:
```
[translation.cpp:271]: (performance) Searching before insertion is not necessary.
[translation.cpp:266] -> [translation.cpp:265]: (warning) Either the condition 'u32line.empty()' is redundant or expression 'u32line[0]' cause access out of bounds.
[translation.cpp:109]: (style) Consider using std::copy algorithm instead of a raw loop.
[translation.cpp:536]: (style) Variable 'out_ptr' is assigned a value that is never used.
[translation.cpp:583]: (style) Variable 'out_ptr' is assigned a value that is never used.
```

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
