### PR TITLE
Update bowling.cpp

### DIFF
--- a/src/items/bowling.cpp
+++ b/src/items/bowling.cpp
@@ -209,7 +209,7 @@ void Bowling::onFireFlyable()
     if( m_owner->getControls().getLookBack())
     {
         y_offset   = -y_offset;
-        m_speed    = -m_speed*2;
+        m_speed = m_owner->getSpeed() < 0 ? -m_speed*4 : -m_speed*2;
     }
     else
     {


### PR DESCRIPTION
When firing backwards, multiply bowling speed by 4 if kart is moving backwards so the player doesn't catch up with the ball, and multiply by 2 otherwise  (useful in soccer).

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
