### PR TITLE
Add previously missing Lap Trial mode in game modes help screen

### DIFF
--- a/data/gui/screens/help2.stkgui
+++ b/data/gui/screens/help2.stkgui
@@ -78,12 +78,21 @@
                             I18N="In the help menu"
                             text="Egg hunt: Explore tracks to find all hidden eggs."/>
                 </div>
+                
                 <div width="100%" proportion="2" layout="horizontal-row">
                     <icon align="center" width="8%" height="100%" icon="gui/icons/mode_ghost.png"/>
                     <spacer width="3%" height="100%"/>
                     <bubble proportion="1" height="100%"
                             I18N="In the help menu"
                             text="Ghost replay: Race against ghost replays in time-trial or egg hunt mode, and record your own!"/>
+                </div>
+                
+                <div width="100%" proportion="2" layout="horizontal-row">
+                    <icon align="center" width="8%" height="100%" icon="gui/icons/mode_normal.png"/>
+                    <spacer width="3%" height="100%"/>
+                    <bubble proportion="1" height="100%"
+                            I18N="In the help menu"
+                            text="Lap Trial: Complete as many laps as possible in a given amount of time."/>
                 </div>
 
                <bubble proportion="4" width="100%" I18N="In the help menu"


### PR DESCRIPTION
## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```

Lap Trial wasn't mentioned in the 'game modes' section of the help screen, even though that Lap Trial was now introduced in the main game.