### PR TITLE
Fix missing argument in warning

### DIFF
--- a/src/input/device_config.cpp
+++ b/src/input/device_config.cpp
@@ -319,7 +319,7 @@ bool DeviceConfig::load(const XMLNode *config)
         const XMLNode *action = config->getNode(i);
         if(action->getName()!="action")
         {
-            Log::warn("DeviceConfig", "Invalid configuration '%s' - ignored.");
+            Log::warn("DeviceConfig", "Invalid configuration '%s' - ignored.", action->getName().c_str());
             continue;
         }
         std::string name;


### PR DESCRIPTION
Add tag name to log message. This might cause a crash / segmentation fault.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
