### PR TITLE
Hide the cursor during gameplay

### DIFF
--- a/src/modes/world.cpp
+++ b/src/modes/world.cpp
@@ -424,6 +424,7 @@ void World::reset(bool restart)
     // Start music from beginning
     music_manager->stopMusic();
 
+#ifndef SERVER_ONLY
     if (m_process_type == PT_MAIN)
     {
         m_force_show_cursor = false;
@@ -431,6 +432,7 @@ void World::reset(bool restart)
         SDL_GetMouseState(&m_last_mouse_pos_x, &m_last_mouse_pos_y);
         SDL_ShowCursor(SDL_DISABLE);
     }
+#endif
 
     // Enable SFX again
     SFXManager::get()->resumeAll();
@@ -622,12 +624,11 @@ World::~World()
 {
     if (m_process_type == PT_MAIN)
     {
+#ifndef SERVER_ONLY
         // This shouldn't be necessary, but just to be sure
         SDL_ShowCursor(SDL_ENABLE);
-    }
+#endif
 
-    if (m_process_type == PT_MAIN)
-    {
         GUIEngine::getDevice()->setResizable(false);
         material_manager->unloadAllTextures();
     }
@@ -1142,6 +1143,7 @@ void World::scheduleTutorial()
  */
 void World::updateGraphics(float dt)
 {
+#ifndef SERVER_ONLY
     if (m_process_type == PT_MAIN)
     {
         int x, y;
@@ -1160,6 +1162,7 @@ void World::updateGraphics(float dt)
         SDL_ShowCursor((m_time_since_last_mouse_mvmt < HIDE_CURSOR_STARTINGAT
                         || m_force_show_cursor) ? SDL_ENABLE : SDL_DISABLE);
     }
+#endif
 
     if (auto cl = LobbyProtocol::get<ClientLobby>())
     {

--- a/src/modes/world.cpp
+++ b/src/modes/world.cpp
@@ -424,10 +424,13 @@ void World::reset(bool restart)
     // Start music from beginning
     music_manager->stopMusic();
 
-    m_force_show_cursor = false;
-    m_ticks_since_last_mouse_movement = HIDE_CURSOR_STARTINGAT;
-    SDL_GetMouseState(&m_last_mouse_pos_x, &m_last_mouse_pos_y);
-    SDL_ShowCursor(SDL_DISABLE);
+    if (m_process_type == PT_MAIN)
+    {
+        m_force_show_cursor = false;
+        m_ticks_since_last_mouse_movement = HIDE_CURSOR_STARTINGAT;
+        SDL_GetMouseState(&m_last_mouse_pos_x, &m_last_mouse_pos_y);
+        SDL_ShowCursor(SDL_DISABLE);
+    }
 
     // Enable SFX again
     SFXManager::get()->resumeAll();
@@ -617,8 +620,11 @@ Controller* World::loadAIController(AbstractKart* kart)
 //-----------------------------------------------------------------------------
 World::~World()
 {
-    // This shouldn't be necessary, but just to be sure
-    SDL_ShowCursor(SDL_ENABLE);
+    if (m_process_type == PT_MAIN)
+    {
+        // This shouldn't be necessary, but just to be sure
+        SDL_ShowCursor(SDL_ENABLE);
+    }
 
     if (m_process_type == PT_MAIN)
     {
@@ -1021,17 +1027,21 @@ void World::updateWorld(int ticks)
     assert(m_magic_number == 0xB01D6543);
 #endif
 
-    int x, y;
-    SDL_GetMouseState(&x, &y);
-    if (m_last_mouse_pos_x != x || m_last_mouse_pos_y != y)
+    if (m_process_type == PT_MAIN)
     {
-        m_ticks_since_last_mouse_movement = 0;
-        m_last_mouse_pos_x = x;
-        m_last_mouse_pos_y = y;
-    }
+        int x, y;
+        SDL_GetMouseState(&x, &y);
+        if (m_last_mouse_pos_x != x || m_last_mouse_pos_y != y)
+        {
+            m_ticks_since_last_mouse_movement = 0;
+            m_last_mouse_pos_x = x;
+            m_last_mouse_pos_y = y;
+        }
 
-    SDL_ShowCursor((m_ticks_since_last_mouse_movement++ < HIDE_CURSOR_STARTINGAT
-                    || m_force_show_cursor) ? SDL_ENABLE : SDL_DISABLE);
+        SDL_ShowCursor((m_ticks_since_last_mouse_movement++ <
+                        HIDE_CURSOR_STARTINGAT || m_force_show_cursor) ?
+                        SDL_ENABLE : SDL_DISABLE);
+    }
 
     if (m_schedule_pause)
     {

--- a/src/modes/world.hpp
+++ b/src/modes/world.hpp
@@ -186,7 +186,7 @@ protected:
 
     int m_last_mouse_pos_x;
     int m_last_mouse_pos_y;
-    int m_ticks_since_last_mouse_movement;
+    float m_time_since_last_mouse_mvmt;
     bool m_force_show_cursor;
 
     virtual void  onGo() OVERRIDE;

--- a/src/modes/world.hpp
+++ b/src/modes/world.hpp
@@ -184,6 +184,11 @@ protected:
 
     bool m_ended_early;
 
+    int m_last_mouse_pos_x;
+    int m_last_mouse_pos_y;
+    int m_ticks_since_last_mouse_movement;
+    bool m_force_show_cursor;
+
     virtual void  onGo() OVERRIDE;
     /** Returns true if the race is over. Must be defined by all modes. */
     virtual bool  isRaceOver() = 0;


### PR DESCRIPTION
https://user-images.githubusercontent.com/66701383/233221592-f06f9031-9dcf-43d5-9d73-a173f1acae6d.mp4

The cursor will show back up whenever:
- The mouse is moved
- The game is paused
- The race finished

----------------------

This is probably not the best implementation, but it's a start.

Some things that could be improved:
- I'm currently using raw SDL_* calls in world.cpp, and I didn't #include SDL.h
- The time before the cursor disappears is stored in a macro; perhaps it could be configured

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
