### PR TITLE
Replace deprecated std::iterator

### DIFF
--- a/src/states_screens/online/online_profile_achievements.cpp
+++ b/src/states_screens/online/online_profile_achievements.cpp
@@ -198,7 +198,7 @@ void BaseOnlineProfileAchievements::displayResults()
             all_achievements_list.push_back(it->second);
         }
 
-        auto compAchievement = [=](Achievement *a, Achievement *b)
+        auto compAchievement = [this](Achievement *a, Achievement *b)
         {
             // Sort by name
             if (m_sort_column == 0)

--- a/src/tracks/track_object_presentation.cpp
+++ b/src/tracks/track_object_presentation.cpp
@@ -1172,7 +1172,7 @@ void TrackObjectPresentationActionTrigger::onTriggerItemApproached(int kart_id)
     {
         Scripting::ScriptEngine::getInstance()->runFunction(true, "void "
             + m_library_name + "::" + m_action +
-            "(int, const string, const string)", [=](asIScriptContext* ctx)
+            "(int, const string, const string)", [this, kart_id](asIScriptContext* ctx)
             {
                 ctx->SetArgDWord(0, kart_id);
                 ctx->SetArgObject(1, &m_library_id);

--- a/src/utils/utf8/checked.h
+++ b/src/utils/utf8/checked.h
@@ -29,6 +29,8 @@ DEALINGS IN THE SOFTWARE.
 #define UTF8_FOR_CPP_CHECKED_H_2675DCD0_9480_4c0c_B92A_CC14C027B731
 
 #include "core.h"
+#include <cstdint>
+#include <iterator>
 #include <stdexcept>
 
 namespace utf8
@@ -326,59 +328,76 @@ namespace utf8
 
     // The iterator class
     template <typename octet_iterator>
-    class iterator : public std::iterator <std::bidirectional_iterator_tag, uint32_t> {
+    class iterator {
+    public:
+       using iterator_category = std::bidirectional_iterator_tag;
+       using value_type = uint32_t;
+       using difference_type = std::ptrdiff_t;
+       using pointer = const uint32_t*;
+       using reference = const uint32_t&;
+
+    private:
       octet_iterator it;
       octet_iterator range_start;
       octet_iterator range_end;
-      public:
-      iterator () {};
-      explicit iterator (const octet_iterator& octet_it,
+
+    public:
+       iterator() = default;
+
+       explicit iterator(const octet_iterator& octet_it,
                          const octet_iterator& range_start,
-                         const octet_iterator& range_end) :
-               it(octet_it), range_start(range_start), range_end(range_end)
-      {
+                         const octet_iterator& range_end)
+          : it(octet_it), range_start(range_start), range_end(range_end)
+       {
           if (it < range_start || it > range_end)
-              throw std::out_of_range("Invalid utf-8 iterator position");
-      }
-      // the default "big three" are OK
-      octet_iterator base () const { return it; }
-      uint32_t operator * () const
-      {
+             throw std::out_of_range("Invalid utf-8 iterator position");
+       }
+
+       octet_iterator base() const { return it; }
+
+       uint32_t operator * () const
+       {
           octet_iterator temp = it;
           return next(temp, range_end);
-      }
-      bool operator == (const iterator& rhs) const
-      {
+       }
+
+       bool operator == (const iterator& rhs) const
+       {
           if (range_start != rhs.range_start || range_end != rhs.range_end)
-              throw std::logic_error("Comparing utf-8 iterators defined with different ranges");
-          return (it == rhs.it);
-      }
-      bool operator != (const iterator& rhs) const
-      {
-          return !(operator == (rhs));
-      }
-      iterator& operator ++ ()
-      {
+             throw std::logic_error("Comparing utf-8 iterators defined with different ranges");
+          return it == rhs.it;
+       }
+
+       bool operator != (const iterator& rhs) const
+       {
+          return !(*this == rhs);
+       }
+
+       iterator& operator ++ ()
+       {
           next(it, range_end);
           return *this;
-      }
-      iterator operator ++ (int)
-      {
+       }
+
+       iterator operator ++ (int)
+       {
           iterator temp = *this;
           next(it, range_end);
           return temp;
-      }
-      iterator& operator -- ()
-      {
+       }
+
+       iterator& operator--()
+       {
           prior(it, range_start);
           return *this;
-      }
-      iterator operator -- (int)
-      {
+       }
+
+       iterator operator--(int)
+       {
           iterator temp = *this;
           prior(it, range_start);
           return temp;
-      }
+       }
     }; // class iterator
 
 } // namespace utf8

--- a/src/utils/utf8/unchecked.h
+++ b/src/utils/utf8/unchecked.h
@@ -28,6 +28,8 @@ DEALINGS IN THE SOFTWARE.
 #ifndef UTF8_FOR_CPP_UNCHECKED_H_2675DCD0_9480_4c0c_B92A_CC14C027B731
 #define UTF8_FOR_CPP_UNCHECKED_H_2675DCD0_9480_4c0c_B92A_CC14C027B731
 
+#include <iterator>
+#include <cstdint>
 #include "core.h"
 
 namespace utf8
@@ -222,49 +224,67 @@ namespace utf8
 
         // The iterator class
         template <typename octet_iterator>
-          class iterator : public std::iterator <std::bidirectional_iterator_tag, uint32_t> {
-            octet_iterator it;
+          class iterator {
             public:
-            iterator () {};
-            explicit iterator (const octet_iterator& octet_it): it(octet_it) {}
-            // the default "big three" are OK
-            octet_iterator base () const { return it; }
-            uint32_t operator * () const
-            {
-                octet_iterator temp = it;
-                return next(temp);
-            }
-            bool operator == (const iterator& rhs) const
-            {
-                return (it == rhs.it);
-            }
-            bool operator != (const iterator& rhs) const
-            {
-                return !(operator == (rhs));
-            }
-            iterator& operator ++ ()
-            {
-                std::advance(it, internal::sequence_length(it));
-                return *this;
-            }
-            iterator operator ++ (int)
-            {
-                iterator temp = *this;
-                std::advance(it, internal::sequence_length(it));
-                return temp;
-            }
-            iterator& operator -- ()
-            {
-                prior(it);
-                return *this;
-            }
-            iterator operator -- (int)
-            {
-                iterator temp = *this;
-                prior(it);
-                return temp;
-            }
-          }; // class iterator
+              using iterator_category = std::bidirectional_iterator_tag;
+              using value_type = uint32_t;
+              using difference_type = std::ptrdiff_t;
+              using pointer = const uint32_t*;
+              using reference = const uint32_t&;
+
+            private:
+              octet_iterator it;
+
+            public:
+              iterator() = default;
+
+              explicit iterator(const octet_iterator& octet_it)
+                 : it(octet_it) {}
+
+              octet_iterator base() const { return it; }
+
+              uint32_t operator * () const
+              {
+                 octet_iterator temp = it;
+                 return next(temp);
+              }
+
+              bool operator == (const iterator& rhs) const
+              {
+                 return it == rhs.it;
+              }
+
+              bool operator != (const iterator& rhs) const
+              {
+                 return !(*this == rhs);
+              }
+
+              iterator& operator ++ ()
+              {
+                 std::advance(it, internal::sequence_length(it));
+                 return *this;
+              }
+
+              iterator operator ++ (int)
+              {
+                 iterator temp = *this;
+                 std::advance(it, internal::sequence_length(it));
+                 return temp;
+              }
+
+              iterator& operator -- ()
+              {
+                 prior(it);
+                 return *this;
+              }
+
+              iterator operator -- (int)
+              {
+                 iterator temp = *this;
+                 prior(it);
+                 return temp;
+              }
+           }; // class iterator
 
     } // namespace utf8::unchecked
 } // namespace utf8


### PR DESCRIPTION
Also fix two lambdas with deprecated capture syntax

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
