### PR TITLE
Use skin color for tooltips

### DIFF
--- a/data/skins/coal/stkskin.xml
+++ b/data/skins/coal/stkskin.xml
@@ -112,7 +112,6 @@ when the border that intersect at this corner are enabled.
       
 <element type="progress" state="fill" image="glasssgauge_fill.png"
       left_border="5" right_border="5" top_border="5" bottom_border="5" />
-<element type="gaugefillrainbow" common="y" image="gauge_fill_rainbow.png" />
 
 <element type="progress" state="neutral" common="y" image="progress_bg.png"
       left_border="31" right_border="31" top_border="15" bottom_border="15" />
@@ -233,6 +232,7 @@ when the border that intersect at this corner are enabled.
 <!-- are always in neutral state for now. No splitting into 9 areas is done; the image is just stretched.
      Note: the body of a guage is the same as for for spinners. -->
 <element type="gaugefill" image="glasssgauge_fill.png" />
+<element type="gaugefillrainbow" common="y" image="gauge_fill_rainbow.png" />
 
 <!-- Lists are always in neutral state for now -->
 <element type="list" image="glass_section.png"

--- a/data/skins/forest/stkskin.xml
+++ b/data/skins/forest/stkskin.xml
@@ -112,7 +112,6 @@ when the border that intersect at this corner are enabled.
       
 <element type="progress" state="fill" image="glasssgauge_fill.png"
       left_border="5" right_border="5" top_border="5" bottom_border="5" />
-<element type="gaugefillrainbow" common="y" image="gauge_fill_rainbow.png" />
 
 <element type="progress" state="neutral" common="y" image="progress_bg.png"
       left_border="31" right_border="31" top_border="15" bottom_border="15" />
@@ -233,6 +232,7 @@ when the border that intersect at this corner are enabled.
 <!-- are always in neutral state for now. No splitting into 9 areas is done; the image is just stretched.
      Note: the body of a guage is the same as for for spinners. -->
 <element type="gaugefill" image="glasssgauge_fill.png" />
+<element type="gaugefillrainbow" common="y" image="gauge_fill_rainbow.png" />
 
 <!-- Lists are always in neutral state for now -->
 <element type="list" common="y" image="glass_section.png"

--- a/data/skins/ocean/stkskin.xml
+++ b/data/skins/ocean/stkskin.xml
@@ -111,7 +111,6 @@ when the border that intersect at this corner are enabled.
       
 <element type="progress" state="fill" image="glasssgauge_fill.png"
       left_border="5" right_border="5" top_border="5" bottom_border="5" />
-<element type="gaugefillrainbow" common="y" image="gauge_fill_rainbow.png" />
 
 <element type="progress" state="neutral" common="y" image="progress_bg.png"
       left_border="31" right_border="31" top_border="15" bottom_border="15" />
@@ -232,6 +231,7 @@ when the border that intersect at this corner are enabled.
 <!-- are always in neutral state for now. No splitting into 9 areas is done; the image is just stretched.
      Note: the body of a guage is the same as for for spinners. -->
 <element type="gaugefill" image="glasssgauge_fill.png" />
+<element type="gaugefillrainbow" common="y" image="gauge_fill_rainbow.png" />
 
 <!-- Lists are always in neutral state for now -->
 <element type="list" common="y" image="glass_section.png"

--- a/data/skins/peach/stkskin.xml
+++ b/data/skins/peach/stkskin.xml
@@ -131,7 +131,6 @@ all types of ttf.
 
 <element type="progress" state="fill" image="glasssgauge_fill.png"
       left_border="10" right_border="10" top_border="10" bottom_border="10" />
-<element type="gaugefillrainbow" common="y" image="gauge_fill_rainbow.png" />
 
 <element type="progress" state="neutral" common="y" image="progress_bg.png"
       left_border="31" right_border="31" top_border="15" bottom_border="15" />
@@ -251,6 +250,7 @@ all types of ttf.
 <!-- are always in neutral state for now. No splitting into 9 areas is done; the image is just stretched.
      Note: the body of a guage is the same as for for spinners. -->
 <element type="gaugefill" image="glasssgauge_fill.png" />
+<element type="gaugefillrainbow" common="y" image="gauge_fill_rainbow.png" />
 
 <!-- Lists are always in neutral state for now -->
 <element type="list" common="y" image="glass_section.png"

--- a/data/skins/ruby/stkskin.xml
+++ b/data/skins/ruby/stkskin.xml
@@ -112,7 +112,6 @@ when the border that intersect at this corner are enabled.
 
 <element type="progress" state="fill" image="glasssgauge_fill.png"
       left_border="10" right_border="10" top_border="10" bottom_border="10" />
-<element type="gaugefillrainbow" common="y" image="gauge_fill_rainbow.png" />
 
 <element type="progress" state="neutral" common="y" image="progress_bg.png"
       left_border="31" right_border="31" top_border="15" bottom_border="15" />
@@ -232,6 +231,7 @@ when the border that intersect at this corner are enabled.
 <!-- are always in neutral state for now. No splitting into 9 areas is done; the image is just stretched.
      Note: the body of a guage is the same as for for spinners. -->
 <element type="gaugefill" image="glasssgauge_fill.png" />
+<element type="gaugefillrainbow" common="y" image="gauge_fill_rainbow.png" />
 
 <!-- Lists are always in neutral state for now -->
 <element type="list" common="y" image="glass_section.png"

--- a/src/guiengine/skin.cpp
+++ b/src/guiengine/skin.cpp
@@ -2206,7 +2206,7 @@ void Skin::drawTooltip(Widget* widget, bool atMouse)
     core::recti r(pos, size);
     drawBoxFromStretchableTexture(widget, r,
                               SkinConfig::m_render_params["tooltip::neutral"]);
-    font->draw(widget->getTooltipText(), r, video::SColor(255, 0, 0, 0),
+    font->draw(widget->getTooltipText(), r, GUIEngine::getSkin()->getColor("text::neutral"),
                false, false);
 }   // drawTooltip
 


### PR DESCRIPTION
Use skin color instead of black for tooltip texts.
Also, put gaugefillrainbow in stkskin.xml close to gaugefill (not to confuse skin designer).

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
