### PR TITLE
speed up computeChecklineRequirements()

### DIFF
--- a/src/tracks/drive_graph.cpp
+++ b/src/tracks/drive_graph.cpp
@@ -317,10 +317,27 @@ void DriveGraph::computeChecklineRequirements(DriveNode* node,
         }
         */
 
+        bool doRecursion = true;
         if (new_latest_checkline != -1)
-            succ->setChecklineRequirements(new_latest_checkline);
-
-        computeChecklineRequirements(succ, new_latest_checkline);
+        {
+            // If we are about to add a 'new_latest_checkline' that has already been added,
+            // we won't add new information and don't need to recurse.
+            // This will greatly speed up computeChecklineRequirements for tracks with a higher number
+            // of alternative drive lines and will also avoid adding the same value more than once.
+            const std::vector<int>& checkline_requirements = succ->getChecklineRequirements();
+            for (unsigned int i=0; i<checkline_requirements.size(); i++)
+            {
+                if (checkline_requirements[i] == new_latest_checkline)
+                {
+                    doRecursion = false;
+                    break;
+                }
+            }
+            if (doRecursion) // we haven't been here, so add it
+                succ->setChecklineRequirements(new_latest_checkline);
+        }
+        if (doRecursion)
+            computeChecklineRequirements(succ, new_latest_checkline);
     }
 }   // computeChecklineRequirements
 


### PR DESCRIPTION
This is related to [a forum post](https://forum.freegamedev.net/viewtopic.php?f=18&t=18044&start=25#p103190) about complex tracks needing a long time to load.

The problem is: When there are multiple alternative drive lines, computeChecklineRequirements() does a lot of unnecessary recursions.

I reworked my approach (different from what I mentioned in the forum post) and this PR produces the correct result while greatly reducing the execution time. As a side effect it also makes sure to not add the same value twice.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
