### PR TITLE
Fix wrong win message in races only with 1 kart

### DIFF
--- a/src/karts/kart.cpp
+++ b/src/karts/kart.cpp
@@ -1021,7 +1021,7 @@ void Kart::finishedRace(float time, bool from_server)
 
             m->addMessage((too_slow     ? _("You were too slow!") :
                            won_the_race ? _("You won the race!")  :
-                                          _("You finished the race in rank %d!", getPosition())),
+                           RaceManager::get()->getNumberOfKarts() > 1 ? _("You finished the race in rank %d!", getPosition()) : _("You finished the race")),
             this, 2.0f, video::SColor(255, 255, 255, 255), true, true, true);
         }
     }

--- a/src/karts/kart.cpp
+++ b/src/karts/kart.cpp
@@ -1012,8 +1012,8 @@ void Kart::finishedRace(float time, bool from_server)
             if (RaceManager::get()->getMinorMode() == RaceManager::MINOR_MODE_FOLLOW_LEADER)
                 win_position = 2;
 
-            if (getPosition() == (int)win_position &&
-                World::getWorld()->getNumKarts() > win_position)
+            if ((getPosition() == (int)win_position &&
+                World::getWorld()->getNumKarts() > win_position) || RaceManager::get()->getNumberOfKarts() == 1)
                 won_the_race = true;
 
             if (RaceManager::get()->hasTimeTarget() && m_finish_time > RaceManager::get()->getTimeTarget())
@@ -1021,7 +1021,7 @@ void Kart::finishedRace(float time, bool from_server)
 
             m->addMessage((too_slow     ? _("You were too slow!") :
                            won_the_race ? _("You won the race!")  :
-                           RaceManager::get()->getNumberOfKarts() > 1 ? _("You finished the race in rank %d!", getPosition()) : _("You finished the race")),
+                                          _("You finished the race in rank %d!", getPosition())),
             this, 2.0f, video::SColor(255, 255, 255, 255), true, true, true);
         }
     }


### PR DESCRIPTION
## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
Fixes #4609 