### PR TITLE
fast game starting if 1 player

### DIFF
--- a/src/network/protocols/server_lobby.cpp
+++ b/src/network/protocols/server_lobby.cpp
@@ -1594,7 +1594,15 @@ void ServerLobby::asynchronousUpdate()
         m_winner_peer_id = std::numeric_limits<uint32_t>::max();
         bool go_on_race = false;
         if (ServerConfig::m_track_voting)
-            go_on_race = handleAllVotes(&winner_vote, &m_winner_peer_id);
+        {
+            if (player_in_game == 1 && !m_peers_votes.empty())
+            {
+                winner_vote =  m_peers_votes.begin()->second;
+                go_on_race = true;  // Race starts immediately
+            }
+            else
+                go_on_race = handleAllVotes(&winner_vote, &m_winner_peer_id);
+        }
         else if (m_game_setup->isGrandPrixStarted() || isVotingOver())
         {
             winner_vote = *m_default_vote;


### PR DESCRIPTION
If there is 1 player on the server, start game immediately after the player has selected the track, and avoid extra waiting time. Helpful in servers like speedruns

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
