### PR TITLE
Minimap and powerup icon settings in user settings

### DIFF
--- a/data/kart_characteristics.xml
+++ b/data/kart_characteristics.xml
@@ -145,7 +145,6 @@
             visual-time: How long it takes for the visual skid to reach maximum.
             revert-visual-time: how long it takes when stopping a skid to revert
                 the visual skid and bring visuals and physics in sync again.
-            angular-velocity: Angular velocity to be used for the kart when skidding.
             min-speed: Minimum speed a kart must have before it can skid. Must be
                 >0, otherwise the kart can skid at the start of the race.
             time-till-bonus: How long a kart needs to skid in order to get a bonus.

--- a/data/stk_config.xml
+++ b/data/stk_config.xml
@@ -102,7 +102,8 @@
        it will be ignored. -->
   <news max-display="10"/>
 
-  <!-- smooth-normals: If the normals (for wheel raycasts) should be smoothened.
+  <!-- Physics
+       smooth-normals: If the normals (for wheel raycasts) should be smoothened.
           This is a global setting, it still needs to be activated for each
           track individually.
        smooth-angle-limits: If the angle between the normal of a vertex and
@@ -188,13 +189,7 @@
   <replay max-frames="12000" delta-t="0.100"  delta-speed="0.6"
           delta-steering="0.26" />
 
-  <!--  Determines the minimap related values.
-        size: The size of the minimap (scaled afterwards) 480 = full screen height)
-        ai-icon: The size of the icons for the AI karts on the minimap.
-        player-icon: The size of the icons for the player karts. -->
-
-  <minimap size="180.0" ai-icon="16.0" player-icon="20.0"/>
-
+  <!-- Special urls -->
   <urls donate="https://supertuxkart.net/Donate"
         password-reset="https://online.supertuxkart.net/password-reset.php"
         assets-download="https://github.com/supertuxkart/stk-assets-mobile/releases/download/"/>
@@ -229,14 +224,15 @@
        differently for bonus (gift) boxes, nitro, bananas and bubble gums -->
   <item-return-time bonusbox="2.0" nitro="2.0" banana="2.0" bubblegum="2.0"/>
 
-  <!-- Powerup collect-mode decides what is collected if a kart has already an
-       powerup: same: get one more item of the same type.
-                new:  always get a new item.
-                only-if-same: if the random item is the same one as the
+  <!-- Powerup
+       collect-mode : decides what is collected if a kart has already an
+               same: get one more item of the same type.
+               new:  always get a new item.
+               only-if-same: if the random item is the same one as the
                       one currently owned, increase the number, otherwise
                       no more/new item s are given to the kart.
        no-explosive-items-timeout determines if world time is less than this value
-       then no cake or basketball is given by bonus boxes. -->
+               then no cake or basketball is given by bonus boxes. -->
   <powerup collect-mode="new" no-explosive-items-timeout="15.0"/>
   <!-- time: How long a switch is being effective.
        items for each item list the index of the item it is switched with.
@@ -244,7 +240,8 @@
                     easter egg-->
   <switch time="5"  items="1 0 4 4 2 2 6"/>
 
-  <!-- disappear-counter: How often bubblegum gets driven over before it disappears.
+  <!-- Bubblegum
+       disappear-counter: How often bubblegum gets driven over before it disappears.
        shield-time: How long the bubblegum shield lasts
        restrict-weapons: If true, using weapons will destroy the user's shield -->
   <bubblegum disappear-counter="1" shield-time="10.0" restrict-weapons="false"/>
@@ -264,12 +261,14 @@
   <networking steering-reduction="1.0"
               max-moveable-objects="15"/>
 
-  <!-- The field od views for 1-4 player split screen. fov-3 is
+  <!-- Camera
+       The field of views for 1-4 player split screen. fov-3 is
        actually not used (since 3 player split screen uses the
        same layout as 4 player split screen) -->
   <camera fov-1="80" fov-2="65" fov-3="50" fov-4="75" cutscene-fov="0.61" />
 
-  <!-- disable-while-unskid: Disable steering when stop skidding during
+  <!-- Steer
+       disable-while-unskid: Disable steering when stop skidding during
            the time it takes to adjust the physical body with the graphics.
        camera-follow-skid: If true the camera will stay behind the kart,
            potentially making it easier to see where the kart is going to
@@ -281,40 +280,7 @@
        ============================ -->
   <general-kart-defaults>
 
-    <!-- Skidding: increase: multiplicative increase of skidding factor in each frame.
-         decrease: multiplicative decrease of skidding factor in each frame.
-         max: maximum skidding factor = maximum increase of steering angle.
-         time-till-max: Time till maximum skidding is reached.
-         visual: Additional graphical rotation of kart. The graphical rotation
-           of the kart also determines the direction the kart is driving to
-           when skidding is stopped.
-         visual-time: How long it takes for the visual skid to reach maximum.
-         revert-visual-time: how long it takes when stopping a skid to revert
-           the visual skid and bring visuals and physics in sync again.
-         angular-velocity: Angular velocity to be used for the kart when skidding.
-         min-speed: Minimum speed a kart must have before it can skid. Must be
-           >0, otherwise the kart can skid at the start of the race.
-         time-till-bonus: How long a kart needs to skid in order to get a bonus.
-         bonus-force: A speedup applied to the kart whick skidded for a while.
-         bonus-time: How long the bonus-force is applied.
-         bonus-force: Additional engine force (this is used to offset the fact
-           that turning after skidding (e.g. to correct direction) often uses
-           up the skid bonus).
-         post-skid-rotate-factor: a factor to be used to determine how much
-           the chassis of a kart should rotate to match the graphical view.
-           A factor of 1 is identical, a smaller factor will rotate the kart
-           less (which might  feel better).
-         physical-jump-time: Time for a physical jump at the beginning of a skid.
-         graphical-jump-time: Time for a graphics-only jump at the beginning
-           of a skid.
-         reduce-turn-min/max: The steering done by the controller (which is in
-           [-1,1]) is mapped to [reduce-turn-min, reduce-turn-max] when skidding
-           is active (for left turn, right turn will use [-max, -min]). The
-           effect is that while you skid (say left) you can adjust the direction
-           of the turn the kart is doing somewhat by steering to the left and right,
-           but you will always keep on doing a left turn, just more or less. -->
-
-    <!-- Kart-specific settings used by the AI.
+  <!-- Kart-specific settings used by the AI.
          use-slipstream: if the AI should try to overtake karts using slipstream.
          disable-slipstream-usage: even if the AI is not trying to use slipstream,
            it can get a lot of bonus, esp. on easy since the AI creates trains.
@@ -337,8 +303,6 @@
          skidding-threshold: only for old-style skidding: when sharp turn
            should be triggered. Smaller values means it will sharp turn
            earlier, resulting in better driving in thight curves.
-
-
          max-item-angle: Items that would need more than this change in
            direction are not considered for collection.
          time-full-steer is the time for the AI to go from neutral steering to
@@ -356,10 +320,8 @@
            direction.
          straight-length-for-zipper is the minimum length a straight
            section of the track should have in order to activate a zipper.
-
            competitive when ahead of the player, or more competitive
            when behind the player.
-
          skid-probability: Since the AI is usually very good at using
            skidding, this is used to implement some rubber-banding for
            the AI: depending on distance to the player, the AI will
@@ -517,7 +479,8 @@
                restitution="0:1.0 5:1.0 20:0.2" bevel-factor="0.5 0.0 0.3"
                physical-wheel-position="0" />
 
-     <!-- Skidding: increase: multiplicative increase of skidding factor in each frame.
+     <!-- Skidding
+              increase: multiplicative increase of skidding factor in each frame.
               decrease: multiplicative decrease of skidding factor in each frame.
               max: maximum skidding factor = maximum increase of steering angle.
               time-till-max: Time till maximum skidding is reached.
@@ -527,11 +490,10 @@
               visual-time: How long it takes for the visual skid to reach maximum.
               revert-visual-time: how long it takes when stopping a skid to revert
                 the visual skid and bring visuals and physics in sync again.
-              angular-velocity: Angular velocity to be used for the kart when skidding.
               min-speed: Minimum speed a kart must have before it can skid. Must be
                 >0, otherwise the kart can skid at the start of the race.
               time-till-bonus: How long a kart needs to skid in order to get a bonus.
-              bonus-force: A speedup applied to the kart whick skidded for a while.
+              bonus-speed: A speedup applied to the kart whick skidded for a while.
               bonus-time: How long the bonus-force is applied.
               bonus-force: Additional engine force (this is used to offset the fact
                 that turning after skidding (e.g. to correct direction) often uses

--- a/src/config/stk_config.cpp
+++ b/src/config/stk_config.cpp
@@ -174,9 +174,6 @@ void STKConfig::load(const std::string &filename)
     CHECK_NEG(m_replay_delta_steering,     "replay delta-steering"      );
     CHECK_NEG(m_replay_delta_speed,        "replay delta-speed     "    );
     CHECK_NEG(m_replay_dt,                 "replay delta-t"             );
-    CHECK_NEG(m_minimap_size,              "minimap size"               );
-    CHECK_NEG(m_minimap_ai_icon,           "minimap ai_icon"            );
-    CHECK_NEG(m_minimap_player_icon,       "minimap player_icon"        );
     CHECK_NEG(m_smooth_angle_limit,        "physics smooth-angle-limit" );
     CHECK_NEG(m_default_track_friction,    "physics default-track-friction");
     CHECK_NEG(m_physics_fps,               "physics fps"                );
@@ -231,9 +228,6 @@ void STKConfig::init_defaults()
     m_replay_delta_steering      = -100;
     m_replay_delta_speed         = -100;
     m_replay_dt                  = -100;
-    m_minimap_size               = -100;
-    m_minimap_ai_icon            = -100;
-    m_minimap_player_icon        = -100;
     m_donate_url                 = "";
     m_password_reset_url         = "";
     m_no_explosive_items_timeout = -100.0f;
@@ -556,13 +550,6 @@ void STKConfig::getAllData(const XMLNode * root)
         replay_node->get("delta-t",     &m_replay_dt               );
         replay_node->get("max-frames",    &m_replay_max_frames     );
 
-    }
-
-    if(const XMLNode *replay_node = root->getNode("minimap"))
-    {
-        replay_node->get("size",        &m_minimap_size         );
-        replay_node->get("ai-icon",     &m_minimap_ai_icon      );
-        replay_node->get("player-icon", &m_minimap_player_icon  );
     }
 
     if (const XMLNode *urls = root->getNode("urls"))

--- a/src/config/user_config.hpp
+++ b/src/config/user_config.hpp
@@ -1211,9 +1211,38 @@ namespace UserConfigParams
             PARAM_DEFAULT(  StringUserConfigParam("peach", "skin_name",
                                                   "Name of the skin to use") );
 
+    // ---- settings for minimap display
+    PARAM_PREFIX GroupUserConfigParam        m_minimap_setup_group
+        PARAM_DEFAULT( GroupUserConfigParam("Minimap",
+                                            "Minimap Setup Settings") );
+
     PARAM_PREFIX IntUserConfigParam        m_minimap_display
-        PARAM_DEFAULT(IntUserConfigParam(0, "minimap_display",
-                      "Minimap: 0 bottom-left, 1 middle-right, 2 hidden, 3 center"));
+        PARAM_DEFAULT(IntUserConfigParam(0, "display",
+                     &m_minimap_setup_group, "display: 0 bottom-left, 1 middle-right, 2 hidden, 3 center"));
+
+    PARAM_PREFIX FloatUserConfigParam      m_minimap_size
+            PARAM_DEFAULT(  FloatUserConfigParam(180.0f, "size",
+            &m_minimap_setup_group, "Size of the the minimap (480 = full screen height; scaled afterwards)") );
+
+    PARAM_PREFIX FloatUserConfigParam      m_minimap_ai_icon_size
+            PARAM_DEFAULT(  FloatUserConfigParam(16.0f, "ai-icon",
+            &m_minimap_setup_group, "The size of the icons for the AI karts on the minimap.") );
+
+    PARAM_PREFIX FloatUserConfigParam      m_minimap_player_icon_size
+            PARAM_DEFAULT(  FloatUserConfigParam(20.0f, "player-icon",
+            &m_minimap_setup_group, "The size of the icons for the player kart.") );
+
+    // ---- settings for powerup display
+    PARAM_PREFIX GroupUserConfigParam      m_powerup_setup_group
+        PARAM_DEFAULT( GroupUserConfigParam("PowerUp",
+                                            "PowerUp Setup Settings") );
+
+    PARAM_PREFIX IntUserConfigParam        m_powerup_display
+        PARAM_DEFAULT(IntUserConfigParam(0, "display",
+            &m_powerup_setup_group, "display: 0 center, 1 right side, 2 hidden (see karts' held powerups)"));
+    PARAM_PREFIX FloatUserConfigParam      m_powerup_size
+            PARAM_DEFAULT(  FloatUserConfigParam(64.0f, "powerup-icon-size",
+            &m_powerup_setup_group, "Size of the powerup icon (scaled afterwards)") );
 
     // ---- Settings for spectator camera
     PARAM_PREFIX GroupUserConfigParam       m_spectator

--- a/src/states_screens/race_gui.cpp
+++ b/src/states_screens/race_gui.cpp
@@ -195,7 +195,7 @@ void RaceGUI::calculateMinimapSize()
     // Originally m_map_height was 100, and we take 480 as minimum res
     float scaling = std::min(irr_driver->getFrameSize().Height,  
                              irr_driver->getFrameSize().Width) / 480.0f;
-    const float map_size = stk_config->m_minimap_size * map_size_splitscreen;
+    const float map_size = UserConfigParams::m_minimap_size * map_size_splitscreen;
     const float top_margin = 3.5f * m_font_height;
     
     // Check if we have enough space for minimap when touch steering is enabled
@@ -218,8 +218,8 @@ void RaceGUI::calculateMinimapSize()
     
     // Marker texture has to be power-of-two for (old) OpenGL compliance
     //m_marker_rendered_size  =  2 << ((int) ceil(1.0 + log(32.0 * scaling)));
-    m_minimap_ai_size       = (int)( stk_config->m_minimap_ai_icon     * scaling);
-    m_minimap_player_size   = (int)( stk_config->m_minimap_player_icon * scaling);
+    m_minimap_ai_size       = (int)(UserConfigParams::m_minimap_ai_icon_size * scaling);
+    m_minimap_player_size   = (int)(UserConfigParams::m_minimap_player_icon_size * scaling);
     m_map_width             = (int)(map_size * scaling);
     m_map_height            = (int)(map_size * scaling);
 

--- a/src/states_screens/race_gui_base.cpp
+++ b/src/states_screens/race_gui_base.cpp
@@ -381,6 +381,8 @@ void RaceGUIBase::drawPowerupIcons(const AbstractKart* kart,
                                    const core::vector2df &scaling)
 {
 #ifndef SERVER_ONLY
+    if (UserConfigParams::m_powerup_display == 2) return;
+
     // If player doesn't have any powerups or has completed race, do nothing.
     const Powerup* powerup = kart->getPowerup();
     if (powerup->getType() == PowerupManager::POWERUP_NOTHING
@@ -397,14 +399,15 @@ void RaceGUIBase::drawPowerupIcons(const AbstractKart* kart,
 
     float scale = (float)(std::min(scaling.X, scaling.Y));
 
-    int nSize = (int)(64.0f * scale);
+    int nSize = (int)(UserConfigParams::m_powerup_size * scale);
 
-    int itemSpacing = (int)(scale * 32.0f);
+    int itemSpacing = (int)(scale * UserConfigParams::m_powerup_size / 2);
 
     int x1, y1;
 
-    // When there is not much height, move items on the side
-    if ((float) viewport.getWidth() / (float) viewport.getHeight() > 2.0f)
+    // When there is not much height or set by user, move items on the side
+    if ((UserConfigParams::m_powerup_display == 1) || 
+        ((float) viewport.getWidth() / (float) viewport.getHeight() > 2.0f))
     {
         x1 = viewport.UpperLeftCorner.X  + 3*(viewport.getWidth()/4)
            - ((n * itemSpacing)/2);


### PR DESCRIPTION
Hi,
i propose this PR in order to allow to customize the dashboard shown while racing
by editing local user config (`config.xml`).

The PR does (with motives):
 - add size and display settings (center, right, hidden) for powerup icon  (motives below)
     - powerup icon may strongly obstruct field of view with custom camera settings
     - powerup icon doesn't provide any additional information if the option to show karts help powerup is active
     - in Soccer Tournament  context, some players wish to remove the powerup icon in order to record the match as spectator (other gui elements are not obstructing but may be subject for future PR)
 - move minimap display settings in user settings (motives below)
      - minimap size is not similar to other core (mostly physics, rules and api) properties define in stk_config
      - minimap size goes well with others ui setting  defined in user settings
      - stk_config is not accessible on some packaged version - e.g. snap
 - fix some comments in stk_config.xml
 
 Limits of the settings :
   - powerup size
       - only sizes between 16 and 64 (16, 24, 32, 48, 64 icon standards) are actually usable values
       - sizes < 32 looks poorly integrated in gui
       - using size 1 or 2 make the icon looks like a deadpixel
   - powerup display
        - the user shall may use  "kart's held powerup" and "soccer player list" settings  if minimap hidden
        - on very small screen the setting indicating "center" position will be overridden pushing the icon to right corner (current  behavior)
   - minimap size
        - ~~users modifying this setting in stk_config.xml  will have to edit local config.xml instead~~ 
   - minimap display
        - users may have to set this setting again after update because both size and display are with this PR attribute of the same xml tag

Best regards.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
