### PR TITLE
make.sh - specify interpreter directly

### DIFF
--- a/android/make.sh
+++ b/android/make.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # (C) 2016-2017 Dawid Gan, under the GPLv3
 #


### PR DESCRIPTION
Run directly it fails with: `./make.sh: 203: Syntax error: "(" unexpected`

A scan on https://www.shellcheck.net/ shows too many issues, this needs to be redesigned a lot to be clean of bashisms

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
