### PR TITLE
declare some ssao.frag variables as highp to avoid precision issues

### DIFF
--- a/data/shaders/ssao.frag
+++ b/data/shaders/ssao.frag
@@ -26,7 +26,7 @@ void main(void)
 {
     vec2 uv = gl_FragCoord.xy / u_screen;
     float lineardepth = textureLod(dtex, uv, 0.).x;
-    int x = int(gl_FragCoord.x), y = int(gl_FragCoord.y);
+    highp int x = int(gl_FragCoord.x), y = int(gl_FragCoord.y);
     vec3 FragPos = getXcYcZc(x, y, lineardepth);
 
     // get the normal of current fragment


### PR DESCRIPTION
this fixes opaque shadow rendering on drivers that implement mediump as 16bit

fixes #4855

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
