### PR TITLE
Replace std::random_shuffle with std::shuffle

### DIFF
--- a/src/karts/kart_properties_manager.cpp
+++ b/src/karts/kart_properties_manager.cpp
@@ -50,7 +50,7 @@ KartPropertiesManager *kart_properties_manager=0;
 std::vector<std::string> KartPropertiesManager::m_kart_search_path;
 
 /** Constructor, only clears internal data structures. */
-KartPropertiesManager::KartPropertiesManager()
+KartPropertiesManager::KartPropertiesManager() : m_random_number_generator(std::random_device{}())
 {
     m_all_groups.clear();
 }   // KartPropertiesManager
@@ -601,8 +601,8 @@ void KartPropertiesManager::getRandomKartList(int count,
 
             assert(random_kart_queue.size() > 0);
 
-            std::random_shuffle(random_kart_queue.begin(),
-                                random_kart_queue.end()   );
+            std::shuffle(random_kart_queue.begin(),
+                         random_kart_queue.end(), m_random_number_generator);
         }
 
         while (count > 0 && random_kart_queue.size() > 0)

--- a/src/karts/kart_properties_manager.hpp
+++ b/src/karts/kart_properties_manager.hpp
@@ -23,6 +23,7 @@
 #include "utils/ptr_vector.hpp"
 #include <map>
 #include <memory>
+#include <random>
 #include <set>
 
 #include "network/remote_kart_info.hpp"
@@ -69,6 +70,8 @@ private:
     std::map<std::string, std::unique_ptr<AbstractCharacteristic> > m_difficulty_characteristics;
     std::map<std::string, std::unique_ptr<AbstractCharacteristic> > m_kart_type_characteristics;
     std::map<std::string, std::unique_ptr<AbstractCharacteristic> > m_player_characteristics;
+
+    std::mt19937 m_random_number_generator;
 
 protected:
 

--- a/src/modes/three_strikes_battle.cpp
+++ b/src/modes/three_strikes_battle.cpp
@@ -48,7 +48,7 @@
 //-----------------------------------------------------------------------------
 /** Constructor. Sets up the clock mode etc.
  */
-ThreeStrikesBattle::ThreeStrikesBattle() : WorldWithRank()
+ThreeStrikesBattle::ThreeStrikesBattle() : WorldWithRank(), m_random_number_generator(std::random_device{}())
 {
     WorldStatus::setClockMode(CLOCK_CHRONO);
     m_use_highscores = false;
@@ -684,8 +684,8 @@ void ThreeStrikesBattle::loadCustomModels()
             }
 
             // Find random nodes to pre-spawn spare tire karts
-            std::random_shuffle(sta_possible_nodes.begin(),
-                sta_possible_nodes.end());
+            std::shuffle(sta_possible_nodes.begin(),
+                         sta_possible_nodes.end(), m_random_number_generator);
 
             // Compute a random kart list
             std::vector<std::string> sta_list;

--- a/src/modes/three_strikes_battle.hpp
+++ b/src/modes/three_strikes_battle.hpp
@@ -23,7 +23,7 @@
 #include "modes/world_with_rank.hpp"
 #include "tracks/track_object.hpp"
 #include "states_screens/race_gui_base.hpp"
-
+#include <random>
 #include <string>
 
 class PhysicalObject;
@@ -91,6 +91,8 @@ private:
 
     std::vector<AbstractKart*> m_spare_tire_karts;
     int m_next_sta_spawn_ticks;
+
+    std::mt19937 m_random_number_generator;
 
 public:
     /** Used to show a nice graph when battle is over */

--- a/src/states_screens/easter_egg_screen.cpp
+++ b/src/states_screens/easter_egg_screen.cpp
@@ -42,7 +42,7 @@ static const char ALL_TRACK_GROUPS_ID[] = "all";
 
 // -----------------------------------------------------------------------------
 
-EasterEggScreen::EasterEggScreen() : Screen("easter_egg.stkgui")
+EasterEggScreen::EasterEggScreen() : Screen("easter_egg.stkgui"), m_random_number_generator(std::random_device{}())
 {
 }
 
@@ -278,7 +278,7 @@ void EasterEggScreen::buildTrackList()
                            0 /* no badge */, IconButtonWidget::ICON_PATH_TYPE_RELATIVE);
 
     tracks_widget->updateItemDisplay();
-    std::random_shuffle( m_random_track_list.begin(), m_random_track_list.end() );
+    std::shuffle( m_random_track_list.begin(), m_random_track_list.end(), m_random_number_generator );
 }
 
 // -----------------------------------------------------------------------------

--- a/src/states_screens/easter_egg_screen.hpp
+++ b/src/states_screens/easter_egg_screen.hpp
@@ -20,6 +20,7 @@
 
 #include "guiengine/screen.hpp"
 #include <deque>
+#include <random>
 
 namespace GUIEngine { class Widget; }
 
@@ -30,6 +31,8 @@ namespace GUIEngine { class Widget; }
 class EasterEggScreen : public GUIEngine::Screen, public GUIEngine::ScreenSingleton<EasterEggScreen>
 {
     friend class GUIEngine::ScreenSingleton<EasterEggScreen>;
+
+    std::mt19937 m_random_number_generator;
 
     EasterEggScreen();
 

--- a/src/states_screens/online/tracks_screen.cpp
+++ b/src/states_screens/online/tracks_screen.cpp
@@ -644,7 +644,7 @@ void TracksScreen::buildTrackList()
                            IconButtonWidget::ICON_PATH_TYPE_RELATIVE);
 
     tracks_widget->updateItemDisplay();
-    std::random_shuffle( m_random_track_list.begin(), m_random_track_list.end() );
+    std::shuffle( m_random_track_list.begin(), m_random_track_list.end(), m_random_number_generator );
 }   // buildTrackList
 
 // -----------------------------------------------------------------------------

--- a/src/states_screens/online/tracks_screen.hpp
+++ b/src/states_screens/online/tracks_screen.hpp
@@ -23,6 +23,7 @@
 
 #include <deque>
 #include <limits>
+#include <random>
 #include <string>
 #include <vector>
 
@@ -88,7 +89,8 @@ private:
 
     void voteForPlayer();
 
-    TracksScreen() : Screen("tracks.stkgui")
+    std::mt19937 m_random_number_generator;
+    TracksScreen() : Screen("tracks.stkgui"), m_random_number_generator(std::random_device{}())
     {
         m_network_tracks = false;
         m_quit_server = false;

--- a/src/states_screens/tracks_and_gp_screen.cpp
+++ b/src/states_screens/tracks_and_gp_screen.cpp
@@ -341,7 +341,7 @@ void TracksAndGPScreen::buildTrackList()
                            IconButtonWidget::ICON_PATH_TYPE_RELATIVE);
 
     tracks_widget->updateItemDisplay();
-    std::random_shuffle( m_random_track_list.begin(), m_random_track_list.end() );
+    std::shuffle( m_random_track_list.begin(), m_random_track_list.end(), m_random_number_generator );
 }   // buildTrackList
 
 // -----------------------------------------------------------------------------

--- a/src/states_screens/tracks_and_gp_screen.hpp
+++ b/src/states_screens/tracks_and_gp_screen.hpp
@@ -21,6 +21,7 @@
 #include "guiengine/screen.hpp"
 #include "guiengine/widgets/text_box_widget.hpp"
 #include <deque>
+#include <random>
 
 namespace GUIEngine { class Widget; }
 
@@ -37,7 +38,8 @@ class TracksAndGPScreen : public GUIEngine::Screen,
 private:
     GUIEngine::TextBoxWidget* m_search_box;
 
-    TracksAndGPScreen() : Screen("tracks_and_gp.stkgui") {}
+    std::mt19937 m_random_number_generator;
+    TracksAndGPScreen() : Screen("tracks_and_gp.stkgui"), m_random_number_generator(std::random_device{}()) {}
 
     /** adds the tracks from the current track group into the tracks ribbon */
     void buildTrackList();

--- a/src/tracks/track.cpp
+++ b/src/tracks/track.cpp
@@ -112,7 +112,7 @@ bool        Track::m_dont_load_navmesh = false;
 std::atomic<Track*> Track::m_current_track[PT_COUNT];
 
 // ----------------------------------------------------------------------------
-Track::Track(const std::string &filename)
+Track::Track(const std::string &filename) : m_random_number_generator(std::random_device{}())
 {
 #ifdef DEBUG
     m_magic_number          = 0x17AC3802;

--- a/src/tracks/track.hpp
+++ b/src/tracks/track.hpp
@@ -29,6 +29,7 @@
 #include <algorithm>
 #include <atomic>
 #include <memory>
+#include <random>
 #include <string>
 #include <vector>
 
@@ -138,6 +139,7 @@ private:
 
     std::vector<Subtitle> m_subtitles;
 
+    std::mt19937 m_random_number_generator;
     /** Start transforms of karts (either the default, or the ones taken
      *  from the scene file). */
     AlignedArray<btTransform> m_start_transforms;
@@ -562,7 +564,7 @@ public:
     */
     void shuffleStartTransforms()
     {
-        std::random_shuffle(m_start_transforms.begin(), m_start_transforms.end());
+        std::shuffle(m_start_transforms.begin(), m_start_transforms.end(), m_random_number_generator);
     }
     // ------------------------------------------------------------------------
     /** Sets pointer to the aabb of this track. */


### PR DESCRIPTION
std::random_shuffle was removed in c++17

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
