### PR TITLE
Fix the icon size in vertical split screen

### DIFF
--- a/src/states_screens/race_gui.cpp
+++ b/src/states_screens/race_gui.cpp
@@ -375,15 +375,8 @@ void RaceGUI::renderPlayerView(const Camera *camera, float dt)
 
     if (!isSpectatorCam) drawPlungerInFace(camera, dt);
 
-    if (viewport.getWidth() != (int)irr_driver->getActualScreenSize().Width)
-    {
-        scaling *= float(viewport.getWidth()) / float(irr_driver->getActualScreenSize().Width); // scale race GUI along screen size
-    }
-    else
-    {
-        scaling *= float(viewport.getWidth()) / 800.0f; // scale race GUI along screen size
-    }
-    
+    scaling *= float(viewport.getWidth()) / 800.0f; // scale race GUI along screen size
+
     drawAllMessages(kart, viewport, scaling);
 
     if(!World::getWorld()->isRacePhase()) return;


### PR DESCRIPTION
## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```

This fixes the icon size (of the powerups, speedmeter, nitrometer and rank in the race) in dual player mode with a vertical split screen specifically. (There was no issue in the horizontal case.) I'm attaching screenshots before and after.

**Before**
![before](https://user-images.githubusercontent.com/99431/103404173-f08b6200-4b52-11eb-9e79-a5a0c383601a.png)

**After**
![after](https://user-images.githubusercontent.com/99431/103404196-ff721480-4b52-11eb-843f-fb96a164a3f3.png)

Thanks for the great game!