### PR TITLE
Improved soccer timing

### DIFF
--- a/src/modes/soccer_world.cpp
+++ b/src/modes/soccer_world.cpp
@@ -333,6 +333,7 @@ void SoccerWorld::reset(bool restart)
     }
 
     m_count_down_reached_zero = false;
+    m_goal_after_count_down_ending = false;
     m_red_scorers.clear();
     m_blue_scorers.clear();
     m_ball_hitter = -1;
@@ -563,6 +564,9 @@ void SoccerWorld::onCheckGoalTriggered(bool first_goal)
                 sd.m_time = getTime();
             m_blue_scorers.push_back(sd);
         }
+        if (RaceManager::get()->hasTimeTarget() and m_count_down_reached_zero) {
+            m_goal_after_count_down_ending = true;
+        }
         if (NetworkConfig::get()->isNetworking() &&
             NetworkConfig::get()->isServer())
         {
@@ -748,7 +752,7 @@ bool SoccerWorld::isRaceOver()
 
     if (RaceManager::get()->hasTimeTarget())
     {
-        return m_count_down_reached_zero;
+        return m_count_down_reached_zero and m_goal_after_count_down_ending;
     }
     // One team scored the target goals ...
     else

--- a/src/modes/soccer_world.cpp
+++ b/src/modes/soccer_world.cpp
@@ -390,6 +390,7 @@ void SoccerWorld::onGo()
 {
     m_ball->setEnabled(true);
     m_ball->reset();
+    WorldStatus::unpauseClockTime();
     WorldWithRank::onGo();
 }   // onGo
 
@@ -495,6 +496,7 @@ void SoccerWorld::onCheckGoalTriggered(bool first_goal)
     m_goal_sound->play();
     m_ball->reset();
     m_ball->setEnabled(false);
+    WorldStatus::pauseClockTime();
     if (m_ball_hitter != -1)
     {
         if (UserConfigParams::m_arena_ai_stats)
@@ -712,6 +714,7 @@ void SoccerWorld::resetKartsToSelfGoals()
 {
     m_ball->setEnabled(true);
     m_ball->reset();
+    WorldStatus::unpauseClockTime();
     m_bgd->resetCheckGoal(Track::getCurrentTrack());
     for (unsigned i = 0; i < m_karts.size(); i++)
     {

--- a/src/modes/soccer_world.hpp
+++ b/src/modes/soccer_world.hpp
@@ -88,6 +88,7 @@ private:
     /** Number of goals needed to win */
     int m_goal_target;
     bool m_count_down_reached_zero;
+    bool m_goal_after_count_down_ending;
 
     SFXBase *m_goal_sound;
 

--- a/src/modes/world_status.cpp
+++ b/src/modes/world_status.cpp
@@ -453,8 +453,10 @@ void WorldStatus::updateTime(int ticks)
         case CLOCK_CHRONO:
             if (m_process_type == PT_CHILD || !device->getTimer()->isStopped())
             {
-                m_time_ticks++;
-                m_time  = stk_config->ticks2Time(m_time_ticks);
+                if (!m_paused_clock_time) {
+                    m_time_ticks++;
+                    m_time  = stk_config->ticks2Time(m_time_ticks);
+                }
                 m_count_up_ticks++;
             }
             break;
@@ -472,8 +474,10 @@ void WorldStatus::updateTime(int ticks)
 
             if (m_process_type == PT_CHILD || !device->getTimer()->isStopped())
             {
-                m_time_ticks--;
-                m_time = stk_config->ticks2Time(m_time_ticks);
+                if (!m_paused_clock_time) {
+                    m_time_ticks--;
+                    m_time = stk_config->ticks2Time(m_time_ticks);
+                }
                 m_count_up_ticks++;
             }
 

--- a/src/modes/world_status.hpp
+++ b/src/modes/world_status.hpp
@@ -116,6 +116,9 @@ private:
 
     /** The clock mode: normal counting forwards, or countdown */ 
     ClockType       m_clock_mode;
+
+    /** The clock timing status : paused means time ticks are not inc/decreasing */
+    bool            m_paused_clock_time;
 protected:
     bool            m_play_track_intro_sound;
     bool            m_play_ready_set_go_sounds;
@@ -216,6 +219,11 @@ public:
     /** Will be called to notify your derived class that the clock,
      *  which is in COUNTDOWN mode, has reached zero. */
     virtual void countdownReachedZero() {};
+
+    // ------------------------------------------------------------------------
+    /** Pause/unpause the clock timing */
+    void    pauseClockTime() { m_paused_clock_time = true; }
+    void    unpauseClockTime() { m_paused_clock_time = false; }
 
     // ------------------------------------------------------------------------
     /** Called when the race actually starts. */

--- a/src/states_screens/race_gui.cpp
+++ b/src/states_screens/race_gui.cpp
@@ -442,7 +442,7 @@ void RaceGUI::drawGlobalTimer()
     {
         // This assumes only challenges have a time target
         // and don't end the race when reaching the target.
-        if (elapsed_time < 0) 
+        if (elapsed_time < 0)
         {
             sw = _("Challenge Failed"); // We just overwrite the default case
             int string_width = GUIEngine::getFont()->getDimension(sw.c_str()).Width;
@@ -450,6 +450,8 @@ void RaceGUI::drawGlobalTimer()
             time_color = video::SColor(255,255,0,0);
             use_digit_font = false;
         }
+        else if (elapsed_time == 0)
+            time_color = video::SColor(255,255,0,0);
         else if (elapsed_time <= 5)
             time_color = video::SColor(255,255,160,0);
         else if (elapsed_time <= 15)


### PR DESCRIPTION
Hi,

I like soccer in STK but I noticed few things. Here are my changes, 3 commits that you can merge or not :

1. In countdown mode, wait for the last goal scored to finish the game. It adds `m_goal_after_count_down_ending` boolean.
2. (Useful for previous commit), it shows the 00:00.000 time in red instead of orange as it was previously.
3. In both modes, but more useful for countdown, it pauses the timing when a goal is scored, and unpauses it when game is relaunched. It needs changes in `WorldStatus` so compilation might take a bit more time, but 2 or 3 minutes at all. It adds `m_paused_clock_time`, `pauseClockTime()` and `unpauseClockTime()`.

Hope you'll like it.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
