### PR TITLE
Clock up CPU while loading on Switch

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -175,6 +175,7 @@ extern "C" {
   #include <switch/services/ssl.h>
 #define Event libnx_Event
   #include <switch/services/set.h>
+  #include <switch/services/applet.h>
   #include <switch/services/nifm.h>
   #include <switch/runtime/pad.h>
 #undef Event
@@ -2076,6 +2077,9 @@ int main(int argc, char *argv[])
     // Needed to get ip address
     nifmInitialize(NifmServiceType_User);
 
+    // Boost CPU while loading:
+    appletSetCpuBoostMode(ApmCpuBoostMode_FastLoad);
+
     // Crashes on Reujinx
 #ifdef DEBUG_NXLINK
     nxlinkStdio();
@@ -2492,6 +2496,11 @@ int main(int argc, char *argv[])
             RaceManager::get()->setupPlayerKartInfo();
             RaceManager::get()->startNew(false);
         }
+
+#ifdef __SWITCH__
+        // Game loaded, bring CPU / GPU clock back to normal
+        appletSetCpuBoostMode(ApmCpuBoostMode_Normal);
+#endif
 
         main_loop->run();
 

--- a/src/race/race_manager.cpp
+++ b/src/race/race_manager.cpp
@@ -63,6 +63,22 @@
 #include "utils/string_utils.hpp"
 #include "utils/translation.hpp"
 
+#ifdef __SWITCH__
+extern "C" {
+  #define u64 uint64_t
+  #define u32 uint32_t
+  #define s64 int64_t
+  #define s32 int32_t
+  #define Event libnx_Event
+  #include <switch/services/applet.h>
+  #undef Event
+  #undef u64
+  #undef u32
+  #undef s64
+  #undef s32
+}
+#endif
+
 //=============================================================================================
 RaceManager* g_race_manager[PT_COUNT];
 //---------------------------------------------------------------------------------------------
@@ -507,6 +523,10 @@ void RaceManager::startNew(bool from_overworld)
  */
 void RaceManager::startNextRace()
 {
+#ifdef __SWITCH__
+    // Throttles GPU while boosting CPU
+    appletSetCpuBoostMode(ApmCpuBoostMode_FastLoad);
+#endif
     ProcessType type = STKProcess::getType();
     main_loop->renderGUI(0);
     // Uncomment to debug audio leaks
@@ -665,6 +685,9 @@ void RaceManager::startNextRace()
         m_kart_status[i].m_last_time  = 0;
     }
     main_loop->renderGUI(8200);
+#ifdef __SWITCH__
+    appletSetCpuBoostMode(ApmCpuBoostMode_Normal);
+#endif
 }   // startNextRace
 
 //---------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```

Seems to lessen loading times somewhat from what I saw :)
We can clock up CPU while loading at the expense of dropping GPU clock to basically nothing.

I would like to see about debugging Irrlicht's filesystem stuff for better performance though, since I think that's where a lot of the bottleneck lies.