### PR TITLE
Add the display of ghosts difficulties in end race screen for replay …

### DIFF
--- a/src/states_screens/race_result_gui.cpp
+++ b/src/states_screens/race_result_gui.cpp
@@ -1367,6 +1367,22 @@ void RaceResultGUI::unload()
     }   // determineGPLayout
 
     //-----------------------------------------------------------------------------
+
+    void addGhostDifficulty(const stringw& difficulty,
+                            irr::gui::ScalableFont* m_font,
+                            int current_x, float y,
+                            video::SColor color,
+                            unsigned int m_width_finish_time,
+                            unsigned int m_width_column_space)
+    {
+        core::recti diff_ghost = core::recti(current_x, y, current_x + 200, y + 20);
+        m_font->draw(difficulty, diff_ghost, color, false, false, NULL, true);
+        current_x += m_width_finish_time + m_width_column_space;
+    }
+
+    // ----------------------------------------------------------------------------
+
+    //-----------------------------------------------------------------------------
     /** Displays the race results for a single kart.
      *  \param n Index of the kart to be displayed.
      *  \param display_points True if GP points should be displayed, too
@@ -1453,6 +1469,51 @@ void RaceResultGUI::unload()
             int laps = World::getWorld()->getFinishedLapsOfKart(ri->m_kart_id);
             m_font->draw(irr::core::stringw(laps), pos_laps, color, false, false,
                 NULL, true /* ignoreRTL */);
+        }
+
+        // Draw the difficulty (only works with descriptive replay filenames)
+        // ------------------------------------------------------------------
+
+        if (RaceManager::get()->isWatchingReplay() && RaceManager::get()->hasGhostKarts() && !RaceManager::get()->isRecordingRace()){
+
+            if (m_second_ghost == false) {
+                if (ReplayPlay::get()->getReplayFilename(2).find("novice") != std::string::npos) {
+                    addGhostDifficulty("Novice", m_font, current_x, y, color, m_width_finish_time, m_width_column_space);
+                }
+                else if (ReplayPlay::get()->getReplayFilename(2).find("intermediate") != std::string::npos) {
+                    addGhostDifficulty("Intermediate", m_font, current_x, y, color, m_width_finish_time, m_width_column_space);
+                }
+                else if (ReplayPlay::get()->getReplayFilename(2).find("expert") != std::string::npos) {
+                    addGhostDifficulty("Expert", m_font, current_x, y, color, m_width_finish_time, m_width_column_space);
+                }
+                else if (ReplayPlay::get()->getReplayFilename(2).find("supertux") != std::string::npos) {
+                    addGhostDifficulty("SuperTux", m_font, current_x, y, color, m_width_finish_time, m_width_column_space);
+                }
+                // other cases (standard race, custom replay... wip)
+                else {
+                }
+                m_second_ghost = true;
+            }
+
+            else if (m_second_ghost == true) {
+                if (ReplayPlay::get()->getReplayFilename().find("novice") != std::string::npos) {
+                    addGhostDifficulty("Novice", m_font, current_x, y, color, m_width_finish_time, m_width_column_space);
+                }
+                else if (ReplayPlay::get()->getReplayFilename().find("intermediate") != std::string::npos) {
+                    addGhostDifficulty("Intermediate", m_font, current_x, y, color, m_width_finish_time, m_width_column_space);
+                }
+                else if (ReplayPlay::get()->getReplayFilename().find("expert") != std::string::npos) {
+                    addGhostDifficulty("Expert", m_font, current_x, y, color, m_width_finish_time, m_width_column_space);
+                }
+                else if (ReplayPlay::get()->getReplayFilename().find("supertux") != std::string::npos) {
+                    addGhostDifficulty("SuperTux", m_font, current_x, y, color, m_width_finish_time, m_width_column_space);
+                }
+                // other cases (custom replay... wip)
+                else {
+                }
+                m_second_ghost = false;
+            }
+
         }
 
         current_x += 100 + m_width_column_space;
@@ -1958,7 +2019,7 @@ void RaceResultGUI::unload()
             // display difficulty
             const core::stringw& difficulty_name =
                 RaceManager::get()->getDifficultyName(RaceManager::get()->getDifficulty());
-            core::stringw difficulty_string = _("Difficulty: %s", difficulty_name);
+            core::stringw difficulty_string = _("Selected difficulty: %s", difficulty_name);
             current_y += int(m_distance_between_meta_rows * 0.8f);
             GUIEngine::getFont()->draw(difficulty_string,
                 // 0.96 from stkgui

--- a/src/states_screens/race_result_gui.hpp
+++ b/src/states_screens/race_result_gui.hpp
@@ -172,6 +172,9 @@ private:
 
     bool                       m_started_race_over_music;
 
+    /** True if second/comparative ghost */
+    bool                       m_second_ghost = false;
+
     /** The previous monospace state of the font. */
     //bool                       m_was_monospace;
 


### PR DESCRIPTION
…files with standard names (#3849)

It is still a work in progress for the local generated files, but this part works and is an improvement.
Would it be possible to make the game generate replay files with a standard name like -> name_racetype_map_difficulty_[time].replay ?
It would simplify a lot of work on replays.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
