### PR TITLE
Update cutscene_gui.cpp

### DIFF
--- a/src/states_screens/cutscene_gui.cpp
+++ b/src/states_screens/cutscene_gui.cpp
@@ -54,7 +54,7 @@ void CutsceneGUI::renderGlobal(float dt)
 
     if (m_subtitle.size() > 0)
     {
-        core::rect<s32> r(0, screen_size.Height - GUIEngine::getFontHeight()*10,
+        core::rect<s32> r(0, screen_size.Height - GUIEngine::getFontHeight()*6,
                           screen_size.Width, screen_size.Height);
 
         if (GUIEngine::getFont()->getDimension(m_subtitle.c_str()).Width > screen_size.Width)

--- a/src/states_screens/cutscene_gui.cpp
+++ b/src/states_screens/cutscene_gui.cpp
@@ -54,7 +54,7 @@ void CutsceneGUI::renderGlobal(float dt)
 
     if (m_subtitle.size() > 0)
     {
-        core::rect<s32> r(0, screen_size.Height - GUIEngine::getFontHeight()*2,
+        core::rect<s32> r(0, screen_size.Height - GUIEngine::getFontHeight()*10,
                           screen_size.Width, screen_size.Height);
 
         if (GUIEngine::getFont()->getDimension(m_subtitle.c_str()).Width > screen_size.Width)


### PR DESCRIPTION
This update will move the subtitles from the bottom of the screen a few pixels above.This is intended so that the subtitles stay above the Skip buttons in cutscenes

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
