### PR TITLE
Improved artist debug mode

### DIFF
--- a/data/gui/dialogs/debug_slider.stkgui
+++ b/data/gui/dialogs/debug_slider.stkgui
@@ -30,5 +30,9 @@
             <label id="SSAO Sigma" raw_text="SSAO sigma" width="7f"/>
             <gauge id="ssao_sigma" min_value="0" max_value="100" proportion="1"/>
         </div>
+
+        <spacer height="1%"/>
+
+        <button id="close" text="Close" align="center"/>
     </div>
 </stkgui>

--- a/data/gui/dialogs/tutorial_message_dialog.stkgui
+++ b/data/gui/dialogs/tutorial_message_dialog.stkgui
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <stkgui>
-    <div x="2%" y="10%" width="96%" height="80%" layout="vertical-row" >
-        <label id="title" width="100%" text_align="left" word_wrap="true" proportion="1" />
+    <div x="2%" y="10%" width="96%" height="88%" layout="vertical-row" >
+        <label id="title" width="100%" height="100%" text_align="left" word_wrap="true" proportion="1" />
 
-        <spacer height="2%" width="10" />
-
-        <button id="continue" I18N="Button in tutorial" text="Continue" align="right"/>
+        <button id="continue" I18N="Button in tutorial" text="Continue" align="center"/>
     </div>
 </stkgui>

--- a/src/config/user_config.hpp
+++ b/src/config/user_config.hpp
@@ -461,7 +461,8 @@ namespace UserConfigParams
             PARAM_DEFAULT(  IntUserConfigParam(0, "game_mode",
                             &m_race_setup_group,
                             "Game mode. 0=standard, 1=time trial, 2=follow "
-                            "the leader, 3=3 strikes") );
+                            "the leader, 3=3 strikes, 4=easter egg hunt, "
+                            "5=soccer, 6=ghost replay") );
     PARAM_PREFIX StringUserConfigParam m_default_kart
             PARAM_DEFAULT( StringUserConfigParam("tux", "kart",
                            "Kart to select by default (the last used kart)") );
@@ -727,13 +728,13 @@ namespace UserConfigParams
     /** If high scores will not be saved. For repeated testing on tracks. */
     PARAM_PREFIX bool m_no_high_scores PARAM_DEFAULT(false);
 
-    /** If gamepad debugging is enabled. */
+    /** If unit testing is enabled. */
     PARAM_PREFIX bool m_unit_testing PARAM_DEFAULT(false);
 
     /** If gamepad debugging is enabled. */
     PARAM_PREFIX bool m_gamepad_debug PARAM_DEFAULT( false );
 
-    /** If gamepad debugging is enabled. */
+    /** If keyboard debugging is enabled. */
     PARAM_PREFIX bool m_keyboard_debug PARAM_DEFAULT(false);
 
     /** Wiimote debugging. */
@@ -755,7 +756,7 @@ namespace UserConfigParams
     /** True if physics debugging should be enabled. */
     PARAM_PREFIX bool m_physics_debug PARAM_DEFAULT( false );
 
-    /** True if fps should be printed each frame. */
+    /** True if FPS should be printed each frame. */
     PARAM_PREFIX bool m_fps_debug PARAM_DEFAULT(false);
 
     /** True if arena (battle/soccer) ai profiling. */

--- a/src/graphics/camera_debug.cpp
+++ b/src/graphics/camera_debug.cpp
@@ -122,6 +122,22 @@ void CameraDebug::update(float dt)
         m_camera->setTarget(xyz);
         m_camera->setPosition(offset.toIrrVector());
     }
+    else if (m_default_debug_Type==CM_DEBUG_INV_SIDE_OF_KART)
+    {
+        core::vector3df xyz = m_kart->getSmoothedXYZ().toIrrVector();
+        Vec3 offset(-3, 0, 0);
+        offset = m_kart->getSmoothedTrans()(offset);
+        m_camera->setTarget(xyz);
+        m_camera->setPosition(offset.toIrrVector());
+    }
+    else if (m_default_debug_Type==CM_DEBUG_FRONT_OF_KART)
+    {
+        core::vector3df xyz = m_kart->getSmoothedXYZ().toIrrVector();
+        Vec3 offset(0, 1, 2);
+        offset = m_kart->getSmoothedTrans()(offset);
+        m_camera->setTarget(xyz);
+        m_camera->setPosition(offset.toIrrVector());
+    }
     // If an explosion is happening, stop moving the camera,
     // but keep it target on the kart.
     else if (dynamic_cast<ExplosionAnimation*>(m_kart->getKartAnimation()))

--- a/src/graphics/camera_debug.cpp
+++ b/src/graphics/camera_debug.cpp
@@ -74,6 +74,8 @@ void CameraDebug::getCameraSettings(float *above_kart, float *cam_angle,
         *distance   = -m_kart->getKartModel()->getLength()-1.0f;
         break;
     case CM_DEBUG_SIDE_OF_KART:
+    case CM_DEBUG_INV_SIDE_OF_KART:
+    case CM_DEBUG_FRONT_OF_KART:
     case CM_DEBUG_TOP_OF_KART:
         *above_kart    = 0.75f;
         *cam_angle     = UserConfigParams::m_camera_forward_up_angle * DEGREE_TO_RAD;

--- a/src/graphics/camera_debug.hpp
+++ b/src/graphics/camera_debug.hpp
@@ -38,6 +38,8 @@ public:
         CM_DEBUG_GROUND,        //!< Camera at ground level, wheel debugging
         CM_DEBUG_BEHIND_KART,   //!< Camera straight behind kart
         CM_DEBUG_SIDE_OF_KART,  //!< Camera to the right of the kart
+        CM_DEBUG_INV_SIDE_OF_KART,  //!< Camera to the left of the kart
+        CM_DEBUG_FRONT_OF_KART,  //!< Camera to the front of the kart
     };   // CameraDebugType
 
 private:

--- a/src/graphics/irr_driver.cpp
+++ b/src/graphics/irr_driver.cpp
@@ -1762,14 +1762,18 @@ video::SColorf IrrDriver::getAmbientLight() const
 void IrrDriver::displayFPS()
 {
 #ifndef SERVER_ONLY
-    gui::IGUIFont* font = GUIEngine::getSmallFont();
+    gui::ScalableFont* font = GUIEngine::getSmallFont();
+    font->setScale(0.7f);
     core::rect<s32> position;
 
     const int fheight = font->getHeightPerLine();
+    const int rwidth = irr_driver->getActualScreenSize().Width / 6;
+    const int swidth = irr_driver->getActualScreenSize().Width / 3;
+
     if (UserConfigParams::m_artist_debug_mode)
-        position = core::rect<s32>(51, 0, 30*fheight+51, 2*fheight + fheight / 3);
+        position = core::rect<s32>(rwidth - 20, 0, int(rwidth * 4.25), 2 * fheight + (fheight / 5));
     else
-        position = core::rect<s32>(75, 0, 18*fheight+75 , fheight + fheight / 5);
+        position = core::rect<s32>(swidth, 0, swidth * 2, fheight + (fheight / 5));
     GL32_draw2DRectangle(video::SColor(150, 96, 74, 196), position, NULL);
     // We will let pass some time to let things settle before trusting FPS counter
     // even if we also ignore fps = 1, which tends to happen in first checks
@@ -1805,12 +1809,15 @@ void IrrDriver::displayFPS()
     {
         no_trust--;
 
-        static video::SColor fpsColor = video::SColor(255, 0, 0, 0);
+        static video::SColor fpsColor = video::SColor(255, 255, 255, 255);
         fps_string = _("FPS: %d/%d/%d - %d KTris, Ping: %dms", "-", "-",
             "-", SP::sp_solid_poly_count / 1000, ping);
 
-        font->drawQuick(fps_string,
-            core::rect< s32 >(100,0,400,50), fpsColor, false);
+        font->setBlackBorder(true);
+        font->setThinBorder(true);
+        font->drawQuick(fps_string, position, fpsColor, false);
+        font->setThinBorder(false);
+        font->setBlackBorder(false);
         return;
     }
 
@@ -1828,9 +1835,8 @@ void IrrDriver::displayFPS()
     if ((UserConfigParams::m_artist_debug_mode)&&(CVS->isGLSL()))
     {
         fps_string = StringUtils::insertValues
-                    (L"FPS: %d/%d/%d  - PolyCount: %d Solid, "
-                      "%d Shadows - LightDist : %d\nComplexity %d, Total skinning joints: %d, "
-                      "Ping: %dms",
+                    (L"FPS: %d/%d/%d - PolyCount: %d Solid, %d Shadows - LightDist: %d\n"
+                      "Complexity %d, Total skinning joints: %d, Ping: %dms",
                     min, fps, max, SP::sp_solid_poly_count,
                     SP::sp_shadow_poly_count, m_last_light_bucket_distance, irr_driver->getSceneComplexity(),
                     m_skinning_joint, ping);
@@ -1849,9 +1855,14 @@ void IrrDriver::displayFPS()
         }
     }
 
-    static video::SColor fpsColor = video::SColor(255, 0, 0, 0);
+    static video::SColor fpsColor = video::SColor(255, 255, 255, 255);
 
-    font->drawQuick( fps_string.c_str(), position, fpsColor, false );
+    font->setBlackBorder(true);
+    font->setThinBorder(true);
+    font->drawQuick(fps_string.c_str(), position, fpsColor, false);
+    font->setThinBorder(false);
+    font->setBlackBorder(false);
+
 #endif
 }   // updateFPS
 

--- a/src/input/input_manager.cpp
+++ b/src/input/input_manager.cpp
@@ -259,15 +259,11 @@ void InputManager::handleStaticAction(int key, int value)
         world->onFirePressed(NULL);
     }
 
-
-    if (world != NULL && UserConfigParams::m_artist_debug_mode &&
-        control_is_pressed && value > 0)
+    if (world != NULL && UserConfigParams::m_artist_debug_mode)
     {
-        if (Debug::handleStaticAction(key))
-            return;
+        Debug::handleStaticAction(key, value, control_is_pressed);
     }
 
-    // TODO: move debug shortcuts to Debug::handleStaticAction
     switch (key)
     {
 #ifdef DEBUG
@@ -285,137 +281,31 @@ void InputManager::handleStaticAction(int key, int value)
         {
             if(!ProfileWorld::isProfileMode() || !world) break;
             int kart_id = key - IRR_KEY_1;
-            if(kart_id<0 || kart_id>=(int)world->getNumKarts()) break;
+            if(kart_id < 0 || kart_id >= (int)world->getNumKarts()) break;
             Camera::getCamera(0)->setKart(world->getKart(kart_id));
             break;
         }
 #endif
-
         case IRR_KEY_CONTROL:
         case IRR_KEY_RCONTROL:
         case IRR_KEY_LCONTROL:
         case IRR_KEY_RMENU:
         case IRR_KEY_LMENU:
         case IRR_KEY_LWIN:
-            control_is_pressed = value!=0;
+        {
+            control_is_pressed = value != 0;
             break;
+        }
         case IRR_KEY_LSHIFT:
         case IRR_KEY_RSHIFT:
         case IRR_KEY_SHIFT:
-            shift_is_pressed = value!=0; break;
-
-        // Flying up and down
-        case IRR_KEY_I:
         {
-            if (!world || !UserConfigParams::m_artist_debug_mode) break;
-
-            AbstractKart* kart = world->getLocalPlayerKart(0);
-            if (kart == NULL) break;
-
-            kart->flyUp();
+            shift_is_pressed = value != 0;
             break;
         }
-        case IRR_KEY_K:
-        {
-            if (!world || !UserConfigParams::m_artist_debug_mode) break;
-
-            AbstractKart* kart = world->getLocalPlayerKart(0);
-            if (kart == NULL) break;
-
-            kart->flyDown();
-            break;
-        }
-        // Moving the first person camera
-        case IRR_KEY_W:
-        {
-            CameraFPS *cam = dynamic_cast<CameraFPS*>(Camera::getActiveCamera());
-            if (world && UserConfigParams::m_artist_debug_mode && cam  )
-            {
-                core::vector3df vel(cam->getLinearVelocity());
-                vel.Z = value ? cam->getMaximumVelocity() : 0;
-                cam->setLinearVelocity(vel);
-            }
-            break;
-        }
-        case IRR_KEY_S:
-        {
-            CameraFPS *cam = dynamic_cast<CameraFPS*>(Camera::getActiveCamera());
-            if (world && UserConfigParams::m_artist_debug_mode && cam)
-            {
-                core::vector3df vel(cam->getLinearVelocity());
-                vel.Z = value ? -cam->getMaximumVelocity() : 0;
-                cam->setLinearVelocity(vel);
-            }
-            break;
-        }
-        case IRR_KEY_D:
-        {
-            CameraFPS *cam = dynamic_cast<CameraFPS*>(Camera::getActiveCamera());
-            if (world && !UserConfigParams::m_artist_debug_mode && cam)
-            {
-                core::vector3df vel(cam->getLinearVelocity());
-                vel.X = value ? -cam->getMaximumVelocity() : 0;
-                cam->setLinearVelocity(vel);
-            }
-            break;
-        }
-        case IRR_KEY_A:
-        {
-            CameraFPS *cam = dynamic_cast<CameraFPS*>(Camera::getActiveCamera());
-            if (world && UserConfigParams::m_artist_debug_mode && cam)
-            {
-                core::vector3df vel(cam->getLinearVelocity());
-                vel.X = value ? cam->getMaximumVelocity() : 0;
-                cam->setLinearVelocity(vel);
-            }
-            break;
-        }
-        case IRR_KEY_R:
-        {
-            CameraFPS *cam = dynamic_cast<CameraFPS*>(Camera::getActiveCamera());
-            if (world && UserConfigParams::m_artist_debug_mode && cam)
-            {
-                core::vector3df vel(cam->getLinearVelocity());
-                vel.Y = value ? cam->getMaximumVelocity() : 0;
-                cam->setLinearVelocity(vel);
-            }
-            break;
-        }
-        case IRR_KEY_F:
-        {
-            CameraFPS *cam = dynamic_cast<CameraFPS*>(Camera::getActiveCamera());
-            if (world && UserConfigParams::m_artist_debug_mode && cam)
-            {
-                core::vector3df vel(cam->getLinearVelocity());
-                vel.Y = value ? -cam->getMaximumVelocity() : 0;
-                cam->setLinearVelocity(vel);
-            }
-            break;
-        }
-        // Rotating the first person camera
-        case IRR_KEY_Q:
-        {
-            CameraFPS *cam = dynamic_cast<CameraFPS*>(Camera::getActiveCamera());
-            if (world && UserConfigParams::m_artist_debug_mode && cam )
-            {
-                cam->setAngularVelocity(value ?
-                    UserConfigParams::m_fpscam_max_angular_velocity : 0.0f);
-            }
-            break;
-        }
-        case IRR_KEY_E:
-        {
-            CameraFPS *cam = dynamic_cast<CameraFPS*>(Camera::getActiveCamera());
-            if (world && UserConfigParams::m_artist_debug_mode && cam)
-            {
-                cam->setAngularVelocity(value ?
-                    -UserConfigParams::m_fpscam_max_angular_velocity : 0);
-            }
-            break;
-        }
-
         case IRR_KEY_SNAPSHOT:
         case IRR_KEY_PRINT:
+        {
             // on windows we don't get a press event, only release.  So
             // save on release only (to avoid saving twice on other platforms)
             if (value == 0)
@@ -431,139 +321,46 @@ void InputManager::handleStaticAction(int key, int value)
                 }
             }
             break;
+        }
+        case IRR_KEY_F10:
+        {
+            if(world && value)
+            {
+                if(control_is_pressed)
+                {
+                    ReplayRecorder::get()->save();
+                }
+                else
+                {
+                    history->Save();
+                }
+            }
+            break;
+        }
         case IRR_KEY_F11:
+        {
             if(value && shift_is_pressed)
             {
 #ifndef SERVER_ONLY
                 ShaderBasedRenderer* sbr = SP::getRenderer();
                 if (sbr)
+                {
                     sbr->dumpRTT();
+                }
 #endif
             }
             break;
-
-            /*
-            else if (UserConfigParams::m_artist_debug_mode && world)
-            {
-                AbstractKart* kart = world->getLocalPlayerKart(0);
-
-                if (control_is_pressed)
-                    kart->setPowerup(PowerupManager::POWERUP_SWATTER, 10000);
-                else
-                    kart->setPowerup(PowerupManager::POWERUP_RUBBERBALL, 10000);
-
-#ifdef FORCE_RESCUE_ON_FIRST_KART
-                // Can be useful for debugging places where the AI gets into
-                // a rescue loop: rescue, drive, crash, rescue to same place
-                world->getKart(0)->forceRescue();
-#endif
-            }
-            break;
-        case IRR_KEY_F2:
-            if (UserConfigParams::m_artist_debug_mode && world)
-            {
-                AbstractKart* kart = world->getLocalPlayerKart(0);
-
-                kart->setPowerup(PowerupManager::POWERUP_PLUNGER, 10000);
-            }
-            break;
-        case IRR_KEY_F3:
-            if (UserConfigParams::m_artist_debug_mode && world)
-            {
-                AbstractKart* kart = world->getLocalPlayerKart(0);
-                kart->setPowerup(PowerupManager::POWERUP_CAKE, 10000);
-            }
-            break;
-        case IRR_KEY_F4:
-            if (UserConfigParams::m_artist_debug_mode && world)
-            {
-                AbstractKart* kart = world->getLocalPlayerKart(0);
-                kart->setPowerup(PowerupManager::POWERUP_SWITCH, 10000);
-            }
-            break;
-        case IRR_KEY_F5:
-            if (UserConfigParams::m_artist_debug_mode && world)
-            {
-                AbstractKart* kart = world->getLocalPlayerKart(0);
-                kart->setPowerup(PowerupManager::POWERUP_BOWLING, 10000);
-            }
-            break;
-        case IRR_KEY_F6:
-            if (UserConfigParams::m_artist_debug_mode && world)
-            {
-                AbstractKart* kart = world->getLocalPlayerKart(0);
-                kart->setPowerup(PowerupManager::POWERUP_BUBBLEGUM, 10000);
-            }
-            break;
-        case IRR_KEY_F7:
-            if (UserConfigParams::m_artist_debug_mode && world)
-            {
-                AbstractKart* kart = world->getLocalPlayerKart(0);
-                kart->setPowerup(PowerupManager::POWERUP_ZIPPER, 10000);
-            }
-            break;
-        case IRR_KEY_F8:
-            if (UserConfigParams::m_artist_debug_mode && value && world)
-            {
-                if (control_is_pressed)
-                {
-                    RaceGUIBase* gui = world->getRaceGUI();
-                    if (gui != NULL) gui->m_enabled = !gui->m_enabled;
-
-                    const int count = World::getWorld()->getNumKarts();
-                    for (int n=0; n<count; n++)
-                    {
-                        if(World::getWorld()->getKart(n)->getController()->isPlayerController())
-                            World::getWorld()->getKart(n)->getNode()
-                                ->setVisible(gui->m_enabled);
-                    }
-                }
-                else
-                {
-                    AbstractKart* kart = world->getLocalPlayerKart(0);
-                    kart->setEnergy(100.0f);
-                }
-            }
-            break;
-        case IRR_KEY_F9:
-            if (UserConfigParams::m_artist_debug_mode && world)
-            {
-                AbstractKart* kart = world->getLocalPlayerKart(0);
-                if(control_is_pressed && RaceManager::get()->getMinorMode()!=
-                                          RaceManager::MINOR_MODE_3_STRIKES)
-                    kart->setPowerup(PowerupManager::POWERUP_RUBBERBALL,
-                                     10000);
-                else
-                    kart->setPowerup(PowerupManager::POWERUP_SWATTER, 10000);
-            }
-            break;
-            */
-        case IRR_KEY_F10:
-            if(world && value)
-            {
-                if(control_is_pressed)
-                    ReplayRecorder::get()->save();
-                else
-                    history->Save();
-            }
-            break;
-            /*
-        case IRR_KEY_F11:
-            if (UserConfigParams::m_artist_debug_mode && value &&
-                control_is_pressed && world)
-            {
-                world->getPhysics()->nextDebugMode();
-            }
-            break;
-            */
+        }
         case IRR_KEY_F12:
-            if(value)
-                UserConfigParams::m_display_fps =
-                    !UserConfigParams::m_display_fps;
+        {
+            if (value)
+            {
+                UserConfigParams::m_display_fps = !UserConfigParams::m_display_fps;
+            }
             break;
-        default:
-            break;
-    } // switch
+        }
+        default : break;
+    }
 }   // handleStaticAction
 
 //-----------------------------------------------------------------------------
@@ -740,15 +537,15 @@ int InputManager::getPlayerKeyboardID() const
 }
 //-----------------------------------------------------------------------------
 /** Handles the conversion from some input to a GameAction and its distribution
- * to the currently active menu.
- * It also handles whether the game is currently sensing input. It does so by
- * suppressing the distribution of the input as a GameAction. Instead the
- * input is stored in 'm_sensed_input' and GA_SENSE_COMPLETE is distributed. If
- * however the input in question has resolved to GA_LEAVE this is treated as
- * an attempt of the user to cancel the sensing. In that case GA_SENSE_CANCEL
- * is distributed.
+ *  to the currently active menu.
+ *  It also handles whether the game is currently sensing input. It does so by
+ *  suppressing the distribution of the input as a GameAction. Instead the
+ *  input is stored in 'm_sensed_input' and GA_SENSE_COMPLETE is distributed. If
+ *  however the input in question has resolved to GA_LEAVE this is treated as
+ *  an attempt of the user to cancel the sensing. In that case GA_SENSE_CANCEL
+ *  is distributed.
  *
- * Note: It is the obligation of the called menu to switch of the sense mode.
+ *  Note: It is the obligation of the called menu to switch of the sense mode.
  *
  */
 void InputManager::dispatchInput(Input::InputType type, int deviceID,
@@ -796,7 +593,7 @@ void InputManager::dispatchInput(Input::InputType type, int deviceID,
                                                          &player, &action);
 
     // in menus, some keyboard keys are standard (before each player selected
-    // his device). So if a key could not be mapped to any known binding,
+    // their device). So if a key could not be mapped to any known binding,
     // fall back to check the defaults.
     if (!action_found &&
             StateManager::get()->getGameState() != GUIEngine::GAME &&

--- a/src/input/input_manager.cpp
+++ b/src/input/input_manager.cpp
@@ -577,8 +577,10 @@ void InputManager::dispatchInput(Input::InputType type, int deviceID,
         return;
     }
 
-    // Abort demo mode if a key is pressed during the race in demo mode
-    if(dynamic_cast<DemoWorld*>(World::getWorld()))
+    // Abort demo mode if a key is pressed during the race in demo mode,
+    // if a dialog is not active
+    if(dynamic_cast<DemoWorld*>(World::getWorld()) &&
+       !GUIEngine::ModalDialog::isADialogActive())
     {
         RaceManager::get()->exitRace();
         StateManager::get()->resetAndGoToScreen(MainMenuScreen::getInstance());

--- a/src/input/input_manager.cpp
+++ b/src/input/input_manager.cpp
@@ -253,7 +253,7 @@ void InputManager::handleStaticAction(int key, int value)
     // When no players... a cutscene
     if (RaceManager::get() &&
         RaceManager::get()->getNumPlayers() == 0 && world != NULL && value > 0 &&
-        (key == IRR_KEY_SPACE || key == IRR_KEY_RETURN || 
+        (key == IRR_KEY_SPACE || key == IRR_KEY_RETURN ||
         key == IRR_KEY_BUTTON_A))
     {
         world->onFirePressed(NULL);
@@ -261,7 +261,7 @@ void InputManager::handleStaticAction(int key, int value)
 
     if (world != NULL && UserConfigParams::m_artist_debug_mode)
     {
-        Debug::handleStaticAction(key, value, control_is_pressed);
+        Debug::handleStaticAction(key, value, control_is_pressed, shift_is_pressed);
     }
 
     switch (key)
@@ -322,32 +322,28 @@ void InputManager::handleStaticAction(int key, int value)
             }
             break;
         }
-        case IRR_KEY_F10:
+        case IRR_KEY_F11:
         {
-            if(world && value)
+            if (value && world)
             {
-                if(control_is_pressed)
-                {
-                    ReplayRecorder::get()->save();
-                }
-                else
+                if (control_is_pressed)
                 {
                     history->Save();
                 }
-            }
-            break;
-        }
-        case IRR_KEY_F11:
-        {
-            if(value && shift_is_pressed)
-            {
-#ifndef SERVER_ONLY
-                ShaderBasedRenderer* sbr = SP::getRenderer();
-                if (sbr)
+                else if (shift_is_pressed)
                 {
-                    sbr->dumpRTT();
-                }
+#ifndef SERVER_ONLY
+                    ShaderBasedRenderer* sbr = SP::getRenderer();
+                    if (sbr)
+                    {
+                        sbr->dumpRTT();
+                    }
 #endif
+                }
+                else
+                {
+                    ReplayRecorder::get()->save();
+                }
             }
             break;
         }
@@ -355,7 +351,21 @@ void InputManager::handleStaticAction(int key, int value)
         {
             if (value)
             {
-                UserConfigParams::m_display_fps = !UserConfigParams::m_display_fps;
+                if (control_is_pressed)
+                {
+                    UserConfigParams::m_karts_powerup_gui =
+                    !UserConfigParams::m_karts_powerup_gui;
+                }
+                else if (shift_is_pressed)
+                {
+                    UserConfigParams::m_soccer_player_list =
+                    !UserConfigParams::m_soccer_player_list;
+                }
+                else
+                {
+                    UserConfigParams::m_display_fps =
+                    !UserConfigParams::m_display_fps;
+                }
             }
             break;
         }
@@ -965,7 +975,7 @@ EventPropagation InputManager::input(const SEvent& event)
             // single letter). Same for spacebar. Same for letters.
             if (GUIEngine::isWithinATextBox())
             {
-                if (key == IRR_KEY_BACK || key == IRR_KEY_SPACE || 
+                if (key == IRR_KEY_BACK || key == IRR_KEY_SPACE ||
                     key == IRR_KEY_SHIFT)
                 {
                     return EVENT_LET;
@@ -998,7 +1008,7 @@ EventPropagation InputManager::input(const SEvent& event)
             // single letter). Same for spacebar. Same for letters.
             if (GUIEngine::isWithinATextBox())
             {
-                if (key == IRR_KEY_BACK || key == IRR_KEY_SPACE || 
+                if (key == IRR_KEY_BACK || key == IRR_KEY_SPACE ||
                     key == IRR_KEY_SHIFT)
                 {
                     return EVENT_LET;
@@ -1121,18 +1131,18 @@ EventPropagation InputManager::input(const SEvent& event)
         }
 
         // Simulate touch events if there is no real device
-        if (UserConfigParams::m_multitouch_active > 1 && 
+        if (UserConfigParams::m_multitouch_active > 1 &&
             !irr_driver->getDevice()->supportsTouchDevice())
         {
             MultitouchDevice* device = m_device_manager->getMultitouchDevice();
-    
+
             if (device != NULL && (type == EMIE_LMOUSE_PRESSED_DOWN ||
                 type == EMIE_LMOUSE_LEFT_UP || type == EMIE_MOUSE_MOVED))
             {
                 device->m_events[0].id = 0;
                 device->m_events[0].x = event.MouseInput.X;
                 device->m_events[0].y = event.MouseInput.Y;
-    
+
                 if (type == EMIE_LMOUSE_PRESSED_DOWN)
                 {
                     device->m_events[0].touched = true;
@@ -1141,7 +1151,7 @@ EventPropagation InputManager::input(const SEvent& event)
                 {
                     device->m_events[0].touched = false;
                 }
-    
+
                 m_device_manager->updateMultitouchDevice();
                 device->updateDeviceState(0);
             }
@@ -1167,7 +1177,7 @@ EventPropagation InputManager::input(const SEvent& event)
         if (device && device->isAccelerometerActive())
         {
             m_device_manager->updateMultitouchDevice();
-            
+
             float factor = UserConfigParams::m_multitouch_tilt_factor;
             factor = std::max(factor, 0.1f);
             if (UserConfigParams::m_multitouch_controls == MULTITOUCH_CONTROLS_GYROSCOPE)

--- a/src/items/powerup.cpp
+++ b/src/items/powerup.cpp
@@ -199,6 +199,18 @@ void Powerup::set(PowerupManager::PowerupType type, int n)
 }  // set
 
 //-----------------------------------------------------------------------------
+/** Sets the amount of the current collected item.
+ *  \param n Number of items.
+ */
+void Powerup::setNum(int n)
+{
+    // Limit to 255 (save space in network state saving)
+    if(n>255) n = 255;
+
+    m_number=n;
+}
+
+//-----------------------------------------------------------------------------
 /** Returns the icon for the currently collected powerup. Used in the
  *  race_gui to display the collected item.
  */

--- a/src/items/powerup.hpp
+++ b/src/items/powerup.hpp
@@ -54,7 +54,8 @@ private:
 public:
                     Powerup      (AbstractKart* kart_);
                    ~Powerup      ();
-    void            set          (PowerupManager::PowerupType _type, int n=1);
+    void            set          (PowerupManager::PowerupType _type, int n = 1);
+    void            setNum       (int n = 1);
     void            reset        ();
     Material*       getIcon      () const;
     void            adjustSound  ();

--- a/src/karts/controller/skidding_ai.cpp
+++ b/src/karts/controller/skidding_ai.cpp
@@ -1252,19 +1252,6 @@ void SkiddingAI::handleItems(const float dt, const Vec3 *aim_point, int last_nod
         }// POWERUP_PARACHUTE
 
     case PowerupManager::POWERUP_ANVIL:
-        // Wait one second more than a previous anvil
-        if(m_time_since_last_shot < m_kart->getKartProperties()->getAnvilDuration() + 1.0f) break;
-
-        if(RaceManager::get()->getMinorMode()==RaceManager::MINOR_MODE_FOLLOW_LEADER)
-        {
-            m_controls->setFire(m_world->getTime()<1.0f &&
-                                m_kart->getPosition()>2    );
-        }
-        else
-        {
-            m_controls->setFire(m_time_since_last_shot > 3.0f &&
-                                m_kart->getPosition()>1          );
-        }
         break;   // POWERUP_ANVIL
 
     case PowerupManager::POWERUP_SWATTER:

--- a/src/karts/controller/skidding_ai.cpp
+++ b/src/karts/controller/skidding_ai.cpp
@@ -1251,6 +1251,22 @@ void SkiddingAI::handleItems(const float dt, const Vec3 *aim_point, int last_nod
         break;
         }// POWERUP_PARACHUTE
 
+    case PowerupManager::POWERUP_ANVIL:
+        // Wait one second more than a previous anvil
+        if(m_time_since_last_shot < m_kart->getKartProperties()->getAnvilDuration() + 1.0f) break;
+
+        if(RaceManager::get()->getMinorMode()==RaceManager::MINOR_MODE_FOLLOW_LEADER)
+        {
+            m_controls->setFire(m_world->getTime()<1.0f &&
+                                m_kart->getPosition()>2    );
+        }
+        else
+        {
+            m_controls->setFire(m_time_since_last_shot > 3.0f &&
+                                m_kart->getPosition()>1          );
+        }
+        break;   // POWERUP_ANVIL
+
     case PowerupManager::POWERUP_SWATTER:
         {
              // if the kart has a shield, do not break it by using a swatter.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -590,6 +590,10 @@ void cmdLineHelp()
                               "seconds.\n"
     "       --unlock-all       Permanently unlock all karts and tracks for testing.\n"
     "       --no-unlock-all    Disable unlock-all (i.e. base unlocking on player achievement).\n"
+    "       --xmas=n           Toggle Xmas/Christmas mode. n=0 Use current date, n=1, Always enable,\n"
+    "                          n=2, Always disable.\n"
+    "       --easter=n         Toggle Easter ears mode. n=0 Use current date, n=1, Always enable,\n"
+    "                          n=2, Always disable.\n"
     "       --no-graphics      Do not display the actual race.\n"
     "       --sp-shader-debug  Enables debug in sp shader, it will print all unavailable uniforms.\n"
     "       --demo-mode=t      Enables demo mode after t seconds of idle time in "
@@ -598,13 +602,7 @@ void cmdLineHelp()
     "                          spaces are allowed in the track names.\n"
     "       --demo-laps=n      Number of laps to use in a demo.\n"
     "       --demo-karts=n     Number of karts to use in a demo.\n"
-    // "       --history          Replay history file 'history.dat'.\n"
-    // "       --test-ai=n        Use the test-ai for every n-th AI kart.\n"
-    // "                          (so n=1 means all Ais will be the test ai)\n"
-    // "
-    // "    --disable-item-collection Disable item collection. Useful for\n"
-    // "                          debugging client/server item management.\n"
-    // "    --network-item-debugging Print item handling debug information.\n"
+    "       --history          Replay history file 'history.dat'.\n"
     "       --server-config=file Specify the server_config.xml for server hosting, it will create\n"
     "                            one if not found.\n"
     "       --network-console  Enable network console.\n"
@@ -646,6 +644,7 @@ void cmdLineHelp()
     "       --no-console-log   Does not write messages in the console but to\n"
     "                          stdout.log.\n"
     "  -h,  --help             Show this help.\n"
+    "       --help-debug       Show help for debugging options.\n"
     "       --log=N            Set the verbosity to a value between\n"
     "                          0 (Debug) and 5 (Only Fatal messages)\n"
     "       --logbuffer=N      Buffers up to N lines log lines before writing.\n"
@@ -687,6 +686,9 @@ void cmdLineHelp()
     "       --apitrace          This will disable buffer storage and\n"
     "                           writing gpu query strings to opengl, which\n"
     "                           can be seen later in apitrace.\n"
+#ifdef ENABLE_WIIUSE
+    "       --wii               Enable usage of Wii Remotes.\n"
+#endif
 #if defined(__linux__) || defined(__FreeBSD__)
     "\n"
     "Environment variables:\n"
@@ -702,6 +704,51 @@ void cmdLineHelp()
     );
 }   // cmdLineHelp
 
+void cmdDebugHelp()
+{
+    fprintf(stdout,
+    "Usage: %s [OPTIONS]\n\n"
+    "Run SuperTuxKart, a go-kart racing game that features "
+    "Tux and friends.\n\n"
+    "Debug options (some work only if artist debug mode is enabled):\n"
+    "       --debug=s                   s=all Log everything, s=addons Log addons management,\n"
+    "                                   s=gui Log GUI events, s=flyable Log flyables,\n"
+    "                                   s=memory Log memory usage, s=misc Log other events.\n"
+    "       --gamepad-visuals           Debug gamepads by visualising their values.\n"
+    "       --no-high-scores            Disable writing high scores.\n"
+    "       --unit-testing              Run unit tests and exit.\n"
+    "       --gamepad-debug             Enable verbose logging of gamepad button presses.\n"
+    "       --keyboard-debug            Enable verbose logging of keyboard key presses.\n"
+    "       --wiimote-debug             Enable verbose logging of Wii Remote button presses.\n"
+    "       --tutorial-debug            Enable verbose logging of the tutorial mode.\n"
+    "       --track-debug               Enable displaying the driveline in tracks.\n"
+    "       --check-debug               Enable displaying the checklines in tracks.\n"
+    "       --kartsize-debug            Enable verbose logging of kart dimensions\n"
+    "                                   and mesh buffer counts.\n"
+    "       --physics-debug             Enable verbose logging of the physics system.\n"
+    "       --material-debug            Enable verbose logging of terrain specific slowdowns.\n"
+    "       --ftl-debug                 Enable verbose logging in follow-the-leader mode.\n"
+    "       --slipstream-debug          Enable displaying of slipstreams more prominently.\n"
+    "       --rendering-debug           Enable displaying of ambient/diffuse/specularity\n"
+    "                                   in RGB & all anisotropic.\n"
+    "       --ai-debug                  Enable displaying of AI controllers as on-screen text.\n"
+    "                                   Makes it easier to distingush between different AI controllers.\n"
+    "       --fps-debug                 Enable verbose logging of the FPS counter on every frame.\n"
+    "       --rewind                    Enable the rewind manager.\n"
+    "       --battle-ai-stats           Enable verbose logging of AI karts in battle modes.\n"
+    "       --soccer-ai-stats           Enable verbose logging of AI karts in soccer mode.\n"
+    "       --test-ai=n                 Use the test-ai for every n-th AI kart.\n"
+    "                                   (so n=1 means all Ais will be the test ai)\n"
+    "       --disable-item-collection   Disable item collection. Useful for\n"
+    "                                   debugging client/server item management.\n"
+    "       --network-item-debugging    Print item handling debug information.\n"
+    "\n"
+    "You can visit SuperTuxKart's homepage at "
+    "https://supertuxkart.net\n\n",
+    CommandLine::getExecName().c_str()
+    );
+}   // cmdDebugHelp
+
 //=============================================================================
 /** For base options that modify the output (loglevel/color) or exit right
  * after being processed (version/help).
@@ -712,6 +759,13 @@ int handleCmdLineOutputModifier()
         CommandLine::has("-h"))
     {
         cmdLineHelp();
+        cleanUserConfig();
+        exit(0);
+    }
+
+    if (CommandLine::has("--help-debug"))
+    {
+        cmdDebugHelp();
         cleanUserConfig();
         exit(0);
     }
@@ -752,8 +806,7 @@ int handleCmdLineOutputModifier()
  */
 int handleCmdLinePreliminary()
 {
-   if(CommandLine::has("--gamepad-visualisation") ||   // only BE
-       CommandLine::has("--gamepad-visualization")    ) // both AE and BE
+    if(CommandLine::has("--gamepad-visuals"))
         UserConfigParams::m_gamepad_visualisation=true;
     if(CommandLine::has("--debug=memory"))
         UserConfigParams::m_verbosity |= UserConfigParams::LOG_MEMORY;
@@ -956,10 +1009,10 @@ int handleCmdLine(bool has_server_config, bool has_parent_process)
 
     irr::core::stringw login, password;
 
-    if (CommandLine::has("--unit-testing"))
-        UserConfigParams::m_unit_testing = true;
     if (CommandLine::has("--no-high-scores"))
         UserConfigParams::m_no_high_scores=true;
+    if (CommandLine::has("--unit-testing"))
+        UserConfigParams::m_unit_testing = true;
     if (CommandLine::has("--gamepad-debug"))
         UserConfigParams::m_gamepad_debug=true;
     if (CommandLine::has("--keyboard-debug"))
@@ -1027,21 +1080,6 @@ int handleCmdLine(bool has_server_config, bool has_parent_process)
 
     if (UserConfigParams::m_artist_debug_mode)
     {
-        if (CommandLine::has("--camera-wheel-debug"))
-        {
-            Camera::setDefaultCameraType(Camera::CM_TYPE_DEBUG);
-            CameraDebug::setDebugType(CameraDebug::CM_DEBUG_GROUND);
-        }
-        if(CommandLine::has("--camera-debug"))
-        {
-            Camera::setDefaultCameraType(Camera::CM_TYPE_DEBUG);
-            CameraDebug::setDebugType(CameraDebug::CM_DEBUG_TOP_OF_KART);
-        }
-        if(CommandLine::has("--camera-kart-debug"))
-        {
-            Camera::setDefaultCameraType(Camera::CM_TYPE_DEBUG);
-            CameraDebug::setDebugType(CameraDebug::CM_DEBUG_BEHIND_KART);
-        }
         if(CommandLine::has("--physics-debug"))
             UserConfigParams::m_physics_debug=1;
         if(CommandLine::has("--check-debug"))

--- a/src/states_screens/dialogs/debug_slider.cpp
+++ b/src/states_screens/dialogs/debug_slider.cpp
@@ -32,7 +32,7 @@ using namespace GUIEngine;
 
 // ------------------------------------------------------------------------------------------------------
 
-DebugSliderDialog::DebugSliderDialog() : ModalDialog(0.85f, 0.4f, MODAL_DIALOG_LOCATION_BOTTOM)
+DebugSliderDialog::DebugSliderDialog() : ModalDialog(0.85f, 0.45f, MODAL_DIALOG_LOCATION_BOTTOM)
 {
     m_fade_background = false;
 
@@ -56,6 +56,13 @@ void DebugSliderDialog::changeLabel(std::string id, std::string new_label)
 
 // ------------------------------------------------------------------------------------------------------
 
+void DebugSliderDialog::toggleSlider(std::string id, bool option)
+{
+    getWidget<SpinnerWidget>(id.c_str())->setActive(option);
+}
+
+// ------------------------------------------------------------------------------------------------------
+
 void DebugSliderDialog::onEnterPressedInternal()
 {
 }
@@ -64,6 +71,12 @@ void DebugSliderDialog::onEnterPressedInternal()
 
 GUIEngine::EventPropagation DebugSliderDialog::processEvent(const std::string& eventSource)
 {
+    if (eventSource == "close")
+    {
+        ModalDialog::dismiss();
+        return GUIEngine::EVENT_BLOCK;
+    }
+
     if (Setters.find(eventSource) == Setters.end())
         return GUIEngine::EVENT_LET;
 

--- a/src/states_screens/dialogs/debug_slider.hpp
+++ b/src/states_screens/dialogs/debug_slider.hpp
@@ -41,6 +41,7 @@ public:
     ~DebugSliderDialog() {};
     void setSliderHook(std::string id, unsigned min, unsigned max, std::function<int()> G, std::function<void(int)> S);
     void changeLabel(std::string id, std::string new_label);
+    void toggleSlider(std::string id, bool option);
 
     virtual void onEnterPressedInternal() OVERRIDE;
     virtual void onUpdate(float dt) OVERRIDE;

--- a/src/states_screens/dialogs/tutorial_message_dialog.cpp
+++ b/src/states_screens/dialogs/tutorial_message_dialog.cpp
@@ -31,7 +31,7 @@ using namespace GUIEngine;
 // ------------------------------------------------------------------------------------------------------
 
 TutorialMessageDialog::TutorialMessageDialog(irr::core::stringw msg, bool stopGame) :
-    ModalDialog(0.85f, 0.25f, MODAL_DIALOG_LOCATION_BOTTOM)
+    ModalDialog(0.85f, 0.95f, MODAL_DIALOG_LOCATION_CENTER)
 {
     m_stop_game = stopGame;
 
@@ -47,10 +47,8 @@ TutorialMessageDialog::TutorialMessageDialog(irr::core::stringw msg, bool stopGa
     LabelWidget* message = getWidget<LabelWidget>("title");
     message->setText( msg.c_str(), false );
 
-    ButtonWidget* cancelbtn = getWidget<ButtonWidget>("continue");
-    cancelbtn->setFocusForPlayer(PLAYER_ID_GAME_MASTER);
-    
-    World::getWorld()->getKart(0)->getControls().reset();
+    ButtonWidget* continuebtn = getWidget<ButtonWidget>("continue");
+    continuebtn->setFocusForPlayer(PLAYER_ID_GAME_MASTER);
 }
 
 // ------------------------------------------------------------------------------------------------------

--- a/src/utils/debug.cpp
+++ b/src/utils/debug.cpp
@@ -145,9 +145,8 @@ enum DebugMenuCommand
     DEBUG_VIEW_KART_EIGHT,
     DEBUG_VIEW_KART_NINE,
     DEBUG_VIEW_KART_TEN,
-    DEBUG_VIEW_KART_ELEVEN,
-    DEBUG_VIEW_KART_TWELVE,
     DEBUG_VIEW_KART_NEXT,
+    DEBUG_VIEW_KART_SLIDER,
     DEBUG_HIDE_KARTS,
     DEBUG_RESCUE_KART,
     DEBUG_PAUSE,
@@ -744,12 +743,6 @@ bool handleContextMenuAction(s32 cmd_id)
     case DEBUG_VIEW_KART_TEN:
         changeCameraTarget(10);
         break;
-    case DEBUG_VIEW_KART_ELEVEN:
-        changeCameraTarget(11);
-        break;
-    case DEBUG_VIEW_KART_TWELVE:
-        changeCameraTarget(12);
-        break;
     case DEBUG_VIEW_KART_NEXT:
     {
         if (kart_num == World::getWorld()->getNumKarts() - 1)
@@ -762,6 +755,27 @@ bool handleContextMenuAction(s32 cmd_id)
         }
         Camera::getActiveCamera()->setKart(World::getWorld()->getKart(kart_num));
         break;
+    }
+    case DEBUG_VIEW_KART_SLIDER:
+    {
+        if (!world) return false;
+        DebugSliderDialog *dsd = new DebugSliderDialog();
+        dsd->changeLabel("Red", "Kart number");
+        dsd->setSliderHook("red_slider", 0, World::getWorld()->getNumKarts() - 1,
+            [](){ return Camera::getActiveCamera()->getKart()->getWorldKartId(); },
+            [](int new_kart_num){Camera::getActiveCamera()->
+            setKart(World::getWorld()->getKart(new_kart_num)); }
+        );
+        dsd->changeLabel("Green", "[None]");
+        dsd->toggleSlider("green_slider", false);
+        dsd->changeLabel("Blue", "[None]");
+        dsd->toggleSlider("blue_slider", false);
+        dsd->changeLabel("SSAO radius", "[None]");
+        dsd->toggleSlider("ssao_radius", false);
+        dsd->changeLabel("SSAO k", "[None]");
+        dsd->toggleSlider("ssao_k", false);
+        dsd->changeLabel("SSAO Sigma", "[None]");
+        dsd->toggleSlider("ssao_sigma", false);
     }
 
     case DEBUG_PRINT_START_POS:
@@ -1058,20 +1072,19 @@ bool onEvent(const SEvent &event)
 
             mnu->addItem(L"Change camera target >",-1,true, true);
             sub = mnu->getSubMenu(5);
+            sub->addItem(L"Pick kart from slider", DEBUG_VIEW_KART_SLIDER);
             sub->addItem(L"To previous kart (Ctrl + F5)", DEBUG_VIEW_KART_PREVIOUS);
             sub->addItem(L"To next kart (Ctrl + F6)", DEBUG_VIEW_KART_NEXT);
-            sub->addItem(L"To kart one", DEBUG_VIEW_KART_ONE);
-            sub->addItem(L"To kart two", DEBUG_VIEW_KART_TWO);
-            sub->addItem(L"To kart three", DEBUG_VIEW_KART_THREE);
-            sub->addItem(L"To kart four", DEBUG_VIEW_KART_FOUR);
-            sub->addItem(L"To kart five", DEBUG_VIEW_KART_FIVE);
-            sub->addItem(L"To kart six", DEBUG_VIEW_KART_SIX);
-            sub->addItem(L"To kart seven", DEBUG_VIEW_KART_SEVEN);
-            sub->addItem(L"To kart eight", DEBUG_VIEW_KART_EIGHT);
-            sub->addItem(L"To kart nine", DEBUG_VIEW_KART_NINE);
-            sub->addItem(L"To kart ten", DEBUG_VIEW_KART_TEN);
-            sub->addItem(L"To kart eleven", DEBUG_VIEW_KART_ELEVEN);
-            sub->addItem(L"To kart twelve", DEBUG_VIEW_KART_TWELVE);
+            sub->addItem(L"To kart 1", DEBUG_VIEW_KART_ONE);
+            sub->addItem(L"To kart 2", DEBUG_VIEW_KART_TWO);
+            sub->addItem(L"To kart 3", DEBUG_VIEW_KART_THREE);
+            sub->addItem(L"To kart 4", DEBUG_VIEW_KART_FOUR);
+            sub->addItem(L"To kart 5", DEBUG_VIEW_KART_FIVE);
+            sub->addItem(L"To kart 6", DEBUG_VIEW_KART_SIX);
+            sub->addItem(L"To kart 7", DEBUG_VIEW_KART_SEVEN);
+            sub->addItem(L"To kart 8", DEBUG_VIEW_KART_EIGHT);
+            sub->addItem(L"To kart 9", DEBUG_VIEW_KART_NINE);
+            sub->addItem(L"To kart 10", DEBUG_VIEW_KART_TEN);
 
             mnu->addItem(L"Font >",-1,true, true);
             sub = mnu->getSubMenu(6);

--- a/src/utils/debug.cpp
+++ b/src/utils/debug.cpp
@@ -870,6 +870,7 @@ bool handleContextMenuAction(s32 cmd_id)
             [](int v){        findNearestLight()->setRadius(float(v)); }
         );
         dsd->changeLabel("SSAO Sigma", "[None]");
+        dsd->toggleSlider("ssao_sigma", false);
         break;
     }
     case DEBUG_SCRIPT_CONSOLE:

--- a/src/utils/debug.cpp
+++ b/src/utils/debug.cpp
@@ -766,7 +766,7 @@ bool handleContextMenuAction(s32 cmd_id)
         for (unsigned int i = 0; i<world->getNumKarts(); i++)
         {
             AbstractKart *kart = world->getKart(i);
-            Log::warn(kart->getIdent().c_str(),
+            Log::info(kart->getIdent().c_str(),
                 "<start position=\"%d\" x=\"%f\" y=\"%f\" z=\"%f\" h=\"%f\"/>",
                 i, kart->getXYZ().getX(), kart->getXYZ().getY(),
                 kart->getXYZ().getZ(), kart->getHeading()*RAD_TO_DEGREE
@@ -1029,8 +1029,8 @@ bool onEvent(const SEvent &event)
             sub->addItem(L"Top view", DEBUG_GUI_CAM_TOP);
             sub->addItem(L"Behind wheel view", DEBUG_GUI_CAM_WHEEL);
             sub->addItem(L"Behind kart view", DEBUG_GUI_CAM_BEHIND_KART);
-            sub->addItem(L"Side of kart view", DEBUG_GUI_CAM_SIDE_OF_KART);
-            sub->addItem(L"Inverse side of kart view", DEBUG_GUI_CAM_INV_SIDE_OF_KART);
+            sub->addItem(L"Right side of kart view", DEBUG_GUI_CAM_SIDE_OF_KART);
+            sub->addItem(L"Left side of kart view", DEBUG_GUI_CAM_INV_SIDE_OF_KART);
             sub->addItem(L"Front of kart view", DEBUG_GUI_CAM_FRONT_OF_KART);
             sub->addItem(L"First person view (Ctrl + F1)", DEBUG_GUI_CAM_FREE);
             sub->addItem(L"Normal view (Ctrl + F2)", DEBUG_GUI_CAM_NORMAL);

--- a/src/utils/debug.cpp
+++ b/src/utils/debug.cpp
@@ -58,7 +58,7 @@
 #include "scriptengine/script_engine.hpp"
 #include "states_screens/dialogs/debug_slider.hpp"
 #include "states_screens/dialogs/general_text_field_dialog.hpp"
-#include "states_screens/dialogs/message_dialog.hpp"
+#include "states_screens/dialogs/tutorial_message_dialog.hpp"
 #include "tracks/track_manager.hpp"
 #include "utils/constants.hpp"
 #include "utils/log.hpp"
@@ -1034,13 +1034,27 @@ bool handleContextMenuAction(s32 cmd_id)
         irr_driver->setRecording(false);
         break;
     case DEBUG_HELP:
-        new MessageDialog(_("Debug keyboard shortcuts:\n"
-                            "* \n"
-                            "* \n"
-                            "* \n"
-                            "* \n"),
-                            MessageDialog::MESSAGE_DIALOG_OK,
-                            NULL, false, false, 0.6f, 0.7f);
+        new TutorialMessageDialog(_("Debug keyboard shortcuts (can conflict with user-defined shortcuts):\n"
+                            "* <~> - Show this help dialog | + <Ctrl> - Adjust lights | + <Shift> - Adjust visuals\n"
+                            "* <F1> - Anvil powerup | + <Ctrl> - Normal view | + <Shift> - Bomb attachment\n"
+                            "* <F2> - Basketball powerup | + <Ctrl> - First person view | + <Shift> - Anvil attachment\n"
+                            "* <F3> - Bowling ball powerup | + <Ctrl> - Top view | + <Shift> - Parachute attachment\n"
+                            "* <F4> - Bubblegum powerup | + <Ctrl> - Behind wheel view | + <Shift> - Flatten kart\n"
+                            "* <F5> - Cake powerup | + <Ctrl> - Behind kart view | + <Shift> - Send plunger to kart front\n"
+                            "* <F6> - Parachute powerup | + <Ctrl> - Right side of kart view | + <Shift> - Explode kart\n"
+                            "* <F7> - Plunger powerup | + <Ctrl> - Left side of kart view | + <Shift> - Scripting console\n"
+                            "* <F8> - Swatter powerup | + <Ctrl> - Front of kart view | + <Shift> - Texture console\n"
+                            "* <F9> - Switch powerup | + <Ctrl> - Kart number slider | + <Shift> - Run cutscene(s)\n"
+                            "* <F10> - Zipper powerup | + <Ctrl> - Powerup amount slider | + <Shift> - Toggle GUI\n"
+                            "* <F11> - Save replay | + <Ctrl> - Save history | + <Shift> - Dump RTT\n"
+                            "* <F12> - Show FPS | + <Ctrl> - Show other karts' powerups | + <Shift> - Show soccer player list\n"
+                            "* <Insert> - Overfilled nitro\n"
+                            "* <Delete> - Clear kart items\n"
+                            "* <Home> - First kart\n"
+                            "* <End> - Last kart\n"
+                            "* <Page Up> - Previous kart\n"
+                            "* <Page Down> - Next kart"
+                            ), true);
         break;
     }
     return false;
@@ -1176,7 +1190,7 @@ bool onEvent(const SEvent &event)
 
             mnu->addItem(L"Set camera target >",-1,true, true);
             sub = mnu->getSubMenu(1);
-            sub->addItem(L"Pick kart from slider", DEBUG_VIEW_KART_SLIDER);
+            sub->addItem(L"Pick kart from slider (Ctrl + F9)", DEBUG_VIEW_KART_SLIDER);
             sub->addSeparator();
             sub->addItem(L"To previous kart (Page Up)", DEBUG_VIEW_KART_PREVIOUS);
             sub->addItem(L"To next kart (Page Down)", DEBUG_VIEW_KART_NEXT);
@@ -1235,7 +1249,7 @@ bool onEvent(const SEvent &event)
 
             mnu->addItem(L"Modify kart items >",-1,true, true);
             sub = mnu->getSubMenu(5);
-            sub->addItem(L"Adjust with slider", DEBUG_POWERUP_SLIDER);
+            sub->addItem(L"Adjust with slider (Ctrl + F10)", DEBUG_POWERUP_SLIDER);
             sub->addSeparator();
             sub->addItem(L"Clear powerup (Delete)", DEBUG_POWERUP_NOTHING );
             sub->addItem(L"Clear nitro (Delete)", DEBUG_NITRO_CLEAR );
@@ -1300,15 +1314,15 @@ bool onEvent(const SEvent &event)
 
             mnu->addItem(L"Lighting >",-1,true, true);
             sub = mnu->getSubMenu(12);
-            sub->addItem(L"Adjust values (Shift + `/~)", DEBUG_VISUAL_VALUES);
-            sub->addItem(L"Adjust lights (Ctrl + `/~)", DEBUG_ADJUST_LIGHTS);
+            sub->addItem(L"Adjust values (Shift + ~)", DEBUG_VISUAL_VALUES);
+            sub->addItem(L"Adjust lights (Ctrl + ~)", DEBUG_ADJUST_LIGHTS);
 
             mnu->addItem(L"FPS >",-1,true, true);
             sub = mnu->getSubMenu(13);
             sub->addItem(L"Do not limit FPS", DEBUG_THROTTLE_FPS);
             sub->addItem(L"Toggle FPS (F12)", DEBUG_FPS);
 
-            mnu->addItem(L"Debug keys (`/~)", DEBUG_HELP);
+            mnu->addItem(L"Debug keys (~)", DEBUG_HELP);
 
             g_debug_menu_visible = true;
             irr_driver->showPointer();
@@ -1412,7 +1426,7 @@ void handleStaticAction(int key, int value, bool control_pressed, bool shift_pre
                 }
                 else if (shift_pressed)
                 {
-                   handleContextMenuAction(DEBUG_ATTACHMENT_PARACHUTE); 
+                   handleContextMenuAction(DEBUG_ATTACHMENT_PARACHUTE);
                 }
                 else
                 {

--- a/src/utils/debug.cpp
+++ b/src/utils/debug.cpp
@@ -123,6 +123,8 @@ enum DebugMenuCommand
     DEBUG_GUI_CAM_WHEEL,
     DEBUG_GUI_CAM_BEHIND_KART,
     DEBUG_GUI_CAM_SIDE_OF_KART,
+    DEBUG_GUI_CAM_INV_SIDE_OF_KART,
+    DEBUG_GUI_CAM_FRONT_OF_KART,
     DEBUG_GUI_CAM_NORMAL,
     DEBUG_GUI_CAM_SMOOTH,
     DEBUG_GUI_CAM_ATTACH,
@@ -135,6 +137,8 @@ enum DebugMenuCommand
     DEBUG_VIEW_KART_SIX,
     DEBUG_VIEW_KART_SEVEN,
     DEBUG_VIEW_KART_EIGHT,
+    DEBUG_VIEW_KART_NINE,
+    DEBUG_VIEW_KART_TEN,
     DEBUG_VIEW_KART_NEXT,
     DEBUG_HIDE_KARTS,
     DEBUG_THROTTLE_FPS,
@@ -169,9 +173,11 @@ void addAttachment(Attachment::AttachmentType type)
     if (world == NULL) return;
     for (unsigned int i = 0; i < world->getNumKarts(); i++)
     {
-        AbstractKart *kart = world->getKart(i);
-        if (!kart->getController()->isLocalPlayerController())
-            continue;
+        AbstractKart *kart = world->getLocalPlayerKart(i);
+        if (kart == NULL)
+           continue;
+        //if (!kart->getController()->isLocalPlayerController())
+        //    continue;
         if (type == Attachment::ATTACH_ANVIL)
         {
             kart->getAttachment()
@@ -587,6 +593,18 @@ bool handleContextMenuAction(s32 cmd_id)
         Camera::getActiveCamera()->setKart(World::getWorld()->getKart(kart_num));
         irr_driver->getDevice()->getCursorControl()->setVisible(true);
         break;
+    case DEBUG_GUI_CAM_INV_SIDE_OF_KART:
+        CameraDebug::setDebugType(CameraDebug::CM_DEBUG_INV_SIDE_OF_KART);
+        Camera::changeCamera(0, Camera::CM_TYPE_DEBUG);
+        Camera::getActiveCamera()->setKart(World::getWorld()->getKart(kart_num));
+        irr_driver->getDevice()->getCursorControl()->setVisible(true);
+        break;
+    case DEBUG_GUI_CAM_FRONT_OF_KART:
+        CameraDebug::setDebugType(CameraDebug::CM_DEBUG_FRONT_OF_KART);
+        Camera::changeCamera(0, Camera::CM_TYPE_DEBUG);
+        Camera::getActiveCamera()->setKart(World::getWorld()->getKart(kart_num));
+        irr_driver->getDevice()->getCursorControl()->setVisible(true);
+        break;
     case DEBUG_GUI_CAM_FREE:
     {
         Camera *camera = Camera::getActiveCamera();
@@ -663,6 +681,12 @@ bool handleContextMenuAction(s32 cmd_id)
         break;
     case DEBUG_VIEW_KART_EIGHT:
         changeCameraTarget(8);
+        break;
+    case DEBUG_VIEW_KART_NINE:
+        changeCameraTarget(9);
+        break;
+    case DEBUG_VIEW_KART_TEN:
+        changeCameraTarget(10);
         break;
     case DEBUG_VIEW_KART_NEXT:
     {
@@ -942,6 +966,8 @@ bool onEvent(const SEvent &event)
             sub->addItem(L"Behind wheel view", DEBUG_GUI_CAM_WHEEL);
             sub->addItem(L"Behind kart view", DEBUG_GUI_CAM_BEHIND_KART);
             sub->addItem(L"Side of kart view", DEBUG_GUI_CAM_SIDE_OF_KART);
+            sub->addItem(L"Inverse side of kart view", DEBUG_GUI_CAM_INV_SIDE_OF_KART);
+            sub->addItem(L"Front of kart view", DEBUG_GUI_CAM_FRONT_OF_KART);
             sub->addItem(L"First person view (Ctrl + F1)", DEBUG_GUI_CAM_FREE);
             sub->addItem(L"Normal view (Ctrl + F2)", DEBUG_GUI_CAM_NORMAL);
             sub->addItem(L"Toggle smooth camera", DEBUG_GUI_CAM_SMOOTH);
@@ -973,6 +999,8 @@ bool onEvent(const SEvent &event)
             sub->addItem(L"To kart six", DEBUG_VIEW_KART_SIX);
             sub->addItem(L"To kart seven", DEBUG_VIEW_KART_SEVEN);
             sub->addItem(L"To kart eight", DEBUG_VIEW_KART_EIGHT);
+            sub->addItem(L"To kart nine", DEBUG_VIEW_KART_NINE);
+            sub->addItem(L"To kart ten", DEBUG_VIEW_KART_TEN);
             sub->addItem(L"To next kart (Ctrl + F6)", DEBUG_VIEW_KART_NEXT);
 
             mnu->addItem(L"Font >",-1,true, true);

--- a/src/utils/debug.cpp
+++ b/src/utils/debug.cpp
@@ -629,10 +629,13 @@ bool handleContextMenuAction(s32 cmd_id)
         irr_driver->getDevice()->getCursorControl()->setVisible(true);
         break;
     case DEBUG_GUI_CAM_WHEEL:
-        CameraDebug::setDebugType(CameraDebug::CM_DEBUG_GROUND);
-        Camera::changeCamera(0, Camera::CM_TYPE_DEBUG);
-        Camera::getActiveCamera()->setKart(World::getWorld()->getKart(kart_num));
-        irr_driver->getDevice()->getCursorControl()->setVisible(true);
+        if (!(World::getWorld()->getKart(kart_num)->isGhostKart()))
+        {
+            CameraDebug::setDebugType(CameraDebug::CM_DEBUG_GROUND);
+            Camera::changeCamera(0, Camera::CM_TYPE_DEBUG);
+            Camera::getActiveCamera()->setKart(World::getWorld()->getKart(kart_num));
+            irr_driver->getDevice()->getCursorControl()->setVisible(true);
+        }
         break;
     case DEBUG_GUI_CAM_BEHIND_KART:
         CameraDebug::setDebugType(CameraDebug::CM_DEBUG_BEHIND_KART);

--- a/src/utils/debug.cpp
+++ b/src/utils/debug.cpp
@@ -44,6 +44,7 @@
 #include "karts/abstract_kart.hpp"
 #include "karts/kart_properties.hpp"
 #include "karts/controller/controller.hpp"
+#include "karts/rescue_animation.hpp"
 #include "modes/cutscene_world.hpp"
 #include "modes/world.hpp"
 #include "physics/irr_debug_drawer.hpp"
@@ -148,6 +149,8 @@ enum DebugMenuCommand
     DEBUG_VIEW_KART_TWELVE,
     DEBUG_VIEW_KART_NEXT,
     DEBUG_HIDE_KARTS,
+    DEBUG_RESCUE_KART,
+    DEBUG_PAUSE,
     DEBUG_THROTTLE_FPS,
     DEBUG_VISUAL_VALUES,
     DEBUG_PRINT_START_POS,
@@ -609,6 +612,16 @@ bool handleContextMenuAction(s32 cmd_id)
                 kart->getNode()->setVisible(false);
         }
         break;
+    case DEBUG_RESCUE_KART:
+        for (unsigned int i = 0; i < RaceManager::get()->getNumLocalPlayers(); i++)
+        {
+            AbstractKart* kart = world->getLocalPlayerKart(i);
+            RescueAnimation::create(kart);
+        }
+        break;
+    case DEBUG_PAUSE:
+        world->escapePressed();
+        break;
     case DEBUG_GUI_CAM_TOP:
         CameraDebug::setDebugType(CameraDebug::CM_DEBUG_TOP_OF_KART);
         Camera::changeCamera(0, Camera::CM_TYPE_DEBUG);
@@ -1042,6 +1055,7 @@ bool onEvent(const SEvent &event)
             mnu->addItem(L"Change camera target >",-1,true, true);
             sub = mnu->getSubMenu(5);
             sub->addItem(L"To previous kart (Ctrl + F5)", DEBUG_VIEW_KART_PREVIOUS);
+            sub->addItem(L"To next kart (Ctrl + F6)", DEBUG_VIEW_KART_NEXT);
             sub->addItem(L"To kart one", DEBUG_VIEW_KART_ONE);
             sub->addItem(L"To kart two", DEBUG_VIEW_KART_TWO);
             sub->addItem(L"To kart three", DEBUG_VIEW_KART_THREE);
@@ -1054,7 +1068,6 @@ bool onEvent(const SEvent &event)
             sub->addItem(L"To kart ten", DEBUG_VIEW_KART_TEN);
             sub->addItem(L"To kart eleven", DEBUG_VIEW_KART_ELEVEN);
             sub->addItem(L"To kart twelve", DEBUG_VIEW_KART_TWELVE);
-            sub->addItem(L"To next kart (Ctrl + F6)", DEBUG_VIEW_KART_NEXT);
 
             mnu->addItem(L"Font >",-1,true, true);
             sub = mnu->getSubMenu(6);
@@ -1071,6 +1084,11 @@ bool onEvent(const SEvent &event)
             sub->addItem(L"Toggle bitangents visualization", DEBUG_SP_BITANGENTS_VIZ);
             sub->addItem(L"Toggle wireframe visualization", DEBUG_SP_WIREFRAME_VIZ);
             sub->addItem(L"Toggle triangle normals visualization", DEBUG_SP_TN_VIZ);
+
+            mnu->addItem(L"Keypress actions >",-1,true, true);
+            sub = mnu->getSubMenu(8);
+            sub->addItem(L"Rescue", DEBUG_RESCUE_KART);
+            sub->addItem(L"Pause", DEBUG_PAUSE);
 
             mnu->addItem(L"Adjust values", DEBUG_VISUAL_VALUES);
 

--- a/src/utils/debug.hpp
+++ b/src/utils/debug.hpp
@@ -28,7 +28,8 @@ namespace Debug
     bool onEvent(const irr::SEvent &event);
     bool isOpen();
     void closeDebugMenu();
-    void handleStaticAction(int key, int value, bool control_pressed);
+    void handleStaticAction(int key, int value,
+                            bool control_pressed, bool shift_pressed);
 }
 
 

--- a/src/utils/debug.hpp
+++ b/src/utils/debug.hpp
@@ -28,7 +28,7 @@ namespace Debug
     bool onEvent(const irr::SEvent &event);
     bool isOpen();
     void closeDebugMenu();
-    bool handleStaticAction(int key);
+    void handleStaticAction(int key, int value, bool control_pressed);
 }
 
 


### PR DESCRIPTION
## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
A significant revamp of the artist debug mode (most changes will not be seen if that mode is disabled) to make it more powerful and add more ways to test things in-game. More significant changes include:

- Kart views changed or added:
  - Side of kart view -> Right side of kart view
  - Left side of kart view
  - Static front of kart view (does not function exactly like looking backwards)
- Camera kart targets added:
  - Pick kart from slider
  - Kart 9
  - Last kart
- Items changes:
  - Anvil/anchor (inaccessible everywhere else, and AI karts can't use it)
  - Clear powerup and nitro options
  - Modify power count and nitro amount with slider
- Attachment changes:
  - Other attachments will work on AI karts
  - Flatten kart as if being hit with a swatter, to see what a kart looks like when flattened, and how its icon changes
  - Send plunger to front of kart, to how its icon changes
  - Clear attachment
- Keypress actions (allow to navigate more parts of the game with only a mouse):
  - Rescue kart (works on AI karts too)
  - Pause game

- Most debug menu entries have been relocated to make some items faster to click on
- Label the debug menu items with the keys that can be used to activate them
- Fix more debug menu items causing game crashes in certain situations
- Debug menu opens at the cursor position, but not at off-screen places
- Ensure that the debug menu stays (almost) within the actual window
- Middle mouse button can also be used to access the debug menu
- Move all items into submenus, rearrange most submenus to keep a compact size, except for the help menu item
- Change print kart positions to info level, to make them easier to see especially in terminals supporting color text
- Prevent crashes when trying to use 'Behind wheel view' on a ghost kart
- Exit demo mode when there also are no dialogs active; fixes related crashes
- The keyboard shortcut for the soccer player list visibility has been changed to (Shift + F12)
- Add close button to the debug slider dialog, and a function to enable/disable spinners
- Improve the appearance of the FPS (frames per second) counter
  - Shift the position closer to the center, so that in-race kart icons are not obscured
  - The box and text position adapt based on the screen resolution
  - Use a thin black border for the font, and make the font white-colored
  - Decrease the font scaling to 0.7, so that other UI elements can be seen more easily
- Fix moving right in 1st-person view not working
- Change the 1st-person view shortcuts to work more like in Blender; E moves view up, Q moves view down, R rotates view right, F rotates view left
- The key to show player list in soccer mode no longer needs to be held down
- Screenshots can now be saved via the debug menu
- Texture reloading can now be done via the debug menu; remove the keyboard shortcut for this action
- Render target textures (RTT) can now be dumped via the debug menu
- Switch the shortcuts used for activating history save and manual replay saving
- Finish labelling the remaining debug actions, complete the debug keys with a repurposed tutorial message dialog
- Document the remaining command-line parameters, clean up some of them
- Rename --gamepad-visuali[s,z]ation to --gamepad-visuals
- Also fix some comments related to the user config, including the game mode numbers

Full list of new or changed debug shortcut keys:
- [~] - Show this help dialog | + [Ctrl] - Adjust lights | + [Shift] - Adjust visuals
- [F1] - Anvil powerup | + [Ctrl] - Normal view | + [Shift] - Bomb attachment
- [F2] - Basketball powerup | + [Ctrl] - First person view | + [Shift] - Anvil attachment
- [F3] - Bowling ball powerup | + [Ctrl] - Top view | + [Shift] - Parachute attachment
- [F4] - Bubblegum powerup | + [Ctrl] - Behind wheel view | + [Shift] - Flatten kart
- [F5] - Cake powerup | + [Ctrl] - Behind kart view | + [Shift] - Send plunger to kart front
- [F6] - Parachute powerup | + [Ctrl] - Right side of kart view | + [Shift] - Explode kart
- [F7] - Plunger powerup | + [Ctrl] - Left side of kart view | + [Shift] - Scripting console
- [F8] - Swatter powerup | + [Ctrl] - Front of kart view | + [Shift] - Texture console
- [F9] - Switch powerup | + [Ctrl] - Kart number slider | + [Shift] - Run cutscene(s)
- [F10] - Zipper powerup | + [Ctrl] - Powerup amount slider | + [Shift] - Toggle GUI
- [F11] - Save replay | + [Ctrl] - Save history | + [Shift] - Dump RTT
- [F12] - Show FPS | + [Ctrl] - Show other karts' powerups | + [Shift] - Show soccer player list
- [Insert] - Overfilled nitro
- [Delete] - Clear kart items
- [Home] - First kart
- [End] - Last kart
- [Page Up] - Previous kart
- [Page Down] - Next kart