### PR TITLE
Allow setting auto-center property for racing wheels (closes #4636)

### DIFF
--- a/src/input/gamepad_config.cpp
+++ b/src/input/gamepad_config.cpp
@@ -64,6 +64,7 @@ GamepadConfig::GamepadConfig( const std::string &name,
     m_deadzone     = 4096;
     m_desensitize  = false;
     m_use_force_feedback = true;
+    m_auto_center = 20;
     setDefaultBinds();
 }   // GamepadConfig
 
@@ -77,6 +78,7 @@ GamepadConfig::GamepadConfig() : DeviceConfig()
     m_deadzone     = 4096;
     m_desensitize  = false;
     m_use_force_feedback = true;
+    m_auto_center = 20;
     setDefaultBinds();
 }   // GamepadConfig
 
@@ -90,6 +92,7 @@ bool GamepadConfig::load(const XMLNode *config)
     config->get("deadzone",     &m_deadzone    );
     config->get("desensitize",  &m_desensitize );
     config->get("force-feedback", &m_use_force_feedback);
+    config->get("auto-center",    &m_auto_center);
     bool ok = DeviceConfig::load(config);
 
     if(getName()=="")
@@ -111,6 +114,7 @@ void GamepadConfig::save (std::ofstream& stream)
     stream << "<gamepad name =\"" << getName()
            << "\" deadzone=\""    << m_deadzone
            << "\" desensitize=\"" << m_desensitize
+           << "\" auto-center=\"" << m_auto_center
            << "\" force-feedback=\"" << m_use_force_feedback << "\" ";
     DeviceConfig::save(stream);
     stream << "</gamepad>\n\n";

--- a/src/input/gamepad_config.hpp
+++ b/src/input/gamepad_config.hpp
@@ -60,6 +60,7 @@ private:
     bool m_desensitize;
 
     bool m_use_force_feedback;
+    int m_auto_center;
 
     std::map<std::tuple<int, Input::AxisDirection>, int> m_sdl_mapping;
 
@@ -124,6 +125,10 @@ public:
     bool useForceFeedback() const             { return m_use_force_feedback; }
     // ------------------------------------------------------------------------
     void setForceFeedback(bool val)            { m_use_force_feedback = val; }
+    // ------------------------------------------------------------------------
+    int getAutoCenterStrength() const                { return m_auto_center; }
+    // ------------------------------------------------------------------------
+    void setAutoCenter(bool val)               { m_auto_center = val; }
 };   // class GamepadConfig
 
 #endif

--- a/src/input/gamepad_device.cpp
+++ b/src/input/gamepad_device.cpp
@@ -246,3 +246,9 @@ bool GamePadDevice::useForceFeedback() const
 {
     return static_cast<GamepadConfig*>(m_configuration)->useForceFeedback();
 }   // useForceFeedback
+
+// ----------------------------------------------------------------------------
+int GamePadDevice::getAutoCenterStrength() const
+{
+    return static_cast<GamepadConfig*>(m_configuration)->getAutoCenterStrength();
+}   // shouldAutoCenter

--- a/src/input/gamepad_device.hpp
+++ b/src/input/gamepad_device.hpp
@@ -62,6 +62,7 @@ public:
     // ------------------------------------------------------------------------
     void setIrrIndex(int i ) { m_irr_index = i; }
     bool useForceFeedback() const;
+    int getAutoCenterStrength() const;
 };   // class GamepadDevice
 
 #endif

--- a/src/input/sdl_controller.cpp
+++ b/src/input/sdl_controller.cpp
@@ -179,12 +179,6 @@ SDLController::SDLController(int device_id)
         cfg->initSDLMapping();
     cfg->setPlugged();
 
-#if SDL_VERSION_ATLEAST(1,3,0)
-    m_haptic = SDL_HapticOpenFromJoystick(m_joystick);
-    if (m_haptic)
-        SDL_HapticRumbleInit(m_haptic);
-#endif
-
     for (int i = 0; i < dm->getGamePadAmount(); i++)
     {
         GamePadDevice* d = dm->getGamePad(i);
@@ -204,6 +198,14 @@ SDLController::SDLController(int device_id)
     dm->addGamepad(m_gamepad);
     if (created)
         dm->save();
+
+#if SDL_VERSION_ATLEAST(1,3,0)
+    m_haptic = SDL_HapticOpenFromJoystick(m_joystick);
+    if (m_haptic) {
+        SDL_HapticRumbleInit(m_haptic);
+        updateAutoCenter(getGamePadDevice()->getAutoCenterStrength());
+    }
+#endif
 }   // SDLController
 
 // ----------------------------------------------------------------------------
@@ -276,6 +278,13 @@ void SDLController::doRumble(float strength_low, float strength_high, uint32_t d
 #endif
     }
 }
+
+#if SDL_VERSION_ATLEAST(1,3,0)
+void SDLController::updateAutoCenter(int state) {
+    m_auto_center = state;
+    SDL_HapticSetAutocenter(m_haptic, m_auto_center);
+}
+#endif
 
 // ----------------------------------------------------------------------------
 #ifdef ANDROID

--- a/src/input/sdl_controller.cpp
+++ b/src/input/sdl_controller.cpp
@@ -202,7 +202,8 @@ SDLController::SDLController(int device_id)
 finish:
 #if SDL_VERSION_ATLEAST(1,3,0)
     m_haptic = SDL_HapticOpenFromJoystick(m_joystick);
-    if (m_haptic) {
+    if (m_haptic)
+    {
         SDL_HapticRumbleInit(m_haptic);
         updateAutoCenter(getGamePadDevice()->getAutoCenterStrength());
     }
@@ -281,7 +282,8 @@ void SDLController::doRumble(float strength_low, float strength_high, uint32_t d
 }
 
 #if SDL_VERSION_ATLEAST(1,3,0)
-void SDLController::updateAutoCenter(int state) {
+void SDLController::updateAutoCenter(int state)
+{
     m_auto_center = state;
     SDL_HapticSetAutocenter(m_haptic, m_auto_center);
 }

--- a/src/input/sdl_controller.cpp
+++ b/src/input/sdl_controller.cpp
@@ -190,7 +190,7 @@ SDLController::SDLController(int device_id)
             d->setConfiguration(cfg);
             if (created)
                 dm->save();
-            return;
+            goto finish;
         }
     }
 
@@ -199,6 +199,7 @@ SDLController::SDLController(int device_id)
     if (created)
         dm->save();
 
+finish:
 #if SDL_VERSION_ATLEAST(1,3,0)
     m_haptic = SDL_HapticOpenFromJoystick(m_joystick);
     if (m_haptic) {

--- a/src/input/sdl_controller.hpp
+++ b/src/input/sdl_controller.hpp
@@ -45,6 +45,7 @@ private:
 
 #if SDL_VERSION_ATLEAST(1,3,0)
     SDL_Haptic* m_haptic;
+    int m_auto_center;
 #endif
 
     int m_buttons;
@@ -62,6 +63,10 @@ private:
     uint64_t m_last_power_level_time;
 #ifdef ANDROID
     void handleDirectScanCode(const SDL_Event& event);
+#endif
+
+#if SDL_VERSION_ATLEAST(1,3,0)
+    void updateAutoCenter(int state);
 #endif
 public:
     // ------------------------------------------------------------------------


### PR DESCRIPTION
Closes #4636 
As is apparently standard for racing wheels, this is a percentage between 0 and 100 indicating the strength with which the wheel will spring back. Modify the atribute in input.xml

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
