### PR TITLE
Fix URLs on Haiku

### DIFF
--- a/src/online/link_helper.cpp
+++ b/src/online/link_helper.cpp
@@ -88,13 +88,13 @@ namespace Online
         ShellExecuteA(NULL, "open", url.c_str(), NULL, NULL, SW_SHOWNORMAL);
 #elif defined(IOS_STK)
         irr::CIrrDeviceiOS::openURLiOS(url.c_str());
-#elif defined(__APPLE__)
+#elif defined(__APPLE__) || defined(__HAIKU__)
         std::string command = std::string("open ").append(url);
         if (system(command.c_str()))
         {
             Log::error("OpenURL", "Command returned non-zero exit status");
         }
-#elif !defined(__ANDROID__) && (defined(__linux__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__HAIKU__))
+#elif !defined(__ANDROID__) && (defined(__linux__) || defined(__FreeBSD__) || defined(__NetBSD__))
         std::string command = std::string("xdg-open ").append(url);
 
         const char* lib_path = getenv("LD_LIBRARY_PATH");


### PR DESCRIPTION
My general strategy of getting ports to work on Haiku is to just take advantage
of whatever makes things work on FreeBSD by adding an additional condition and
then fixing up things later once it compiles successfully. This generally
works, as Haiku contains FreeBSD headers for compatibility and code that
takes other operating systems into account other than Windows, Linux and OS X
and has a higher degree of POSIX compatibility tends to work on FreeBSD and
Haiku. This strategy is not perfect, and this commit proves it.

Haiku is the successor of BeOS, which, in turn, shows similarities to macOS
every now and then, as the company almost acquired Be, Inc., but later chose to
acquired NeXT, Inc. instead.

`xdg-open` is not available on Haiku the same way it is on FreeBSD and Linux.
With that in mind, this should fix URLs, which do not not work properly on
Haiku.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
