### PR TITLE
Add multiple skin container & Fix #4891

### DIFF
--- a/src/guiengine/skin.cpp
+++ b/src/guiengine/skin.cpp
@@ -1119,7 +1119,7 @@ void Skin::drawProgressBarInScreen(SkinWidgetContainer* swc,
     core::recti rect2 = rect;
     rect2.LowerRightCorner.X -= (rect.getWidth())
                               - int(progress * rect.getWidth());
-    drawBoxFromStretchableTexture(swc, rect2,
+    drawBoxFromStretchableTexture(swc->m_next, rect2,
         SkinConfig::m_render_params["progress::fill"], deactivated);
 }   // drawProgress
 
@@ -1180,10 +1180,10 @@ void Skin::drawRatingBar(Widget *w, const core::recti &rect,
                                       texture_w * (step + 1), texture_h);
 
         draw2DImage(texture,
-                                            star_rect, source_area,
-                                            0 /* no clipping */,
-                                           (w->m_deactivated || ID_DEBUG) ? colors : 0,
-                                            true /* alpha */);
+                    star_rect, source_area,
+                    0 /* no clipping */,
+                    (w->m_deactivated || ID_DEBUG) ? colors : 0,
+                    true /* alpha */);
     }
 #endif
 }   // drawRatingBar

--- a/src/guiengine/skin.hpp
+++ b/src/guiengine/skin.hpp
@@ -176,6 +176,8 @@ namespace GUIEngine
 
         short m_skin_r, m_skin_g, m_skin_b;
 
+        SkinWidgetContainer *m_next;
+
         SkinWidgetContainer()
         {
             m_skin_dest_areas_inited = false;
@@ -187,7 +189,16 @@ namespace GUIEngine
             m_skin_r = -1;
             m_skin_g = -1;
             m_skin_b = -1;
+            m_next = nullptr;
         }   // SkinWidgetContainer
+
+        ~SkinWidgetContainer()
+        {
+            if (m_next != nullptr)
+            {
+                delete m_next;
+            }
+        }
     };   // class SkinWidgetContainer
 
     // ========================================================================

--- a/src/guiengine/widgets/progress_bar_widget.cpp
+++ b/src/guiengine/widgets/progress_bar_widget.cpp
@@ -32,6 +32,9 @@ using namespace irr;
 
 ProgressBarWidget::ProgressBarWidget(bool show_label) : Widget(WTYPE_PROGRESS)
 {
+    // A progress bar consists of two parts, so need two containers
+    m_next = new SkinWidgetContainer; 
+    
     m_value = 0;
     m_target_value = 0;
     m_previous_value = 0;


### PR DESCRIPTION
Issue #4891 seems like a result of using the same SkinContainer to render different parts for progress bar, so SkinContainer should be a list.