### PR TITLE
RFC: Use Cartoon skin by default?

### DIFF
--- a/data/skins/coal/stkskin.xml
+++ b/data/skins/coal/stkskin.xml
@@ -65,7 +65,7 @@ when the border that intersect at this corner are enabled.
 
 -->
 
-<skin name="Coal" author="Alayan">
+<skin name="Classic - Coal" author="Alayan">
 
 <!--  Stateless -->
 <element type="background" image="background.jpg" />

--- a/data/skins/forest/stkskin.xml
+++ b/data/skins/forest/stkskin.xml
@@ -65,7 +65,7 @@ when the border that intersect at this corner are enabled.
 
 -->
 
-<skin name="Forest" author="Benau">
+<skin name="Classic - Forest" author="Benau">
 
 <!--  Stateless -->
 <element type="background" common="y" image="background.jpg" />

--- a/data/skins/ocean/stkskin.xml
+++ b/data/skins/ocean/stkskin.xml
@@ -64,7 +64,7 @@ when the border that intersect at this corner are enabled.
 
 -->
 
-<skin name="Ocean" author="Dakal & Marianne Gagnon (Auria)">
+<skin name="Classic - Ocean" author="Dakal & Marianne Gagnon (Auria)">
 
 <!--  Stateless -->
 <element type="background" common="y" image="background.jpg" />

--- a/data/skins/peach/stkskin.xml
+++ b/data/skins/peach/stkskin.xml
@@ -65,7 +65,7 @@ when the border that intersect at this corner are enabled.
 When there is a common="y" with image tag, the image will be loaded only from data/skins/common in stk-code.
 -->
 
-<skin name="Peach" author="Dakal & Marianne Gagnon (Auria)">
+<skin name="Classic - Peach" author="Dakal & Marianne Gagnon (Auria)">
 
 <!--
 Here you can configure advanced theming rules for this skin

--- a/data/skins/ruby/stkskin.xml
+++ b/data/skins/ruby/stkskin.xml
@@ -65,7 +65,7 @@ when the border that intersect at this corner are enabled.
 
 -->
 
-<skin name="Ruby" author="Benau">
+<skin name="Classic - Ruby" author="Benau">
 
 <!--  Stateless -->
 <element type="background" common="y" image="background.jpg" />

--- a/src/config/user_config.hpp
+++ b/src/config/user_config.hpp
@@ -1183,7 +1183,7 @@ namespace UserConfigParams
                            "If debug logging should be enabled for rich presence") );
 
     PARAM_PREFIX StringUserConfigParam      m_skin_file
-            PARAM_DEFAULT(  StringUserConfigParam("peach", "skin_name",
+            PARAM_DEFAULT(  StringUserConfigParam("cartoon", "gui_skin_name",
                                                   "Name of the skin to use") );
 
     PARAM_PREFIX IntUserConfigParam        m_minimap_display


### PR DESCRIPTION
Many users seem to prefer it as it has a much more consistent icon set (reference https://github.com/supertuxkart/stk-code/issues/4531, https://forum.freegamedev.net/viewtopic.php?f=90&t=18285&p=104294#p104297).

This labels the older skins as "Classic" and sets the default skin to Cartoon.  Additionally, it changes the entry name in user_config so that existing users will have their skin setting reset on upgrade of STK (they can easily change it back if they prefer the Classic skins).

Putting this here to gather wider feedback.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
