### PR TITLE
Items animation

### DIFF
--- a/src/items/item.cpp
+++ b/src/items/item.cpp
@@ -116,11 +116,7 @@ void ItemState::initItem(ItemType type, const Vec3& xyz, const Vec3& normal)
 void ItemState::update(int ticks)
 {
     if (m_deactive_ticks > 0) m_deactive_ticks -= ticks;
-    if (m_ticks_till_return>0)
-    {
-        m_ticks_till_return -= ticks;
-    }   // if collected
-
+    m_ticks_till_return -= ticks;
 }   // update
 
 // ----------------------------------------------------------------------------
@@ -430,7 +426,13 @@ void Item::updateGraphics(float dt)
             m_node->setRotation(hpr.toIrrHPR());
         }
         m_node->setVisible(true);
-        m_node->setScale(core::vector3df(1, 1, 1)*(1 - time_till_return));
+
+        float f = time_till_return, p = (1.0f - time_till_return);
+        float factor_v = sin(-13.0f * M_PI_2 * (p + 1.0f))
+                        * pow(2.0f, -10.0f * p) + 1.0f;
+        float factor_h = 1.0f - (f * f * f * f * f - f * f * f * sin(f * M_PI));
+
+        m_node->setScale(core::vector3df(factor_h, factor_v, factor_h));
     }
     if (isAvailable())
     {

--- a/src/items/item.cpp
+++ b/src/items/item.cpp
@@ -458,6 +458,10 @@ void Item::updateGraphics(float dt)
                         * pow(2.0f, -10.0f * p) + 1.0f;
         float factor_h = 1.0f - (f * f * f * f * f - f * f * f * sin(f * M_PI));
 
+        // This will do a "bump" when items become available.
+        factor_v *= 0.8f;
+        factor_h *= 0.8f;
+
         m_node->setScale(core::vector3df(factor_h, factor_v, factor_h));
     }
     if (isAvailable())

--- a/src/items/item.cpp
+++ b/src/items/item.cpp
@@ -480,20 +480,6 @@ void Item::updateGraphics(float dt)
 
     if (!isAvailable() && time_till_return <= 1.0f)
     {
-        // Make it visible by scaling it from 0 to 1:
-        /*if (rotating())
-        {
-            float angle =
-                fmodf((float)(World::getWorld()->getTicksSinceStart() +
-                getTicksTillReturn()) / 40.0f, M_PI * 2);
-            btMatrix3x3 m;
-            m.setRotation(getOriginalRotation());
-            btQuaternion r = btQuaternion(m.getColumn(1), angle) *
-                getOriginalRotation();
-            Vec3 hpr;
-            hpr.setHPR(r);
-            m_node->setRotation(hpr.toIrrHPR());
-        }*/
         m_node->setVisible(true);
 
         // Make it de facto invisible, but the model needs to be visible for

--- a/src/items/item.cpp
+++ b/src/items/item.cpp
@@ -532,7 +532,7 @@ void Item::updateGraphics(float dt)
         float t = time_since_return + 0.5f;
         float t2 = time_since_return + 1.0f;
 
-        float node_angle =
+        float node_angle = !rotating() ? 0.0f :
                 fmodf((float)World::getWorld()->getTicksSinceStart() / 40.0f,
                 M_PI * 2);
 

--- a/src/items/item.cpp
+++ b/src/items/item.cpp
@@ -220,6 +220,7 @@ Item::Item(ItemType type, const Vec3& xyz, const Vec3& normal,
            const std::string& icon, const AbstractKart *owner)
     : ItemState(type, owner)
 {
+    m_icon_node = NULL;
     m_was_available_previously = true;
     m_distance_2        = 1.2f;
     initItem(type, xyz, normal);

--- a/src/items/item.hpp
+++ b/src/items/item.hpp
@@ -88,6 +88,10 @@ private:
      *  > 0 it means that the item is not available. */
     int m_ticks_till_return;
 
+    /** Time since the item either was last collected, if it isn't available, or
+     *  the time since the item last respawned, if it is available. */
+    int m_ticks_since_last_event;
+
     /** Index in item_manager field. This field can also take on a negative
      *  value when used in the NetworkItemManager. */
     int  m_item_id;
@@ -199,8 +203,9 @@ public:
     /** Resets an item to its start state. */
     virtual void reset()
     {
-        m_deactive_ticks    = 0;
-        m_ticks_till_return = 0;
+        m_deactive_ticks         = 0;
+        m_ticks_till_return      = 0;
+        m_ticks_since_last_event = 0;
         setDisappearCounter();
         // If the item was switched:
         if (m_original_type != ITEM_NONE)
@@ -262,6 +267,12 @@ public:
     // ------------------------------------------------------------------------
     /** Returns true if this item is currently collected. */
     bool isAvailable() const { return m_ticks_till_return <= 0; }
+    // ------------------------------------------------------------------------
+    /** Returns the number of ticks since the last event (collection/respawn) */
+    int getTicksSinceLastEvent() const { return m_ticks_since_last_event; }
+    // ------------------------------------------------------------------------
+    /** Sets the number of ticks since the last event (collection/respawn) */
+    void setTicksSinceLastEvent(int t) { m_ticks_since_last_event = t; }
     // ------------------------------------------------------------------------
     /** Returns the type of this item. */
     ItemType getType() const { return m_type; }
@@ -329,6 +340,9 @@ private:
 
     /** Graphical type of the mesh. */
     ItemType m_graphical_type;
+
+    /** Vector containing the sparks */
+    std::vector<scene::ISceneNode*> m_spark_nodes;
 
     /** Stores if the item was available in the previously rendered frame. */
     bool m_was_available_previously;

--- a/src/items/item.hpp
+++ b/src/items/item.hpp
@@ -350,9 +350,7 @@ private:
      *  is not on any quad. */
     float m_distance_from_center;
 
-    /** Time ticks when the item either was last collected, if it isn't
-     *  available, or the time since the item last respawned, if it is
-     *  available. */
+    /** Time ticks since the item last respawned */
     int m_animation_start_ticks;
 
     /** The closest point to the left and right of this item at which it

--- a/src/items/item.hpp
+++ b/src/items/item.hpp
@@ -88,10 +88,6 @@ private:
      *  > 0 it means that the item is not available. */
     int m_ticks_till_return;
 
-    /** Time since the item either was last collected, if it isn't available, or
-     *  the time since the item last respawned, if it is available. */
-    int m_ticks_since_return;
-
     /** Index in item_manager field. This field can also take on a negative
      *  value when used in the NetworkItemManager. */
     int  m_item_id;
@@ -203,9 +199,8 @@ public:
     /** Resets an item to its start state. */
     virtual void reset()
     {
-        m_deactive_ticks         = 0;
-        m_ticks_till_return      = 0;
-        m_ticks_since_return = 0;
+        m_deactive_ticks    = 0;
+        m_ticks_till_return = 0;
         setDisappearCounter();
         // If the item was switched:
         if (m_original_type != ITEM_NONE)
@@ -267,12 +262,6 @@ public:
     // ------------------------------------------------------------------------
     /** Returns true if this item is currently collected. */
     bool isAvailable() const { return m_ticks_till_return <= 0; }
-    // ------------------------------------------------------------------------
-    /** Returns the number of ticks since the last event (collection/respawn) */
-    int getTicksSinceReturn() const { return m_ticks_since_return; }
-    // ------------------------------------------------------------------------
-    /** Sets the number of ticks since the last event (collection/respawn) */
-    void setTicksSinceReturn(int t) { m_ticks_since_return = t; }
     // ------------------------------------------------------------------------
     /** Returns the type of this item. */
     ItemType getType() const { return m_type; }
@@ -360,6 +349,11 @@ private:
      *  >0 if it is to the right of the center, and undefined if this quad
      *  is not on any quad. */
     float m_distance_from_center;
+
+    /** Time ticks when the item either was last collected, if it isn't
+     *  available, or the time since the item last respawned, if it is
+     *  available. */
+    int m_animation_start_ticks;
 
     /** The closest point to the left and right of this item at which it
      *  would not be collected. Used by the AI to avoid items. */

--- a/src/items/item.hpp
+++ b/src/items/item.hpp
@@ -90,7 +90,7 @@ private:
 
     /** Time since the item either was last collected, if it isn't available, or
      *  the time since the item last respawned, if it is available. */
-    int m_ticks_since_last_event;
+    int m_ticks_since_return;
 
     /** Index in item_manager field. This field can also take on a negative
      *  value when used in the NetworkItemManager. */
@@ -205,7 +205,7 @@ public:
     {
         m_deactive_ticks         = 0;
         m_ticks_till_return      = 0;
-        m_ticks_since_last_event = 0;
+        m_ticks_since_return = 0;
         setDisappearCounter();
         // If the item was switched:
         if (m_original_type != ITEM_NONE)
@@ -269,10 +269,10 @@ public:
     bool isAvailable() const { return m_ticks_till_return <= 0; }
     // ------------------------------------------------------------------------
     /** Returns the number of ticks since the last event (collection/respawn) */
-    int getTicksSinceLastEvent() const { return m_ticks_since_last_event; }
+    int getTicksSinceReturn() const { return m_ticks_since_return; }
     // ------------------------------------------------------------------------
     /** Sets the number of ticks since the last event (collection/respawn) */
-    void setTicksSinceLastEvent(int t) { m_ticks_since_last_event = t; }
+    void setTicksSinceReturn(int t) { m_ticks_since_return = t; }
     // ------------------------------------------------------------------------
     /** Returns the type of this item. */
     ItemType getType() const { return m_type; }
@@ -344,6 +344,9 @@ private:
     /** Vector containing the sparks */
     std::vector<scene::ISceneNode*> m_spark_nodes;
 
+    /** Billboard that shows when the item is about to respawn */
+    scene::ISceneNode* m_icon_node;
+
     /** Stores if the item was available in the previously rendered frame. */
     bool m_was_available_previously;
 
@@ -369,7 +372,7 @@ private:
 public:
                   Item(ItemType type, const Vec3& xyz, const Vec3& normal,
                        scene::IMesh* mesh, scene::IMesh* lowres_mesh,
-                       const AbstractKart *owner);
+                       const std::string& icon, const AbstractKart *owner);
     virtual       ~Item ();
     virtual void  updateGraphics(float dt) OVERRIDE;
     virtual void  reset() OVERRIDE;

--- a/src/items/item_manager.cpp
+++ b/src/items/item_manager.cpp
@@ -47,6 +47,7 @@
 std::vector<scene::IMesh *>  ItemManager::m_item_mesh;
 std::vector<scene::IMesh *>  ItemManager::m_item_lowres_mesh;
 std::vector<video::SColorf>  ItemManager::m_glow_color;
+std::vector<std::string>     ItemManager::m_icon;
 bool                         ItemManager::m_disable_item_collection = false;
 std::mt19937                 ItemManager::m_random_engine;
 uint32_t                     ItemManager::m_random_seed = 0;
@@ -59,9 +60,11 @@ void ItemManager::loadDefaultItemMeshes()
     m_item_mesh.clear();
     m_item_lowres_mesh.clear();
     m_glow_color.clear();
+    m_icon.clear();
     m_item_mesh.resize(ItemState::ITEM_LAST-ItemState::ITEM_FIRST+1, NULL);
     m_glow_color.resize(ItemState::ITEM_LAST-ItemState::ITEM_FIRST+1,
                         video::SColorf(255.0f, 255.0f, 255.0f) );
+    m_icon.resize(ItemState::ITEM_LAST-ItemState::ITEM_FIRST+1, "");
 
     m_item_lowres_mesh.resize(ItemState::ITEM_LAST-ItemState::ITEM_FIRST+1, NULL);
 
@@ -113,6 +116,7 @@ void ItemManager::loadDefaultItemMeshes()
 #endif
             m_item_lowres_mesh[i]->grab();
         }
+        m_icon[i] = "icon-" + item_names[(ItemState::ItemType)i] + ".png";
     }   // for i
     delete root;
 }   // loadDefaultItemMeshes
@@ -297,7 +301,8 @@ Item* ItemManager::dropNewItem(ItemState::ItemType type,
     }
 
     Item* item = new Item(type, pos, normal, m_item_mesh[mesh_type],
-                          m_item_lowres_mesh[mesh_type], /*prev_owner*/kart);
+                          m_item_lowres_mesh[mesh_type], m_icon[mesh_type],
+                          /*prev_owner*/kart);
 
     // restoreState in NetworkItemManager will handle the insert item
     if (!server_xyz)
@@ -329,7 +334,8 @@ Item* ItemManager::placeItem(ItemState::ItemType type, const Vec3& xyz,
     ItemState::ItemType mesh_type = type;
 
     Item* item = new Item(type, xyz, normal, m_item_mesh[mesh_type],
-                          m_item_lowres_mesh[mesh_type], /*prev_owner*/NULL);
+                          m_item_lowres_mesh[mesh_type], m_icon[mesh_type],
+                          /*prev_owner*/NULL);
 
     insertItem(item);
     if (m_switch_ticks >= 0)

--- a/src/items/item_manager.hpp
+++ b/src/items/item_manager.hpp
@@ -88,6 +88,10 @@ public:
     static scene::IMesh* getItemLowResolutionModel(ItemState::ItemType type)
                                       { return m_item_lowres_mesh[type]; }
     // ------------------------------------------------------------------------
+    /** Returns the mesh for a certain item. */
+    static std::string getIcon(ItemState::ItemType type)
+                                      { return m_icon[type]; }
+    // ------------------------------------------------------------------------
     /** Returns the glow color for an item. */
     static video::SColorf& getGlowColor(ItemState::ItemType type)
                                       { return m_glow_color[type]; }
@@ -112,6 +116,9 @@ private:
 
     /** Stores all low-resolution item models. */
     static std::vector<scene::IMesh *> m_item_lowres_mesh;
+
+    /** Stores all item models. */
+    static std::vector<std::string> m_icon;
 
 protected:
     /** Remaining time that items should remain switched. If the

--- a/src/tracks/track.cpp
+++ b/src/tracks/track.cpp
@@ -2904,7 +2904,7 @@ void Track::copyFromMainProcess()
     {
         ItemState* it = m_item_manager->getItem(i);
         nim->insertItem(new Item(it->getType(), it->getXYZ(), it->getNormal(),
-            NULL/*mesh*/, NULL/*lowres_mesh*/, NULL/*owner*/));
+            NULL/*mesh*/, NULL/*lowres_mesh*/, "", NULL/*owner*/));
     }
     m_item_manager = nim;
 }   // copyFromMainProcess

--- a/src/utils/constants.hpp
+++ b/src/utils/constants.hpp
@@ -42,6 +42,9 @@
 #ifndef M_PI
 #  define M_PI 3.14159265358979323846f  /* As in Linux's math.h */
 #endif
+#ifndef M_PI_2
+#  define M_PI_2 1.57079632679489661923
+#endif
 
 #define NINETY_DEGREE_RAD  (M_PI/2.0f)
 #define DEGREE_TO_RAD      (M_PI/180.0f)


### PR DESCRIPTION
This adds an animation when items respawn.

https://user-images.githubusercontent.com/66701383/148840908-b5c655dc-01f9-46df-893b-fe08b98a13cc.mp4

**Note:** With this animation alone, the only visual cue that happened when the item became pickable again was the resuming of rotation.

I wanted to add more visual cues to make it as intuitive as possible. I originally wanted to make the item much darker while respawning, then reverting back to normal brightness when the item was available again; however, I couldn't get this to work.

Instead, it works by making the item slightly smaller when respawning, then by taking its full size only when the respawn animation finished. I'm a bit unsatisfied with this option, but it seems to work.

If someone could help me with changing items' colors at runtime, please let me know.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
