### PR TITLE
add configuration for item return times in stk_config.xml

### DIFF
--- a/data/stk_config.xml
+++ b/data/stk_config.xml
@@ -224,6 +224,11 @@
        to timer when bomb is passed on. -->
   <bomb time="30.0" time-increase="0.0"/>
 
+  <!-- Item return times.
+       Time until an item that has been collected returns. Can be set
+       differently for bonus (gift) boxes, nitro, bananas and bubble gums -->
+  <item-return-time bonusbox="2.0" nitro="2.0" banana="2.0" bubblegum="2.0"/>
+
   <!-- Powerup collect-mode decides what is collected if a kart has already an
        powerup: same: get one more item of the same type.
                 new:  always get a new item.

--- a/src/config/stk_config.cpp
+++ b/src/config/stk_config.cpp
@@ -191,6 +191,10 @@ void STKConfig::load(const std::string &filename)
     CHECK_NEG(m_snb_min_adjust_speed, "network smoothing: min-adjust-speed");
     CHECK_NEG(m_snb_max_adjust_time, "network smoothing: max-adjust-time");
     CHECK_NEG(m_snb_adjust_length_threshold, "network smoothing: adjust-length-threshold");
+    CHECK_NEG(m_bonusbox_item_return_ticks, "bonus box return time");
+    CHECK_NEG(m_nitro_item_return_ticks, "nitro return time");
+    CHECK_NEG(m_banana_item_return_ticks, "banana return time");
+    CHECK_NEG(m_bubblegum_item_return_ticks, "bubble gum return time");
 
     // Square distance to make distance checks cheaper (no sqrt)
     m_default_kart_properties->checkAllSet(filename);
@@ -261,6 +265,11 @@ void STKConfig::init_defaults()
     m_snb_min_adjust_length = m_snb_max_adjust_length =
         m_snb_min_adjust_speed = m_snb_max_adjust_time =
         m_snb_adjust_length_threshold = UNDEFINED;
+
+    m_bonusbox_item_return_ticks  = -100;
+    m_nitro_item_return_ticks     = -100;
+    m_banana_item_return_ticks    = -100;
+    m_bubblegum_item_return_ticks = -100;
 
     m_score_increase.clear();
     m_leader_intervals.clear();
@@ -476,6 +485,19 @@ void STKConfig::getAllData(const XMLNode * root)
     {
         bomb_node->get("time", &m_bomb_time);
         bomb_node->get("time-increase", &m_bomb_time_increase);
+    }
+
+    if(const XMLNode *item_return_node= root->getNode("item-return-time"))
+    {
+        float f;
+        if(item_return_node->get("bonusbox", &f))
+            m_bonusbox_item_return_ticks = time2Ticks(f);
+        if(item_return_node->get("nitro", &f))
+            m_nitro_item_return_ticks = time2Ticks(f);
+        if(item_return_node->get("banana", &f))
+            m_banana_item_return_ticks = time2Ticks(f);
+        if(item_return_node->get("bubblegum", &f))
+            m_bubblegum_item_return_ticks = time2Ticks(f);
     }
 
     if(const XMLNode *powerup_node= root->getNode("powerup"))

--- a/src/config/stk_config.hpp
+++ b/src/config/stk_config.hpp
@@ -67,6 +67,11 @@ public:
     }
     m_same_powerup_mode;
 
+    int   m_bonusbox_item_return_ticks;  /** Time until a bonus box collected by a kart returns */
+    int   m_nitro_item_return_ticks;     /** Time until a nitro collected by a kart returns */
+    int   m_banana_item_return_ticks;    /** Time until a banana collected by a kart return */
+    int   m_bubblegum_item_return_ticks; /** Time until a bubble gum collected bý a kart returns */
+
     static float UNDEFINED;
     float m_bomb_time;                 /**<Time before a bomb explodes.        */
     float m_bomb_time_increase;        /**<Time added to bomb timer when it's

--- a/src/items/item.cpp
+++ b/src/items/item.cpp
@@ -147,7 +147,26 @@ void ItemState::collected(const AbstractKart *kart)
     }
     else
     {
-        m_ticks_till_return = stk_config->time2Ticks(2.0f);
+        switch (m_type)
+        {
+            case ITEM_BONUS_BOX:
+                m_ticks_till_return = stk_config->m_bonusbox_item_return_ticks;
+                break;
+            case ITEM_NITRO_BIG:
+            case ITEM_NITRO_SMALL:
+                m_ticks_till_return = stk_config->m_nitro_item_return_ticks;
+                break;
+            case ITEM_BANANA:
+                m_ticks_till_return = stk_config->m_banana_item_return_ticks;
+                break;
+            case ITEM_BUBBLEGUM:
+            case ITEM_BUBBLEGUM_NOLOK:
+                m_ticks_till_return = stk_config->m_bubblegum_item_return_ticks;
+                break;
+            default:
+                m_ticks_till_return = stk_config->time2Ticks(2.0f);
+                break;
+        }
     }
 
     if (RaceManager::get()->isBattleMode())


### PR DESCRIPTION
Recently we tried some different item settings online and changing some values for swatter and item return time turned out to be a lot of fun. STK already offers a lot of configuration, but item return time is hard coded into item.cpp.
This PR adds configuration for item return times in stk_config.xml.
In online play, the values used by the server will overwrite the client's values and we didn't experience any problems.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
