### PR TITLE
Ignore clangd files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ stk-editor/
 .vscode/
 tags.*
 
+# clangd
+.cache/
+compile_commands.json
+
 .config/
 supertuxkart-64
 make*.bat


### PR DESCRIPTION
Clangd can be used to detect errors in real time while programming. It also offers useful warnings to help improve code quality.

It does, however, generate some files at the root of the repository. I added them to the `.gitignore` file in this PR.

If it can be useful for other developers as well, I'm offering my changes back to the repository.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
