### PR TITLE
Add digital speedometer

### DIFF
--- a/data/gui/screens/options_ui.stkgui
+++ b/data/gui/screens/options_ui.stkgui
@@ -70,6 +70,14 @@
                 <spacer width="5" height="2%"/>
 
                 <div layout="horizontal-row" width="100%" height="fit">
+                    <checkbox id="digital_speedometer" />
+                    <spacer width="1%" height="100%" />
+                    <label height="100%" x="0" y="0" I18N="In the ui settings" text="Show digital speedometer above graphical one"/>
+                </div>
+
+                <spacer width="5" height="2%"/>
+
+                <div layout="horizontal-row" width="100%" height="fit">
                     <checkbox id="showfps"/>
                     <spacer width="1%" height="100%" />
                     <label height="100%" I18N="In the ui settings" text="Display FPS" word_wrap="true"/>

--- a/data/tips.xml
+++ b/data/tips.xml
@@ -3,6 +3,7 @@
     <tipset id="general">
         <tip text="The UI skin can be changed in the UI options."/>
         <tip text="You can see other karts' powerups by enabling it in the UI options."/>
+        <tip text="You can see exactly how fast your kart is travelling at by enabling it in the UI options."/>
         <tip text="The font size can be changed in the UI options."/>
         <tip text="The help menu has lots of useful information."/>
         <tip text="In single-player, you can watch and challenge recorded time-trials."/>

--- a/src/config/user_config.hpp
+++ b/src/config/user_config.hpp
@@ -1215,6 +1215,10 @@ namespace UserConfigParams
         PARAM_DEFAULT(IntUserConfigParam(0, "minimap_display",
                       "Minimap: 0 bottom-left, 1 middle-right, 2 hidden, 3 center"));
 
+    PARAM_PREFIX BoolUserConfigParam       m_digital_speedometer
+            PARAM_DEFAULT(BoolUserConfigParam(false, "digital_speedometer",
+                                             "Whether to show a digital speedometer on top of the current one, showing speed in km/h and m/s."));
+
     // ---- Settings for spectator camera
     PARAM_PREFIX GroupUserConfigParam       m_spectator
             PARAM_DEFAULT( GroupUserConfigParam("Spectator",

--- a/src/states_screens/options/options_screen_ui.cpp
+++ b/src/states_screens/options/options_screen_ui.cpp
@@ -324,6 +324,10 @@ void OptionsScreenUI::init()
     }
     speedrun_timer->setState( UserConfigParams::m_speedrun_mode );
 
+    GUIEngine::CheckBoxWidget* digital_speedometer = getWidget<GUIEngine::CheckBoxWidget>("digital_speedometer");
+    assert( digital_speedometer != NULL );
+    digital_speedometer->setState(UserConfigParams::m_digital_speedometer);
+
     // --- select the right skin in the spinner
     bool currSkinFound = false;
     const std::string& user_skin = UserConfigParams::m_skin_file;
@@ -549,6 +553,12 @@ void OptionsScreenUI::eventCallback(Widget* widget, const std::string& name, con
     else if(name == "custom_camera")
     {
         new CustomCameraSettingsDialog(0.8f, 0.95f);
+    }
+    else if (name == "digital_speedometer")
+    {
+        GUIEngine::CheckBoxWidget* digital_speedometer = getWidget<GUIEngine::CheckBoxWidget>("digital_speedometer");
+        assert( digital_speedometer != NULL );
+        UserConfigParams::m_digital_speedometer = digital_speedometer->getState();
     }
 #endif
 }   // eventCallback

--- a/src/states_screens/race_gui.cpp
+++ b/src/states_screens/race_gui.cpp
@@ -1091,6 +1091,31 @@ void RaceGUI::drawSpeedEnergyRank(const AbstractKart* kart,
         }
     }
 
+    // Draw speed in numbers, above the graphical speedometer, if enabled
+    if (UserConfigParams::m_digital_speedometer)
+    {
+        gui::ScalableFont* font = GUIEngine::getFont();
+        static video::SColor color = video::SColor(255, 255, 255, 255);
+        font->setBlackBorder(true);
+
+        std::ostringstream speedOSS;
+        speedOSS.setf(std::ios::fixed);
+        speedOSS.precision(1);
+
+        float speedKM = speed * 3.6; // Speed in kilometers per hour
+
+        core::recti digiPos;
+        digiPos.UpperLeftCorner = core::vector2di(int(offset.X + 0.0f*meter_width),
+                                                  int(offset.Y - 1.17f*meter_height));
+        digiPos.LowerRightCorner = core::vector2di(int(offset.X + meter_width),
+                                                   int(offset.Y - 1.15f*meter_height));
+
+        speedOSS << speed << "m/s | " << speedKM << "km/h";
+        font->draw(speedOSS.str().c_str(), digiPos, color);
+
+        font->setBlackBorder(false);
+    }
+
     unsigned int count = computeVerticesForMeter(position, threshold, vertices, vertices_count, 
                                                      speed_ratio, meter_width, meter_height, offset);
 


### PR DESCRIPTION
This is an attempted resurrection of #4476.

It only adds a single checkbox in the options menu, and shows meters/sec and km/h just above the current speedometer. Imperial units have been removed.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
