### PR TITLE
Fix start positions for negative sidewards distance

### DIFF
--- a/src/tracks/drive_graph.cpp
+++ b/src/tracks/drive_graph.cpp
@@ -411,6 +411,12 @@ void DriveGraph::setDefaultStartPositions(AlignedArray<btTransform>
     int current_node = getNode(getStartNode())->getPredecessor(0);
 
     float distance_from_start = 0.75f+forwards_distance;
+    float multiplier = 1.0f;
+    if (sidewards_distance < 0)
+    {
+        sidewards_distance = -sidewards_distance;
+        multiplier = -1.0f;
+    }
 
     // Maximum distance to left (or right) of centre line
     const float max_x_dist    = 0.5f*(karts_per_row-0.5f)*sidewards_distance;
@@ -444,7 +450,7 @@ void DriveGraph::setDefaultStartPositions(AlignedArray<btTransform>
 
             Vec3 start = dn->getUpperCenter()
                        + center_line     * distance_from_start
-                       + horizontal_line * x_pos;
+                       + horizontal_line * x_pos * multiplier;
             // Add a certain epsilon to the height in case that the
             // drivelines are beneath the track.
             (*start_transforms)[i].setOrigin(start+Vec3(0,upwards_distance,0));


### PR DESCRIPTION
When setting sidewards-distance for a track to a negative value, this commit produces an effect that the starting grid is mirrored compared to the grid of corresponding positive value.

It may be useful for the tracks where the first turn goes right. For some of them (e.g. Oliver's Math Class), the first starting position is not the best one.

As much as I'm aware, currently all existing tracks use positive sidewards distance, so this shouldn't cause side effects for them (until they are updated, or until there is a track with negative sidewards distance).

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
