### PR TITLE
Fix #5116

### DIFF
--- a/src/graphics/explosion.hpp
+++ b/src/graphics/explosion.hpp
@@ -32,7 +32,10 @@ using namespace irr;
 
 class Vec3;
 class SFXBase;
+
+#ifndef SERVER_ONLY
 class ParticleEmitter;
+#endif
 
 /**
   * \ingroup graphics
@@ -42,7 +45,11 @@ class Explosion : public HitSFX
 private:
     int              m_remaining_ticks;
     int              m_emission_frames;
+
+#ifndef SERVER_ONLY
     ParticleEmitter* m_emitter;
+#endif
+
     int              m_explosion_ticks;
 
 

--- a/src/graphics/particle_emitter.hpp
+++ b/src/graphics/particle_emitter.hpp
@@ -16,6 +16,8 @@
 //  along with this program; if not, write to the Free Software
 //  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
+#ifndef SERVER_ONLY
+
 #ifndef HEADER_SMOKE_HPP
 #define HEADER_SMOKE_HPP
 
@@ -100,6 +102,8 @@ public:
 
     bool         randomizeInitialY() const { return m_randomize_initial_y; }
 };
-#endif
+#endif // HEADER_SMOKE_HPP
+
+#endif // !SERVER_ONLY
 
 

--- a/src/karts/controller/local_player_controller.cpp
+++ b/src/karts/controller/local_player_controller.cpp
@@ -107,9 +107,9 @@ LocalPlayerController::~LocalPlayerController()
 void LocalPlayerController::initParticleEmitter()
 {
     // Attach Particle System
+#ifndef SERVER_ONLY
     m_sky_particles_emitter = nullptr;
     Track *track = Track::getCurrentTrack();
-#ifndef SERVER_ONLY
     if (!GUIEngine::isNoGraphics() &&
         UserConfigParams::m_particles_effects > 1 &&
         track->getSkyParticles() != NULL)

--- a/src/karts/controller/local_player_controller.hpp
+++ b/src/karts/controller/local_player_controller.hpp
@@ -25,10 +25,13 @@
 #include <memory>
 
 class AbstractKart;
-class ParticleEmitter;
 class SFXBase;
 class SFXBuffer;
 class btTransform;
+
+#ifndef SERVER_ONLY
+class ParticleEmitter;
+#endif
 
 /** PlayerKart manages control events from the player and moves
   * them to the Kart
@@ -46,7 +49,9 @@ private:
     bool           m_has_started;
     bool           m_is_above_nitro_target;
 
+#ifndef SERVER_ONLY
     std::unique_ptr<ParticleEmitter> m_sky_particles_emitter;
+#endif
 
     /** The index of the camera attached to the kart for this controller. The
      *  camera object is managed in the Camera class, so no need to free it. */

--- a/src/karts/kart.cpp
+++ b/src/karts/kart.cpp
@@ -127,7 +127,9 @@ Kart::Kart (const std::string& ident, unsigned int world_kart_id,
     m_initial_position     = position;
     m_race_result          = false;
     m_wheel_box            = NULL;
+#ifndef SERVER_ONLY
     m_collision_particles  = NULL;
+#endif
     m_controller           = NULL;
     m_saved_controller     = NULL;
     m_consumption_per_tick = stk_config->ticks2Time(1) *
@@ -283,7 +285,9 @@ Kart::~Kart()
     m_nitro_sound ->deleteSFX();
     if(m_terrain_sound)          m_terrain_sound->deleteSFX();
     if(m_previous_terrain_sound) m_previous_terrain_sound->deleteSFX();
+#ifndef SERVER_ONLY
     if(m_collision_particles)    delete m_collision_particles;
+#endif
 
     if (m_wheel_box) m_wheel_box->remove();
 
@@ -3283,7 +3287,10 @@ void Kart::updateGraphics(float dt)
     // Update particle effects (creation rate, and emitter size
     // depending on speed)
     m_kart_gfx->update(dt);
+
+#ifndef SERVER_ONLY
     if (m_collision_particles) m_collision_particles->update(dt);
+#endif
 
     // --------------------------------------------------------
     float nitro_frac = 0;

--- a/src/karts/kart.hpp
+++ b/src/karts/kart.hpp
@@ -46,7 +46,6 @@ class ItemState;
 class KartGFX;
 class KartRewinder;
 class MaxSpeed;
-class ParticleEmitter;
 class ParticleKind;
 class SFXBase;
 class Shadow;
@@ -55,6 +54,10 @@ class SkidMarks;
 class SlipStream;
 class Stars;
 class TerrainInfo;
+
+#ifndef SERVER_ONLY
+class ParticleEmitter;
+#endif
 
 /** The main kart class. All type of karts are of this object, but with
  *  different controllers. The controllers are what turn a kart into a
@@ -155,8 +158,10 @@ protected:
     };
     std::unique_ptr<btCompoundShape, btCompoundShapeDeleter> m_kart_chassis;
 
+#ifndef SERVER_ONLY
     /** For collisions */
     ParticleEmitter *m_collision_particles;
+#endif
 
     /** The main controller of this object, used for driving. This
      *  controller is used to run the kart. It will be replaced

--- a/src/karts/kart_gfx.cpp
+++ b/src/karts/kart_gfx.cpp
@@ -128,8 +128,10 @@ KartGFX::KartGFX(const AbstractKart *kart, bool is_day)
     }
     else
     {
+#ifndef SERVER_ONLY
         m_all_emitters.push_back(NULL);
         m_all_emitters.push_back(NULL);
+#endif
     }
 
 }   // KartGFX
@@ -139,13 +141,13 @@ KartGFX::KartGFX(const AbstractKart *kart, bool is_day)
  */
 KartGFX::~KartGFX()
 {
+#ifndef SERVER_ONLY
     for(unsigned int i=0; i<KGFX_COUNT; i++)
     {
         if(m_all_emitters[i])
             delete m_all_emitters[i];
     }   // for i < KGFX_COUNT
 
-#ifndef SERVER_ONLY    
     if (!GUIEngine::isNoGraphics() && CVS->isGLSL())
     {
         m_nitro_light->drop();
@@ -221,8 +223,6 @@ void KartGFX::addEffect(KartGFXType type, const std::string &file_name,
         m_skid_kind1 = kind;
     else if (type==KGFX_SKID2L || type==KGFX_SKID2R)
         m_skid_kind2 = kind;
-#else
-    m_all_emitters.push_back(NULL);
 #endif
 }   // addEffect
 
@@ -442,11 +442,13 @@ void KartGFX::update(float dt)
 {
     m_wheel_toggle = 1 - m_wheel_toggle;
 
+#ifndef SERVER_ONLY
     for (unsigned int i = 0; i < m_all_emitters.size(); i++)
     {
         if (m_all_emitters[i])
             m_all_emitters[i]->update(dt);
     }
+#endif
 
 }  // update
 

--- a/src/karts/kart_gfx.hpp
+++ b/src/karts/kart_gfx.hpp
@@ -26,9 +26,12 @@
 #include <string>
 
 class AbstractKart;
-class ParticleEmitter;
 class ParticleKind;
 class Vec3;
+
+#ifndef SERVER_ONLY
+class ParticleEmitter;
+#endif
 
 namespace irr {
     namespace scene {
@@ -73,8 +76,10 @@ private:
     /** The particle kind for skidding bonus level 2. */
     const ParticleKind *m_skid_kind2;
 
+#ifndef SERVER_ONLY
     /** Vector of all particle emitters. */
     std::vector<ParticleEmitter*> m_all_emitters;
+#endif
 
     /** Pointer to the owner of this kart. */
     const AbstractKart *m_kart;

--- a/src/tracks/track.hpp
+++ b/src/tracks/track.hpp
@@ -65,7 +65,6 @@ class ItemManager;
 class ModelDefinitionLoader;
 class MovingTexture;
 class MusicInformation;
-class ParticleEmitter;
 class ParticleKind;
 class PhysicalObject;
 class RenderTarget;

--- a/src/tracks/track_object_presentation.cpp
+++ b/src/tracks/track_object_presentation.cpp
@@ -476,12 +476,12 @@ TrackObjectPresentationMesh::TrackObjectPresentationMesh(
     m_node         = NULL;
     m_is_in_skybox = false;
     m_render_info  = NULL;
-    bool animated  = (UserConfigParams::m_particles_effects > 1 ||
-                      World::getWorld()->getIdent() == IDENT_CUTSCENE);
 
     m_model_file = model_file;
     file_manager->pushTextureSearchPath(StringUtils::getPath(model_file), "");
 #ifndef SERVER_ONLY
+    bool animated  = (UserConfigParams::m_particles_effects > 1 ||
+                      World::getWorld()->getIdent() == IDENT_CUTSCENE);
     if (file_manager->fileExists(model_file))
     {
         if (animated)
@@ -879,7 +879,9 @@ TrackObjectPresentationParticles::TrackObjectPresentationParticles(
         m_init_hpr.Z = 0;
     }
 
+#ifndef SERVER_ONLY
     m_emitter = NULL;
+#endif
     m_lod_emitter_node = NULL;
     std::string path;
     xml_node.get("kind", &path);
@@ -937,6 +939,7 @@ TrackObjectPresentationParticles::TrackObjectPresentationParticles(
 // ----------------------------------------------------------------------------
 TrackObjectPresentationParticles::~TrackObjectPresentationParticles()
 {
+#ifndef SERVER_ONLY
     if (m_emitter)
     {
         if (m_lod_emitter_node != NULL)
@@ -946,15 +949,18 @@ TrackObjectPresentationParticles::~TrackObjectPresentationParticles()
         }
         delete m_emitter; // this will also delete m_node
     }
+#endif
 }   // ~TrackObjectPresentationParticles
 
 // ----------------------------------------------------------------------------
 void TrackObjectPresentationParticles::updateGraphics(float dt)
 {
+#ifndef SERVER_ONLY
     if (m_emitter != NULL)
     {
         m_emitter->update(dt);
     }
+#endif
 
     if (m_delayed_stop)
     {

--- a/src/tracks/track_object_presentation.hpp
+++ b/src/tracks/track_object_presentation.hpp
@@ -35,7 +35,6 @@
 #include <string>
 
 class SFXBase;
-class ParticleEmitter;
 class PhysicalObject;
 class ThreeDAnimation;
 class ModelDefinitionLoader;
@@ -43,6 +42,10 @@ namespace GE { class GERenderInfo; }
 class STKInstancedSceneNode;
 class XMLNode;
 class TrackObject;
+
+#ifndef SERVER_ONLY
+class ParticleEmitter;
+#endif
 
 namespace irr
 {
@@ -335,7 +338,9 @@ public:
 class TrackObjectPresentationParticles : public TrackObjectPresentationSceneNode
 {
 private:
+#ifndef SERVER_ONLY
     ParticleEmitter* m_emitter;
+#endif
     LODNode* m_lod_emitter_node;
     std::string m_trigger_condition;
     bool m_delayed_stop;


### PR DESCRIPTION
Moved the entirety of ParticleEmitter and the objects referring to it under `#ifndef SERVER_ONLY`, as all the operations with them in non-header files were already done only in non-server code.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
