### PR TITLE
Fix #5121: Check if chat messages start with 'name: '

### DIFF
--- a/src/network/protocols/server_lobby.cpp
+++ b/src/network/protocols/server_lobby.cpp
@@ -478,25 +478,13 @@ void ServerLobby::handleChat(Event* event)
     core::stringw message;
     event->data().decodeString16(&message, 360/*max_len*/);
 
-    // Check if the message starts with "(one of profile names): " to prevent
+    // Check if the message starts with "(the name of main profile): " to prevent
     // impersonation, see #5121.
-    // If the server allows many messages in a row and there are many players
-    // inside one peer, naive check can become a problem. For most cases,
-    // it should be completely fine.
-    bool valid_message = false;
     std::string message_utf8 = StringUtils::wideToUtf8(message);
-    for (auto& profile: event->getPeer()->getPlayerProfiles())
-    {
-        std::string prefix = StringUtils::wideToUtf8(
-            profile->getName()) + ": ";
-        if (StringUtils::startsWith(message_utf8, prefix))
-        {
-            valid_message = true;
-            break;
-        }
-    }
-
-    if (!valid_message)
+    std::string prefix = StringUtils::wideToUtf8(
+        event->getPeer()->getPlayerProfiles()[0]->getName()) + ": ";
+    
+    if (!StringUtils::startsWith(message_utf8, prefix))
     {
         NetworkString* chat = getNetworkString();
         chat->setSynchronous(true);


### PR DESCRIPTION
~~I suppose it's fine to check it naively, as we don't have many players inside one peer, and as the number of messages per peer can already be limited in the server config (and is not big in general).~~

~~If there will be a need in many similar checks, I can make a separate data structure for that.~~

Apparently only one username can appear in the message. There's no need to send it, either, but removing the name from the messages would break the network protocol with other 1.x versions, so I'm just checking one username now.

---

You can test it against the [client](https://github.com/kimden/stk-code/tree/impersonation) modified to reproduce this issue.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
