### PR TITLE
Make bot names start at 1

### DIFF
--- a/src/network/protocols/client_lobby.cpp
+++ b/src/network/protocols/client_lobby.cpp
@@ -462,10 +462,7 @@ void ClientLobby::update(int ticks)
 #else
                 name = _("Bot");
 #endif
-                if (i > 0)
-                {
-                    name += core::stringw(" ") + StringUtils::toWString(i);
-                }
+                name += core::stringw(" ") + StringUtils::toWString(i + 1);
             }
             rest->encodeString(name).
                 addFloat(player->getDefaultKartColor());

--- a/src/network/protocols/server_lobby.cpp
+++ b/src/network/protocols/server_lobby.cpp
@@ -3845,8 +3845,8 @@ void ServerLobby::handleUnencryptedConnection(std::shared_ptr<STKPeer> peer,
 #else
             core::stringw name = _("Bot");
 #endif
-            if (i > 0)
-                name += core::stringw(" ") + StringUtils::toWString(i);
+            name += core::stringw(" ") + StringUtils::toWString(i + 1);
+            
             m_ai_profiles.push_back(std::make_shared<NetworkPlayerProfile>
                 (peer, name, peer->getHostId(), 0.0f, 0, HANDICAP_NONE,
                 player_count + i, KART_TEAM_NONE, ""));


### PR DESCRIPTION
## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```

---

## Changes

When playing with some friends I noticed the bot names went as follows: "Bot", "Bot 1", "Bot 2" etc.

With these changes, it goes as follows instead: "Bot 1", "Bot 2", "Bot 3", etc.