### PR TITLE
Automatically update list when search string is changed in addons_screen

### DIFF
--- a/src/states_screens/addons_screen.cpp
+++ b/src/states_screens/addons_screen.cpp
@@ -170,6 +170,9 @@ void AddonsScreen::init()
     GUIEngine::TextBoxWidget* w_filter_name =
                         getWidget<GUIEngine::TextBoxWidget>("filter_name");
     w_filter_name->setText(L"");
+    // Add listener for incremental update when search text is changed
+    w_filter_name->clearListeners();
+    w_filter_name->addListener(this);
     GUIEngine::SpinnerWidget* w_filter_date =
                         getWidget<GUIEngine::SpinnerWidget>("filter_date");
     w_filter_date->setValue(0);

--- a/src/states_screens/addons_screen.hpp
+++ b/src/states_screens/addons_screen.hpp
@@ -21,6 +21,7 @@
 #include "addons/addons_manager.hpp"
 #include "guiengine/screen.hpp"
 #include "guiengine/widgets/label_widget.hpp"
+#include "guiengine/widgets/text_box_widget.hpp"
 #include "states_screens/dialogs/addons_loading.hpp"
 
 /* used for the installed/unsinstalled icons*/
@@ -41,7 +42,8 @@ struct DateFilter {
   */
 class AddonsScreen : public GUIEngine::Screen,
                      public GUIEngine::ScreenSingleton<AddonsScreen>,
-                     public GUIEngine::IListWidgetHeaderListener
+                     public GUIEngine::IListWidgetHeaderListener,
+                     public GUIEngine::ITextBoxWidgetListener
 {
     friend class GUIEngine::ScreenSingleton<AddonsScreen>;
 private:
@@ -102,6 +104,12 @@ public:
 
     /** \brief implement callback from parent class GUIEngine::Screen */
     virtual void onUpdate(float dt) OVERRIDE;
+
+    /** \brief rebuild the list based on search text */
+    virtual void onTextUpdated() OVERRIDE
+    {
+        loadList();
+    }
 
     void    setLastSelected();
 


### PR DESCRIPTION
This adds the feature requested in the forum: https://forum.freegamedev.net/viewtopic.php?f=17&t=17734

The add-on list is updated whenever the search string is changed.
Since this is my first pull request here, I hope I've not made any mistakes concerning coding style etc.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
