### PR TITLE
Request AMD GPU on Enduro Devices

### DIFF
--- a/src/graphics/glwrap.cpp
+++ b/src/graphics/glwrap.cpp
@@ -693,9 +693,10 @@ bool checkGLError()
 }
 
 #ifdef WIN32
-// Tell system that it should use nvidia on optimus devices
+// Tell system that it should use nvidia on optimus devices and amd on enduro devices
 extern "C" {
     __declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
+    __declspec(dllexport) DWORD AmdPowerXpressRequestHighPerformance = 0x00000001;
 }
 #endif
 


### PR DESCRIPTION
It seems AMD provides an equivalent to `NvOptimusEnablement` called `AmdPowerXpressRequestHighPerformance`

See https://gpuopen.com/learn/amdpowerxpressrequesthighperformance/

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
