### PR TITLE
Notify players of needed updates for addons

### DIFF
--- a/src/addons/addons_manager.cpp
+++ b/src/addons/addons_manager.cpp
@@ -273,6 +273,12 @@ void AddonsManager::initAddons(const XMLNode *xml)
 
     for(unsigned int i=0; i<count;)
     {
+        // if installed addon needs an update, set flag
+        if (m_addons_list.getData()[i].isInstalled() &&
+            m_addons_list.getData()[i].needsUpdate())
+        {
+            m_has_new_addons = true;
+        }
         if(m_addons_list.getData()[i].getStillExists() ||
             m_addons_list.getData()[i].isInstalled())
         {
@@ -568,6 +574,16 @@ bool AddonsManager::install(const Addon &addon)
             Log::error("addons", "Cannot load track '%s' : %s.",
                         addon.getDataDir().c_str(), e.what());
         }
+    }
+    // if we have installed/updated at least one addon
+    // we remove the notification in main menu
+    m_has_new_addons = false;
+    // check if there are still addons that need an update
+    for (unsigned int i=0; i<addons_manager->getNumAddons() && !m_has_new_addons; i++)
+    {
+        const Addon & addon = addons_manager->getAddon(i);
+        if (addon.isInstalled() && addon.needsUpdate())
+            m_has_new_addons = true;
     }
     saveInstalled();
     return true;


### PR DESCRIPTION
Currently the notification for new / updated addons (green arrow on addons widget in main menu) disappears after STK is restarted. This PR makes the notification stay as long as there are updates.

There is one corner case which is not addressed here:
When there is an update for an addon, but instead of updating, the user removes that addon, the notification will stay until another addon is installed or STK is restarted.

I think most players won't remove an addon, when there are updates, so it shouldn't be a problem.
If you want me to change it, so that removing an addon also resets the flag, just tell me. This would however not follow your specification from Discord completely... 🤓

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
