### PR TITLE
Fix vk_mvk_moltenvk.h on macOS 10.12 and earlier

### DIFF
--- a/lib/graphics_engine/include/vk_mvk_moltenvk.h
+++ b/lib/graphics_engine/include/vk_mvk_moltenvk.h
@@ -26,13 +26,12 @@
 extern "C" {
 #endif	//  __cplusplus
 	
-#include <IOSurface/IOSurfaceRef.h>
-
 #ifdef __OBJC__
 #import <Metal/Metal.h>
 #else
 typedef unsigned long MTLLanguageVersion;
 typedef unsigned long MTLArgumentBuffersTier;
+typedef void *IOSurfaceRef;
 #endif
 
 


### PR DESCRIPTION
IOSurfaceRef.h does not exist on macOS 10.12 and earlier. However the `IOSurfaceRef` type will be indirectly included by the Metal include, so we just need to ensure IOSurfaceRef is defined when `__OBJC__` is not. This can be done with a typedef.

See: https://trac.macports.org/ticket/67263

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
