### PR TITLE
Added animation to stars

### DIFF
--- a/src/graphics/stars.hpp
+++ b/src/graphics/stars.hpp
@@ -53,7 +53,7 @@ private:
     /** Whether stars are currently enabled */
     bool m_enabled;
 
-    float m_fade_in_time;
+    float m_period;
     float m_remaining_time;
 
  public:


### PR DESCRIPTION
This adds a little animation to stars that appear after a kart has been hit.

The animation is a subtle bouncing effect, with more intensity at then end:

https://user-images.githubusercontent.com/66701383/148719770-1882e2c0-772a-484e-becd-1fcb5dd78f01.mp4

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
