### PR TITLE
Remove false compiler warnings in mini_glm.hpp

### DIFF
--- a/src/utils/mini_glm.hpp
+++ b/src/utils/mini_glm.hpp
@@ -436,16 +436,16 @@ namespace MiniGLM
                 q.w() / length
             }};
         int extra_2_bit = 0;
-        float max_val = abs(normalized[0]);
-        if (max_val < abs(normalized[1])) {
+        float max_val = std::abs(normalized[0]);
+        if (max_val < std::abs(normalized[1])) {
             extra_2_bit = 1;
-            max_val = abs(normalized[1]);
+            max_val = std::abs(normalized[1]);
         }
-        if (max_val < abs(normalized[2])) {
+        if (max_val < std::abs(normalized[2])) {
             extra_2_bit = 2;
-            max_val = abs(normalized[2]);
+            max_val = std::abs(normalized[2]);
         }
-        if (max_val < abs(normalized[3])) {
+        if (max_val < std::abs(normalized[3])) {
             extra_2_bit = 3;
         }
         const float sqrt_2 = sqrtf(2.0f);

--- a/src/utils/mini_glm.hpp
+++ b/src/utils/mini_glm.hpp
@@ -448,7 +448,7 @@ namespace MiniGLM
         if (max_val < abs(normalized[3])) {
             extra_2_bit = 3;
         }
-        float sqrt_2 = sqrtf(2.0f);
+        const float sqrt_2 = sqrtf(2.0f);
         std::array<float, 3> tmp_3;
         switch (extra_2_bit)
         {

--- a/src/utils/mini_glm.hpp
+++ b/src/utils/mini_glm.hpp
@@ -436,9 +436,19 @@ namespace MiniGLM
                 q.w() / length
             }};
         std::array<float, 3> tmp_3;
-        auto ret = std::max_element(normalized.begin(), normalized.end(),
-            [](float a, float b) { return std::abs(a) < std::abs(b); });
-        int extra_2_bit = int(std::distance(normalized.begin(), ret));
+        int extra_2_bit = 0;
+        float max_val = abs(normalized[0]);
+        if (max_val < abs(normalized[1])) {
+            extra_2_bit = 1;
+            max_val = abs(normalized[1]);
+        }
+        if (max_val < abs(normalized[2])) {
+            extra_2_bit = 2;
+            max_val = abs(normalized[2]);
+        }
+        if (max_val < abs(normalized[3])) {
+            extra_2_bit = 3;
+        }
         float sqrt_2 = sqrtf(2.0f);
         switch (extra_2_bit)
         {

--- a/src/utils/mini_glm.hpp
+++ b/src/utils/mini_glm.hpp
@@ -428,7 +428,7 @@ namespace MiniGLM
     {
         const float length = q.length();
         assert(length != 0.0f);
-        std::array<float, 4> tmp_2 =
+        std::array<float, 4> normalized =
             {{
                 q.x() / length,
                 q.y() / length,
@@ -436,42 +436,42 @@ namespace MiniGLM
                 q.w() / length
             }};
         std::array<float, 3> tmp_3;
-        auto ret = std::max_element(tmp_2.begin(), tmp_2.end(),
+        auto ret = std::max_element(normalized.begin(), normalized.end(),
             [](float a, float b) { return std::abs(a) < std::abs(b); });
-        int extra_2_bit = int(std::distance(tmp_2.begin(), ret));
+        int extra_2_bit = int(std::distance(normalized.begin(), ret));
         float sqrt_2 = sqrtf(2.0f);
         switch (extra_2_bit)
         {
         case 0:
         {
-            float neg = tmp_2[0] < 0.0f ? -1.0f : 1.0f;
-            tmp_3[0] = tmp_2[1] * neg * sqrt_2;
-            tmp_3[1] = tmp_2[2] * neg * sqrt_2;
-            tmp_3[2] = tmp_2[3] * neg * sqrt_2;
+            float neg = normalized[0] < 0.0f ? -1.0f : 1.0f;
+            tmp_3[0] = normalized[1] * neg * sqrt_2;
+            tmp_3[1] = normalized[2] * neg * sqrt_2;
+            tmp_3[2] = normalized[3] * neg * sqrt_2;
             break;
         }
         case 1:
         {
-            float neg = tmp_2[1] < 0.0f ? -1.0f : 1.0f;
-            tmp_3[0] = tmp_2[0] * neg * sqrt_2;
-            tmp_3[1] = tmp_2[2] * neg * sqrt_2;
-            tmp_3[2] = tmp_2[3] * neg * sqrt_2;
+            float neg = normalized[1] < 0.0f ? -1.0f : 1.0f;
+            tmp_3[0] = normalized[0] * neg * sqrt_2;
+            tmp_3[1] = normalized[2] * neg * sqrt_2;
+            tmp_3[2] = normalized[3] * neg * sqrt_2;
             break;
         }
         case 2:
         {
-            float neg = tmp_2[2] < 0.0f ? -1.0f : 1.0f;
-            tmp_3[0] = tmp_2[0] * neg * sqrt_2;
-            tmp_3[1] = tmp_2[1] * neg * sqrt_2;
-            tmp_3[2] = tmp_2[3] * neg * sqrt_2;
+            float neg = normalized[2] < 0.0f ? -1.0f : 1.0f;
+            tmp_3[0] = normalized[0] * neg * sqrt_2;
+            tmp_3[1] = normalized[1] * neg * sqrt_2;
+            tmp_3[2] = normalized[3] * neg * sqrt_2;
             break;
         }
         case 3:
         {
-            float neg = tmp_2[3] < 0.0f ? -1.0f : 1.0f;
-            tmp_3[0] = tmp_2[0] * neg * sqrt_2;
-            tmp_3[1] = tmp_2[1] * neg * sqrt_2;
-            tmp_3[2] = tmp_2[2] * neg * sqrt_2;
+            float neg = normalized[3] < 0.0f ? -1.0f : 1.0f;
+            tmp_3[0] = normalized[0] * neg * sqrt_2;
+            tmp_3[1] = normalized[1] * neg * sqrt_2;
+            tmp_3[2] = normalized[2] * neg * sqrt_2;
             break;
         }
         default:

--- a/src/utils/mini_glm.hpp
+++ b/src/utils/mini_glm.hpp
@@ -449,12 +449,12 @@ namespace MiniGLM
             extra_2_bit = 3;
         }
         const float sqrt_2 = sqrtf(2.0f);
+        const float neg = normalized[extra_2_bit] < 0.0f ? -1.0f : 1.0f;
         std::array<float, 3> compressed;
         switch (extra_2_bit)
         {
         case 0:
         {
-            float neg = normalized[0] < 0.0f ? -1.0f : 1.0f;
             compressed[0] = normalized[1] * neg * sqrt_2;
             compressed[1] = normalized[2] * neg * sqrt_2;
             compressed[2] = normalized[3] * neg * sqrt_2;
@@ -462,7 +462,6 @@ namespace MiniGLM
         }
         case 1:
         {
-            float neg = normalized[1] < 0.0f ? -1.0f : 1.0f;
             compressed[0] = normalized[0] * neg * sqrt_2;
             compressed[1] = normalized[2] * neg * sqrt_2;
             compressed[2] = normalized[3] * neg * sqrt_2;
@@ -470,7 +469,6 @@ namespace MiniGLM
         }
         case 2:
         {
-            float neg = normalized[2] < 0.0f ? -1.0f : 1.0f;
             compressed[0] = normalized[0] * neg * sqrt_2;
             compressed[1] = normalized[1] * neg * sqrt_2;
             compressed[2] = normalized[3] * neg * sqrt_2;
@@ -478,7 +476,6 @@ namespace MiniGLM
         }
         case 3:
         {
-            float neg = normalized[3] < 0.0f ? -1.0f : 1.0f;
             compressed[0] = normalized[0] * neg * sqrt_2;
             compressed[1] = normalized[1] * neg * sqrt_2;
             compressed[2] = normalized[2] * neg * sqrt_2;

--- a/src/utils/mini_glm.hpp
+++ b/src/utils/mini_glm.hpp
@@ -449,46 +449,46 @@ namespace MiniGLM
             extra_2_bit = 3;
         }
         const float sqrt_2 = sqrtf(2.0f);
-        std::array<float, 3> tmp_3;
+        std::array<float, 3> compressed;
         switch (extra_2_bit)
         {
         case 0:
         {
             float neg = normalized[0] < 0.0f ? -1.0f : 1.0f;
-            tmp_3[0] = normalized[1] * neg * sqrt_2;
-            tmp_3[1] = normalized[2] * neg * sqrt_2;
-            tmp_3[2] = normalized[3] * neg * sqrt_2;
+            compressed[0] = normalized[1] * neg * sqrt_2;
+            compressed[1] = normalized[2] * neg * sqrt_2;
+            compressed[2] = normalized[3] * neg * sqrt_2;
             break;
         }
         case 1:
         {
             float neg = normalized[1] < 0.0f ? -1.0f : 1.0f;
-            tmp_3[0] = normalized[0] * neg * sqrt_2;
-            tmp_3[1] = normalized[2] * neg * sqrt_2;
-            tmp_3[2] = normalized[3] * neg * sqrt_2;
+            compressed[0] = normalized[0] * neg * sqrt_2;
+            compressed[1] = normalized[2] * neg * sqrt_2;
+            compressed[2] = normalized[3] * neg * sqrt_2;
             break;
         }
         case 2:
         {
             float neg = normalized[2] < 0.0f ? -1.0f : 1.0f;
-            tmp_3[0] = normalized[0] * neg * sqrt_2;
-            tmp_3[1] = normalized[1] * neg * sqrt_2;
-            tmp_3[2] = normalized[3] * neg * sqrt_2;
+            compressed[0] = normalized[0] * neg * sqrt_2;
+            compressed[1] = normalized[1] * neg * sqrt_2;
+            compressed[2] = normalized[3] * neg * sqrt_2;
             break;
         }
         case 3:
         {
             float neg = normalized[3] < 0.0f ? -1.0f : 1.0f;
-            tmp_3[0] = normalized[0] * neg * sqrt_2;
-            tmp_3[1] = normalized[1] * neg * sqrt_2;
-            tmp_3[2] = normalized[2] * neg * sqrt_2;
+            compressed[0] = normalized[0] * neg * sqrt_2;
+            compressed[1] = normalized[1] * neg * sqrt_2;
+            compressed[2] = normalized[2] * neg * sqrt_2;
             break;
         }
         default:
             assert(false);
             break;
         }
-        return normalizedSignedFloatsTo1010102(tmp_3, extra_2_bit);
+        return normalizedSignedFloatsTo1010102(compressed, extra_2_bit);
     }   // compressQuaternion
     // ------------------------------------------------------------------------
     inline uint32_t compressIrrQuaternion(const core::quaternion& q)

--- a/src/utils/mini_glm.hpp
+++ b/src/utils/mini_glm.hpp
@@ -435,7 +435,6 @@ namespace MiniGLM
                 q.z() / length,
                 q.w() / length
             }};
-        std::array<float, 3> tmp_3;
         int extra_2_bit = 0;
         float max_val = abs(normalized[0]);
         if (max_val < abs(normalized[1])) {
@@ -450,6 +449,7 @@ namespace MiniGLM
             extra_2_bit = 3;
         }
         float sqrt_2 = sqrtf(2.0f);
+        std::array<float, 3> tmp_3;
         switch (extra_2_bit)
         {
         case 0:


### PR DESCRIPTION
In the `compressQuaternion` function, the value of an `extra_2_bit` variable is strictly limited between 0 and 3 by the logic of an algorithm. Unfortunately, the compiler can't infer this limitation from the code and assumes that in some cases it may have another value. This leads to a lot of false warnings: "‘tmp_3’ may be used uninitialized" during the release build (since usage of this variable is not guarded by the `assert(false)` anymore).

In this PR, we replace usage of `std::max_value` and `std::distance` with manual iteration over quarternion coordinates during the search for index of the longest item. This may look ugly, but now the compiler could understand that the compressed vector is always initialized. By removing of the false warning, we improve visibility of other warnings that could point us to potential errors in the code.

Additionally, the change contains few renames and code shuffling. Feel free to point on any commit that looks inappropriate for you. It will be removed/reverted.


## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
