### PR TITLE
Animate the parachute and bubblegum shield

### DIFF
--- a/src/items/attachment.cpp
+++ b/src/items/attachment.cpp
@@ -617,9 +617,34 @@ void Attachment::updateGraphics(float dt)
             World::getWorld()->getTicksSinceStart()) / 0.7f;
         if (scale_ratio > 0.0f)
         {
-            float scale = 0.3f * scale_ratio +
-                wanted_node_scale * (1.0f - scale_ratio);
-            m_node->setScale(core::vector3df(scale, scale, scale));
+            if (m_type == ATTACH_PARACHUTE)
+            {
+                const float progress = 1.0f - scale_ratio;
+
+                const float x = 0.2f * atan(25.0f * progress - 5.0f) + 0.69f;
+                const float y = x;
+                const float z = 1.0f - pow(2.0f, -20.f * progress);
+
+                m_node->setScale(core::vector3df(x * wanted_node_scale,
+                                                 y * wanted_node_scale,
+                                                 z * wanted_node_scale));
+            }
+            else
+            {
+                if (is_shield)
+                {
+                    // Taken from https://easings.net/#easeInElastic
+                    const float c4 = (2.0f * PI) / 3.0f;
+                    const float x = scale_ratio;
+
+                    scale_ratio = x <= 0 ? 0 : x >= 1 ? 1
+                      : -pow(2, 10 * x - 10) * sin((x * 10 - 10.75) * c4);
+                }
+
+                float scale = 0.3f * scale_ratio +
+                    wanted_node_scale * (1.0f - scale_ratio);
+                m_node->setScale(core::vector3df(scale, scale, scale));
+            }
         }
         else
         {


### PR DESCRIPTION
I've added a simple animation for the spawning of the bubblegum shield and parachute items.

It's all done in the code, no asset update needed. I've been careful not to affect the internal state of the objects, so it shouldn't affect networking.

https://github.com/user-attachments/assets/ffdcfefb-7fc4-4072-9653-3119432ef5c5

https://github.com/user-attachments/assets/9e7ac3b7-16dd-4228-a001-fe228118abc4


## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
