### PR TITLE
remove penalty warning from soccer mode

### DIFF
--- a/src/karts/controller/local_player_controller.cpp
+++ b/src/karts/controller/local_player_controller.cpp
@@ -324,7 +324,8 @@ void LocalPlayerController::displayPenaltyWarning()
 {
     PlayerController::displayPenaltyWarning();
     RaceGUIBase* m=World::getWorld()->getRaceGUI();
-    if (m)
+    if (m && 
+    RaceManager::get()->getMinorMode() != RaceManager::MINOR_MODE_SOCCER)
     {
         m->addMessage(_("Penalty time!!"), m_kart, 2.0f,
                       GUIEngine::getSkin()->getColor("font::top"), true /* important */,


### PR DESCRIPTION
## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```

Does it make sense to display penalty warning "Penalty time Dont accelerate before set" in soccer mode?
