### PR TITLE
Add DisplayVersion to Windows registry on install (+typo)

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -258,11 +258,12 @@ jobs:
             cp supertuxkart-github-actions.nsi $arch.nsi
             sed -i "s/define APPNAMEANDVERSION \"\"/define APPNAMEANDVERSION \"SuperTuxKart ${{ env.release_tag }}\"/g" $arch.nsi
             sed -i "s/define ARCH \"\"/define ARCH \"$arch\"/g" $arch.nsi
+            sed -i "s/define VERSION \"\"/define VERSION \"${{ env.release_tag }}\"/g" $arch.nsi
             sed -i "s/OutFile \"\"/OutFile \"SuperTuxKart-${{ env.release_tag }}-installer-$arch.exe\"/g" $arch.nsi
             for filename in $(ls ../../build-$arch/bin)
             do
               file="\\\\$filename"
-              sed -i "286a\  DELETE /REBOOTOK \"\$INSTDIR$file\"" $arch.nsi
+              sed -i "288a\  DELETE /REBOOTOK \"\$INSTDIR$file\"" $arch.nsi
             done
             # Print result
             #cat $arch.nsi

--- a/tools/windows_installer/supertuxkart-64bit-mingw.nsi
+++ b/tools/windows_installer/supertuxkart-64bit-mingw.nsi
@@ -28,7 +28,7 @@
 ;General
 
   ; Version information
-  ; TOOD get these from the source code directly
+  ; TODO get these from the source code directly
   !define VERSION_MAJOR 1
   !define VERSION_MINOR 2
   !define VERSION_REVISION 0

--- a/tools/windows_installer/supertuxkart-64bit-mingw.nsi
+++ b/tools/windows_installer/supertuxkart-64bit-mingw.nsi
@@ -38,6 +38,7 @@
   ;Name and file
   !define APPNAME "SuperTuxKart"
   !define APPNAMEANDVERSION "${APPNAME} ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_REVISION}${VERSION_BUILD}"
+  !define VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_REVISION}${VERSION_BUILD}"
   !define DESCRIPTION "3D open-source arcade racer with a variety characters, tracks, and modes to play"
 
   Name "${APPNAMEANDVERSION}"
@@ -239,6 +240,7 @@ Section "Install" SecMain
   WriteRegStr HKLM "${ADD_REMOVE_KEY_NAME}" "Publisher" "${APPNAME}"
   WriteRegStr HKLM "${ADD_REMOVE_KEY_NAME}" "UninstallString" "$\"$INSTDIR\Uninstall.exe$\""
   WriteRegStr HKLM "${ADD_REMOVE_KEY_NAME}" "DisplayIcon" "$\"$INSTDIR\icon.ico$\""
+  WriteRegStr HKLM "${ADD_REMOVE_KEY_NAME}" "DisplayVersion" "${VERSION}"
   WriteRegStr HKLM "${ADD_REMOVE_KEY_NAME}" "HelpLink" "$\"${HELPURL}$\""
   WriteRegStr HKLM "${ADD_REMOVE_KEY_NAME}" "URLUpdateInfo" "$\"${UPDATEURL}$\""
   WriteRegStr HKLM "${ADD_REMOVE_KEY_NAME}" "URLInfoAbout" "$\"${ABOUTURL}$\""

--- a/tools/windows_installer/supertuxkart-github-actions.nsi
+++ b/tools/windows_installer/supertuxkart-github-actions.nsi
@@ -35,9 +35,18 @@ Unicode True
 ;--------------------------------
 ;General
 
+  ; Version information
+  ; TODO get these from the source code directly
+  !define VERSION_MAJOR 1
+  !define VERSION_MINOR 2
+  !define VERSION_REVISION 0
+  ; Empty means stable, could be -git, -rc1
+  !define VERSION_BUILD ""
+
   ;Name and file
   !define APPNAME "SuperTuxKart"
-  !define APPNAMEANDVERSION ""
+  !define APPNAMEANDVERSION "${APPNAME} ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_REVISION}${VERSION_BUILD}"
+  !define VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_REVISION}${VERSION_BUILD}"
   !define ARCH ""
   !define DESCRIPTION "3D open-source arcade racer with a variety characters, tracks, and modes to play"
 
@@ -257,6 +266,7 @@ Section "Install" SecMain
   WriteRegStr HKLM "${ADD_REMOVE_KEY_NAME}" "Publisher" "SuperTuxKart Team"
   WriteRegStr HKLM "${ADD_REMOVE_KEY_NAME}" "UninstallString" "$\"$INSTDIR\Uninstall.exe$\""
   WriteRegStr HKLM "${ADD_REMOVE_KEY_NAME}" "DisplayIcon" "$\"$INSTDIR\icon.ico$\""
+  WriteRegStr HKLM "${ADD_REMOVE_KEY_NAME}" "DisplayVersion" "${VERSION}"
   WriteRegStr HKLM "${ADD_REMOVE_KEY_NAME}" "HelpLink" "${HELPURL}"
   WriteRegStr HKLM "${ADD_REMOVE_KEY_NAME}" "URLUpdateInfo" "${UPDATEURL}"
   WriteRegStr HKLM "${ADD_REMOVE_KEY_NAME}" "URLInfoAbout" "${ABOUTURL}"

--- a/tools/windows_installer/supertuxkart-github-actions.nsi
+++ b/tools/windows_installer/supertuxkart-github-actions.nsi
@@ -35,19 +35,11 @@ Unicode True
 ;--------------------------------
 ;General
 
-  ; Version information
-  ; TODO get these from the source code directly
-  !define VERSION_MAJOR 1
-  !define VERSION_MINOR 2
-  !define VERSION_REVISION 0
-  ; Empty means stable, could be -git, -rc1
-  !define VERSION_BUILD ""
-
   ;Name and file
   !define APPNAME "SuperTuxKart"
-  !define APPNAMEANDVERSION "${APPNAME} ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_REVISION}${VERSION_BUILD}"
-  !define VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_REVISION}${VERSION_BUILD}"
+  !define APPNAMEANDVERSION ""
   !define ARCH ""
+  !define VERSION ""
   !define DESCRIPTION "3D open-source arcade racer with a variety characters, tracks, and modes to play"
 
   Name "${APPNAMEANDVERSION}"

--- a/tools/windows_installer/supertuxkart-mingw.nsi
+++ b/tools/windows_installer/supertuxkart-mingw.nsi
@@ -38,6 +38,7 @@
   ;Name and file
   !define APPNAME "SuperTuxKart"
   !define APPNAMEANDVERSION "${APPNAME} ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_REVISION}${VERSION_BUILD}"
+  !define VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_REVISION}${VERSION_BUILD}"
   !define DESCRIPTION "3D open-source arcade racer with a variety characters, tracks, and modes to play"
 
   Name "${APPNAMEANDVERSION}"
@@ -238,6 +239,7 @@ Section "Install" SecMain
   WriteRegStr HKLM "${ADD_REMOVE_KEY_NAME}" "Publisher" "${APPNAME}"
   WriteRegStr HKLM "${ADD_REMOVE_KEY_NAME}" "UninstallString" "$\"$INSTDIR\Uninstall.exe$\""
   WriteRegStr HKLM "${ADD_REMOVE_KEY_NAME}" "DisplayIcon" "$\"$INSTDIR\icon.ico$\""
+  WriteRegStr HKLM "${ADD_REMOVE_KEY_NAME}" "DisplayVersion" "${VERSION}"
   WriteRegStr HKLM "${ADD_REMOVE_KEY_NAME}" "HelpLink" "$\"${HELPURL}$\""
   WriteRegStr HKLM "${ADD_REMOVE_KEY_NAME}" "URLUpdateInfo" "$\"${UPDATEURL}$\""
   WriteRegStr HKLM "${ADD_REMOVE_KEY_NAME}" "URLInfoAbout" "$\"${ABOUTURL}$\""

--- a/tools/windows_installer/supertuxkart-mingw.nsi
+++ b/tools/windows_installer/supertuxkart-mingw.nsi
@@ -28,7 +28,7 @@
 ;General
 
   ; Version information
-  ; TOOD get these from the source code directly
+  ; TODO get these from the source code directly
   !define VERSION_MAJOR 1
   !define VERSION_MINOR 2
   !define VERSION_REVISION 0


### PR DESCRIPTION
Winget relies on this value to get the version of a program.
If it's missing winget will just download the newest version even if the program is up to date.
See https://github.com/microsoft/winget-cli/issues/1255


## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
