### PR TITLE
GitHub Actions workflow can now be triggered manually

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,7 @@ on:
     tags:
       - '*'
   pull_request: {}
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```


(I also agree to release those changes under CC0 in addition to both of the above licenses)