### PR TITLE
src/network/protocols/ranking.hpp: add missing `<stdint.h>` include

### DIFF
--- a/src/network/protocols/ranking.hpp
+++ b/src/network/protocols/ranking.hpp
@@ -22,6 +22,7 @@
 #include <map>
 #include <memory>
 #include <vector>
+#include <stdint.h>
 
 class XMLNode;
 class NetworkPlayerProfile;


### PR DESCRIPTION
Without the chnage the build fails on upcoming `gcc-15` as:

    /build/source/src/network/protocols/ranking.hpp:31:5: error: 'uint32_t' does not name a type
       31 |     uint32_t online_id;
          |     ^~~~~~~~

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
