### PR TITLE
Fix #3894

### DIFF
--- a/src/karts/controller/ai_base_controller.cpp
+++ b/src/karts/controller/ai_base_controller.cpp
@@ -42,7 +42,16 @@ AIBaseController::AIBaseController(AbstractKart *kart)
     m_kart_width    = m_kart->getKartWidth();
     m_ai_properties = m_kart->getKartProperties()
                             ->getAIPropertiesForDifficulty();
+
+    m_wee_sound    = SFXManager::get()->createSoundSource("wee");
 }   // AIBaseController
+
+//-----------------------------------------------------------------------------
+/** Destructor for AI kart
+ */
+AIBaseController::~AIBaseController(){
+    m_wee_sound->deleteSFX();
+}
 
 //-----------------------------------------------------------------------------
 
@@ -224,6 +233,23 @@ bool AIBaseController::disableSlipstreamBonus() const
     return m_ai_properties->disableSlipstreamUsage();
 }   // disableSlipstreamBonus
 
+//-----------------------------------------------------------------------------
+/** Called when a kart hits or uses a zipper.
+ */
+void AIBaseController::handleZipper(bool play_sound)
+{
+    m_kart->showZipperFire();
+
+    // Only play a zipper sound if it's not already playing, and
+    // if the material has changed (to avoid machine gun effect
+    // on conveyor belt zippers).
+    if (play_sound || (m_wee_sound->getStatus() != SFXBase::SFX_PLAYING &&
+                       m_kart->getMaterial()!=m_kart->getLastMaterial()      ) )
+    {
+        m_wee_sound->setPosition(m_kart->getXYZ());
+        m_wee_sound->play();
+    }
+}
 //-----------------------------------------------------------------------------
 /** This is called when the kart crashed with the terrain. This subroutine
  *  tries to detect if the AI is stuck by determining if a certain number

--- a/src/karts/controller/ai_base_controller.hpp
+++ b/src/karts/controller/ai_base_controller.hpp
@@ -21,10 +21,19 @@
 
 #include "karts/controller/controller.hpp"
 #include "utils/cpp2011.hpp"
+#include "audio/sfx_base.hpp"
 
 class AIProperties;
 class Track;
 class Vec3;
+class SFXBuffer;
+class SFXBase; 
+// SFXBase is required to properly play the zipper sound.
+// There should be a better way to do this after restructuring
+// the class hierarchy. Currently handleZipper() is duplicated
+// and separately overriden for AIBaseController and
+// PlayerController
+
 
 /** A base class for all AI karts. This class basically provides some
  *  common low level functions.
@@ -41,6 +50,8 @@ private:
     /** A flag that is set during the physics processing to indicate that
     *  this kart is stuck and needs to be rescued. */
     bool m_stuck;
+
+    SFXBase     *m_wee_sound;
 
 protected:
     bool m_enabled_network_ai;
@@ -83,7 +94,7 @@ protected:
 
 public:
              AIBaseController(AbstractKart *kart);
-    virtual ~AIBaseController() {};
+    virtual ~AIBaseController();
     virtual void reset() OVERRIDE;
     virtual bool disableSlipstreamBonus() const OVERRIDE;
     virtual void crashed(const Material *m) OVERRIDE;
@@ -91,7 +102,7 @@ public:
     static  void setTestAI(int n) {m_test_ai = n; }
     static  int  getTestAI() { return m_test_ai; }
     virtual void crashed(const AbstractKart *k) OVERRIDE {};
-    virtual void handleZipper(bool play_sound) OVERRIDE {};
+    virtual void handleZipper(bool play_sound) OVERRIDE;
     virtual void finishedRace(float time) OVERRIDE {};
     virtual void collectedItem(const ItemState &item,
                                float previous_energy=0) OVERRIDE {};

--- a/src/karts/controller/local_player_controller.cpp
+++ b/src/karts/controller/local_player_controller.cpp
@@ -386,6 +386,7 @@ void LocalPlayerController::handleZipper(bool play_sound)
     if (play_sound || (m_wee_sound->getStatus() != SFXBase::SFX_PLAYING &&
                        m_kart->getMaterial()!=m_kart->getLastMaterial()      ) )
     {
+        m_wee_sound->setPosition(m_kart->getXYZ());
         m_wee_sound->play();
     }
 

--- a/src/karts/controller/local_player_controller.cpp
+++ b/src/karts/controller/local_player_controller.cpp
@@ -84,7 +84,6 @@ LocalPlayerController::LocalPlayerController(AbstractKart *kart,
         m_camera_index = camera->getIndex();
     }
 
-    m_wee_sound    = SFXManager::get()->createSoundSource("wee");
     m_bzzt_sound   = SFXManager::get()->getBuffer("bzzt");
     m_ugh_sound    = SFXManager::get()->getBuffer("ugh");
     m_grab_sound   = SFXManager::get()->getBuffer("grab_collectable");
@@ -100,7 +99,7 @@ LocalPlayerController::LocalPlayerController(AbstractKart *kart,
  */
 LocalPlayerController::~LocalPlayerController()
 {
-    m_wee_sound->deleteSFX();
+
 }   // ~LocalPlayerController
 
 //-----------------------------------------------------------------------------
@@ -380,16 +379,6 @@ void LocalPlayerController::handleZipper(bool play_sound)
 {
     PlayerController::handleZipper(play_sound);
 
-    // Only play a zipper sound if it's not already playing, and
-    // if the material has changed (to avoid machine gun effect
-    // on conveyor belt zippers).
-    if (play_sound || (m_wee_sound->getStatus() != SFXBase::SFX_PLAYING &&
-                       m_kart->getMaterial()!=m_kart->getLastMaterial()      ) )
-    {
-        m_wee_sound->setPosition(m_kart->getXYZ());
-        m_wee_sound->play();
-    }
-
 #ifndef SERVER_ONLY
     // Apply the motion blur according to the speed of the kart
     if (!GUIEngine::isNoGraphics())
@@ -397,6 +386,7 @@ void LocalPlayerController::handleZipper(bool play_sound)
 #endif
 
 }   // handleZipper
+
 
 //-----------------------------------------------------------------------------
 /** Called when a kart hits an item. It plays certain sfx (e.g. nitro full,

--- a/src/karts/controller/local_player_controller.hpp
+++ b/src/karts/controller/local_player_controller.hpp
@@ -26,7 +26,6 @@
 
 class AbstractKart;
 class ParticleEmitter;
-class SFXBase;
 class SFXBuffer;
 class btTransform;
 
@@ -56,7 +55,6 @@ private:
 
     HandicapLevel m_handicap;
 
-    SFXBase     *m_wee_sound;
     SFXBuffer   *m_bzzt_sound;
     SFXBuffer   *m_ugh_sound;
     SFXBuffer   *m_grab_sound;

--- a/src/karts/controller/network_player_controller.hpp
+++ b/src/karts/controller/network_player_controller.hpp
@@ -25,21 +25,16 @@ class Player;
 
 class NetworkPlayerController : public PlayerController
 {
-private:
-    SFXBase     *m_wee_sound;
-
 public:
     NetworkPlayerController(AbstractKart *kart) : PlayerController(kart)
     {
-        m_wee_sound    = SFXManager::get()->createSoundSource("wee");
         Log::info("NetworkPlayerController",
                   "New network player controller.");
     }   // NetworkPlayerController
     // ------------------------------------------------------------------------
-    ~NetworkPlayerController()
-    {
-        m_wee_sound->deleteSFX();
-    }   // ~NetworkPlayerController
+    virtual ~NetworkPlayerController(){
+    
+    } // ~NetworkPlayerController
     // ------------------------------------------------------------------------
     virtual bool canGetAchievements() const OVERRIDE          { return false; }
     // ------------------------------------------------------------------------
@@ -49,22 +44,6 @@ public:
     {
         return false; 
     }   // isLocal
-    // ------------------------------------------------------------------------
-    /** Called when a kart hits or uses a zipper. */
-    virtual void handleZipper      (bool play_sound) OVERRIDE
-    {
-        PlayerController::handleZipper(play_sound);
-        // Only play a zipper sound if it's not already playing, and
-        // if the material has changed (to avoid machine gun effect
-        // on conveyor belt zippers).
-        if (play_sound || (m_wee_sound->getStatus() != SFXBase::SFX_PLAYING &&
-                           m_kart->getMaterial()!=m_kart->getLastMaterial()))
-        {
-            m_wee_sound->setPosition(m_kart->getXYZ());
-            m_wee_sound->play();
-        }
-       // There is probably no need to apply graphical effects for a network player
-    }
     // ------------------------------------------------------------------------
     /** Update for network controller. For player with a high ping it is
      *  useful to reduce shaking by reducing the steering somewhat in each

--- a/src/karts/controller/network_player_controller.hpp
+++ b/src/karts/controller/network_player_controller.hpp
@@ -25,15 +25,20 @@ class Player;
 
 class NetworkPlayerController : public PlayerController
 {
+private:
+    SFXBase     *m_wee_sound;
+
 public:
     NetworkPlayerController(AbstractKart *kart) : PlayerController(kart)
     {
+        m_wee_sound    = SFXManager::get()->createSoundSource("wee");
         Log::info("NetworkPlayerController",
                   "New network player controller.");
     }   // NetworkPlayerController
     // ------------------------------------------------------------------------
-    virtual ~NetworkPlayerController()
+    ~NetworkPlayerController()
     {
+        m_wee_sound->deleteSFX();
     }   // ~NetworkPlayerController
     // ------------------------------------------------------------------------
     virtual bool canGetAchievements() const OVERRIDE          { return false; }
@@ -44,6 +49,22 @@ public:
     {
         return false; 
     }   // isLocal
+    // ------------------------------------------------------------------------
+    /** Called when a kart hits or uses a zipper. */
+    virtual void handleZipper      (bool play_sound) OVERRIDE
+    {
+        PlayerController::handleZipper(play_sound);
+        // Only play a zipper sound if it's not already playing, and
+        // if the material has changed (to avoid machine gun effect
+        // on conveyor belt zippers).
+        if (play_sound || (m_wee_sound->getStatus() != SFXBase::SFX_PLAYING &&
+                           m_kart->getMaterial()!=m_kart->getLastMaterial()))
+        {
+            m_wee_sound->setPosition(m_kart->getXYZ());
+            m_wee_sound->play();
+        }
+       // There is probably no need to apply graphical effects for a network player
+    }
     // ------------------------------------------------------------------------
     /** Update for network controller. For player with a high ping it is
      *  useful to reduce shaking by reducing the steering somewhat in each

--- a/src/karts/controller/player_controller.cpp
+++ b/src/karts/controller/player_controller.cpp
@@ -41,11 +41,13 @@
 #include "utils/string_utils.hpp"
 #include "utils/translation.hpp"
 
+
 #include <cstdlib>
 
 PlayerController::PlayerController(AbstractKart *kart)
                 : Controller(kart)
 {
+    m_wee_sound    = SFXManager::get()->createSoundSource("wee");
     m_penalty_ticks = 0;
 }   // PlayerController
 
@@ -54,6 +56,7 @@ PlayerController::PlayerController(AbstractKart *kart)
  */
 PlayerController::~PlayerController()
 {
+    m_wee_sound->deleteSFX();
 }   // ~PlayerController
 
 //-----------------------------------------------------------------------------
@@ -313,6 +316,24 @@ void PlayerController::steer(int ticks, int steer_val)
 }   // steer
 
 //-----------------------------------------------------------------------------
+/** Called when a kart hits or uses a zipper.
+ */
+void PlayerController::handleZipper(bool play_sound)
+{
+    m_kart->showZipperFire();
+
+    // Only play a zipper sound if it's not already playing, and
+    // if the material has changed (to avoid machine gun effect
+    // on conveyor belt zippers).
+    if (play_sound || (m_wee_sound->getStatus() != SFXBase::SFX_PLAYING &&
+                       m_kart->getMaterial()!=m_kart->getLastMaterial()      ) )
+    {
+        m_wee_sound->setPosition(m_kart->getXYZ());
+        m_wee_sound->play();
+    }
+}
+
+//-----------------------------------------------------------------------------
 /** Callback when the skidding bonus is triggered. The player controller
  *  resets the current steering to 0, which makes the kart easier to control.
  */
@@ -364,14 +385,6 @@ void PlayerController::update(int ticks)
         m_controls->setRescue(false);
     }
 }   // update
-
-//-----------------------------------------------------------------------------
-/** Called when a kart hits or uses a zipper.
- */
-void PlayerController::handleZipper(bool play_sound)
-{
-    m_kart->showZipperFire();
-}   // handleZipper
 
 //-----------------------------------------------------------------------------
 bool PlayerController::saveState(BareNetworkString *buffer) const

--- a/src/karts/controller/player_controller.hpp
+++ b/src/karts/controller/player_controller.hpp
@@ -20,13 +20,23 @@
 #define HEADER_PLAYER_CONTROLLER_HPP
 
 #include "karts/controller/controller.hpp"
+#include "audio/sfx_base.hpp"
 
 class AbstractKart;
 class Player;
+class SFXBuffer;
+class SFXBase; 
+// SFXBase is required to properly play the zipper sound.
+// There should be a better way to do this after restructuring
+// the class hierarchy. Currently handleZipper() is duplicated
+// and separately overriden for AIBaseController and
+// PlayerController
 
 class PlayerController : public Controller
 {
 friend class KartRewinder;
+private:
+    SFXBase     *m_wee_sound;
 protected:
     int            m_steer_val, m_steer_val_l, m_steer_val_r;
     uint16_t       m_prev_accel;


### PR DESCRIPTION
## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
Make the zipper sound positional. Make network racers zipper sound be played.
This probably requires the corresponding stk-assets sfx.xml edit to be pushed
to work properly.