### PR TITLE
Add 144 FPS cap option

### DIFF
--- a/src/states_screens/options/options_screen_video.cpp
+++ b/src/states_screens/options/options_screen_video.cpp
@@ -247,7 +247,7 @@ void OptionsScreenVideo::init()
     vsync->clearLabels();
     //I18N: In the video options
     vsync->addLabel(_("Vertical Sync"));
-    std::set<int> fps = { 30, 60, 120, 180, 250, 500, 1000 };
+    std::set<int> fps = { 30, 60, 120, 144, 180, 250, 500, 1000 };
     fps.insert(UserConfigParams::m_max_fps);
     for (auto& i : fps)
         vsync->addLabel(core::stringw(i));


### PR DESCRIPTION
Adds 144 as an option for 'Maximum FPS' in the graphics settings. This is useful for people that have 144 Hz monitors that do not wish to use vsync.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
