### PR TITLE
Always build tinygettext as a static library

### DIFF
--- a/lib/tinygettext/CMakeLists.txt
+++ b/lib/tinygettext/CMakeLists.txt
@@ -94,7 +94,7 @@ file(GLOB TINYGETTEXT_HEADERS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} include/tinyg
 
 ## define a target for building the library
 
-add_library(tinygettext ${TINYGETTEXT_SOURCES})
+add_library(tinygettext STATIC ${TINYGETTEXT_SOURCES})
 
 ## Add tinygettext dir to search path
 


### PR DESCRIPTION
Explicitly pass STATIC to tinygettext add_library() call to make sure
it's always built as static, even when distro's cmake is configured to
build libs shared by default.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
