### PR TITLE
CImageLoaderSVG: don't rescale on server

### DIFF
--- a/lib/irrlicht/source/Irrlicht/CImageLoaderSVG.cpp
+++ b/lib/irrlicht/source/Irrlicht/CImageLoaderSVG.cpp
@@ -13,7 +13,9 @@
 #include "os.h"
 #include "irrString.h"
 #include "CNullDriver.h"
+#ifndef SERVER_ONLY
 #include "ge_main.hpp"
+#endif
 
 namespace irr
 {
@@ -103,10 +105,12 @@ IImage* CImageLoaderSVG::loadImage(io::IReadFile* file, bool skip_checking) cons
     // only rescale the icons
     if ( strstr(file->getFileName().c_str(),"gui/icons/") )
     {
+#ifndef SERVER_ONLY
         // determine scaling based on screen size
         float screen_height = (float)GE::getDriver()->getCurrentRenderTargetSize().Height;
         float desired_icon_size = 0.21*screen_height + 30.0f; // phenomenological
         scale = desired_icon_size/img->height;
+#endif
     }
 
     // create surface


### PR DESCRIPTION
Builds on `SERVER_ONLY` were failing:

```
/home/purple/stk-code/lib/irrlicht/source/Irrlicht/CImageLoaderSVG.cpp:16:10: fatal error: ge_main.hpp: No such file or directory
   16 | #include "ge_main.hpp"
      |          ^~~~~~~~~~~~~
```

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```