### PR TITLE
Allow specifying a base skin

### DIFF
--- a/data/skins/cartoon/stkskin.xml
+++ b/data/skins/cartoon/stkskin.xml
@@ -61,30 +61,29 @@ and explicitely specify which parts you want to see. The 4 corner areas are only
 when the border that intersect at this corner are enabled.
 
 When there is a common="y" with image tag, the image will be loaded only from data/skins/common in stk-code.
+
+Any information not specified in this theme will be inherited from the specified base theme,
+if any.  To specify a base theme, add base_theme="themename" to the <skin> tag.
+
+To use an icon theme, place the replacement icons (PNG or SVG) into [skin folder]/data/gui/icons
+STK will prefer these icons first, if not found it will fallback to icons from the base theme(s).
 -->
 
 <skin name="Cartoon" author="LCP and QwertyChouskie">
 
 <!--
 Here you can configure advanced theming rules for this skin
-Currently STK supports:
-1. Icon theme
-2. Font
 
-To allow icon theme, use the tag icon_theme="y" and then place the replacement png into
-(local skin folder)/data/gui/icons, STK will prefer those first, if not found it will fallback to bundled icon.
+For TTF specify the list like the following, for normal and digit ttf it will be added at the beginning of the
+font list in STK, so those TTF will be used first, and any missing characters will be rendered from the base
+theme font list. For color emoji ttf it will replace the base theme color emoji directly. You are not required
+to specify all types of ttf.
 
-For TTF specify the list like the following, for normal and digit ttf it will be added in the beginning of font
-list in STK, so those TTF will be used first, and any missing character will be rendered from the bundled font
-list. For color emoji ttf it will be replace the bundled color emoji directly. You are not required to specify
-all types of ttf.
-<advanced icon_theme="y"
-          normal_ttf="xxx.ttf yyy.ttf"
+<advanced normal_ttf="xxx.ttf yyy.ttf"
           digit_ttf="zzz.ttf"
           color_emoji_ttf="www.ttf"/>
 -->
-<advanced icon_theme="y"
-          normal_ttf="Inter-UI-Black.ttf NotoSansThai-Black.ttf NotoSansHebrew-Black.ttf NotoSansArabicUI-Black.ttf NotoSansMalayalam-Bold.ttf" />
+<advanced normal_ttf="Inter-UI-Black.ttf NotoSansThai-Black.ttf NotoSansHebrew-Black.ttf NotoSansArabicUI-Black.ttf NotoSansMalayalam-Bold.ttf" />
 
 <!--  Stateless -->
 <element type="background" image="background.jpg" />

--- a/data/skins/coal/stkskin.xml
+++ b/data/skins/coal/stkskin.xml
@@ -58,14 +58,34 @@ that take a float from 0 to 1, representing the percentage of each border that g
 area (this might include stuff like shadows, etc.). The 'h' one is for horizontal borders,
 the 'v' one is for vertical borders.
 
-Finnally : the image is split, as shown above, into 9 areas. In osme cases, you may not want
+Finnally : the image is split, as shown above, into 9 areas. In some cases, you may not want
 all areas to be rendered. Then you can pass parameter areas="body+left+right+top+bottom"
 and explicitely specify which parts you want to see. The 4 corner areas are only visible
 when the border that intersect at this corner are enabled.
 
+When there is a common="y" with image tag, the image will be loaded only from data/skins/common in stk-code.
+
+Any information not specified in this theme will be inherited from the specified base theme,
+if any.  To specify a base theme, add base_theme="themename" to the <skin> tag.
+
+To use an icon theme, place the replacement icons (PNG or SVG) into [skin folder]/data/gui/icons
+STK will prefer these icons first, if not found it will fallback to icons from the base theme(s).
 -->
 
-<skin name="Coal" author="Alayan">
+<skin name="Coal" author="Alayan" base_theme="peach">
+
+<!--
+Here you can configure advanced theming rules for this skin
+
+For TTF specify the list like the following, for normal and digit ttf it will be added at the beginning of the
+font list in STK, so those TTF will be used first, and any missing characters will be rendered from the base
+theme font list. For color emoji ttf it will replace the base theme color emoji directly. You are not required
+to specify all types of ttf.
+
+<advanced normal_ttf="xxx.ttf yyy.ttf"
+          digit_ttf="zzz.ttf"
+          color_emoji_ttf="www.ttf"/>
+-->
 
 <!--  Stateless -->
 <element type="background" image="background.jpg" />

--- a/data/skins/forest/stkskin.xml
+++ b/data/skins/forest/stkskin.xml
@@ -58,14 +58,34 @@ that take a float from 0 to 1, representing the percentage of each border that g
 area (this might include stuff like shadows, etc.). The 'h' one is for horizontal borders,
 the 'v' one is for vertical borders.
 
-Finnally : the image is split, as shown above, into 9 areas. In osme cases, you may not want
+Finnally : the image is split, as shown above, into 9 areas. In some cases, you may not want
 all areas to be rendered. Then you can pass parameter areas="body+left+right+top+bottom"
 and explicitely specify which parts you want to see. The 4 corner areas are only visible
 when the border that intersect at this corner are enabled.
 
+When there is a common="y" with image tag, the image will be loaded only from data/skins/common in stk-code.
+
+Any information not specified in this theme will be inherited from the specified base theme,
+if any.  To specify a base theme, add base_theme="themename" to the <skin> tag.
+
+To use an icon theme, place the replacement icons (PNG or SVG) into [skin folder]/data/gui/icons
+STK will prefer these icons first, if not found it will fallback to icons from the base theme(s).
 -->
 
-<skin name="Forest" author="Benau">
+<skin name="Forest" author="Benau" base_theme="peach">
+
+<!--
+Here you can configure advanced theming rules for this skin
+
+For TTF specify the list like the following, for normal and digit ttf it will be added at the beginning of the
+font list in STK, so those TTF will be used first, and any missing characters will be rendered from the base
+theme font list. For color emoji ttf it will replace the base theme color emoji directly. You are not required
+to specify all types of ttf.
+
+<advanced normal_ttf="xxx.ttf yyy.ttf"
+          digit_ttf="zzz.ttf"
+          color_emoji_ttf="www.ttf"/>
+-->
 
 <!--  Stateless -->
 <element type="background" common="y" image="background.jpg" />

--- a/data/skins/ocean/stkskin.xml
+++ b/data/skins/ocean/stkskin.xml
@@ -57,14 +57,34 @@ that take a float from 0 to 1, representing the percentage of each border that g
 area (this might include stuff like shadows, etc.). The 'h' one is for horizontal borders,
 the 'v' one is for vertical borders.
 
-Finnally : the image is split, as shown above, into 9 areas. In osme cases, you may not want
+Finnally : the image is split, as shown above, into 9 areas. In some cases, you may not want
 all areas to be rendered. Then you can pass parameter areas="body+left+right+top+bottom"
 and explicitely specify which parts you want to see. The 4 corner areas are only visible
 when the border that intersect at this corner are enabled.
 
+When there is a common="y" with image tag, the image will be loaded only from data/skins/common in stk-code.
+
+Any information not specified in this theme will be inherited from the specified base theme,
+if any.  To specify a base theme, add base_theme="themename" to the <skin> tag.
+
+To use an icon theme, place the replacement icons (PNG or SVG) into [skin folder]/data/gui/icons
+STK will prefer these icons first, if not found it will fallback to icons from the base theme(s).
 -->
 
-<skin name="Ocean" author="Dakal & Marianne Gagnon (Auria)">
+<skin name="Ocean" author="Dakal & Marianne Gagnon (Auria)" base_theme="peach">
+
+<!--
+Here you can configure advanced theming rules for this skin
+
+For TTF specify the list like the following, for normal and digit ttf it will be added at the beginning of the
+font list in STK, so those TTF will be used first, and any missing characters will be rendered from the base
+theme font list. For color emoji ttf it will replace the base theme color emoji directly. You are not required
+to specify all types of ttf.
+
+<advanced normal_ttf="xxx.ttf yyy.ttf"
+          digit_ttf="zzz.ttf"
+          color_emoji_ttf="www.ttf"/>
+-->
 
 <!--  Stateless -->
 <element type="background" common="y" image="background.jpg" />

--- a/data/skins/peach/stkskin.xml
+++ b/data/skins/peach/stkskin.xml
@@ -57,31 +57,31 @@ that take a float from 0 to 1, representing the percentage of each border that g
 area (this might include stuff like shadows, etc.). The 'h' one is for horizontal borders,
 the 'v' one is for vertical borders.
 
-Finnally : the image is split, as shown above, into 9 areas. In osme cases, you may not want
+Finnally : the image is split, as shown above, into 9 areas. In some cases, you may not want
 all areas to be rendered. Then you can pass parameter areas="body+left+right+top+bottom"
 and explicitely specify which parts you want to see. The 4 corner areas are only visible
 when the border that intersect at this corner are enabled.
 
 When there is a common="y" with image tag, the image will be loaded only from data/skins/common in stk-code.
+
+Any information not specified in this theme will be inherited from the specified base theme,
+if any.  To specify a base theme, add base_theme="themename" to the <skin> tag.
+
+To use an icon theme, place the replacement icons (PNG or SVG) into [skin folder]/data/gui/icons
+STK will prefer these icons first, if not found it will fallback to icons from the base theme(s).
 -->
 
 <skin name="Peach" author="Dakal & Marianne Gagnon (Auria)">
 
 <!--
 Here you can configure advanced theming rules for this skin
-Currently STK supports:
-1. Icon theme
-2. Font
 
-To allow icon theme, use the tag icon_theme="y" and then place the replacement png into
-(local skin folder)/data/gui/icons, STK will prefer those first, if not found it will fallback to bundled icon.
+For TTF specify the list like the following, for normal and digit ttf it will be added at the beginning of the
+font list in STK, so those TTF will be used first, and any missing characters will be rendered from the base
+theme font list. For color emoji ttf it will replace the base theme color emoji directly. You are not required
+to specify all types of ttf.
 
-For TTF specify the list like the following, for normal and digit ttf it will be added in the beginning of font
-list in STK, so those TTF will be used first, and any missing character will be rendered from the bundled font
-list. For color emoji ttf it will be replace the bundled color emoji directly. You are not required to specify
-all types of ttf.
-<advanced icon_theme="y"
-          normal_ttf="xxx.ttf yyy.ttf"
+<advanced normal_ttf="xxx.ttf yyy.ttf"
           digit_ttf="zzz.ttf"
           color_emoji_ttf="www.ttf"/>
 -->

--- a/data/skins/ruby/stkskin.xml
+++ b/data/skins/ruby/stkskin.xml
@@ -58,14 +58,34 @@ that take a float from 0 to 1, representing the percentage of each border that g
 area (this might include stuff like shadows, etc.). The 'h' one is for horizontal borders,
 the 'v' one is for vertical borders.
 
-Finnally : the image is split, as shown above, into 9 areas. In osme cases, you may not want
+Finnally : the image is split, as shown above, into 9 areas. In some cases, you may not want
 all areas to be rendered. Then you can pass parameter areas="body+left+right+top+bottom"
 and explicitely specify which parts you want to see. The 4 corner areas are only visible
 when the border that intersect at this corner are enabled.
 
+When there is a common="y" with image tag, the image will be loaded only from data/skins/common in stk-code.
+
+Any information not specified in this theme will be inherited from the specified base theme,
+if any.  To specify a base theme, add base_theme="themename" to the <skin> tag.
+
+To use an icon theme, place the replacement icons (PNG or SVG) into [skin folder]/data/gui/icons
+STK will prefer these icons first, if not found it will fallback to icons from the base theme(s).
 -->
 
-<skin name="Ruby" author="Benau">
+<skin name="Ruby" author="Benau" base_theme="peach">
+
+<!--
+Here you can configure advanced theming rules for this skin
+
+For TTF specify the list like the following, for normal and digit ttf it will be added at the beginning of the
+font list in STK, so those TTF will be used first, and any missing characters will be rendered from the base
+theme font list. For color emoji ttf it will replace the base theme color emoji directly. You are not required
+to specify all types of ttf.
+
+<advanced normal_ttf="xxx.ttf yyy.ttf"
+          digit_ttf="zzz.ttf"
+          color_emoji_ttf="www.ttf"/>
+-->
 
 <!--  Stateless -->
 <element type="background" common="y" image="background.jpg" />

--- a/src/graphics/irr_driver.cpp
+++ b/src/graphics/irr_driver.cpp
@@ -1055,8 +1055,7 @@ void IrrDriver::applyResolutionSettings(bool recreate_device)
         SP::loadShaders();
 #endif
 
-    font_manager = new FontManager();
-    font_manager->loadFonts();
+    font_manager = new FontManager(); // Fonts are loaded in GUIEngine::init
 
     input_manager = new InputManager();
     input_manager->setMode(InputManager::MENU);

--- a/src/guiengine/engine.cpp
+++ b/src/guiengine/engine.cpp
@@ -1137,6 +1137,8 @@ namespace GUIEngine
             }
         }
 
+        font_manager->loadFonts();
+
         RegularFace* regular = font_manager->getFont<RegularFace>();
         BoldFace* bold = font_manager->getFont<BoldFace>();
         DigitFace* digit = font_manager->getFont<DigitFace>();

--- a/src/guiengine/skin.cpp
+++ b/src/guiengine/skin.cpp
@@ -2938,13 +2938,6 @@ std::string Skin::getThemedIcon(const std::string& relative_path) const
             }
         }
 
-        if (relative_path2.find(SkinConfig::m_data_path) != std::string::npos &&
-            file_manager->fileExists(relative_path2))
-        {
-            // Absolute path given
-            return relative_path2;
-        }
-
         std::string test_path = SkinConfig::m_data_path + "data/" + relative_path2;
         if (file_manager->fileExists(test_path))
         {

--- a/src/guiengine/skin.cpp
+++ b/src/guiengine/skin.cpp
@@ -172,7 +172,7 @@ namespace SkinConfig
       * \brief loads skin information from a STK skin file
       * \throw std::runtime_error if file cannot be read
       */
-    static void loadFromFile(std::string file, bool load_advanced_only)
+    static void loadFromFile(std::string file)
     {
         // Clear global variables for android
         m_render_params.clear();
@@ -208,11 +208,11 @@ namespace SkinConfig
         {
             const XMLNode* node = root->getNode(i);
 
-            if (node->getName() == "element" && !load_advanced_only)
+            if (node->getName() == "element")
             {
                 parseElement(node);
             }
-            else if (node->getName() == "color" && !load_advanced_only)
+            else if (node->getName() == "color")
             {
                 parseColor(node);
             }
@@ -271,7 +271,7 @@ namespace SkinConfig
                         list_ttf_path.begin(), list_ttf_path.end());
                 }
             }
-            else if (!load_advanced_only)
+            else
             {
                 Log::error("skin", "Unknown node in XML file '%s'.",
                            node->getName().c_str());
@@ -507,7 +507,6 @@ X##_yflip.LowerRightCorner.Y =  y1;}
 
 Skin::Skin(IGUISkin* fallback_skin)
 {
-    // fallback_skin will be null if load only basic theming data
     std::string skin_id = UserConfigParams::m_skin_file;
     std::string skin_name = skin_id.find("addon_") != std::string::npos ?
         file_manager->getAddonsFile(
@@ -516,7 +515,7 @@ Skin::Skin(IGUISkin* fallback_skin)
 
     try
     {
-        SkinConfig::loadFromFile(skin_name, /*load_advanced_only*/fallback_skin == NULL);
+        SkinConfig::loadFromFile(skin_name);
     }
     catch (std::runtime_error& e)
     {
@@ -526,18 +525,14 @@ Skin::Skin(IGUISkin* fallback_skin)
         std::string default_skin_id = UserConfigParams::m_skin_file;
         skin_name = file_manager->getAsset(FileManager::SKIN,
                                            default_skin_id + "/stkskin.xml");
-        SkinConfig::loadFromFile(skin_name, /*load_advanced_only*/fallback_skin == NULL);
+        SkinConfig::loadFromFile(skin_name);
     }
 
     m_bg_image = NULL;
 
-    m_fallback_skin = NULL;
-    if (fallback_skin)
-    {
-        m_fallback_skin = fallback_skin;
-        m_fallback_skin->grab();
-        assert(fallback_skin != NULL);
-    }
+    assert(fallback_skin != NULL);
+    m_fallback_skin = fallback_skin;
+    m_fallback_skin->grab();
 
     m_dialog = false;
     m_dialog_size = 0.0f;

--- a/src/guiengine/skin.cpp
+++ b/src/guiengine/skin.cpp
@@ -2878,12 +2878,6 @@ void Skin::setSpriteBank (IGUISpriteBank *bank)
 }   // setSpriteBank
 
 // -----------------------------------------------------------------------------
-const std::string& Skin::getDataPath() const
-{
-    return SkinConfig::m_data_path;
-}   // getDataPath
-
-// -----------------------------------------------------------------------------
 /* All TTF list here are in absolute path. */
 const std::vector<std::string>& Skin::getNormalTTF() const
 {

--- a/src/guiengine/skin.hpp
+++ b/src/guiengine/skin.hpp
@@ -424,8 +424,6 @@ namespace GUIEngine
 
         gui::IGUISkin* getFallbackSkin() { return m_fallback_skin; }
 
-        const std::string& getDataPath() const;
-
         bool hasIconTheme() const;
 
         bool hasFont() const;

--- a/src/io/file_manager.cpp
+++ b/src/io/file_manager.cpp
@@ -795,16 +795,7 @@ std::string FileManager::getAsset(FileManager::AssetType type,
 {
     if (type == GUI_ICON && GUIEngine::getSkin()->hasIconTheme())
     {
-        // remove the extension to check both .svg and .png
-        const std::string test_path = StringUtils::removeExtension
-            (GUIEngine::getSkin()->getDataPath() + "data/gui/icons/" + name);
-        // first check if there is an SVG version
-        if (fileExists(test_path + ".svg"))
-            return test_path + ".svg";
-        else if (fileExists(test_path + ".png"))
-            return test_path + ".png";
-        else
-            return m_subdir_name[type] + name;
+        return GUIEngine::getSkin()->getThemedIcon("gui/icons/" + name);
     }
     return m_subdir_name[type] + name;
 }   // getAsset

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1863,13 +1863,7 @@ void initRest()
         exit(0);
     }
 
-    // We need a temporary skin to load the font list from skin (if any)
-    GUIEngine::Skin* tmp_skin = new GUIEngine::Skin(NULL);
-    GUIEngine::setSkin(tmp_skin);
-    font_manager = new FontManager();
-    font_manager->loadFonts();
-    delete tmp_skin;
-    GUIEngine::setSkin(NULL);
+    font_manager = new FontManager(); // Fonts are loaded in GUIEngine::init
 
     input_manager = new InputManager();
 #ifdef __SWITCH__

--- a/src/states_screens/options/options_screen_ui.cpp
+++ b/src/states_screens/options/options_screen_ui.cpp
@@ -583,8 +583,7 @@ void OptionsScreenUI::reloadGUIEngine()
         if (reload_font)
         {
             delete font_manager;
-            font_manager = new FontManager();
-            font_manager->loadFonts();
+            font_manager = new FontManager(); // Fonts are loaded in GUIEngine::init
             GUIEngine::init(irr_driver->getDevice(), irr_driver->getVideoDriver(),
                 StateManager::get(), false/*loading*/);
         }


### PR DESCRIPTION
Anything not provided or defined by a skin will be used from the defined base skin, if specified.

For example, if a skin provides a base_theme of "cartoon", any icons/buttons/etc. not provided by the skin will be pulled from "cartoon".

My goal is to make color variants of the Cartoon skin, but before this PR it would have required bundling an entire duplicate icon theme with each skin, now the skins can just specify `base_theme="cartoon"`.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
