### PR TITLE
Add missing 1.4 release into AppData

### DIFF
--- a/data/supertuxkart.appdata.xml
+++ b/data/supertuxkart.appdata.xml
@@ -403,6 +403,9 @@
     <content_attribute id="social-chat">intense</content_attribute>
   </content_rating>
   <releases>
+    <release version="1.4" date="2022-10-31">
+      <url>https://blog.supertuxkart.net/2022/11/supertuxkart-14-release.html</url>
+    </release>
     <release version="1.3" date="2021-09-28">
       <url>https://blog.supertuxkart.net/2021/09/supertuxkart-13-release.html</url>
     </release>


### PR DESCRIPTION
## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
The release entry for STK 1.4 was sadly not added before 1.4 was released. This is a problem for many package management formats that use AppData and will have to be manually patched. I am at least adding it now.

/cc @Benau