### PR TITLE
Screen-space refection: many fixes + optimization

### DIFF
--- a/data/shaders/IBL.frag
+++ b/data/shaders/IBL.frag
@@ -60,18 +60,8 @@ vec3 RayCast(vec3 dir, inout vec3 hitCoord, out float dDepth, in vec3 fallback)
 
         if(dDepth < 0.0)
         {
-            // Texture wrapping to extand artifcially the range of the lookup texture
-            // FIXME can be improved to lessen the distortion
-            projectedCoord.y = min(.99, projectedCoord.y);
-            projectedCoord.x = min(.99, projectedCoord.x);
-            projectedCoord.x = max(.01, projectedCoord.x);
-
-            // We want only reflection on nearly horizontal surfaces
-            float cutout = dot(dir, vec3(0., 0., -1.));
-
             if ((projectedCoord.x > 0.0 && projectedCoord.x < 1.0) 
                 && (projectedCoord.y > 0.0 && projectedCoord.y < 1.0) 
-                && (cutout > 10.0)
                )
             {
                 // FIXME We need to generate mipmap to take into account the gloss map

--- a/data/shaders/IBL.frag
+++ b/data/shaders/IBL.frag
@@ -58,12 +58,17 @@ vec2 RayCast(vec3 dir, inout vec3 hitCoord, out float dDepth)
         float depth             = CalcViewPositionFromDepth(projectedCoord.xy).z;
         dDepth                  = hitCoord.z - depth;
 
-        if (dDepth < 0.0 
-            && (projectedCoord.x > 0.0 && projectedCoord.x < 1.0) 
-            && (projectedCoord.y > 0.0 && projectedCoord.y < 1.0) 
-            )
+        if (dDepth < 0.0)
         {
-            return projectedCoord.xy;
+            if (projectedCoord.x > 0.0 && projectedCoord.x < 1.0 &&
+                projectedCoord.y > 0.0 && projectedCoord.y < 1.0)
+            {
+                return projectedCoord.xy;
+            }
+            else
+            {
+                return vec2(0.f);
+            }
         }
     }
 

--- a/data/shaders/IBL.frag
+++ b/data/shaders/IBL.frag
@@ -91,15 +91,10 @@ void main(void)
 #else
     // :::::::: Compute Space Screen Reflection ::::::::::::::::::::::::::::::::::::
 
-    float lineardepth = textureLod(dtex, uv, 0.).x;
-
     // Fallback (if the ray can't find an intersection we display the sky)
     vec3 fallback = .25 * SpecularIBL(normal, eyedir, specval);
 
-    float View_Depth            = makeLinear(1000.0, 1.0, lineardepth);
-    vec3 ScreenPos              = xpos.xyz;
-    vec4 View_Pos               = u_inverse_projection_matrix * vec4(ScreenPos, 1.0f);
-         View_Pos              /= View_Pos.w;
+    vec3 View_Pos               = CalcViewPositionFromDepth(uv);
 
     // Reflection vector
     vec3 reflected              = normalize(reflect(eyedir, normal));
@@ -107,7 +102,7 @@ void main(void)
     // Ray cast
     vec3 hitPos                 = View_Pos.xyz;
     float dDepth;
-    float minRayStep            = 100.0f;
+    float minRayStep            = 50.0f;
 
     vec2 coords = RayCast(reflected * max(minRayStep, -View_Pos.z),
                             hitPos, dDepth);


### PR DESCRIPTION
This is a significant improvement in many regards, though I still haven't managed to fix #4574.

Before:
![Screenshot from 2021-08-10 16-18-08](https://user-images.githubusercontent.com/13989090/128947767-2197f431-97f0-44ba-a56a-a2db06325b1e.png)

After:
![Screenshot from 2021-08-10 16-22-41](https://user-images.githubusercontent.com/13989090/128947777-7f656fb9-400e-4220-813c-6bd0508099ef.png)

(Ignore the massive FPS difference here, when clicking the launcher icon it defaults to my 3060 but when running from the terminal it defaults to my iGPU.)

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
