### PR TITLE
Add benchmark mode to command-line options

### DIFF
--- a/src/config/user_config.hpp
+++ b/src/config/user_config.hpp
@@ -849,6 +849,8 @@ namespace UserConfigParams
 
     PARAM_PREFIX bool m_disable_addon_tracks  PARAM_DEFAULT( false );
 
+    PARAM_PREFIX bool m_benchmark  PARAM_DEFAULT( false );
+
     // ---- Networking
     PARAM_PREFIX StringToUIntUserConfigParam    m_server_bookmarks
         PARAM_DEFAULT(StringToUIntUserConfigParam("server-bookmarks",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -592,6 +592,7 @@ void cmdLineHelp()
                               "laps.\n"
     "       --profile-time=n   Enable automatic driven profile mode for n "
                               "seconds.\n"
+    "       --benchmark        Start Benchmark Mode, save results and exit. \n"
     "       --unlock-all       Permanently unlock all karts and tracks for testing.\n"
     "       --no-unlock-all    Disable unlock-all (i.e. base unlocking on player achievement).\n"
     "       --xmas=n           Toggle Xmas/Christmas mode. n=0 Use current date, n=1, Always enable,\n"
@@ -1707,6 +1708,14 @@ int handleCmdLine(bool has_server_config, bool has_parent_process)
             RaceManager::get()->setNumLaps(n);
         }
     }   // --profile-laps
+
+    if(CommandLine::has("--benchmark"))
+    {
+        Log::verbose("main", "Benchmark mode requested from command-line");
+        UserConfigParams::m_no_start_screen = true;
+        UserConfigParams::m_max_fps = 9999;
+        UserConfigParams::m_benchmark = true;
+    }   // --benchmark
     
     if(CommandLine::has("--unlock-all"))
     {
@@ -2552,11 +2561,18 @@ int main(int argc, char *argv[])
         {
             if(UserConfigParams::m_no_start_screen)
             {
-                // Quickstart (-N)
-                // ===============
-                // all defaults are set in InitTuxkart()
-                RaceManager::get()->setupPlayerKartInfo();
-                RaceManager::get()->startNew(false);
+                if (UserConfigParams::m_benchmark)
+                {
+                    profiler.startBenchmark();
+                }
+                else
+                {
+                    // Quickstart (-N)
+                    // ===============
+                    // all defaults are set in InitTuxkart()
+                    RaceManager::get()->setupPlayerKartInfo();
+                    RaceManager::get()->startNew(false);
+                }
             }
         }
         else  // profile

--- a/src/states_screens/race_result_gui.cpp
+++ b/src/states_screens/race_result_gui.cpp
@@ -70,6 +70,7 @@
 #include "utils/profiler.hpp"
 #include "utils/string_utils.hpp"
 #include "utils/translation.hpp"
+#include "main_loop.hpp"
 
 #include <algorithm>
 
@@ -1269,7 +1270,16 @@ void RaceResultGUI::renderGlobal(float dt)
     }
     else if (RaceManager::get()->isBenchmarking())
     {
-        displayBenchmarkSummary();
+        if(!UserConfigParams::m_benchmark)
+        {
+            displayBenchmarkSummary();
+        }
+        else
+        {
+            // Benchmark requested from CLI, write to file and exit
+            profiler.writeToFile();
+            main_loop->requestAbort();
+        }
     }
     else
     {


### PR DESCRIPTION
Adding `--benchmark` to command-line options to automatically start benchmark mode, set unlimited fps, save results and exit.

Closes #5177 

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.
```
