### PR TITLE
load speedfore.png and speedback.png from skin

### DIFF
--- a/src/states_screens/race_gui.cpp
+++ b/src/states_screens/race_gui.cpp
@@ -91,10 +91,8 @@ RaceGUI::RaceGUI()
     m_is_tutorial = (RaceManager::get()->getTrackName() == "tutorial");
 
     // Load speedmeter texture before rendering the first frame
-    m_speed_meter_icon = material_manager->getMaterial("speedback.png");
-    m_speed_meter_icon->getTexture(false,false);
-    m_speed_bar_icon   = material_manager->getMaterial("speedfore.png");
-    m_speed_bar_icon->getTexture(false,false);
+    m_speed_meter_icon = irr_driver->getTexture(FileManager::GUI_ICON, "speedback.png");
+    m_speed_bar_icon   = irr_driver->getTexture(FileManager::GUI_ICON, "speedfore.png");
     //createMarkerTexture();
 
     // Load icon textures for later reuse
@@ -1010,10 +1008,9 @@ void RaceGUI::drawSpeedEnergyRank(const AbstractKart* kart,
                                     (int)(offset.Y-meter_height),
                                     (int)(offset.X+meter_width),
                                     (int)offset.Y);
-    video::ITexture *meter_texture = m_speed_meter_icon->getTexture();
     const core::rect<s32> meter_texture_coords(core::position2d<s32>(0,0),
-                                               meter_texture->getSize());
-    draw2DImage(meter_texture, meter_pos, meter_texture_coords, NULL,
+                                               m_speed_meter_icon->getSize());
+    draw2DImage(m_speed_meter_icon, meter_pos, meter_texture_coords, NULL,
                        NULL, true);
     // TODO: temporary workaround, shouldn't have to use
     // draw2DVertexPrimitiveList to render a simple rectangle
@@ -1104,7 +1101,7 @@ void RaceGUI::drawSpeedEnergyRank(const AbstractKart* kart,
                                                      speed_ratio, meter_width, meter_height, offset);
 
 
-    drawMeterTexture(m_speed_bar_icon->getTexture(), vertices, count);
+    drawMeterTexture(m_speed_bar_icon, vertices, count);
 #endif
 }   // drawSpeedEnergyRank
 

--- a/src/states_screens/race_gui.hpp
+++ b/src/states_screens/race_gui.hpp
@@ -41,9 +41,6 @@ class RaceGUI : public RaceGUIBase
 {
 private:
 
-    Material        *m_speed_meter_icon;
-    Material        *m_speed_bar_icon;
-
     // Minimap related variables
     // -------------------------
     /** The size of a single marker on the screen for AI karts,
@@ -102,6 +99,10 @@ private:
     irr::video::ITexture *m_basket_ball_icon;
     /** Texture for the hit limit icon*/
     irr::video::ITexture* m_champion;
+
+    /** Texture for speedometer. */
+    irr::video::ITexture *m_speed_meter_icon;
+    irr::video::ITexture *m_speed_bar_icon;
 
     /** Animation state: none, getting smaller (old value),
      *  getting bigger (new number). */

--- a/src/states_screens/race_gui_overworld.cpp
+++ b/src/states_screens/race_gui_overworld.cpp
@@ -99,8 +99,8 @@ RaceGUIOverworld::RaceGUIOverworld()
 
     calculateMinimapSize();
 
-    m_speed_meter_icon = material_manager->getMaterial("speedback.png");
-    m_speed_bar_icon   = material_manager->getMaterial("speedfore.png");
+    m_speed_meter_icon = irr_driver->getTexture(FileManager::GUI_ICON, "speedback.png");
+    m_speed_bar_icon   = irr_driver->getTexture(FileManager::GUI_ICON, "speedfore.png");
     //createMarkerTexture();
 
     m_active_challenge = NULL;

--- a/src/states_screens/race_gui_overworld.hpp
+++ b/src/states_screens/race_gui_overworld.hpp
@@ -49,9 +49,6 @@ class RaceGUIOverworld : public RaceGUIBase
 {
 private:
 
-    Material        *m_speed_meter_icon;
-    Material        *m_speed_bar_icon;
-
     bool             m_close_to_a_challenge;
 
     // Minimap related variables
@@ -63,6 +60,10 @@ private:
 
 
     video::ITexture* m_icons[7];
+
+    /** Texture for speedometer. */
+    irr::video::ITexture *m_speed_meter_icon;
+    irr::video::ITexture *m_speed_bar_icon;
 
     /** The size of a single marker on the screen for AI karts,
      *  need not be a power of 2. */


### PR DESCRIPTION
This makes the speedometer images loadable from the Skin folder. A skin can have its own speedometer.
Not sure if they really need to be defined as _Materials_.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
