### PR TITLE
Few improvements of spinner and option UI

### DIFF
--- a/data/gui/dialogs/custom_camera_settings.stkgui
+++ b/data/gui/dialogs/custom_camera_settings.stkgui
@@ -5,7 +5,7 @@
         <spacer width="100%" height="3%"/>
         <div width="100%" height="91%" layout="vertical-row" >
 
-            <label width="100%" I18N="In the ui/camera settings" text="Player camera"/>
+            <label id="camera_name" width="100%" I18N="In the ui/camera settings" text="Player camera"/>
             <spacer width="5" height="1%"/>
 
             <div width="100%" height="fit" layout="horizontal-row">

--- a/src/guiengine/widgets/spinner_widget.cpp
+++ b/src/guiengine/widgets/spinner_widget.cpp
@@ -417,7 +417,7 @@ void SpinnerWidget::setValue(const int new_value)
         std::string imagefile = file_manager->searchTexture(s);
         ((IGUIImage*)(m_children[1].m_element))->setImage(irr_driver->getTexture(imagefile));
     }
-    else if (m_labels.size() > 0 && m_children.size() > 0 && !m_deactivated)
+    else if (m_labels.size() > 0 && m_children.size() > 0)
     {
         assert(new_value >= 0);
         assert(new_value < (int)m_labels.size());
@@ -501,15 +501,6 @@ void SpinnerWidget::setActive(bool active)
         {
             setCustomText(m_custom_text);
         }
-    }
-    else
-    {
-        // Save it temporary because setValue(which is uses for update in
-        // this case) overwrites it
-        core::stringw custom_text = m_custom_text;
-        //setText(L"-");
-        setValue(getValue()); // Update the display
-        m_custom_text = custom_text;
     }
 }   // setActive
 

--- a/src/guiengine/widgets/spinner_widget.cpp
+++ b/src/guiengine/widgets/spinner_widget.cpp
@@ -507,7 +507,7 @@ void SpinnerWidget::setActive(bool active)
         // Save it temporary because setValue(which is uses for update in
         // this case) overwrites it
         core::stringw custom_text = m_custom_text;
-        setText(L"-");
+        //setText(L"-");
         setValue(getValue()); // Update the display
         m_custom_text = custom_text;
     }

--- a/src/states_screens/dialogs/custom_camera_settings.cpp
+++ b/src/states_screens/dialogs/custom_camera_settings.cpp
@@ -63,7 +63,7 @@ void CustomCameraSettingsDialog::beforeAddingWidgets()
     getWidget<SpinnerWidget>("backward_camera_angle")->setRange(0 , 45);
     if (UserConfigParams::m_camera_present == 1) // Standard camera
     {
-        getWidget<LabelWidget>("camera_name")->setText(_("Standard Camera"), false);
+        getWidget<LabelWidget>("camera_name")->setText(_("Standard"), false);
         getWidget<SpinnerWidget>("fov")->setValue(UserConfigParams::m_standard_camera_fov);
         getWidget<SpinnerWidget>("camera_distance")->setFloatValue(UserConfigParams::m_standard_camera_distance);
         getWidget<SpinnerWidget>("camera_angle")->setValue(UserConfigParams::m_standard_camera_forward_up_angle);
@@ -78,7 +78,7 @@ void CustomCameraSettingsDialog::beforeAddingWidgets()
     }
     else if (UserConfigParams::m_camera_present == 2) // Drone chase camera
     {
-        getWidget<LabelWidget>("camera_name")->setText(_("Drone chase Camera"), false);
+        getWidget<LabelWidget>("camera_name")->setText(_("Drone chase"), false);
         getWidget<SpinnerWidget>("fov")->setValue(UserConfigParams::m_drone_camera_fov);
         getWidget<SpinnerWidget>("camera_distance")->setFloatValue(UserConfigParams::m_drone_camera_distance);
         getWidget<SpinnerWidget>("camera_angle")->setValue(UserConfigParams::m_drone_camera_forward_up_angle);
@@ -93,7 +93,7 @@ void CustomCameraSettingsDialog::beforeAddingWidgets()
     }
     else // Custom camera
     {
-        getWidget<LabelWidget>("camera_name")->setText(_("Custom Camera"), false);
+        getWidget<LabelWidget>("camera_name")->setText(_("Custom"), false);
         getWidget<SpinnerWidget>("fov")->setValue(UserConfigParams::m_saved_camera_fov);
         getWidget<SpinnerWidget>("camera_distance")->setFloatValue(UserConfigParams::m_saved_camera_distance);
         getWidget<SpinnerWidget>("camera_angle")->setValue(UserConfigParams::m_saved_camera_forward_up_angle);

--- a/src/states_screens/dialogs/custom_camera_settings.cpp
+++ b/src/states_screens/dialogs/custom_camera_settings.cpp
@@ -19,6 +19,7 @@
 
 #include "config/user_config.hpp"
 #include "guiengine/widgets/check_box_widget.hpp"
+#include "guiengine/widgets/label_widget.hpp"
 #include "guiengine/widgets/spinner_widget.hpp"
 #include "states_screens/options/options_screen_ui.hpp"
 #include "utils/translation.hpp"
@@ -62,6 +63,11 @@ void CustomCameraSettingsDialog::beforeAddingWidgets()
     getWidget<SpinnerWidget>("backward_camera_angle")->setRange(0 , 45);
     if (UserConfigParams::m_camera_present == 1) // Standard camera
     {
+        getWidget<LabelWidget>("camera_name")->setText(_("Standard Camera"), false);
+        getWidget<SpinnerWidget>("fov")->setValue(UserConfigParams::m_standard_camera_fov);
+        getWidget<SpinnerWidget>("camera_distance")->setFloatValue(UserConfigParams::m_standard_camera_distance);
+        getWidget<SpinnerWidget>("camera_angle")->setValue(UserConfigParams::m_standard_camera_forward_up_angle);
+        getWidget<SpinnerWidget>("backward_camera_angle")->setValue(UserConfigParams::m_standard_camera_backward_up_angle);
         getWidget<CheckBoxWidget>("camera_smoothing")->setState(UserConfigParams::m_standard_camera_forward_smoothing);
         getWidget<CheckBoxWidget>("use_soccer_camera")->setState(UserConfigParams::m_standard_reverse_look_use_soccer_cam);
         // Not allowed to change fov, distance, and angles. Only allow to change smoothing and follow soccer
@@ -72,6 +78,11 @@ void CustomCameraSettingsDialog::beforeAddingWidgets()
     }
     else if (UserConfigParams::m_camera_present == 2) // Drone chase camera
     {
+        getWidget<LabelWidget>("camera_name")->setText(_("Drone chase Camera"), false);
+        getWidget<SpinnerWidget>("fov")->setValue(UserConfigParams::m_drone_camera_fov);
+        getWidget<SpinnerWidget>("camera_distance")->setFloatValue(UserConfigParams::m_drone_camera_distance);
+        getWidget<SpinnerWidget>("camera_angle")->setValue(UserConfigParams::m_drone_camera_forward_up_angle);
+        getWidget<SpinnerWidget>("backward_camera_angle")->setValue(UserConfigParams::m_drone_camera_backward_up_angle);
         getWidget<CheckBoxWidget>("camera_smoothing")->setState(UserConfigParams::m_drone_camera_forward_smoothing);
         getWidget<CheckBoxWidget>("use_soccer_camera")->setState(UserConfigParams::m_drone_reverse_look_use_soccer_cam);
         // Not allowed to change fov, distance, and angles. Only allow to change smoothing and follow soccer
@@ -82,6 +93,7 @@ void CustomCameraSettingsDialog::beforeAddingWidgets()
     }
     else // Custom camera
     {
+        getWidget<LabelWidget>("camera_name")->setText(_("Custom Camera"), false);
         getWidget<SpinnerWidget>("fov")->setValue(UserConfigParams::m_saved_camera_fov);
         getWidget<SpinnerWidget>("camera_distance")->setFloatValue(UserConfigParams::m_saved_camera_distance);
         getWidget<SpinnerWidget>("camera_angle")->setValue(UserConfigParams::m_saved_camera_forward_up_angle);

--- a/src/states_screens/options/options_screen_audio.cpp
+++ b/src/states_screens/options/options_screen_audio.cpp
@@ -83,6 +83,11 @@ void OptionsScreenAudio::init()
     sfx->setState( UserConfigParams::m_sfx );
     music->setState( UserConfigParams::m_music );
 
+    if(!UserConfigParams::m_sfx)
+        getWidget<SpinnerWidget>("sfx_volume")->setActive(false);
+    if(!UserConfigParams::m_music)
+        getWidget<SpinnerWidget>("music_volume")->setActive(false);
+
 }   // init
 
 // -----------------------------------------------------------------------------

--- a/src/states_screens/options/options_screen_audio.cpp
+++ b/src/states_screens/options/options_screen_audio.cpp
@@ -155,9 +155,15 @@ void OptionsScreenAudio::eventCallback(Widget* widget, const std::string& name, 
         Log::info("OptionsScreenAudio", "Music is now %s", ((bool) UserConfigParams::m_music) ? "on" : "off");
 
         if(w->getState() == false)
+        {
             music_manager->stopMusic();
+            getWidget<SpinnerWidget>("music_volume")->setActive(false);
+        }
         else
+        {
             music_manager->startMusic();
+            getWidget<SpinnerWidget>("music_volume")->setActive(true);
+        }
     }
     else if(name == "sfx_enabled")
     {
@@ -169,6 +175,11 @@ void OptionsScreenAudio::eventCallback(Widget* widget, const std::string& name, 
         if (UserConfigParams::m_sfx)
         {
             SFXManager::get()->quickSound("horn");
+            getWidget<SpinnerWidget>("sfx_volume")->setActive(true);
+        }
+        else
+        {
+            getWidget<SpinnerWidget>("sfx_volume")->setActive(false);
         }
     }
 }   // eventCallback

--- a/src/states_screens/options/options_screen_ui.cpp
+++ b/src/states_screens/options/options_screen_ui.cpp
@@ -150,6 +150,20 @@ void OptionsScreenUI::loadedFromFile()
         font_size->m_properties[GUIEngine::PROP_MAX_VALUE] = "5";
     }
 
+    // Setup camera spinner
+    GUIEngine::SpinnerWidget* camera_preset = getWidget<GUIEngine::SpinnerWidget>("camera_preset");
+    assert( camera_preset != NULL );
+
+    camera_preset->m_properties[PROP_WRAP_AROUND] = "true";
+    camera_preset->clearLabels();
+    //I18N: In the UI options, Camera setting: Custom
+    camera_preset->addLabel( core::stringw(_("Custom")));
+    //I18N: In the UI options, Camera setting: Standard
+    camera_preset->addLabel( core::stringw(_("Standard")));
+    //I18N: In the UI options, Camera setting: Drone chase
+    camera_preset->addLabel( core::stringw(_("Drone chase")));
+    camera_preset->m_properties[GUIEngine::PROP_MIN_VALUE] = "0";
+    camera_preset->m_properties[GUIEngine::PROP_MAX_VALUE] = "2";
     updateCameraPresetSpinner();
 
     font_size->setValueUpdatedCallback([this](SpinnerWidget* spinner)
@@ -339,21 +353,11 @@ void OptionsScreenUI::init()
         irr_driver->setMaxTextureSize();
     }
 
+    // --- select the right camera in the spinner
     GUIEngine::SpinnerWidget* camera_preset = getWidget<GUIEngine::SpinnerWidget>("camera_preset");
     assert( camera_preset != NULL );
 
-    camera_preset->m_properties[PROP_WRAP_AROUND] = "true";
-    camera_preset->clearLabels();
-    //I18N: In the UI options, Camera setting: Custom
-    camera_preset->addLabel( core::stringw(_("Custom")));
-    //I18N: In the UI options, Camera setting: Standard
-    camera_preset->addLabel( core::stringw(_("Standard")));
-    //I18N: In the UI options, Camera setting: Drone chase
-    camera_preset->addLabel( core::stringw(_("Drone chase")));
-    camera_preset->m_properties[GUIEngine::PROP_MIN_VALUE] = "1";
-    camera_preset->m_properties[GUIEngine::PROP_MAX_VALUE] = "2";
     camera_preset->setValue(UserConfigParams::m_camera_present); // use the saved camera
-
     updateCameraPresetSpinner();
 }   // init
 


### PR DESCRIPTION
Hi, the changes are:
1. When a spinner is not active, still show its value instead of showing "-".
2. Show the camera name in custom_camera_setting UI
3. On the audio setting UI, disable the spinner if the checkbox is not ticked.

Here are some screenshots. Hope you like it.

![Screenshot from 2020-12-24 14-24-56](https://user-images.githubusercontent.com/4726939/103106955-8bd68180-45ff-11eb-9f3b-037b1110a1d4.png)
![Screenshot from 2020-12-24 14-25-11](https://user-images.githubusercontent.com/4726939/103106964-9abd3400-45ff-11eb-9c0b-6e0310b11884.png)
![Screenshot from 2020-12-24 15-32-20](https://user-images.githubusercontent.com/4726939/103106969-a4469c00-45ff-11eb-83d8-25039d9c9f3a.png)


## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
