### PR TITLE
fix parachute powerup

### DIFF
--- a/src/items/powerup.cpp
+++ b/src/items/powerup.cpp
@@ -434,13 +434,13 @@ void Powerup::use()
             {
                 AbstractKart *kart=world->getKart(i);
                 if(kart->isEliminated() || kart== m_kart || kart->isInvulnerable()) continue;
-                if(kart->isShielded())
-                {
-                    kart->decreaseShieldTime();
-                    continue;
-                }
                 if(m_kart->getPosition() > kart->getPosition())
                 {
+                    if(kart->isShielded())
+                    {
+                        kart->decreaseShieldTime();
+                        continue;
+                    }
                     float rank_mult, position_factor;
                     //0 if the one before the item user ; 1 if first ; scaled inbetween
                     if (kart->getPosition() == 1)


### PR DESCRIPTION
only deshield karts ahead of the kart firing the parachute

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
