### PR TITLE
ReplayRecorder: write correct number of transformation into "size"

### DIFF
--- a/src/replay/replay_recorder.cpp
+++ b/src/replay/replay_recorder.cpp
@@ -434,10 +434,12 @@ void ReplayRecorder::save()
     for (unsigned int k = 0; k < num_karts; k++)
     {
         if (world->getKart(k)->isGhostKart()) continue;
-        fprintf(fd, "size:     %d\n", m_count_transforms[k]);
 
-        unsigned int num_transforms = std::min(m_max_frames,
-                                               m_count_transforms[k]);
+        const unsigned int num_transforms = std::min(m_max_frames,
+                                                     m_count_transforms[k]);
+
+        fprintf(fd, "size:     %d\n", num_transforms);
+
         for (unsigned int i = 0; i < num_transforms; i++)
         {
             const TransformEvent *p  = &(m_transform_events[k][i]);


### PR DESCRIPTION
## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
This should resolve #4758 - at least on my system it did :-)