### PR TITLE
Mark servers as password protected on RR_INCORRECT_PASSWORD

### DIFF
--- a/src/network/protocols/client_lobby.cpp
+++ b/src/network/protocols/client_lobby.cpp
@@ -938,6 +938,7 @@ void ClientLobby::connectionRefused(Event* event)
     }
     case RR_INCORRECT_PASSWORD:
         m_server->setReconnectWhenQuitLobby(true);
+        m_server->setIsPasswordProtected(true);
         STKHost::get()->setErrorMessage(
             _("Connection refused: Server password is incorrect."));
         break;

--- a/src/network/server.hpp
+++ b/src/network/server.hpp
@@ -202,6 +202,8 @@ public:
     // ------------------------------------------------------------------------
     virtual void saveServer() const {}
     // ------------------------------------------------------------------------
+    void setIsPasswordProtected(bool password_protected) { m_password_protected = password_protected; }
+    // ------------------------------------------------------------------------
     bool reconnectWhenQuitLobby() const { return m_reconnect_when_quit_lobby; }
     // ------------------------------------------------------------------------
     void setReconnectWhenQuitLobby(bool val)


### PR DESCRIPTION
## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```

Fix for #4507