### PR TITLE
Clear switch actions cache

### DIFF
--- a/.github/workflows/switch.yml
+++ b/.github/workflows/switch.yml
@@ -85,7 +85,7 @@ jobs:
             stk-code/cmake_build/*.txt
 
           # Make sure PRs can't overwrite!
-          key: switch-${{ github.ref }}-${{ github.run_number }}
+          key: switch-2-${{ github.ref }}-${{ github.run_number }}
           restore-keys: |
             ${{ env.cache_1 }}
             ${{ env.cache_2 }}


### PR DESCRIPTION
Probably, something broke when a new version was released... devkitPro made some update

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```