### PR TITLE
Avoid giving bomb to team mate

### DIFF
--- a/src/items/attachment.cpp
+++ b/src/items/attachment.cpp
@@ -400,7 +400,8 @@ void Attachment::hitBanana(ItemState *item_state)
  */
 void Attachment::handleCollisionWithKart(AbstractKart *other)
 {
-    Attachment *attachment_other=other->getAttachment();
+    Attachment *attachment_other = other->getAttachment();
+    const World*  world          = World::getWorld();
 
     if(getType()==Attachment::ATTACH_BOMB)
     {
@@ -410,6 +411,13 @@ void Attachment::handleCollisionWithKart(AbstractKart *other)
             other->decreaseShieldTime();
             return;
         }
+
+        // Don't hit teammates in team world
+        if (world->hasTeam() &&
+            world->getKartTeam(other->getWorldKartId()) ==
+            world->getKartTeam(m_kart->getWorldKartId()))
+            return;
+
         // If both karts have a bomb, explode them immediately:
         if(attachment_other->getType()==Attachment::ATTACH_BOMB)
         {
@@ -420,7 +428,7 @@ void Attachment::handleCollisionWithKart(AbstractKart *other)
         {
             // if there are only two karts, let them switch bomb from one to other
             if (getPreviousOwner() != other ||
-                World::getWorld()->getNumKarts() <= 2)
+                world->getNumKarts() <= 2)
             {
                 // Don't move if this bomb was from other kart originally
                 other->getAttachment()
@@ -435,7 +443,7 @@ void Attachment::handleCollisionWithKart(AbstractKart *other)
     }   // type==BOMB
     else if(attachment_other->getType()==Attachment::ATTACH_BOMB &&
              (attachment_other->getPreviousOwner()!=m_kart || 
-               World::getWorld()->getNumKarts() <= 2         )      )
+               world->getNumKarts() <= 2         )      )
     {
         // Don't attach a bomb when the kart is shielded
         if(m_kart->isShielded())


### PR DESCRIPTION
This pull request avoid a thing I noticed in football mode, that you can give your bomb to your teammate. <ins>But maybe this is intended, so not sure</ins> (however I did not find anything relevant).

I just copy-pasted the code from the swatter.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
