### PR TITLE
graphical_restrictions.xml: Remove restrictions for Android Emulator

### DIFF
--- a/data/graphical_restrictions.xml
+++ b/data/graphical_restrictions.xml
@@ -34,8 +34,6 @@
   <card                           os="android"                     disable="ColorBufferFloat"/>
   <card                           os="android"                     disable="TextureCompressionS3TC"/>
   <card contains="Adreno"         os="android"  version="<=19"     disable="VertexIdWorking"/>
-  <card contains="Android Emulator" os="android"                   disable="ForceLegacyDevice"/>
-  <card contains="Android Emulator" os="android"                   disable="NpotTextures"/>
   <card contains="Apple Software Renderer" os="ios"                disable="ForceLegacyDevice"/>
   <card contains="Apple Software Renderer" os="ios"                disable="NpotTextures"/>
   <card vendor="Broadcom"         os="linux"                       disable="HighDefinitionTextures256"/>


### PR DESCRIPTION
Android Emulator supports proper hardware acceleration nowadays, we shouldn't be forcing the legacy pipeline if it's not needed.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
