### PR TITLE
small fix of kart color slider and kart icon in result screen

### DIFF
--- a/src/states_screens/dialogs/kart_color_slider_dialog.cpp
+++ b/src/states_screens/dialogs/kart_color_slider_dialog.cpp
@@ -168,7 +168,7 @@ void KartColorSliderDialog::toggleSlider()
     if (m_toggle_slider->getValue() == 1)
     {
         m_color_slider->setActive(true);
-        m_color_slider->setValue(100);
+        m_color_slider->setValue(int(m_player_profile->getDefaultKartColor() * 100.0f));
         m_model_view->getModelViewRenderInfo()->setHue(1.0f);
     }
     else

--- a/src/states_screens/race_result_gui.cpp
+++ b/src/states_screens/race_result_gui.cpp
@@ -681,8 +681,8 @@ void RaceResultGUI::displayCTFResults()
         source_rect = core::recti(core::vector2di(0, 0), kart_icon->getSize());
         irr::u32 offset_x =
             (irr::u32)(font->getDimension(result_text.c_str()).Width / 1.5f);
-        dest_rect = core::recti(current_x - offset_x - 30, current_y,
-            current_x - offset_x, current_y + 30);
+        dest_rect = core::recti(current_x - offset_x - font->getDimension(L"0").Height, current_y,
+            current_x - offset_x, current_y + font->getDimension(L"0").Height);
         draw2DImage(kart_icon, dest_rect, source_rect, NULL, NULL, true);
     }
 
@@ -729,8 +729,8 @@ void RaceResultGUI::displayCTFResults()
         source_rect = core::recti(core::vector2di(0, 0), kart_icon->getSize());
         irr::u32 offset_x = (irr::u32)
             (font->getDimension(result_text.c_str()).Width / 1.5f);
-        dest_rect = core::recti(current_x - offset_x - 30, current_y,
-            current_x - offset_x, current_y + 30);
+        dest_rect = core::recti(current_x - offset_x - font->getDimension(L"0").Height, current_y,
+            current_x - offset_x, current_y + font->getDimension(L"0").Height);
         draw2DImage(kart_icon, dest_rect, source_rect, NULL, NULL, true);
     }
 #endif
@@ -1505,7 +1505,8 @@ void RaceResultGUI::displayCTFResults()
             {
                 source_rect = core::recti(core::vector2di(0, 0), scorer_icon->getSize());
                 irr::u32 offset_x = (irr::u32)(font->getDimension(result_text.c_str()).Width / 1.5f);
-                core::recti r = core::recti(current_x - offset_x - 30, current_y, current_x - offset_x, current_y + 30);
+                core::recti r = core::recti(current_x - offset_x - font->getDimension(L"0").Height, current_y,
+                    current_x - offset_x, current_y + font->getDimension(L"0").Height);
                 draw2DImage(scorer_icon, r, source_rect,
                     NULL, NULL, true);
             }
@@ -1566,7 +1567,8 @@ void RaceResultGUI::displayCTFResults()
             {
                 source_rect = core::recti(core::vector2di(0, 0), scorer_icon->getSize());
                 irr::u32 offset_x = (irr::u32)(font->getDimension(result_text.c_str()).Width / 1.5f);
-                core::recti r = core::recti(current_x - offset_x - 30, current_y, current_x - offset_x, current_y + 30);
+                core::recti r = core::recti(current_x - offset_x - font->getDimension(L"0").Height, current_y,
+                    current_x - offset_x, current_y + font->getDimension(L"0").Height);
                 draw2DImage(scorer_icon, r, source_rect,
                     NULL, NULL, true);
             }

--- a/src/states_screens/race_result_gui.cpp
+++ b/src/states_screens/race_result_gui.cpp
@@ -681,8 +681,8 @@ void RaceResultGUI::displayCTFResults()
         source_rect = core::recti(core::vector2di(0, 0), kart_icon->getSize());
         irr::u32 offset_x =
             (irr::u32)(font->getDimension(result_text.c_str()).Width / 1.5f);
-        dest_rect = core::recti(current_x - offset_x - font->getDimension(L"0").Height, current_y,
-            current_x - offset_x, current_y + font->getDimension(L"0").Height);
+        dest_rect = core::recti(current_x - offset_x - m_width_icon, current_y,
+            current_x - offset_x, current_y + m_width_icon);
         draw2DImage(kart_icon, dest_rect, source_rect, NULL, NULL, true);
     }
 
@@ -729,8 +729,8 @@ void RaceResultGUI::displayCTFResults()
         source_rect = core::recti(core::vector2di(0, 0), kart_icon->getSize());
         irr::u32 offset_x = (irr::u32)
             (font->getDimension(result_text.c_str()).Width / 1.5f);
-        dest_rect = core::recti(current_x - offset_x - font->getDimension(L"0").Height, current_y,
-            current_x - offset_x, current_y + font->getDimension(L"0").Height);
+        dest_rect = core::recti(current_x - offset_x - m_width_icon, current_y,
+            current_x - offset_x, current_y + m_width_icon);
         draw2DImage(kart_icon, dest_rect, source_rect, NULL, NULL, true);
     }
 #endif
@@ -1505,8 +1505,8 @@ void RaceResultGUI::displayCTFResults()
             {
                 source_rect = core::recti(core::vector2di(0, 0), scorer_icon->getSize());
                 irr::u32 offset_x = (irr::u32)(font->getDimension(result_text.c_str()).Width / 1.5f);
-                core::recti r = core::recti(current_x - offset_x - font->getDimension(L"0").Height, current_y,
-                    current_x - offset_x, current_y + font->getDimension(L"0").Height);
+                core::recti r = core::recti(current_x - offset_x - m_width_icon, current_y,
+                    current_x - offset_x, current_y + m_width_icon);
                 draw2DImage(scorer_icon, r, source_rect,
                     NULL, NULL, true);
             }
@@ -1567,8 +1567,8 @@ void RaceResultGUI::displayCTFResults()
             {
                 source_rect = core::recti(core::vector2di(0, 0), scorer_icon->getSize());
                 irr::u32 offset_x = (irr::u32)(font->getDimension(result_text.c_str()).Width / 1.5f);
-                core::recti r = core::recti(current_x - offset_x - font->getDimension(L"0").Height, current_y,
-                    current_x - offset_x, current_y + font->getDimension(L"0").Height);
+                core::recti r = core::recti(current_x - offset_x - m_width_icon, current_y,
+                    current_x - offset_x, current_y + m_width_icon);
                 draw2DImage(scorer_icon, r, source_rect,
                     NULL, NULL, true);
             }


### PR DESCRIPTION
Hi, some small fix:
1. use default kart color instead of the hardcoded 100
2. deal with the problem of extremely small kart icon on a 4K screen, see following figure:

![Screenshot from 2020-12-25 13-42-22](https://user-images.githubusercontent.com/4726939/103141457-154a8a00-46ba-11eb-801c-2c8eae6cc907.png)

There are various places where the icon size are based on the original size of the icon. This can be a problem for svg icons. It is better to scale according to the text size.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
