### PR TITLE
Initialize vulkan handles properly

### DIFF
--- a/lib/graphics_engine/src/ge_vulkan_array_texture.cpp
+++ b/lib/graphics_engine/src/ge_vulkan_array_texture.cpp
@@ -78,7 +78,7 @@ void GEVulkanArrayTexture::reloadInternal(const std::vector<io::path>& list,
     std::vector<video::IImage*> images;
     std::vector<GEMipmapGenerator*> mipmaps;
 
-    VkBuffer staging_buffer = NULL;
+    VkBuffer staging_buffer = VK_NULL_HANDLE;
     VmaAllocation staging_buffer_allocation = NULL;
     VmaAllocationCreateInfo staging_buffer_create_info = {};
     staging_buffer_create_info.usage = VMA_MEMORY_USAGE_AUTO;

--- a/lib/graphics_engine/src/ge_vulkan_texture.cpp
+++ b/lib/graphics_engine/src/ge_vulkan_texture.cpp
@@ -437,7 +437,7 @@ bool GEVulkanTexture::createImageView(VkImageAspectFlags aspect_flags)
     }
 
     auto image_view = std::make_shared<std::atomic<VkImageView> >();
-    VkImageView view_ptr = NULL;
+    VkImageView view_ptr = VK_NULL_HANDLE;
     VkResult result = vkCreateImageView(m_vulkan_device, &view_info, NULL,
         &view_ptr);
     if (result == VK_SUCCESS)


### PR DESCRIPTION
## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.
```
I'm not really into vulkan, but this code does not build on FreeBSD/i386:
```
/work/usr/ports/games/supertuxkart/work/SuperTuxKart-1.4-rc1-src/lib/graphics_engine/src/ge_vulkan_texture.cpp:440:17: error: cannot initialize a variable of type 'VkImageView' (aka 'unsigned long long') with an rvalue of type 'nullptr_t'
    VkImageView view_ptr = NULL;
                ^          ~~~~
1 error generated.
```
so these types are not pointers and may not be initialized with `NULL`. Judging by vulkan code these may be pointers or ints depending on platform, and `VK_NULL_HANDLE` seems to be the right way to initialize them.