### PR TITLE
camera settings

### DIFF
--- a/data/gui/dialogs/custom_camera_settings.stkgui
+++ b/data/gui/dialogs/custom_camera_settings.stkgui
@@ -64,6 +64,17 @@
                 </div>
             </div>
 
+            <spacer height="2%" width="100%" />
+
+            <div width="100%" height="fit" layout="horizontal-row">
+                <spacer width="3%" height="100%" />
+                <div proportion="1" height="fit" layout="horizontal-row" >
+                    <checkbox id="use_soccer_camera"/>
+                    <spacer width="1%" height="100%" />
+                    <label height="100%" text_align="left" I18N="In the ui/camera screen" text="Follow ball in soccer mode"/>
+                </div>
+            </div>
+
             <spacer width="100%" height="2%"/>
             <button id="close" text="Apply" align="center"/>
             <spacer width="100%" height="1%"/>

--- a/data/gui/screens/options_ui.stkgui
+++ b/data/gui/screens/options_ui.stkgui
@@ -70,14 +70,6 @@
                 <spacer width="5" height="2%"/>
 
                 <div layout="horizontal-row" width="100%" height="fit">
-                    <checkbox id="follow_ball_backward_camera"/>
-                    <spacer width="1%" height="100%" />
-                    <label height="100%" I18N="In the ui settings" text="Follow ball in soccer mode for backward camera" word_wrap="true"/>
-                </div>
-
-                <spacer width="5" height="2%"/>
-
-                <div layout="horizontal-row" width="100%" height="fit">
                     <checkbox id="showfps"/>
                     <spacer width="1%" height="100%" />
                     <label height="100%" I18N="In the ui settings" text="Display FPS" word_wrap="true"/>

--- a/src/config/user_config.hpp
+++ b/src/config/user_config.hpp
@@ -968,7 +968,88 @@ namespace UserConfigParams
             &m_camera_normal,
             "Focal distance (single player)"));
 
-    // ---- Saved custom camera settings
+    PARAM_PREFIX BoolUserConfigParam       m_reverse_look_use_soccer_cam
+            PARAM_DEFAULT(  BoolUserConfigParam(false, "reverse-look-use-soccer-cam",
+                            "Use ball camera in soccer mode, instead of reverse") );
+
+    // ---- The present camera (default: Standard)
+    PARAM_PREFIX IntUserConfigParam       m_camera_present
+            PARAM_DEFAULT(  IntUserConfigParam(1, "camera-present",
+                            "The current used camera. 0=Custom; 1=Standard; 2=Drone chase") );
+
+    // ---- Standard camera settings
+    PARAM_PREFIX GroupUserConfigParam        m_standard_camera_settings
+            PARAM_DEFAULT( GroupUserConfigParam(
+                        "standard-camera-settings",
+                        "Standard camera settings for player.") );
+
+    PARAM_PREFIX FloatUserConfigParam         m_standard_camera_distance
+            PARAM_DEFAULT(  FloatUserConfigParam(1.0, "distance",
+            &m_standard_camera_settings,
+            "Distance between kart and camera"));
+
+    PARAM_PREFIX FloatUserConfigParam         m_standard_camera_forward_up_angle
+            PARAM_DEFAULT(  FloatUserConfigParam(0, "forward-up-angle",
+            &m_standard_camera_settings,
+            "Angle between camera and plane of kart (pitch) when the camera is pointing forward"));
+
+    PARAM_PREFIX BoolUserConfigParam         m_standard_camera_forward_smoothing
+            PARAM_DEFAULT(  BoolUserConfigParam(true, "forward-smoothing",
+            &m_standard_camera_settings,
+            "if true, use smoothing (forward-up-angle become relative to speed) when pointing forward"));
+
+    PARAM_PREFIX FloatUserConfigParam         m_standard_camera_backward_up_angle
+            PARAM_DEFAULT(  FloatUserConfigParam(5, "backward-up-angle",
+            &m_standard_camera_settings,
+            "Angle between camera and plane of kart (pitch) when the camera is pointing backwards. This is usually larger than the forward-up-angle, since the kart itself otherwise obstricts too much of the view"));
+
+    PARAM_PREFIX IntUserConfigParam         m_standard_camera_fov
+            PARAM_DEFAULT(  IntUserConfigParam(80, "fov",
+            &m_standard_camera_settings,
+            "Focal distance (single player)"));
+
+    PARAM_PREFIX BoolUserConfigParam         m_standard_reverse_look_use_soccer_cam
+            PARAM_DEFAULT(  BoolUserConfigParam(false, "reverse-look-use-soccer-cam",
+            &m_standard_camera_settings,
+            "Use ball camera in soccer mode, instead of reverse"));
+
+    // ---- Drone chase camera settings
+    PARAM_PREFIX GroupUserConfigParam        m_drone_camera_settings
+            PARAM_DEFAULT( GroupUserConfigParam(
+                        "drone-camera-settings",
+                        "Drone chase camera settings for player.") );
+
+    PARAM_PREFIX FloatUserConfigParam         m_drone_camera_distance
+            PARAM_DEFAULT(  FloatUserConfigParam(2.6, "distance",
+            &m_drone_camera_settings,
+            "Distance between kart and camera"));
+
+    PARAM_PREFIX FloatUserConfigParam         m_drone_camera_forward_up_angle
+            PARAM_DEFAULT(  FloatUserConfigParam(33, "forward-up-angle",
+            &m_drone_camera_settings,
+            "Angle between camera and plane of kart (pitch) when the camera is pointing forward"));
+
+    PARAM_PREFIX BoolUserConfigParam         m_drone_camera_forward_smoothing
+            PARAM_DEFAULT(  BoolUserConfigParam(false, "forward-smoothing",
+            &m_drone_camera_settings,
+            "if true, use smoothing (forward-up-angle become relative to speed) when pointing forward"));
+
+    PARAM_PREFIX FloatUserConfigParam         m_drone_camera_backward_up_angle
+            PARAM_DEFAULT(  FloatUserConfigParam(10, "backward-up-angle",
+            &m_drone_camera_settings,
+            "Angle between camera and plane of kart (pitch) when the camera is pointing backwards. This is usually larger than the forward-up-angle, since the kart itself otherwise obstricts too much of the view"));
+
+    PARAM_PREFIX IntUserConfigParam         m_drone_camera_fov
+            PARAM_DEFAULT(  IntUserConfigParam(100, "fov",
+            &m_drone_camera_settings,
+            "Focal distance (single player)"));
+
+    PARAM_PREFIX BoolUserConfigParam         m_drone_reverse_look_use_soccer_cam
+            PARAM_DEFAULT(  BoolUserConfigParam(false, "reverse-look-use-soccer-cam",
+            &m_drone_camera_settings,
+            "Use ball camera in soccer mode, instead of reverse"));
+
+    // ---- Custom camera settings
     PARAM_PREFIX GroupUserConfigParam        m_saved_camera_settings
             PARAM_DEFAULT( GroupUserConfigParam(
                         "saved-camera-settings",
@@ -999,6 +1080,10 @@ namespace UserConfigParams
             &m_saved_camera_settings,
             "Focal distance (single player)"));
 
+    PARAM_PREFIX BoolUserConfigParam         m_saved_reverse_look_use_soccer_cam
+            PARAM_DEFAULT(  BoolUserConfigParam(false, "reverse-look-use-soccer-cam",
+            &m_saved_camera_settings,
+            "Use ball camera in soccer mode, instead of reverse"));
 
     // camera in artist mode
     PARAM_PREFIX GroupUserConfigParam        m_camera
@@ -1062,11 +1147,6 @@ namespace UserConfigParams
     PARAM_PREFIX FloatUserConfigParam        m_spectator_camera_angle
             PARAM_DEFAULT(  FloatUserConfigParam(40.0, "camera-angle", &m_spectator,
                                                   "Angle between ground, kart and camera.") );
-
-    // ---- Special settings for soccer mode
-    PARAM_PREFIX BoolUserConfigParam       m_reverse_look_use_soccer_cam
-            PARAM_DEFAULT(  BoolUserConfigParam(false, "reverse-look-use-soccer-cam",
-                            "Use ball camera in soccer mode, instead of reverse") );
 
     // ---- Handicap
     PARAM_PREFIX GroupUserConfigParam       m_handicap

--- a/src/states_screens/dialogs/custom_camera_settings.cpp
+++ b/src/states_screens/dialogs/custom_camera_settings.cpp
@@ -57,14 +57,38 @@ void CustomCameraSettingsDialog::beforeAddingWidgets()
 {
 #ifndef SERVER_ONLY
     getWidget<SpinnerWidget>("fov")->setRange(75, 115);
-    getWidget<SpinnerWidget>("fov")->setValue(UserConfigParams::m_saved_camera_fov);
     getWidget<SpinnerWidget>("camera_distance")->setRange(0 , 20, 0.1);
-    getWidget<SpinnerWidget>("camera_distance")->setFloatValue(UserConfigParams::m_saved_camera_distance);
     getWidget<SpinnerWidget>("camera_angle")->setRange(0 , 45);
-    getWidget<SpinnerWidget>("camera_angle")->setValue(UserConfigParams::m_saved_camera_forward_up_angle);
-    getWidget<CheckBoxWidget>("camera_smoothing")->setState(UserConfigParams::m_saved_camera_forward_smoothing);
     getWidget<SpinnerWidget>("backward_camera_angle")->setRange(0 , 45);
-    getWidget<SpinnerWidget>("backward_camera_angle")->setValue(UserConfigParams::m_saved_camera_backward_up_angle);
+    if (UserConfigParams::m_camera_present == 1) // Standard camera
+    {
+        getWidget<CheckBoxWidget>("camera_smoothing")->setState(UserConfigParams::m_standard_camera_forward_smoothing);
+        getWidget<CheckBoxWidget>("use_soccer_camera")->setState(UserConfigParams::m_standard_reverse_look_use_soccer_cam);
+        // Not allowed to change fov, distance, and angles. Only allow to change smoothing and follow soccer
+        getWidget<SpinnerWidget>("fov")->setActive(false);
+        getWidget<SpinnerWidget>("camera_distance")->setActive(false);
+        getWidget<SpinnerWidget>("camera_angle")->setActive(false);
+        getWidget<SpinnerWidget>("backward_camera_angle")->setActive(false);
+    }
+    else if (UserConfigParams::m_camera_present == 2) // Drone chase camera
+    {
+        getWidget<CheckBoxWidget>("camera_smoothing")->setState(UserConfigParams::m_drone_camera_forward_smoothing);
+        getWidget<CheckBoxWidget>("use_soccer_camera")->setState(UserConfigParams::m_drone_reverse_look_use_soccer_cam);
+        // Not allowed to change fov, distance, and angles. Only allow to change smoothing and follow soccer
+        getWidget<SpinnerWidget>("fov")->setActive(false);
+        getWidget<SpinnerWidget>("camera_distance")->setActive(false);
+        getWidget<SpinnerWidget>("camera_angle")->setActive(false);
+        getWidget<SpinnerWidget>("backward_camera_angle")->setActive(false);
+    }
+    else // Custom camera
+    {
+        getWidget<SpinnerWidget>("fov")->setValue(UserConfigParams::m_saved_camera_fov);
+        getWidget<SpinnerWidget>("camera_distance")->setFloatValue(UserConfigParams::m_saved_camera_distance);
+        getWidget<SpinnerWidget>("camera_angle")->setValue(UserConfigParams::m_saved_camera_forward_up_angle);
+        getWidget<CheckBoxWidget>("camera_smoothing")->setState(UserConfigParams::m_saved_camera_forward_smoothing);
+        getWidget<SpinnerWidget>("backward_camera_angle")->setValue(UserConfigParams::m_saved_camera_backward_up_angle);
+        getWidget<CheckBoxWidget>("use_soccer_camera")->setState(UserConfigParams::m_saved_reverse_look_use_soccer_cam);
+    }
 #endif
 }
 
@@ -75,16 +99,32 @@ GUIEngine::EventPropagation CustomCameraSettingsDialog::processEvent(const std::
 #ifndef SERVER_ONLY
     if (eventSource == "close")
     {
-        UserConfigParams::m_camera_fov = getWidget<SpinnerWidget>("fov")->getValue();
-        UserConfigParams::m_camera_distance = getWidget<SpinnerWidget>("camera_distance")->getFloatValue();
-        UserConfigParams::m_camera_forward_up_angle = getWidget<SpinnerWidget>("camera_angle")->getValue();
         UserConfigParams::m_camera_forward_smoothing = getWidget<CheckBoxWidget>("camera_smoothing")->getState();
-        UserConfigParams::m_camera_backward_up_angle = getWidget<SpinnerWidget>("backward_camera_angle")->getValue();
-        UserConfigParams::m_saved_camera_fov = UserConfigParams::m_camera_fov;
-        UserConfigParams::m_saved_camera_distance = UserConfigParams::m_camera_distance;
-        UserConfigParams::m_saved_camera_forward_up_angle = UserConfigParams::m_camera_forward_up_angle;
-        UserConfigParams::m_saved_camera_forward_smoothing = UserConfigParams::m_camera_forward_smoothing;
-        UserConfigParams::m_saved_camera_backward_up_angle = UserConfigParams::m_camera_backward_up_angle;
+        UserConfigParams::m_reverse_look_use_soccer_cam = getWidget<CheckBoxWidget>("use_soccer_camera")->getState();
+        if (UserConfigParams::m_camera_present == 1) // Standard camera, only smoothing and follow soccer is customizable
+        {
+            UserConfigParams::m_saved_camera_forward_smoothing = UserConfigParams::m_camera_forward_smoothing;
+            UserConfigParams::m_standard_reverse_look_use_soccer_cam = UserConfigParams::m_reverse_look_use_soccer_cam;
+
+        }
+        else if (UserConfigParams::m_camera_present == 2) // Drone chase camera, only smoothing and follow soccer is customizable
+        {
+            UserConfigParams::m_drone_camera_forward_smoothing = UserConfigParams::m_camera_forward_smoothing;
+            UserConfigParams::m_drone_reverse_look_use_soccer_cam = UserConfigParams::m_reverse_look_use_soccer_cam;
+        }
+        else // Custom camera, everything is customizable
+        {
+            UserConfigParams::m_camera_fov = getWidget<SpinnerWidget>("fov")->getValue();
+            UserConfigParams::m_camera_distance = getWidget<SpinnerWidget>("camera_distance")->getFloatValue();
+            UserConfigParams::m_camera_forward_up_angle = getWidget<SpinnerWidget>("camera_angle")->getValue();
+            UserConfigParams::m_camera_backward_up_angle = getWidget<SpinnerWidget>("backward_camera_angle")->getValue();
+            UserConfigParams::m_saved_camera_fov = UserConfigParams::m_camera_fov;
+            UserConfigParams::m_saved_camera_distance = UserConfigParams::m_camera_distance;
+            UserConfigParams::m_saved_camera_forward_up_angle = UserConfigParams::m_camera_forward_up_angle;
+            UserConfigParams::m_saved_camera_forward_smoothing = UserConfigParams::m_camera_forward_smoothing;
+            UserConfigParams::m_saved_camera_backward_up_angle = UserConfigParams::m_camera_backward_up_angle;
+            UserConfigParams::m_saved_reverse_look_use_soccer_cam = UserConfigParams::m_reverse_look_use_soccer_cam;
+        }
         OptionsScreenUI::getInstance()->updateCameraPresetSpinner();
         m_self_destroy = true;
         return GUIEngine::EVENT_BLOCK;


### PR DESCRIPTION
Hi, I made a few changes on the camera setting:
1. Put the 'ball camera in soccer' back to the custom_camera_settings UI.
2. Add the ability to customize 'camera smoothing' and 'ball camera in soccer' of Standard and Drone chase camera. Gray out the rest settings in the custom_camera_settings UI. The 'Custom...' button will be used for all three cameras.
3. Put the settings of Standard and Drone chase camera in the config file, instead of hard-coded.

Benefit of this PR:
1. The ball camera setting really belongs to the camera setting UI. We can save one line on the option UI.
2. Camera smoothing can also be customizable for Standard and Drone chase camera.
3. For advanced users, they can modify the config file to have better 'Standard' and 'Drone chase' settings for their need. I think it is better than the hard-coded settings.

Hope you like it.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
