### PR TITLE
Rename AppStream metadata file to a rDNS format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -910,7 +910,7 @@ install(FILES data/supertuxkart_128.png DESTINATION share/icons/hicolor/128x128/
 install(FILES data/supertuxkart_256.png DESTINATION share/icons/hicolor/256x256/apps RENAME supertuxkart.png)
 install(FILES data/supertuxkart_512.png DESTINATION share/icons/hicolor/512x512/apps RENAME supertuxkart.png)
 install(FILES data/supertuxkart_1024.png DESTINATION share/icons/hicolor/1024x1024/apps RENAME supertuxkart.png)
-install(FILES data/supertuxkart.appdata.xml DESTINATION share/metainfo)
+install(FILES data/net.supertuxkart.SuperTuxKart.metainfo.xml DESTINATION share/metainfo)
 
 if(MINGW)
     install(DIRECTORY ${CMAKE_BINARY_DIR}/bin/ DESTINATION ${STK_INSTALL_BINARY_DIR}

--- a/data/net.supertuxkart.SuperTuxKart.metainfo.xml
+++ b/data/net.supertuxkart.SuperTuxKart.metainfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<component type="desktop">
-  <id>supertuxkart.desktop</id>
+<component type="desktop-application">
+  <id>net.supertuxkart.SuperTuxKart</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0+</project_license>
   <launchable type="desktop-id">supertuxkart.desktop</launchable>

--- a/data/po/update_desktop_file_appdata.py
+++ b/data/po/update_desktop_file_appdata.py
@@ -66,10 +66,11 @@ STK_APPDATA_P7 = 'If you need more stability, consider using the stable version:
 STK_STABLE_URL = 'https://play.google.com/store/apps/details?id=org.supertuxkart.stk'
 
 STK_APPDATA_FILE_1 = """<?xml version=\"1.0\" encoding=\"UTF-8\"?>
-<component type=\"desktop\">
-  <id>supertuxkart.desktop</id>
+<component type=\"desktop-application\">
+  <id>net.supertuxkart.SuperTuxKart</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0+</project_license>
+  <launchable type="desktop-id">supertuxkart.desktop</launchable>
 """
 # Split it to avoid SuperTuxKart being translated
 STK_APPDATA_FILE_2 = """  <name>SuperTuxKart</name>
@@ -156,14 +157,14 @@ STK_APPDATA_FILE_6 = """  </languages>
 </component>
 """
 
-appdata_file = open('supertuxkart.appdata.xml', 'w')
+appdata_file = open('net.supertuxkart.SuperTuxKart.metainfo.xml', 'w')
 appdata_file.write(STK_APPDATA_FILE_1 + STK_APPDATA_FILE_3 + STK_APPDATA_FILE_4 \
 + STK_APPDATA_FILE_5 + STK_APPDATA_FILE_6)
 appdata_file.close()
 
 os.system('xgettext -j -d supertuxkart --add-comments=\"I18N:\" \
                     -p ./data/po -o supertuxkart.pot \
-                    --package-name=supertuxkart supertuxkart.desktop supertuxkart.appdata.xml')
+                    --package-name=supertuxkart supertuxkart.desktop net.supertuxkart.SuperTuxKart.metainfo.xml')
 
 desktop_file = open('supertuxkart.desktop', 'w')
 desktop_file.write(STK_DESKTOP_FILE_P1 + STK_DESKTOP_FILE_P2 + STK_DESKTOP_FILE_P3)
@@ -234,13 +235,13 @@ for po_filename in po_list:
 
 lingas.close()
 appdata += STK_APPDATA_FILE_6
-appdata_file = open('supertuxkart.appdata.xml', 'w')
+appdata_file = open('net.supertuxkart.SuperTuxKart.metainfo.xml', 'w')
 appdata_file.write(appdata)
 appdata_file.close()
 
 os.system('msgfmt --desktop -d data/po --template supertuxkart.desktop -o data/supertuxkart.desktop')
-os.system('msgfmt --xml -d data/po --template supertuxkart.appdata.xml -o data/supertuxkart.appdata.xml')
+os.system('msgfmt --xml -d data/po --template net.supertuxkart.SuperTuxKart.metainfo.xml -o data/net.supertuxkart.SuperTuxKart.metainfo.xml')
 os.remove('./supertuxkart.desktop')
-os.remove('./supertuxkart.appdata.xml')
+os.remove('./net.supertuxkart.SuperTuxKart.metainfo.xml')
 os.remove('./data/po/LINGUAS')
 os.remove('./data/po/zh_HK.po')


### PR DESCRIPTION
Also:
- Set the component type to desktop-application instead of a deprecated desktop one.
- Update data/po/update_desktop_file_appdata.py + add the previously added launchable type there.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```

Follow-up to the [previous PR](https://github.com/supertuxkart/stk-code/pull/5104).

/cc @CodingJellyfish