### PR TITLE
Use tilde for pre-release versioning in appdata

### DIFF
--- a/data/supertuxkart.appdata.xml
+++ b/data/supertuxkart.appdata.xml
@@ -345,7 +345,7 @@
     <release version="1.3" date="2021-09-28">
       <url>https://blog.supertuxkart.net/2021/09/supertuxkart-13-release.html</url>
     </release>
-    <release version="1.3-rc1" date="2021-08-31">
+    <release version="1.3~rc1" date="2021-08-31">
       <url>https://blog.supertuxkart.net/2021/08/supertuxkart-13-release-candiate.html</url>
     </release>
     <release version="1.2" date="2020-08-27"/>


### PR DESCRIPTION
Version 1.3-rc is considered to be higher than 1.3 as per appdata
version comparison logic, which leads to 'appstream-util validate-relax'
complaining:

<release> versions are not in order [1.3 before 1.3-rc1]

Fix this by using tilde instead of a dash to make sure 1.3~rc sorts
lower than 1.3.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
