### PR TITLE
Allow commandline arguments to be passed in on Android

### DIFF
--- a/android/src/main/java/SuperTuxKartActivity.java
+++ b/android/src/main/java/SuperTuxKartActivity.java
@@ -49,9 +49,11 @@ import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 import android.util.DisplayMetrics;
+import android.util.Log;
 
 import java.io.InputStream;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.Optional;
 import java.util.Set;
 
 import org.minidns.hla.DnssecResolverApi;
@@ -61,6 +63,7 @@ import org.minidns.record.TXT;
 
 public class SuperTuxKartActivity extends SDLActivity
 {
+    private String[] argv;
     private AlertDialog m_progress_dialog;
     private ProgressBar m_progress_bar;
     private ImageView m_splash_screen;
@@ -191,6 +194,8 @@ public class SuperTuxKartActivity extends SDLActivity
     public void onCreate(Bundle instance)
     {
         super.onCreate(instance);
+        argv = Optional.ofNullable(getIntent().getStringArrayExtra("argv")).orElse(new String[0]);
+        Log.i("SuperTuxKartActivity", String.format("cmdline: %s", String.join(" ", argv)));
         m_keyboard_height = new AtomicInteger();
         m_moved_height = new AtomicInteger();
         m_progress_dialog = null;
@@ -298,6 +303,11 @@ public class SuperTuxKartActivity extends SDLActivity
     protected String getMainSharedObject()
     {
         return getContext().getApplicationInfo().nativeLibraryDir + "/libmain.so";
+    }
+    // ------------------------------------------------------------------------
+    protected String[] getArguments()
+    {
+        return argv;
     }
     // ------------------------------------------------------------------------
     public void showKeyboard(final int type, final int y)


### PR DESCRIPTION
Currently on Android there is no way of using commandline arguments. With this patch at least Android users can do something like `am start --esa argv "--demo-mode=1,--demo-tracks=zengarden\,xr591,--demo-laps=1,--demo-karts=10" org.supertuxkart.stk/.SuperTuxKartActivity`.


## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
