### PR TITLE
Fix #4997

### DIFF
--- a/src/network/stk_peer.hpp
+++ b/src/network/stk_peer.hpp
@@ -302,6 +302,9 @@ public:
     void setAlwaysSpectate(AlwaysSpectateMode mode)
                                              { m_always_spectate.store(mode); }
     // ------------------------------------------------------------------------
+    AlwaysSpectateMode getAlwaysSpectate() const
+                       { return (AlwaysSpectateMode)m_always_spectate.load(); }
+    // ------------------------------------------------------------------------
     bool alwaysSpectate() const
                                { return m_always_spectate.load() != ASM_NONE; }
     // ------------------------------------------------------------------------


### PR DESCRIPTION
In startSelection, assets are erased only after the spectators are determined. If a spectator doesn't have the picked map, it's not loaded, but the spectator mode stays afterwards.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
