### PR TITLE
Fixing minor ambient lighting bug

### DIFF
--- a/src/graphics/spherical_harmonics.cpp
+++ b/src/graphics/spherical_harmonics.cpp
@@ -597,7 +597,7 @@ void SphericalHarmonics::setAmbientLight(const video::SColor &ambient)
     unsigned sh_h = 16;
     unsigned ambr, ambg, ambb;
 
-    ambr = ambient.getBlue();
+    ambr = ambient.getRed();
     ambg = ambient.getGreen();
     ambb = ambient.getBlue();
 


### PR DESCRIPTION
Spherical harmonics: if no ambient map assigned, use specified color (but correctly)

This is a minor bug I noticed while revamping the Blender exporter tools. Seems like as long no map for the spherical harmonics is used, the ambient color (sun XML node) is interpreted wrongly.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
