### PR TITLE
Stop installing app icon in pixmaps location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -798,7 +798,6 @@ install(FILES data/supertuxkart_128.png DESTINATION share/icons/hicolor/128x128/
 install(FILES data/supertuxkart_256.png DESTINATION share/icons/hicolor/256x256/apps RENAME supertuxkart.png)
 install(FILES data/supertuxkart_512.png DESTINATION share/icons/hicolor/512x512/apps RENAME supertuxkart.png)
 install(FILES data/supertuxkart_1024.png DESTINATION share/icons/hicolor/1024x1024/apps RENAME supertuxkart.png)
-install(FILES data/supertuxkart_512.png DESTINATION share/pixmaps RENAME supertuxkart.png)
 install(FILES data/supertuxkart.appdata.xml DESTINATION share/metainfo)
 
 if(MINGW)


### PR DESCRIPTION
The `/usr/share/pixmaps` location is considered a legacy location for application icons; since the application icons are already installed in the global XDG hicolor theme, then simply stop installing the 512px one in the legacy pixmaps location.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
