### PR TITLE
More configurable music (loop end support, different race result music)

### DIFF
--- a/data/stk_config.xml
+++ b/data/stk_config.xml
@@ -151,8 +151,20 @@
            solver-split-impulse-threshold="-0.00001"
            solver-mode=""/>
 
-  <!-- The title and default musics. -->
-  <music title="main_theme.music" default="kart_grand_prix.music"/>
+  <!-- Various replaceable music tracks that play during certain events.
+       title: Plays on the main menu.
+       default: Plays if a track's music was not found.
+       race-win: Plays when a player finishes in 1st place.
+       race-neutral: Plays when a player finishes anywhere in the top half
+       of the total karts but 1st place.
+       race-lose: Plays when a player finishes in the bottom half of the
+       total karts.
+       -->
+  <music title="main_theme.music"
+         default="kart_grand_prix.music"
+         race-win="race_win_theme.music"
+         race-neutral="race_summary.music"
+         race-lose="lose_theme.music"/>
 
   <!--  Replay related values, mostly concerned with saving less data
         and using interpolation instead.

--- a/data/stk_config.xml
+++ b/data/stk_config.xml
@@ -159,12 +159,19 @@
        of the total karts but 1st place.
        race-lose: Plays when a player finishes in the bottom half of the
        total karts.
+       gp-win: Plays when a player finishes a grand prix in one of the top
+       three positions.
+       gp-lose: Plays when a player fails a grand prix.
+       unlock: Plays when a kart, track, or other content is unlocked.
        -->
   <music title="main_theme.music"
          default="kart_grand_prix.music"
          race-win="race_win_theme.music"
          race-neutral="race_summary.music"
-         race-lose="lose_theme.music"/>
+         race-lose="lose_theme.music"
+         gp-win="win_theme.music"
+         gp-lose="lose_theme.music"
+         unlock="win_theme.music"/>
 
   <!--  Replay related values, mostly concerned with saving less data
         and using interpolation instead.

--- a/src/audio/music_information.cpp
+++ b/src/audio/music_information.cpp
@@ -53,12 +53,11 @@ MusicInformation *MusicInformation::create(const std::string &filename)
     }
     std::string s;
     if(!root->get("title",    &s) ||
-       !root->get("composer", &s) ||
        !root->get("file",     &s)    )
 
     {
         Log::error("MusicInformation",
-                    "One of 'title', 'composer' or 'file' attribute "
+                    "One of 'title' or 'file' attribute "
                     "is missing in the music XML file '%s'!\n",
                     filename.c_str());
         delete root;
@@ -92,11 +91,12 @@ MusicInformation::MusicInformation(const XMLNode *root,
 
     // Otherwise read config file
     // --------------------------
-    std::string s;
-    root->get("title",           &s                  );
-    m_title = StringUtils::xmlDecode(s);
-    root->get("composer",        &s                  );
-    m_composer = StringUtils::xmlDecode(s);
+    std::string title_raw;
+    std::string composer_raw;
+    root->get("title",           &title_raw          );
+    m_title = StringUtils::xmlDecode(title_raw);
+    root->get("composer",        &composer_raw       );
+    m_composer = StringUtils::xmlDecode(composer_raw);
     root->get("file",            &m_normal_filename  );
     root->get("gain",            &m_gain             );
     root->get("tracks",          &m_all_tracks       );

--- a/src/audio/music_information.cpp
+++ b/src/audio/music_information.cpp
@@ -82,6 +82,8 @@ MusicInformation::MusicInformation(const XMLNode *root,
     m_fast_music        = NULL;
     m_normal_loop_start = 0.0f;
     m_fast_loop_start   = 0.0f;
+    m_normal_loop_end   = -1.0f;
+    m_fast_loop_end     = -1.0f;
     m_enable_fast       = false;
     m_music_waiting     = false;
     m_faster_time       = 1.0f;
@@ -103,7 +105,9 @@ MusicInformation::MusicInformation(const XMLNode *root,
     root->get("fast",            &m_enable_fast      );
     root->get("fast-filename",   &m_fast_filename    );
     root->get("loop-start",      &m_normal_loop_start);
+    root->get("loop-end",        &m_normal_loop_end  );
     root->get("fast-loop-start", &m_fast_loop_start  );
+    root->get("fast-loop-end",   &m_fast_loop_end    );
 
     // Get the path from the filename and add it to the ogg filename
     std::string path  = StringUtils::getPath(filename);
@@ -175,7 +179,7 @@ void MusicInformation::startMusic()
 #ifdef ENABLE_SOUND
     if (UserConfigParams::m_enable_sound)
     {
-        m_normal_music = new MusicOggStream(m_normal_loop_start);
+        m_normal_music = new MusicOggStream(m_normal_loop_start, m_normal_loop_end);
     }
     else
 #endif
@@ -214,7 +218,7 @@ void MusicInformation::startMusic()
 #ifdef ENABLE_SOUND
     if (UserConfigParams::m_enable_sound)
     {
-        m_fast_music = new MusicOggStream(m_fast_loop_start);
+        m_fast_music = new MusicOggStream(m_fast_loop_start, m_fast_loop_end);
     }
     else
 #endif

--- a/src/audio/music_information.hpp
+++ b/src/audio/music_information.hpp
@@ -61,6 +61,8 @@ private:
 
     float                    m_normal_loop_start;
     float                    m_fast_loop_start;
+    float                    m_normal_loop_end;
+    float                    m_fast_loop_end;
 
     /** Either time for fading faster music in, or time to change pitch. */
     float                    m_faster_time;

--- a/src/audio/music_ogg.cpp
+++ b/src/audio/music_ogg.cpp
@@ -28,7 +28,7 @@
 #include "utils/file_utils.hpp"
 #include "utils/log.hpp"
 
-MusicOggStream::MusicOggStream(float loop_start)
+MusicOggStream::MusicOggStream(float loop_start, float loop_end)
 {
     //m_oggStream= NULL;
     m_soundBuffers[0] = m_soundBuffers[1]= 0;
@@ -36,6 +36,7 @@ MusicOggStream::MusicOggStream(float loop_start)
     m_pausedMusic     = true;
     m_playing.store(false);
     m_loop_start      = loop_start;
+    m_loop_end        = loop_end;
 }   // MusicOggStream
 
 //-----------------------------------------------------------------------------
@@ -284,9 +285,12 @@ void MusicOggStream::update()
         if(!check("alSourceUnqueueBuffers")) return;
 
         active = streamIntoBuffer(buffer);
-        if(!active)
+        float cur_time = (float)ov_time_tell(&m_oggStream);
+        Log::info("MusicOgg", "Current time in music: %f | Target time: %f", cur_time, m_loop_end);
+        if(!active || (m_loop_end > 0 && (m_loop_end - cur_time) < 1e-3))
         {
-            // no more data. Seek to loop start (causes the sound to loop)
+            Log::info("MusicOgg", "Restarting music to %f", m_loop_start);
+            // No more data, or reached loop end. Seek to loop start (causes the sound to loop)
             ov_time_seek(&m_oggStream, m_loop_start);
             active = streamIntoBuffer(buffer);//now there really should be data
         }

--- a/src/audio/music_ogg.cpp
+++ b/src/audio/music_ogg.cpp
@@ -286,10 +286,8 @@ void MusicOggStream::update()
 
         active = streamIntoBuffer(buffer);
         float cur_time = (float)ov_time_tell(&m_oggStream);
-        Log::info("MusicOgg", "Current time in music: %f | Target time: %f", cur_time, m_loop_end);
         if(!active || (m_loop_end > 0 && (m_loop_end - cur_time) < 1e-3))
         {
-            Log::info("MusicOgg", "Restarting music to %f", m_loop_start);
             // No more data, or reached loop end. Seek to loop start (causes the sound to loop)
             ov_time_seek(&m_oggStream, m_loop_start);
             active = streamIntoBuffer(buffer);//now there really should be data

--- a/src/audio/music_ogg.hpp
+++ b/src/audio/music_ogg.hpp
@@ -50,7 +50,7 @@
 class MusicOggStream : public Music
 {
 public:
-    MusicOggStream(float loop_start);
+    MusicOggStream(float loop_start, float loop_end);
     virtual ~MusicOggStream();
 
     virtual void update();
@@ -75,6 +75,7 @@ private:
     bool streamIntoBuffer(ALuint buffer);
 
     float           m_loop_start;
+    float           m_loop_end;
     std::string     m_fileName;
     FILE*           m_oggFile;
     OggVorbis_File  m_oggStream;

--- a/src/config/stk_config.cpp
+++ b/src/config/stk_config.cpp
@@ -42,18 +42,30 @@ STKConfig::STKConfig()
     m_has_been_loaded         = false;
     m_title_music             = NULL;
     m_default_music           = NULL;
+    m_race_win_music          = NULL;
+    m_race_neutral_music      = NULL;
+    m_race_lose_music         = NULL;
     m_default_kart_properties = new KartProperties();
 }   // STKConfig
 //-----------------------------------------------------------------------------
 STKConfig::~STKConfig()
 {
-    if(m_title_music)
+    if (m_title_music)
         delete m_title_music;
 
     if (m_default_music)
         delete m_default_music;
 
-    if(m_default_kart_properties)
+    if (m_race_win_music)
+        delete m_race_win_music;
+
+    if (m_race_neutral_music)
+        delete m_race_neutral_music;
+
+    if (m_race_lose_music)
+        delete m_race_lose_music;
+
+    if (m_default_kart_properties)
         delete m_default_kart_properties;
 
     for(std::map<std::string, KartProperties*>::iterator it = m_kart_properties.begin();
@@ -216,6 +228,9 @@ void STKConfig::init_defaults()
     m_network_steering_reduction = -100;
     m_title_music                = NULL;
     m_default_music              = NULL;
+    m_race_win_music             = NULL;
+    m_race_neutral_music         = NULL;
+    m_race_lose_music            = NULL;
     m_solver_split_impulse       = false;
     m_smooth_normals             = false;
     m_same_powerup_mode          = POWERUP_MODE_ONLY_IF_SAME;
@@ -400,6 +415,18 @@ void STKConfig::getAllData(const XMLNode * root)
         music_node->get("default", &m_default_music_file);
         assert(m_default_music_file.size() > 0);
         m_default_music_file = file_manager->getAsset(FileManager::MUSIC, m_default_music_file);
+
+        music_node->get("race-win", &m_race_win_music_file);
+        assert(m_race_win_music_file.size() > 0);
+        m_race_win_music_file = file_manager->getAsset(FileManager::MUSIC, m_race_win_music_file);
+
+        music_node->get("race-neutral", &m_race_neutral_music_file);
+        assert(m_race_neutral_music_file.size() > 0);
+        m_race_neutral_music_file = file_manager->getAsset(FileManager::MUSIC, m_race_neutral_music_file);
+
+        music_node->get("race-lose", &m_race_lose_music_file);
+        assert(m_race_lose_music_file.size() > 0);
+        m_race_lose_music_file = file_manager->getAsset(FileManager::MUSIC, m_race_lose_music_file);
     }
 
     if(const XMLNode *skidmarks_node = root->getNode("skid-marks"))
@@ -591,6 +618,27 @@ void STKConfig::initMusicFiles()
     {
         Log::error("StkConfig", "Cannot load default music: %s.",
             m_default_music_file.c_str());
+    }
+
+    m_race_win_music = MusicInformation::create(m_race_win_music_file);
+    if (!m_race_win_music)
+    {
+        Log::error("StkConfig", "Cannot load race win music: %s.",
+            m_race_win_music_file.c_str());
+    }
+
+    m_race_neutral_music = MusicInformation::create(m_race_neutral_music_file);
+    if (!m_race_neutral_music)
+    {
+        Log::error("StkConfig", "Cannot load race neutral music: %s.",
+            m_race_neutral_music_file.c_str());
+    }
+
+    m_race_lose_music = MusicInformation::create(m_race_lose_music_file);
+    if (!m_race_lose_music)
+    {
+        Log::error("StkConfig", "Cannot load race lose music: %s.",
+            m_race_lose_music_file.c_str());
     }
 }   // initMusicFiles
 

--- a/src/config/stk_config.cpp
+++ b/src/config/stk_config.cpp
@@ -45,6 +45,9 @@ STKConfig::STKConfig()
     m_race_win_music          = NULL;
     m_race_neutral_music      = NULL;
     m_race_lose_music         = NULL;
+    m_gp_win_music            = NULL;
+    m_gp_lose_music           = NULL;
+    m_unlock_music            = NULL;
     m_default_kart_properties = new KartProperties();
 }   // STKConfig
 //-----------------------------------------------------------------------------
@@ -64,6 +67,15 @@ STKConfig::~STKConfig()
 
     if (m_race_lose_music)
         delete m_race_lose_music;
+
+    if (m_gp_win_music)
+        delete m_gp_win_music;
+
+    if (m_gp_lose_music)
+        delete m_gp_lose_music;
+
+    if (m_unlock_music)
+        delete m_unlock_music;
 
     if (m_default_kart_properties)
         delete m_default_kart_properties;
@@ -231,6 +243,9 @@ void STKConfig::init_defaults()
     m_race_win_music             = NULL;
     m_race_neutral_music         = NULL;
     m_race_lose_music            = NULL;
+    m_gp_win_music               = NULL;
+    m_gp_lose_music              = NULL;
+    m_unlock_music               = NULL;
     m_solver_split_impulse       = false;
     m_smooth_normals             = false;
     m_same_powerup_mode          = POWERUP_MODE_ONLY_IF_SAME;
@@ -427,6 +442,18 @@ void STKConfig::getAllData(const XMLNode * root)
         music_node->get("race-lose", &m_race_lose_music_file);
         assert(m_race_lose_music_file.size() > 0);
         m_race_lose_music_file = file_manager->getAsset(FileManager::MUSIC, m_race_lose_music_file);
+
+        music_node->get("gp-win", &m_gp_win_music_file);
+        assert(m_gp_win_music_file.size() > 0);
+        m_gp_win_music_file = file_manager->getAsset(FileManager::MUSIC, m_gp_win_music_file);
+
+        music_node->get("gp-lose", &m_gp_lose_music_file);
+        assert(m_gp_lose_music_file.size() > 0);
+        m_gp_lose_music_file = file_manager->getAsset(FileManager::MUSIC, m_gp_lose_music_file);
+
+        music_node->get("unlock", &m_unlock_music_file);
+        assert(m_unlock_music_file.size() > 0);
+        m_unlock_music_file = file_manager->getAsset(FileManager::MUSIC, m_unlock_music_file);
     }
 
     if(const XMLNode *skidmarks_node = root->getNode("skid-marks"))
@@ -639,6 +666,27 @@ void STKConfig::initMusicFiles()
     {
         Log::error("StkConfig", "Cannot load race lose music: %s.",
             m_race_lose_music_file.c_str());
+    }
+
+    m_gp_win_music = MusicInformation::create(m_gp_win_music_file);
+    if (!m_gp_win_music)
+    {
+        Log::error("StkConfig", "Cannot load grand prix win music: %s.",
+            m_gp_win_music_file.c_str());
+    }
+
+    m_gp_lose_music = MusicInformation::create(m_gp_lose_music_file);
+    if (!m_gp_lose_music)
+    {
+        Log::error("StkConfig", "Cannot load grand prix lose music: %s.",
+            m_gp_lose_music_file.c_str());
+    }
+
+    m_unlock_music = MusicInformation::create(m_unlock_music_file);
+    if (!m_unlock_music)
+    {
+        Log::error("StkConfig", "Cannot load unlock music: %s.",
+            m_unlock_music_file.c_str());
     }
 }   // initMusicFiles
 

--- a/src/config/stk_config.hpp
+++ b/src/config/stk_config.hpp
@@ -164,8 +164,19 @@ public:
     /** Filename of the title music to play.*/
     MusicInformation *m_title_music;
 
-    /** Filename of the music that is played when the track's music was not found */
+    /** Filename of the music that is played when the track's music was not found.*/
     MusicInformation *m_default_music;
+
+    /** Filename of the music to play when a player finishes in 1st place.*/
+    MusicInformation *m_race_win_music;
+
+    /** Filename of the music to play when a player finishes anywhere in the top half
+     *  of the total karts but 1st place, rounded down.*/
+    MusicInformation *m_race_neutral_music;
+
+    /** Filename of the music to play when a player finishes in the bottom half of
+      * the total karts.*/
+    MusicInformation *m_race_lose_music;
 
     /** Maximum number of transform events of a replay. */
     int m_replay_max_frames;
@@ -252,6 +263,10 @@ private:
 
     std::string m_title_music_file;
     std::string m_default_music_file;
+    std::string m_race_win_music_file;
+    std::string m_race_neutral_music_file;
+    std::string m_race_lose_music_file;
+
 public:
     STKConfig();
     ~STKConfig();

--- a/src/config/stk_config.hpp
+++ b/src/config/stk_config.hpp
@@ -178,6 +178,15 @@ public:
       * the total karts.*/
     MusicInformation *m_race_lose_music;
 
+    /** Filename of the grand prix win music to play.*/
+    MusicInformation *m_gp_win_music;
+
+    /** Filename of the grand prix lose music to play.*/
+    MusicInformation *m_gp_lose_music;
+
+    /** Filename of the feature unlock music to play.*/
+    MusicInformation *m_unlock_music;
+
     /** Maximum number of transform events of a replay. */
     int m_replay_max_frames;
 
@@ -266,6 +275,9 @@ private:
     std::string m_race_win_music_file;
     std::string m_race_neutral_music_file;
     std::string m_race_lose_music_file;
+    std::string m_gp_win_music_file;
+    std::string m_gp_lose_music_file;
+    std::string m_unlock_music_file;
 
 public:
     STKConfig();

--- a/src/karts/kart.cpp
+++ b/src/karts/kart.cpp
@@ -1018,7 +1018,7 @@ void Kart::finishedRace(float time, bool from_server)
 
             m->addMessage((too_slow     ? _("You were too slow!") :
                            won_the_race ? _("You won the race!")  :
-                                          _("You finished the race!")),
+                                          _("You finished the race in rank %d!", getPosition())),
             this, 2.0f, video::SColor(255, 255, 255, 255), true, true, true);
         }
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1487,6 +1487,11 @@ int handleCmdLine(bool has_server_config, bool has_parent_process)
         RaceManager::get()->setNumKarts((int)l.size());
     }   // --aiNP
 
+    if(CommandLine::has("--reverse"))
+    {
+        RaceManager::get()->setReverseTrack(true);
+    }
+
     if(CommandLine::has("--track", &s) || CommandLine::has("-t", &s))
     {
         RaceManager::get()->setTrack(s);

--- a/src/states_screens/feature_unlocked.cpp
+++ b/src/states_screens/feature_unlocked.cpp
@@ -24,6 +24,7 @@
 #include "challenges/challenge_data.hpp"
 #include "challenges/unlock_manager.hpp"
 #include "config/player_manager.hpp"
+#include "config/stk_config.hpp"
 #include "config/user_config.hpp"
 #include "graphics/central_settings.hpp"
 #include "graphics/sp/sp_base.hpp"
@@ -759,6 +760,6 @@ void FeatureUnlockedCutScene::eventCallback(GUIEngine::Widget* widget,
 
 MusicInformation* FeatureUnlockedCutScene::getInGameMenuMusic() const
 {
-    MusicInformation* mi = music_manager->getMusicInformation("win_theme.music");
+    MusicInformation* mi = stk_config->m_unlock_music;
     return mi;
 }

--- a/src/states_screens/grand_prix_lose.cpp
+++ b/src/states_screens/grand_prix_lose.cpp
@@ -22,6 +22,7 @@
 #include "audio/sfx_manager.hpp"
 #include "challenges/unlock_manager.hpp"
 #include "config/player_manager.hpp"
+#include "config/stk_config.hpp"
 #include "graphics/irr_driver.hpp"
 #include "graphics/lod_node.hpp"
 #include "graphics/lod_node.hpp"
@@ -237,7 +238,7 @@ void GrandPrixLose::setKarts(std::vector<std::pair<std::string, float> > ident_a
 
 MusicInformation* GrandPrixLose::getInGameMenuMusic() const
 {
-    MusicInformation* mi = music_manager->getMusicInformation("lose_theme.music");
+    MusicInformation* mi = stk_config->m_gp_lose_music;
     return mi;
 }
 

--- a/src/states_screens/grand_prix_win.cpp
+++ b/src/states_screens/grand_prix_win.cpp
@@ -22,6 +22,7 @@
 #include "audio/sfx_manager.hpp"
 #include "challenges/unlock_manager.hpp"
 #include "config/player_manager.hpp"
+#include "config/stk_config.hpp"
 #include "graphics/irr_driver.hpp"
 #include "graphics/lod_node.hpp"
 #include "graphics/render_info.hpp"
@@ -424,7 +425,7 @@ void GrandPrixWin::setKarts(const std::pair<std::string, float> idents_arg[3])
 
 MusicInformation* GrandPrixWin::getInGameMenuMusic() const
 {
-    MusicInformation* mi = music_manager->getMusicInformation("win_theme.music");
+    MusicInformation* mi = stk_config->m_gp_win_music;
     return mi;
 }
 

--- a/src/states_screens/race_result_gui.cpp
+++ b/src/states_screens/race_result_gui.cpp
@@ -108,9 +108,14 @@ void RaceResultGUI::init()
             human_win = human_win && kart->getRaceResult();
 
             if (RaceManager::get()->getMinorMode() == RaceManager::MINOR_MODE_FOLLOW_LEADER)
-            {in_first_place = kart->getPosition() <= 2;}
+            {
+                // It's possible the winning kart can get ahead of the leader.
+                in_first_place = kart->getPosition() <= 2;
+            }
             else
-            {in_first_place = kart->getPosition() == 1;}
+            {
+                in_first_place = kart->getPosition() == 1;
+            }
         }
     }
 
@@ -119,21 +124,31 @@ void RaceResultGUI::init()
 
     // Play different result music based on player kart positions.
     if (has_human_players)
+    {
         if (human_win)
         {
             if (in_first_place)
-            // At least one player kart is in 1st place.
-            {m_race_over_music = stk_config->m_race_win_music;}
+            {
+                // At least one player kart is in 1st place.
+                m_race_over_music = stk_config->m_race_win_music;
+            }
             else
-            // All player karts finished in winning positions, but none in 1st place.
-            {m_race_over_music = stk_config->m_race_neutral_music;}
+            {
+                // All player karts finished in winning positions, but none in 1st place.
+                m_race_over_music = stk_config->m_race_neutral_music;
+            }
         }
         else
-        // No player karts finished in winning positions.
-        {m_race_over_music = stk_config->m_race_lose_music;}
+        {
+            // No player karts finished in winning positions.
+            m_race_over_music = stk_config->m_race_lose_music;
+        }
+    }
     else
-    // For races with only AI karts and no human players.
-    {m_race_over_music = stk_config->m_race_neutral_music;}
+    {
+        // For races with only AI karts and no human players.
+        m_race_over_music = stk_config->m_race_neutral_music;
+    }
 
     if (!m_finish_sound)
     {

--- a/src/states_screens/race_result_gui.cpp
+++ b/src/states_screens/race_result_gui.cpp
@@ -332,21 +332,25 @@ void RaceResultGUI::eventCallback(GUIEngine::Widget* widget,
     const std::string& name, const int playerID)
 {
     int n_tracks = RaceManager::get()->getGrandPrix().getNumberOfTracks();
-    if (name == "up_button" && n_tracks > m_max_tracks && m_start_track > 0)
+    if (name == "up_button")
     {
-        m_start_track--;
-        m_end_track--;
-        displayScreenShots();
+        if (n_tracks > m_max_tracks && m_start_track > 0)
+        {
+            m_start_track--;
+            m_end_track--;
+            displayScreenShots();
+        }
     }
-    else if (name == "down_button" && n_tracks > m_max_tracks &&
-        m_start_track < (n_tracks - m_max_tracks))
+    else if (name == "down_button")
     {
-        m_start_track++;
-        m_end_track++;
-        displayScreenShots();
+        if (n_tracks > m_max_tracks && m_start_track < (n_tracks - m_max_tracks))
+        {
+            m_start_track++;
+            m_end_track++;
+            displayScreenShots();
+        }
     }
-
-    if(name == "operations")
+    else if (name == "operations")
     {
         const std::string& action =
             getWidget<GUIEngine::RibbonWidget>("operations")->getSelectionIDString(PLAYER_ID_GAME_MASTER);


### PR DESCRIPTION
Adding the following features surrounding music:
- Add support for loop end of music.
- Make composer field in music information files optional. 
- Support playing different music on race results screen (configurable via stk_config.xml).
- Allow configuring grand prix win/lose and feature unlocked music (configurable via stk_config.xml).

Three different soundtracks can play at the end of a race, depending on these three conditions:
- At least one player kart is in 1st place: race_win_theme.music
- All player karts finished in winning positions, but none in 1st place: race_summary.music
- No player karts finished in winning positions: lose_theme.music
- For races with only AI karts and no human players: race_summary.music

The race win music (race_win_theme.music) is from the STK media repo at https://sourceforge.net/p/supertuxkart/code/HEAD/tree/media/trunk/music/oggs/win_theme.ogg. It is not yet in use, but I have used it in the situation where a player kart is in 1st place. Use the ZIP archive below; it has the .music file included.
[race-win-music.zip](https://github.com/supertuxkart/stk-code/files/5713959/race-win-music.zip)

I recommend seeking out better win and lose music if possible, such as on OpenGameArt; the code mainly gives the framework needed to make it easier to replace such music in the future.
## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```

