### PR TITLE
Upgrade c++ standard from gnu++0x to c++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -500,7 +500,7 @@ endif()
 
 # Set some compiler options
 if(UNIX OR MINGW)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++0x")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-unused-function")
 endif()
 

--- a/src/font/font_manager.cpp
+++ b/src/font/font_manager.cpp
@@ -909,7 +909,7 @@ void FontManager::unitTesting()
         // Hide gettext warning
         Log::setLogLevel(5);
         delete translations;
-#ifdef WIN32
+#if defined(WIN32) || defined(__MINGW32__)
         std::string s=std::string("LANGUAGE=") + lang.c_str();
         _putenv(s.c_str());
 #else

--- a/src/io/file_manager.cpp
+++ b/src/io/file_manager.cpp
@@ -921,7 +921,7 @@ bool FileManager::checkAndCreateDirectory(const std::string &path)
     Log::info("FileManager", "Creating directory '%s'.", path.c_str());
 
     // Otherwise try to create the directory:
-#if defined(WIN32)
+#if defined(WIN32) || defined(__MINGW32__)
     bool error = _wmkdir(StringUtils::utf8ToWide(path).c_str()) != 0;
 #else
     bool error = mkdir(path.c_str(), 0777) != 0;

--- a/src/io/rich_presence.hpp
+++ b/src/io/rich_presence.hpp
@@ -1,5 +1,5 @@
 #include <atomic>
-#ifdef WIN32
+#if defined(WIN32) || defined(__MINGW32__)
 #include <namedpipeapi.h>
 #endif
 #include <thread>
@@ -26,7 +26,7 @@ namespace RichPresenceNS
         bool m_connected;
         std::atomic_bool m_ready;
         time_t m_last;
-#ifdef WIN32
+#if defined(WIN32) || defined(__MINGW32__)
         HANDLE m_socket;
 #else
         int m_socket;

--- a/src/network/socket_address.hpp
+++ b/src/network/socket_address.hpp
@@ -23,7 +23,7 @@
 
 #include "utils/types.hpp"
 
-#ifdef WIN32
+#if defined(WIN32) || defined(__MINGW32__)
 #  include <winsock2.h>
 #  include <ws2tcpip.h>
 #else

--- a/src/network/stk_ipv6.cpp
+++ b/src/network/stk_ipv6.cpp
@@ -16,7 +16,7 @@
 //  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include <string.h>
-#ifdef WIN32
+#if defined(WIN32) || defined(__MINGW32__)
 #ifdef __GNUC__
 #    include <ws2tcpip.h>    // Mingw / gcc on windows
 #    undef _WIN32_WINNT

--- a/src/states_screens/options/options_screen_language.cpp
+++ b/src/states_screens/options/options_screen_language.cpp
@@ -126,7 +126,7 @@ void OptionsScreenLanguage::eventCallback(Widget* widget, const std::string& nam
 
         if (selection == "system")
         {
-#ifdef WIN32
+#if defined(WIN32) || defined(__MINGW32__)
             _putenv("LANGUAGE=");
 #else
             unsetenv("LANGUAGE");
@@ -134,7 +134,7 @@ void OptionsScreenLanguage::eventCallback(Widget* widget, const std::string& nam
         }
         else
         {
-#ifdef WIN32
+#if defined(WIN32) || defined(__MINGW32__)
             std::string s=std::string("LANGUAGE=")+selection.c_str();
             _putenv(s.c_str());
 #else

--- a/src/utils/file_utils.cpp
+++ b/src/utils/file_utils.cpp
@@ -24,7 +24,7 @@
 #include <sys/stat.h>
 
 // ----------------------------------------------------------------------------
-#if defined(WIN32)
+#if defined(WIN32) || defined(__MINGW32__)
 #include <windows.h>
 // ----------------------------------------------------------------------------
 namespace u8checker
@@ -117,7 +117,7 @@ std::string FileUtils::Private::getShortPathWriting(const std::string& u8_path)
  */
 FILE* FileUtils::fopenU8Path(const std::string& u8_path, const char* mode)
 {
-#if defined(WIN32)
+#if defined(WIN32) || defined(__MINGW32__)
     std::vector<wchar_t> mode_str;
     for (unsigned i = 0; i < strlen(mode); i++)
         mode_str.push_back((wchar_t)mode[i]);
@@ -133,7 +133,7 @@ FILE* FileUtils::fopenU8Path(const std::string& u8_path, const char* mode)
  */
 int FileUtils::statU8Path(const std::string& u8_path, struct stat *buf)
 {
-#if defined(WIN32)
+#if defined(WIN32) || defined(__MINGW32__)
     struct _stat st;
     int ret = _wstat(StringUtils::utf8ToWide(u8_path).c_str(), &st);
     buf->st_dev = st.st_dev;
@@ -159,7 +159,7 @@ int FileUtils::statU8Path(const std::string& u8_path, struct stat *buf)
 int FileUtils::renameU8Path(const std::string& u8_path_old,
                             const std::string& u8_path_new)
 {
-#if defined(WIN32)
+#if defined(WIN32) || defined(__MINGW32__)
     return _wrename(StringUtils::utf8ToWide(u8_path_old).c_str(),
         StringUtils::utf8ToWide(u8_path_new).c_str());
 #else

--- a/src/utils/file_utils.hpp
+++ b/src/utils/file_utils.hpp
@@ -43,7 +43,7 @@ namespace FileUtils
      * u8_path is unicode encoded. */
     inline std::string getPortableWritingPath(const std::string& u8_path)
     {
-#if defined(WIN32)
+#if defined(WIN32) || defined(__MINGW32__)
         return Private::getShortPathWriting(u8_path);
 #else
         return u8_path;
@@ -54,7 +54,7 @@ namespace FileUtils
      * is unicode encoded. */
     inline std::string getPortableReadingPath(const std::string& u8_path)
     {
-#if defined(WIN32)
+#if defined(WIN32) || defined(__MINGW32__)
         return Private::getShortPath(u8_path);
 #else
         return u8_path;

--- a/src/utils/time.cpp
+++ b/src/utils/time.cpp
@@ -50,7 +50,7 @@ std::string StkTime::getLogTime()
     time_t time_now = 0;
     time(&time_now);
     std::tm timeptr = {};
-#ifdef WIN32
+#if defined(WIN32) || defined(__MINGW32__)
     localtime_s(&timeptr, &time_now);
 #else
     localtime_r(&time_now, &timeptr);

--- a/src/utils/translation.cpp
+++ b/src/utils/translation.cpp
@@ -306,7 +306,7 @@ Translations::Translations() //: m_dictionary_manager("UTF-16")
     // LC_ALL does not work, sscanf will then not always be able
     // to scan for example: s=-1.1,-2.3,-3.3 correctly, which is
     // used in driveline files.
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if (defined(WIN32) || defined(__MINGW32__)) && !defined(__CYGWIN__)
     // Windows does not have LC_MESSAGES
     setlocale(LC_CTYPE,    "");
 #else


### PR DESCRIPTION
Make sure it builds for mingw. The WIN32 macro appears not to be set when building for mingw. However, __MINGW32__ is set for both 32-bit and 64-bit

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
