### PR TITLE
Revert "Fix build when SDL2 is built with DirectFB support"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,12 +304,6 @@ if (NOT SERVER_ONLY)
         include_directories("${SDL2_INCLUDEDIR}")
         MESSAGE(STATUS "Use system SDL2: ${SDL2_LIBRARY}")
     endif()
-    # DirectFB. Necessary if system SDL2 is built with DirectFB support.
-    find_path(DIRECTFB_INCLUDEDIR NAMES directfb.h directfb++.h PATH_SUFFIXES directfb include/directfb include PATHS)
-    if (DIRECTFB_INCLUDEDIR)
-        include_directories("${DIRECTFB_INCLUDEDIR}")
-        message(STATUS "Adding DirectFB include directories for DirectFB support in SDL2")
-    endif()
 endif()
 
 # Build the irrlicht library


### PR DESCRIPTION
The upstream bug that required this will be fixed in a future SDL release, so marking as a draft until that happens.

See https://github.com/libsdl-org/SDL/pull/6084

This reverts commit f5d4475efc1a54400a8e75710317f5de1b1a68b5.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
