### PR TITLE
Use CURLOPT_XFERINFOFUNCTION instead of CURLOPT_PROGRESSFUNCTION

### DIFF
--- a/src/online/http_request.hpp
+++ b/src/online/http_request.hpp
@@ -31,11 +31,13 @@
 #include <assert.h>
 #include <string>
 
-#if defined(CURLOPT_XFERINFODATA)
+#if LIBCURL_VERSION_MAJOR > 7 || (LIBCURL_VERSION_MAJOR == 7 && LIBCURL_VERSION_MINOR > 31)
+// Use CURLOPT_XFERINFOFUNCTION (introduced in 7.32.0)
 #define PROGRESSDATA     CURLOPT_XFERINFODATA
 #define PROGRESSFUNCTION CURLOPT_XFERINFOFUNCTION
 typedef curl_off_t progress_t;
 #else
+// Use CURLOPT_PROGRESSFUNCTION (deprecated since 7.32.0)
 #define PROGRESSDATA     CURLOPT_PROGRESSDATA
 #define PROGRESSFUNCTION CURLOPT_PROGRESSFUNCTION
 typedef double progress_t;


### PR DESCRIPTION
## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
