### PR TITLE
Add fflush(stdout) after writing to stdout with printf

### DIFF
--- a/src/utils/log.cpp
+++ b/src/utils/log.cpp
@@ -266,6 +266,7 @@ void Log::writeLine(const char *line, int level)
             CIrrDeviceiOS::debugPrint(line);
 #else
             printf("%s", line);
+            fflush(stdout);
 #endif
         }
         resetTerminalColor();  // this prints a \n


### PR DESCRIPTION
I just added one line so it flushes the stdout after writing to it.
This fixes issues where it creates a backlog of piped output (e.g. if server is running through a wrapper or any sort of piped output)
## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
