### PR TITLE
Remove newline

### DIFF
--- a/src/utils/crash_reporting.cpp
+++ b/src/utils/crash_reporting.cpp
@@ -101,7 +101,7 @@
                 getCallStack(callstack);
 
             std::string msg =   "SuperTuxKart crashed!\n"
-                                "If you continue to encounter this issue, please hit Ctrl+C to copy this error\n"
+                                "If you continue to encounter this issue, please hit Ctrl+C to copy this error "
                                 "to the clipboard and report the problem to the developers on our forum:\n"
                                 "http://forum.freegamedev.net/viewforum.php?f=17\n"
                                 "\n"


### PR DESCRIPTION
So the text does not appear as "...copy[newline]this error[newline]to..." in the dialog.