### PR TITLE
Fixes for handleAllVotes

### DIFF
--- a/src/network/protocols/server_lobby.cpp
+++ b/src/network/protocols/server_lobby.cpp
@@ -4358,9 +4358,11 @@ bool ServerLobby::handleAllVotes(PeerVote* winner_vote,
         }
         if (it == m_peers_votes.end())
         {
+            // Don't end if no vote matches all majority choices
             Log::warn("ServerLobby",
                 "Missing track %s from majority.", top_track.c_str());
             it = m_peers_votes.begin();
+            return false;
         }
         *winner_peer_id = it->first;
         *winner_vote = it->second;

--- a/src/network/protocols/server_lobby.cpp
+++ b/src/network/protocols/server_lobby.cpp
@@ -4308,7 +4308,7 @@ bool ServerLobby::handleAllVotes(PeerVote* winner_vote,
     }
 
     std::string top_track = m_default_vote->m_track_name;
-    int top_laps = m_default_vote->m_num_laps;
+    unsigned top_laps = m_default_vote->m_num_laps;
     bool top_reverse = m_default_vote->m_reverse;
 
     std::map<std::string, unsigned> tracks;
@@ -4319,7 +4319,6 @@ bool ServerLobby::handleAllVotes(PeerVote* winner_vote,
     float tracks_rate = 0.0f;
     float laps_rate = 0.0f;
     float reverses_rate = 0.0f;
-    RandomGenerator rg;
 
     for (auto& p : m_peers_votes)
     {
@@ -4340,57 +4339,9 @@ bool ServerLobby::handleAllVotes(PeerVote* winner_vote,
             reverse_vote->second++;
     }
 
-    unsigned vote = 0;
-    auto track_vote = tracks.begin();
-    // rg.get(2) == 0 will allow not always the "less" in map get picked
-    for (auto c_vote = tracks.begin(); c_vote != tracks.end(); c_vote++)
-    {
-        if (c_vote->second > vote ||
-            (c_vote->second >= vote && rg.get(2) == 0))
-        {
-            vote = c_vote->second;
-            track_vote = c_vote;
-        }
-    }
-    if (track_vote != tracks.end())
-    {
-        top_track = track_vote->first;
-        tracks_rate = float(track_vote->second) / cur_players;
-    }
-
-    vote = 0;
-    auto lap_vote = laps.begin();
-    for (auto c_vote = laps.begin(); c_vote != laps.end(); c_vote++)
-    {
-        if (c_vote->second > vote ||
-            (c_vote->second >= vote && rg.get(2) == 0))
-        {
-            vote = c_vote->second;
-            lap_vote = c_vote;
-        }
-    }
-    if (lap_vote != laps.end())
-    {
-        top_laps = lap_vote->first;
-        laps_rate = float(lap_vote->second) / cur_players;
-    }
-
-    vote = 0;
-    auto reverse_vote = reverses.begin();
-    for (auto c_vote = reverses.begin(); c_vote != reverses.end(); c_vote++)
-    {
-        if (c_vote->second > vote ||
-            (c_vote->second >= vote && rg.get(2) == 0))
-        {
-            vote = c_vote->second;
-            reverse_vote = c_vote;
-        }
-    }
-    if (reverse_vote != reverses.end())
-    {
-        top_reverse = reverse_vote->first;
-        reverses_rate = float(reverse_vote->second) / cur_players;
-    }
+    findMajorityValue<std::string>(tracks, cur_players, &top_track, &tracks_rate);
+    findMajorityValue<unsigned>(laps, cur_players, &top_laps, &laps_rate);
+    findMajorityValue<bool>(reverses, cur_players, &top_reverse, &reverses_rate);
 
     // End early if there is majority agreement which is all entries rate > 0.5
     it = m_peers_votes.begin();
@@ -4424,10 +4375,10 @@ bool ServerLobby::handleAllVotes(PeerVote* winner_vote,
         while (it != m_peers_votes.end())
         {
             if (it->second.m_track_name == top_track &&
-                std::abs((int)it->second.m_num_laps - top_laps) < diff)
+                std::abs((int)it->second.m_num_laps - (int)top_laps) < diff)
             {
                 closest_lap = it;
-                diff = std::abs((int)it->second.m_num_laps - top_laps);
+                diff = std::abs((int)it->second.m_num_laps - (int)top_laps);
             }
             else
                 it++;
@@ -4438,6 +4389,42 @@ bool ServerLobby::handleAllVotes(PeerVote* winner_vote,
     }
     return false;
 }   // handleAllVotes
+
+// ----------------------------------------------------------------------------
+template<typename T>
+void ServerLobby::findMajorityValue(const std::map<T, unsigned>& choices, unsigned cur_players,
+                       T* best_choice, float* rate)
+{
+    RandomGenerator rg;
+    unsigned max_votes = 0;
+    auto best_iter = choices.begin();
+    unsigned best_iters_count = 1;
+    // Among choices with max votes, we need to pick one uniformly,
+    // thus we have to keep track of their number
+    for (auto iter = choices.begin(); iter != choices.end(); iter++)
+    {
+        if (iter->second > max_votes)
+        {
+            max_votes = iter->second;
+            best_iter = iter;
+            best_iters_count = 1;
+        }
+        else if (iter->second == max_votes)
+        {
+            best_iters_count++;
+            if (rg.get(best_iters_count) == 0)
+            {
+                max_votes = iter->second;
+                best_iter = iter;
+            }
+        }
+    }
+    if (best_iter != choices.end())
+    {
+        *best_choice = best_iter->first;
+        *rate = float(best_iter->second) / cur_players;
+    }
+}   // findMajorityValue
 
 // ----------------------------------------------------------------------------
 void ServerLobby::getHitCaptureLimit()

--- a/src/network/protocols/server_lobby.cpp
+++ b/src/network/protocols/server_lobby.cpp
@@ -4362,13 +4362,14 @@ bool ServerLobby::handleAllVotes(PeerVote* winner_vote,
             Log::warn("ServerLobby",
                 "Missing track %s from majority.", top_track.c_str());
             it = m_peers_votes.begin();
-            return false;
+            if (!isVotingOver())
+                return false;
         }
         *winner_peer_id = it->first;
         *winner_vote = it->second;
         return true;
     }
-    else if (isVotingOver())
+    if (isVotingOver())
     {
         // Pick the best lap (or soccer goal / time) from only the top track
         // if no majority agreement from all

--- a/src/network/protocols/server_lobby.hpp
+++ b/src/network/protocols/server_lobby.hpp
@@ -330,6 +330,9 @@ private:
                                   const irr::core::stringw& online_name,
                                   const std::string& country_code);
     bool handleAllVotes(PeerVote* winner, uint32_t* winner_peer_id);
+    template<typename T>
+    void findMajorityValue(const std::map<T, unsigned>& choices, unsigned cur_players,
+                           T* best_choice, float* rate);
     void getRankingForPlayer(std::shared_ptr<NetworkPlayerProfile> p);
     void submitRankingsToAddons();
     void computeNewRankings();


### PR DESCRIPTION
This fixes the following issues related to voting for a map in the server lobby:

1. When several maps have the same number of votes, the code currently iterates over them and picks the next one with probability $\frac{1}{2}$, so if there are $n$ different votes, $i$-th of them is chosen with probability $2^{\max(i, 2)} / 2^{n + 1}$. This PR changes all probabilities to $\frac{1}{n}$.
2. When the majority exists for maps, for lap counts, and for directions, but there's no vote with exactly the same map, lap count, and direction, the first vote (that is, the vote of players with smallest host id?) was picked instead. This PR postpones the decision until the voting is over.

I also tried to get rid of repeated code, thus moved it to another function.


## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```