### PR TITLE
Increase default max FPS to suit 144 Hz and 165 Hz displays

### DIFF
--- a/src/config/user_config.hpp
+++ b/src/config/user_config.hpp
@@ -657,8 +657,8 @@ namespace UserConfigParams
             PARAM_DEFAULT(  BoolUserConfigParam(false, "show_speedrun_timer",
                             &m_video_group, "Display the speedrun timer") );
     PARAM_PREFIX IntUserConfigParam         m_max_fps
-            PARAM_DEFAULT(  IntUserConfigParam(120, "max_fps",
-                       &m_video_group, "Maximum fps, should be at least 60") );
+            PARAM_DEFAULT(  IntUserConfigParam(167, "max_fps",
+                       &m_video_group, "Maximum frames per second rendered, should be at least 60") );
     PARAM_PREFIX BoolUserConfigParam        m_force_legacy_device
         PARAM_DEFAULT(BoolUserConfigParam(false, "force_legacy_device",
         &m_video_group, "Force OpenGL 2 context, even if OpenGL 3 is available."));

--- a/src/main_loop.cpp
+++ b/src/main_loop.cpp
@@ -314,7 +314,7 @@ float MainLoop::getLimitedDt()
         // For iOS devices most at locked at 60, for new iPad Pro supports 120
         // which is currently m_max_fps
         const int max_fps =
-            UserConfigParams::m_swap_interval == 2 ? UserConfigParams::m_max_fps :
+            UserConfigParams::m_swap_interval == 2 ? 120 :
             UserConfigParams::m_swap_interval == 1 ? 60 :
             30;
 #else


### PR DESCRIPTION
The frame limiter's timer lacks precision, which seems to limit it to millisecond timing (rather than microsecond timing). This means we can't limit to 145 FPS (for 144 Hz displays), as this requires a sleep duration of roughly 6.9 milliseconds (and not 7 milliseconds).

We can however set the sleep duration to 6 milliseconds, which is good for both 144 Hz and 165 Hz displays. Both refresh rates are becoming increasingly common in displays used for gaming.

For context, see https://www.phoronix.com/news/SuperTuxKart-1.4 :slightly_smiling_face:
That said, for benchmarking, you'll still want to increase `max_fps` to `1000` in the configuration file. Values above `1000` don't seem to act any different compared to `1000`.


## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```