### PR TITLE
Remove unused variables, fix #5161

### DIFF
--- a/lib/bullet/src/BulletCollision/BroadphaseCollision/btAxisSweep3.h
+++ b/lib/bullet/src/BulletCollision/BroadphaseCollision/btAxisSweep3.h
@@ -628,8 +628,6 @@ void btAxisSweep3Internal<BP_FP_INT_TYPE>::resetPool(btDispatcher* dispatcher)
 	}
 }       
 
-
-extern int gOverlappingPairs;
 //#include <stdio.h>
 
 template <typename BP_FP_INT_TYPE>
@@ -696,7 +694,6 @@ void	btAxisSweep3Internal<BP_FP_INT_TYPE>::calculateOverlappingPairs(btDispatche
 				pair.m_pProxy0 = 0;
 				pair.m_pProxy1 = 0;
 				m_invalidPair++;
-				//gOverlappingPairs--;
 			} 
 			
 		}

--- a/lib/bullet/src/BulletCollision/BroadphaseCollision/btMultiSapBroadphase.cpp
+++ b/lib/bullet/src/BulletCollision/BroadphaseCollision/btMultiSapBroadphase.cpp
@@ -22,7 +22,6 @@ subject to the following restrictions:
 ///	btSapBroadphaseArray	m_sapBroadphases;
 
 ///	btOverlappingPairCache*	m_overlappingPairs;
-extern int gOverlappingPairs;
 
 /*
 class btMultiSapSortedOverlappingPairCache : public btSortedOverlappingPairCache
@@ -429,7 +428,6 @@ void    btMultiSapBroadphase::calculateOverlappingPairs(btDispatcher* dispatcher
 				pair.m_pProxy0 = 0;
 				pair.m_pProxy1 = 0;
 				m_invalidPair++;
-				gOverlappingPairs--;
 			} 
 			
 		}

--- a/lib/bullet/src/BulletCollision/BroadphaseCollision/btOverlappingPairCache.cpp
+++ b/lib/bullet/src/BulletCollision/BroadphaseCollision/btOverlappingPairCache.cpp
@@ -23,11 +23,6 @@ subject to the following restrictions:
 
 #include <stdio.h>
 
-//int	gOverlappingPairs = 0;
-
-//int gRemovePairs =0;
-//int gAddedPairs =0;
-//int gFindPairs =0;
 
 
 
@@ -135,7 +130,6 @@ void	btHashedOverlappingPairCache::removeOverlappingPairsContainingProxy(btBroad
 
 btBroadphasePair* btHashedOverlappingPairCache::findPair(btBroadphaseProxy* proxy0, btBroadphaseProxy* proxy1)
 {
-	//gFindPairs++;
 	if(proxy0->m_uniqueId>proxy1->m_uniqueId) 
 		btSwap(proxy0,proxy1);
 	int proxyId1 = proxy0->getUid();
@@ -272,7 +266,6 @@ btBroadphasePair* btHashedOverlappingPairCache::internalAddPair(btBroadphaseProx
 
 void* btHashedOverlappingPairCache::removeOverlappingPair(btBroadphaseProxy* proxy0, btBroadphaseProxy* proxy1,btDispatcher* dispatcher)
 {
-	//gRemovePairs++;
 	if(proxy0->m_uniqueId>proxy1->m_uniqueId) 
 		btSwap(proxy0,proxy1);
 	int proxyId1 = proxy0->getUid();
@@ -387,8 +380,6 @@ void	btHashedOverlappingPairCache::processAllOverlappingPairs(btOverlapCallback*
 		if (callback->processOverlap(*pair))
 		{
 			removeOverlappingPair(pair->m_pProxy0,pair->m_pProxy1,dispatcher);
-
-			//gOverlappingPairs--;
 		} else
 		{
 			i++;
@@ -436,7 +427,6 @@ void*	btSortedOverlappingPairCache::removeOverlappingPair(btBroadphaseProxy* pro
 		int findIndex = m_overlappingPairArray.findLinearSearch(findPair);
 		if (findIndex < m_overlappingPairArray.size())
 		{
-			//gOverlappingPairs--;
 			btBroadphasePair& pair = m_overlappingPairArray[findIndex];
 			void* userData = pair.m_internalInfo1;
 			cleanOverlappingPair(pair,dispatcher);
@@ -469,9 +459,6 @@ btBroadphasePair*	btSortedOverlappingPairCache::addOverlappingPair(btBroadphaseP
 	
 	void* mem = &m_overlappingPairArray.expandNonInitializing();
 	btBroadphasePair* pair = new (mem) btBroadphasePair(*proxy0,*proxy1);
-	
-	//gOverlappingPairs++;
-	//gAddedPairs++;
 	
 	if (m_ghostPairCallback)
 		m_ghostPairCallback->addOverlappingPair(proxy0, proxy1);
@@ -527,7 +514,6 @@ void	btSortedOverlappingPairCache::processAllOverlappingPairs(btOverlapCallback*
 			pair->m_pProxy1 = 0;
 			m_overlappingPairArray.swap(i,m_overlappingPairArray.size()-1);
 			m_overlappingPairArray.pop_back();
-			//gOverlappingPairs--;
 		} else
 		{
 			i++;
@@ -560,7 +546,6 @@ void	btSortedOverlappingPairCache::cleanOverlappingPair(btBroadphasePair& pair,b
 			pair.m_algorithm->~btCollisionAlgorithm();
 			dispatcher->freeCollisionAlgorithm(pair.m_algorithm);
 			pair.m_algorithm=0;
-			//gRemovePairs--;
 		}
 	}
 }

--- a/lib/bullet/src/BulletCollision/BroadphaseCollision/btOverlappingPairCache.h
+++ b/lib/bullet/src/BulletCollision/BroadphaseCollision/btOverlappingPairCache.h
@@ -49,9 +49,6 @@ struct btOverlapFilterCallback
 
 
 
-extern int gRemovePairs;
-extern int gAddedPairs;
-extern int gFindPairs;
 
 const int BT_NULL_PAIR=0xffffffff;
 
@@ -121,8 +118,6 @@ public:
 	// no new pair is created and the old one is returned.
 	virtual btBroadphasePair* 	addOverlappingPair(btBroadphaseProxy* proxy0,btBroadphaseProxy* proxy1)
 	{
-		//gAddedPairs++;
-
 		if (!needsBroadphaseCollision(proxy0,proxy1))
 			return 0;
 

--- a/lib/bullet/src/BulletCollision/BroadphaseCollision/btSimpleBroadphase.cpp
+++ b/lib/bullet/src/BulletCollision/BroadphaseCollision/btSimpleBroadphase.cpp
@@ -24,8 +24,6 @@ subject to the following restrictions:
 
 #include <new>
 
-extern int gOverlappingPairs;
-
 void	btSimpleBroadphase::validate()
 {
 	for (int i=0;i<m_numHandles;i++)
@@ -315,7 +313,6 @@ void	btSimpleBroadphase::calculateOverlappingPairs(btDispatcher* dispatcher)
 					pair.m_pProxy0 = 0;
 					pair.m_pProxy1 = 0;
 					m_invalidPair++;
-					gOverlappingPairs--;
 				} 
 
 			}


### PR DESCRIPTION
Previously some of them were commented in one file without realizing they are extern in another file.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
