### PR TITLE
fix race_result_gui's GP ranks after RR_RESORT_TABLE

### DIFF
--- a/src/states_screens/race_result_gui.cpp
+++ b/src/states_screens/race_result_gui.cpp
@@ -1354,6 +1354,7 @@ void RaceResultGUI::unload()
             ri->m_centre_point = m_top + (gp_position + j)*m_distance_between_rows*0.5f;
             int p = RaceManager::get()->getKartScore(i);
             ri->m_new_overall_points = p;
+            ri->m_new_gp_rank = gp_position;
         }   // i < num_karts
 #endif
     }   // determineGPLayout
@@ -1373,13 +1374,22 @@ void RaceResultGUI::unload()
             : video::SColor(255, 255, 255, 255);
 
         unsigned int current_x = x;
+
+        // Draw rank order
+        // (only when num. of karts >=10 )
         if (RaceManager::get()->getMinorMode() != RaceManager::MINOR_MODE_FREE_FOR_ALL &&
             !ri->m_finish_time_string.empty() &&
             RaceManager::get()->getNumberOfKarts() >= 10)
         {
-            int pos_rank_width = m_font->getDimension(core::stringw(n + 1).c_str()).Width;
+            int rankNo = (
+                m_animation_state >= RR_RESORT_TABLE
+                    ? ri->m_new_gp_rank
+                    : n
+            ) + 1;
+
+            int pos_rank_width = m_font->getDimension(core::stringw(rankNo).c_str()).Width;
             core::recti pos_rank(current_x, y, pos_rank_width, m_distance_between_rows);
-            m_font->draw(core::stringw(n + 1), pos_rank, color);
+            m_font->draw(core::stringw(rankNo), pos_rank, color);
             current_x += 48;
         }
 

--- a/src/states_screens/race_result_gui.hpp
+++ b/src/states_screens/race_result_gui.hpp
@@ -95,6 +95,8 @@ private:
         float            m_new_points;
         /** New overall points after this race. */
         int              m_new_overall_points;
+        /** New GP rank after this race. */
+        int              m_new_gp_rank;
         /** When updating the number of points in the display, this is the
             currently displayed number of points. This is a floating point number
             since it stores the increments during increasing the points. */


### PR DESCRIPTION
see the videos.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
