### PR TITLE
Avoid triggering other goal lines when the goal is already scored

### DIFF
--- a/src/modes/soccer_world.cpp
+++ b/src/modes/soccer_world.cpp
@@ -487,6 +487,8 @@ void SoccerWorld::onCheckGoalTriggered(bool first_goal)
         NetworkConfig::get()->isClient()))
         return;
 
+    if (getTicksSinceStart() < m_ticks_back_to_own_goal)
+        return;
     m_ticks_back_to_own_goal = getTicksSinceStart() +
         stk_config->time2Ticks(3.0f);
     m_goal_sound->play();


### PR DESCRIPTION
When the goal is scored, the ball is moved from its current position to its Blender position. If another goal line is intersected during this movement, it's apparently triggered too, causing double goals. This commit seems to fix it.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
