### PR TITLE
Fix exit crash when built for GLES2 on Linux

### DIFF
--- a/lib/irrlicht/source/Irrlicht/CIrrDeviceSDL.cpp
+++ b/lib/irrlicht/source/Irrlicht/CIrrDeviceSDL.cpp
@@ -18,6 +18,7 @@
 #include <stdlib.h>
 #include "SIrrCreationParameters.h"
 #include "COpenGLExtensionHandler.h"
+#include "COGLES2Driver.h"
 
 #include "guiengine/engine.hpp"
 #include "ge_main.hpp"
@@ -240,6 +241,12 @@ CIrrDeviceSDL::~CIrrDeviceSDL()
 		irr::video::COpenGLExtensionHandler* h = dynamic_cast<irr::video::COpenGLExtensionHandler*>(VideoDriver);
 		if (h)
 			h->clearGLExtensions();
+#endif
+#ifdef _IRR_COMPILE_WITH_OGLES2_
+		irr::video::COGLES2Driver* es2 = dynamic_cast<irr::video::COGLES2Driver*>(VideoDriver);
+		if (es2) {
+			es2->cleanUp();
+		}
 #endif
 		GE::GEVulkanDriver* gevk = dynamic_cast<GE::GEVulkanDriver*>(VideoDriver);
 		if (gevk)

--- a/lib/irrlicht/source/Irrlicht/COGLES2Driver.cpp
+++ b/lib/irrlicht/source/Irrlicht/COGLES2Driver.cpp
@@ -122,9 +122,7 @@ namespace video
 	//! destructor
 	COGLES2Driver::~COGLES2Driver()
 	{
-		deleteMaterialRenders();
-		delete MaterialRenderer2D;
-		deleteAllTextures();
+		cleanUp();
 
 		if (BridgeCalls)
 			delete BridgeCalls;

--- a/lib/irrlicht/source/Irrlicht/COGLES2Driver.h
+++ b/lib/irrlicht/source/Irrlicht/COGLES2Driver.h
@@ -48,6 +48,7 @@ namespace irr
 #include "EDriverFeatures.h"
 #include "fast_atof.h"
 #include "COGLES2ExtensionHandler.h"
+#include "COGLES2Renderer2D.h"
 
 class ContextManagerEGL;
 
@@ -396,6 +397,15 @@ namespace video
 #if defined(_IRR_COMPILE_WITH_EGL_)
 		ContextManagerEGL* getEGLContext() {return EglContext;}
 #endif
+
+		void cleanUp() {
+			deleteMaterialRenders();
+			if (MaterialRenderer2D) {
+				delete MaterialRenderer2D;
+				MaterialRenderer2D = NULL;
+			}
+			deleteAllTextures();
+		}
 
 	private:
 		// Bridge calls.


### PR DESCRIPTION
## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
This commit tries to fix the exit/resolution-change crash due to GLES functions being cleaned up before being called to release GLES resources.