### PR TITLE
fix: only use ranks in GP, else use row number.

### DIFF
--- a/src/states_screens/race_result_gui.cpp
+++ b/src/states_screens/race_result_gui.cpp
@@ -1382,6 +1382,7 @@ void RaceResultGUI::unload()
             RaceManager::get()->getNumberOfKarts() >= 10)
         {
             int rankNo = (
+                RaceManager::get()->getMajorMode()==RaceManager::MAJOR_MODE_GRAND_PRIX &&
                 m_animation_state >= RR_RESORT_TABLE
                     ? ri->m_new_gp_rank
                     : n


### PR DESCRIPTION
Fixed a bug in my last commit.
The rank numbers are all "1" when not in GP mode.
Can be reproduced when plays in single race and battle with 10+ karts.
```
race result:
1 John
1 Mary
1 Sam
1 Peter
1 Ken
1 Joe
...
```



## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
