### PR TITLE
Removed glow under main menu options

### DIFF
--- a/src/guiengine/skin.cpp
+++ b/src/guiengine/skin.cpp
@@ -1424,10 +1424,11 @@ void Skin::drawRibbonChild(const core::recti &rect, Widget* widget,
         }
 
         const bool mark_focused =
-            focused || (parent_focused && parentRibbonWidget != NULL &&
+            (focused || (parent_focused && parentRibbonWidget != NULL &&
                           parentRibbonWidget->m_mouse_focus == widget) ||
                        (mark_selected && !always_show_selection &&
-                          parent_focused);
+                          parent_focused)) &&
+                        widget->m_properties[PROP_FOCUS_ICON].size() == 0;
 
         /* draw "selection bubble" if relevant */
         if (always_show_selection && mark_selected)


### PR DESCRIPTION
## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```

This follows the proposal in #5109 to remove the glow under the five main menu options, and derives its approach from the recommendation given when #5222 was closed.

To see if an icon button has a focus image specified, I check if the size of `m_properties[PROP_FOCUS_ICON]` exceeds 0, as is done when assinging `m_highlight_texture` in `icon_button_widget.cpp`.
