### PR TITLE
Feature/remove old code

### DIFF
--- a/data/gui/icons/materials.xml
+++ b/data/gui/icons/materials.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0"?>
 <materials>
- 
   <material name="speedback.png"    compositing="test" clampU="Y" clampV="Y" light="N" ignore="Y"/>
   <material name="speedfore.png"    compositing="test" clampU="Y" clampV="Y" light="N" ignore="Y"/>
   <material name="notes.png"             compositing="test" light="N" ignore="Y"/>
-  <material name="soccer_player_red.png"             compositing="blend" light="N" ignore="Y"/>
-  <material name="soccer_player_blue.png"             compositing="blend" light="N" ignore="Y"/>
-
+  <material name="soccer_player_red.png"             shader="alphablend" ignore="Y"/>
+  <material name="soccer_player_blue.png"             shader="alphablend" ignore="Y"/>
 </materials>

--- a/data/gui/icons/materials.xml
+++ b/data/gui/icons/materials.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <materials>
-  <material name="speedback.png"    compositing="test" clampU="Y" clampV="Y" light="N" ignore="Y"/>
-  <material name="speedfore.png"    compositing="test" clampU="Y" clampV="Y" light="N" ignore="Y"/>
-  <material name="notes.png"             compositing="test" light="N" ignore="Y"/>
-  <material name="soccer_player_red.png"             shader="alphablend" ignore="Y"/>
-  <material name="soccer_player_blue.png"             shader="alphablend" ignore="Y"/>
+  <material name="speedback.png"              shader="alphatest"  clampU="Y" clampV="Y" ignore="Y"/>
+  <material name="speedfore.png"              shader="alphatest"  clampU="Y" clampV="Y" ignore="Y"/>
+  <material name="notes.png"                  shader="alphatest"  ignore="Y"/>
+  <material name="soccer_player_red.png"      shader="alphablend" ignore="Y"/>
+  <material name="soccer_player_blue.png"     shader="alphablend" ignore="Y"/>
 </materials>

--- a/data/shaders/sunlight.frag
+++ b/data/shaders/sunlight.frag
@@ -35,13 +35,4 @@ void main() {
 
     Diff = vec4(NdotL * Diffuse * sun_color, 1.);
     Spec = vec4(NdotL * Specular * sun_color, 1.);
-
-/*	if (hasclouds == 1)
-	{
-		vec2 cloudcoord = (xpos.xz * 0.00833333) + wind;
-		float cloud = texture(cloudtex, cloudcoord).x;
-		//float cloud = step(0.5, cloudcoord.x) * step(0.5, cloudcoord.y);
-
-		outcol *= cloud;
-	}*/
 }

--- a/lib/irrlicht/include/ISceneManager.h
+++ b/lib/irrlicht/include/ISceneManager.h
@@ -741,29 +741,6 @@ namespace scene
 			video::ITexture* left, video::ITexture* right, video::ITexture* front,
 			video::ITexture* back, ISceneNode* parent = 0, s32 id=-1) = 0;
 
-		//! Adds a skydome scene node to the scene graph.
-		/** A skydome is a large (half-) sphere with a panoramic texture
-		on the inside and is drawn around the camera position.
-		\param texture: Texture for the dome.
-		\param horiRes: Number of vertices of a horizontal layer of the sphere.
-		\param vertRes: Number of vertices of a vertical layer of the sphere.
-		\param texturePercentage: How much of the height of the
-		texture is used. Should be between 0 and 1.
-		\param spherePercentage: How much of the sphere is drawn.
-		Value should be between 0 and 2, where 1 is an exact
-		half-sphere and 2 is a full sphere.
-		\param radius The Radius of the sphere
-		\param parent: Parent scene node of the dome. A dome usually has no parent,
-		so this should be null. Note: If a parent is set, the dome will not
-		change how it is drawn.
-		\param id: An id of the node. This id can be used to identify the node.
-		\return Pointer to the sky dome if successful, otherwise NULL.
-		This pointer should not be dropped. See IReferenceCounted::drop() for more information. */
-		virtual ISceneNode* addSkyDomeSceneNode(video::ITexture* texture,
-			u32 horiRes=16, u32 vertRes=8,
-			f32 texturePercentage=0.9, f32 spherePercentage=2.0,f32 radius = 1000.f,
-			ISceneNode* parent=0, s32 id=-1) = 0;
-
 		//! Adds a particle system scene node to the scene graph.
 		/** \param withDefaultEmitter: Creates a default working point emitter
 		which emitts some particles. Set this to true to see a particle system

--- a/lib/irrlicht/source/Irrlicht/CDefaultSceneNodeFactory.cpp
+++ b/lib/irrlicht/source/Irrlicht/CDefaultSceneNodeFactory.cpp
@@ -81,8 +81,6 @@ ISceneNode* CDefaultSceneNodeFactory::addSceneNode(ESCENE_NODE_TYPE type, IScene
 							4, ETPS_17, 0, true);
 	case ESNT_SKY_BOX:
 		return Manager->addSkyBoxSceneNode(0,0,0,0,0,0, parent);
-	case ESNT_SKY_DOME:
-		return Manager->addSkyDomeSceneNode(0, 16, 8, 0.9f, 2.0f, 1000.0f, parent);
 	case ESNT_SHADOW_VOLUME:
 		return 0;
 	case ESNT_OCTREE:

--- a/lib/irrlicht/source/Irrlicht/CSceneManager.cpp
+++ b/lib/irrlicht/source/Irrlicht/CSceneManager.cpp
@@ -581,24 +581,6 @@ ISceneNode* CSceneManager::addSkyBoxSceneNode(video::ITexture* top, video::IText
 	return node;
 }
 
-
-//! Adds a skydome scene node. A skydome is a large (half-) sphere with a
-//! panoramic texture on it and is drawn around the camera position.
-ISceneNode* CSceneManager::addSkyDomeSceneNode(video::ITexture* texture,
-	u32 horiRes, u32 vertRes, f32 texturePercentage,f32 spherePercentage, f32 radius,
-	ISceneNode* parent, s32 id)
-{
-	if (!parent)
-		parent = this;
-
-	ISceneNode* node = new CSkyDomeSceneNode(texture, horiRes, vertRes,
-		texturePercentage, spherePercentage, radius, parent, this, id);
-
-	node->drop();
-	return node;
-}
-
-
 //! Adds a particle system scene node.
 IParticleSystemSceneNode* CSceneManager::addParticleSystemSceneNode(
 	bool withDefaultEmitter, ISceneNode* parent, s32 id,

--- a/lib/irrlicht/source/Irrlicht/CSceneManager.h
+++ b/lib/irrlicht/source/Irrlicht/CSceneManager.h
@@ -164,13 +164,6 @@ namespace scene
 			video::ITexture* left, video::ITexture* right, video::ITexture* front,
 			video::ITexture* back, ISceneNode* parent = 0, s32 id=-1);
 
-		//! Adds a skydome scene node. A skydome is a large (half-) sphere with a
-		//! panoramic texture on it and is drawn around the camera position.
-		virtual ISceneNode* addSkyDomeSceneNode(video::ITexture* texture,
-			u32 horiRes=16, u32 vertRes=8,
-			f32 texturePercentage=0.9, f32 spherePercentage=2.0,f32 radius = 1000.f,
-			ISceneNode* parent=0, s32 id=-1);
-
 		//! Adds a text scene node, which is able to display
 		//! 2d text at a position in three dimensional space
 		virtual ITextSceneNode* addTextSceneNode(gui::IGUIFont* font, const wchar_t* text,

--- a/src/graphics/irr_driver.cpp
+++ b/src/graphics/irr_driver.cpp
@@ -1543,30 +1543,6 @@ scene::IAnimatedMeshSceneNode *IrrDriver::addAnimatedMesh(scene::IAnimatedMesh *
 }   // addAnimatedMesh
 
 // ----------------------------------------------------------------------------
-/** Adds a sky dome. Documentation from irrlicht:
- *  A skydome is a large (half-) sphere with a panoramic texture on the inside
- *  and is drawn around the camera position.
- *  \param texture: Texture for the dome.
- *  \param horiRes: Number of vertices of a horizontal layer of the sphere.
- *  \param vertRes: Number of vertices of a vertical layer of the sphere.
- *  \param texturePercentage: How much of the height of the texture is used.
- *         Should be between 0 and 1.
- *  \param spherePercentage: How much of the sphere is drawn. Value should be
- *          between 0 and 2, where 1 is an exact half-sphere and 2 is a full
- *          sphere.
- */
-scene::ISceneNode *IrrDriver::addSkyDome(video::ITexture *texture,
-                                         int hori_res, int vert_res,
-                                         float texture_percent,
-                                         float sphere_percent)
-{
-    Log::error("skybox", "Using deprecated SkyDome");
-    return m_scene_manager->addSkyDomeSceneNode(texture, hori_res, vert_res,
-                                                texture_percent,
-                                                sphere_percent);
-}   // addSkyDome
-
-// ----------------------------------------------------------------------------
 /** Adds a skybox using. Irrlicht documentation:
  *  A skybox is a big cube with 6 textures on it and is drawn around the camera
  *  position.

--- a/src/graphics/irr_driver.hpp
+++ b/src/graphics/irr_driver.hpp
@@ -249,9 +249,6 @@ public:
                                        scene::ISceneNode* parent=NULL);
     scene::IParticleSystemSceneNode
                          *addParticleNode(bool default_emitter=true);
-    scene::ISceneNode    *addSkyDome(video::ITexture *texture, int hori_res,
-                                     int vert_res, float texture_percent,
-                                     float sphere_percent);
     scene::ISceneNode    *addSkyBox(const std::vector<video::ITexture*> &texture_names,
                                     const std::vector<video::ITexture*> &spherical_harmonics_textures);
     void suppressSkyBox();

--- a/src/graphics/material.cpp
+++ b/src/graphics/material.cpp
@@ -218,16 +218,7 @@ Material::Material(const XMLNode *node, bool deprecated)
         }
         if (node->get("compositing", &s))
         {
-            if (s == "test")
-            {
-                m_shader_name = "alphatest";
-            }
-            else if (s == "additive")
-            {
-                m_shader_name = "additive";
-            }
-            else if (s != "none")
-                Log::warn("material", "Unknown compositing mode '%s'", s.c_str());
+            Log::warn("material", "compositing property is deprecated and removed. Please use shaders now");
         }
 
         s = "";

--- a/src/graphics/material.cpp
+++ b/src/graphics/material.cpp
@@ -218,21 +218,13 @@ Material::Material(const XMLNode *node, bool deprecated)
         }
         if (node->get("compositing", &s))
         {
-            if (s == "blend")
-            {
-                m_shader_name = "alphablend";
-            }
-            else if (s == "test")
+            if (s == "test")
             {
                 m_shader_name = "alphatest";
             }
             else if (s == "additive")
             {
                 m_shader_name = "additive";
-            }
-            else if (s == "coverage")
-            {
-                m_shader_name = "alphatest";
             }
             else if (s != "none")
                 Log::warn("material", "Unknown compositing mode '%s'", s.c_str());

--- a/src/graphics/material.cpp
+++ b/src/graphics/material.cpp
@@ -195,30 +195,28 @@ Material::Material(const XMLNode *node, bool deprecated)
     if (!node->get("shader", &s))
     {
         // BACKWARS COMPATIBILITY, EVENTUALLY REMOVE
-
         bool b = false;
-        node->get("additive", &b);
-        if (b)
+        if (node->get("additive", &b))
         {
-            m_shader_name = "alphablend";
+            Log::warn("material", "'additive=' property is deprecated and removed. Please use shaders now");
         }
-
         b = false;
-        node->get("alpha", &b);
-        if (b)
+        if (node->get("alpha", &b))
         {
-            m_shader_name = "alphablend";
+            Log::warn("material", "'alpha=' property is deprecated and removed. Please use shaders now");
         }
-
         b = true;
-        node->get("light", &b);
-        if (!b)
+        if (node->get("light", &b))
         {
-            m_shader_name = "unlit";
+            Log::warn("material", "'light=' property is deprecated and removed. Please use shaders now");
         }
         if (node->get("compositing", &s))
         {
-            Log::warn("material", "compositing property is deprecated and removed. Please use shaders now");
+            Log::warn("material", "'compositing=' property is deprecated and removed. Please use shaders now");
+        }
+        if (node->get("transparency", &s))
+        {
+            Log::warn("material", "'transparency=' property is deprecated and removed. Please use shaders now");
         }
 
         s = "";

--- a/src/graphics/material.cpp
+++ b/src/graphics/material.cpp
@@ -204,15 +204,6 @@ Material::Material(const XMLNode *node, bool deprecated)
         }
 
         b = false;
-        node->get("transparency", &b);
-        if (b)
-        {
-            m_shader_name = "alphatest";
-        }
-
-        //node->get("lightmap", &m_lightmap);
-
-        b = false;
         node->get("alpha", &b);
         if (b)
         {

--- a/src/tracks/track.cpp
+++ b/src/tracks/track.cpp
@@ -954,7 +954,6 @@ void Track::convertTrackToBullet(scene::ISceneNode *node)
              mesh = ((scene::IAnimatedMeshSceneNode*)node)->getMesh();
              break;
         case scene::ESNT_SKY_BOX :
-        case scene::ESNT_SKY_DOME:
         case scene::ESNT_PARTICLE_SYSTEM :
         case scene::ESNT_TEXT:
             // These are non-physical
@@ -2093,30 +2092,7 @@ void Track::loadTrackModel(bool reverse_track, unsigned int mode_id)
     // --------------------------
     irr_driver->suppressSkyBox();
 #ifndef SERVER_ONLY
-    if(!CVS->isGLSL() && m_sky_type==SKY_DOME && m_sky_textures.size() > 0)
-    {
-        scene::ISceneNode *node = irr_driver->addSkyDome(m_sky_textures[0],
-                                                         m_sky_hori_segments,
-                                                         m_sky_vert_segments,
-                                                         m_sky_texture_percent,
-                                                         m_sky_sphere_percent);
-        for(unsigned int i=0; i<node->getMaterialCount(); i++)
-        {
-            main_loop->renderGUI(5350, i, node->getMaterialCount());
-
-            video::SMaterial &irrMaterial=node->getMaterial(i);
-            for(unsigned int j=0; j<video::MATERIAL_MAX_TEXTURES; j++)
-            {
-                video::ITexture* t=irrMaterial.getTexture(j);
-                if(!t) continue;
-                core::matrix4 *m = &irrMaterial.getTextureMatrix(j);
-                m_animated_textures.push_back(new MovingTexture(m, m_sky_dx, m_sky_dy));
-            }   // for j<MATERIAL_MAX_TEXTURES
-        }   // for i<getMaterialCount
-
-        m_all_nodes.push_back(node);
-    }
-    else if(m_sky_type==SKY_BOX && m_sky_textures.size() == 6)
+    if(m_sky_type==SKY_BOX && m_sky_textures.size() == 6)
     {
         //if (m_spherical_harmonics_textures.size() > 0)
             m_all_nodes.push_back(irr_driver->addSkyBox(m_sky_textures, m_spherical_harmonics_textures));
@@ -2449,34 +2425,7 @@ void Track::loadObjects(const XMLNode* root, const std::string& path,
  */
 void Track::handleSky(const XMLNode &xml_node, const std::string &filename)
 {
-    if(xml_node.getName()=="sky-dome")
-    {
-        m_sky_type            = SKY_DOME;
-        m_sky_vert_segments   = 16;
-        m_sky_hori_segments   = 16;
-        m_sky_sphere_percent  = 1.0f;
-        m_sky_texture_percent = 1.0f;
-        std::string s;
-        xml_node.get("texture",          &s                   );
-        video::ITexture *t = irr_driver->getTexture(s);
-        if (t != NULL)
-        {
-            t->grab();
-            m_sky_textures.push_back(t);
-            xml_node.get("vertical",        &m_sky_vert_segments  );
-            xml_node.get("horizontal",      &m_sky_hori_segments  );
-            xml_node.get("sphere-percent",  &m_sky_sphere_percent );
-            xml_node.get("texture-percent", &m_sky_texture_percent);
-            xml_node.get("speed-x", &m_sky_dx );
-            xml_node.get("speed-y", &m_sky_dy);
-        }
-        else
-        {
-            Log::error("track", "Sky-dome texture '%s' not found - ignored.",
-                        s.c_str());
-        }
-    }   // if sky-dome
-    else if(xml_node.getName()=="sky-box")
+    if(xml_node.getName()=="sky-box")
     {
         std::string s;
         xml_node.get("texture", &s);

--- a/src/tracks/track.cpp
+++ b/src/tracks/track.cpp
@@ -151,7 +151,6 @@ Track::Track(const std::string &filename)
     m_bloom_threshold       = 0.75f;
     m_color_inlevel         = core::vector3df(0.0,1.0, 255.0);
     m_color_outlevel        = core::vector2df(0.0, 255.0);
-    m_clouds                = false;
     m_godrays               = false;
     m_displacement_speed    = 1.0f;
     m_physical_object_uid   = 0;
@@ -565,7 +564,6 @@ void Track::loadTrackInfo()
     root->get("reverse",               &m_reverse_available);
     root->get("default-number-of-laps",&m_default_number_of_laps);
     root->get("push-back",             &m_enable_push_back);
-    root->get("clouds",                &m_clouds);
     root->get("bloom",                 &m_bloom);
     root->get("bloom-threshold",       &m_bloom_threshold);
     root->get("shadows",               &m_shadows);

--- a/src/tracks/track.hpp
+++ b/src/tracks/track.hpp
@@ -359,8 +359,6 @@ private:
     float                   m_minimap_x_scale;
     float                   m_minimap_y_scale;
 
-    bool m_clouds;
-
     bool m_bloom;
     float m_bloom_threshold;
 
@@ -669,9 +667,6 @@ public:
 
     // ------------------------------------------------------------------------
     const std::vector<Subtitle>& getSubtitles() const { return m_subtitles; }
-
-    // ------------------------------------------------------------------------
-    bool hasClouds() const { return m_clouds; }
 
     // ------------------------------------------------------------------------
     bool hasBloom() const { return m_bloom; }

--- a/src/tracks/track.hpp
+++ b/src/tracks/track.hpp
@@ -246,7 +246,7 @@ private:
 
     /** The type of sky to be used for the track. */
     enum {SKY_NONE, SKY_BOX,
-          SKY_DOME, SKY_COLOR}          m_sky_type;
+          SKY_COLOR}          m_sky_type;
 
     /** sky rotation speed */
     float m_sky_dx, m_sky_dy;


### PR DESCRIPTION
Through the years and various we accumulated way too many unused, old, deprecated properties.

## Materials.xml

Not only many of those effects are not used or broken, there is now a much easier and more powerful way to do almost the same with shaders. With the release of blender 2.8 and newer we had to anyway redo the property system and most of those old properties are already removed on the blender side.

In Antarctica I removed a lot of those property but left warning messages so addons creators will know if they are using unsupported properties.

I also quickly removed / replaced most of those properties in the assets. So it should not break (aka crash) the game.

## General properties

Clouds: Was a feature for having moving clouds on the terrain. Never really used and anyway the code was commented. Can be done again in the future with shaders.

Skydome: Was not used anywhere + also desecrated in irrlicht.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
