### PR TITLE
Fix #4984 & #4995

### DIFF
--- a/data/shaders/utils/decodeNormal.frag
+++ b/data/shaders/utils/decodeNormal.frag
@@ -1,7 +1,9 @@
-
 vec3 DecodeNormal(vec2 n)
 {
-  float z = dot(n, n) * 2. - 1.;
-  vec2 xy = normalize(n) * sqrt(1. - z * z);
-  return vec3(xy,z);
+    n = n * 2.0 - 1.0;
+    vec3 ret = vec3(n.x, n.y, 1.0 - abs(n.x) - abs(n.y));
+    float t = max(-ret.z, 0.0);
+    ret.x += ret.x >= 0.0 ? -t : t;
+    ret.y += ret.y >= 0.0 ? -t : t;
+    return normalize(ret);
 }

--- a/data/shaders/utils/encode_normal.frag
+++ b/data/shaders/utils/encode_normal.frag
@@ -1,5 +1,17 @@
-// from Crytek "a bit more deferred CryEngine"
+// Octahedron Normal Vector 
+
+vec2 OctWrap(vec2 v)
+{
+    vec2 w = 1.0 - abs( v.yx );
+    if (v.x < 0.0) w.x = -w.x;
+    if (v.y < 0.0) w.y = -w.y;
+    return w;
+}
+
 vec2 EncodeNormal(vec3 n)
 {
-    return normalize(n.xy) * sqrt(n.z * 0.5 + 0.5);
+    n /= (abs(n.x) + abs(n.y) + abs(n.z));
+    n.xy = n.z >= 0.0 ? n.xy : OctWrap(n.xy);
+    n.xy = n.xy * 0.5 + 0.5;
+    return n.xy;
 }


### PR DESCRIPTION
Changing normal encoding into https://knarkowicz.wordpress.com/2014/04/16/octahedron-normal-vector-encoding/
## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
