### PR TITLE
Make loading screen icons fit ~40% of it

### DIFF
--- a/src/graphics/irr_driver.cpp
+++ b/src/graphics/irr_driver.cpp
@@ -1140,6 +1140,7 @@ void IrrDriver::applyResolutionSettings(bool recreate_device)
     // Input manager set first so it recieves SDL joystick event
     // Re-init GUI engine
     GUIEngine::init(m_device, m_video_driver, StateManager::get());
+    GUIEngine::reserveLoadingIcons(3);
     // If not recreate device we need to add the previous joystick manually
     if (!recreate_device)
         input_manager->addJoystick();

--- a/src/guiengine/engine.hpp
+++ b/src/guiengine/engine.hpp
@@ -251,6 +251,9 @@ namespace GUIEngine
     /** \brief poll events during rendering to prevent unresponsive window */
     void flushRenderLoading(bool launching);
 
+    /** \brief The engine is being told there will be more icons. */
+    void reserveLoadingIcons(int count);
+
     /** \brief to spice up a bit the loading icon : add icons to the loading screen */
     void addLoadingIcon(irr::video::ITexture* icon);
 

--- a/src/karts/kart_model.cpp
+++ b/src/karts/kart_model.cpp
@@ -1323,7 +1323,7 @@ void KartModel::initInverseBoneMatrices()
     float striaght_frame = (float)m_animation_frame[AF_STRAIGHT];
     if (m_animation_frame[AF_STRAIGHT] == -1)
     {
-        Log::warn("KartModel", "%s has no striaght frame defined.",
+        Log::warn("KartModel", "%s has no straight frame defined.",
             m_model_filename.c_str());
         striaght_frame = 0.0f;
     }

--- a/src/karts/kart_properties_manager.cpp
+++ b/src/karts/kart_properties_manager.cpp
@@ -207,6 +207,7 @@ void KartPropertiesManager::loadAllKarts(bool loading_icon)
         // --------------------------------------------
         std::set<std::string> result;
         file_manager->listFiles(result, *dir);
+        GUIEngine::reserveLoadingIcons(result.size());
         for(std::set<std::string>::const_iterator subdir=result.begin();
             subdir!=result.end(); subdir++)
         {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1889,6 +1889,7 @@ void clearGlobalVariables()
 //=============================================================================
 void initRest()
 {
+    GUIEngine::reserveLoadingIcons(2);
     SP::setMaxTextureSize();
     irr_driver = new IrrDriver();
 
@@ -2310,6 +2311,7 @@ int main(int argc, char *argv[])
         wiimote_manager = new WiimoteManager();
 #endif
 
+        GUIEngine::reserveLoadingIcons(4);
         int parent_pid;
         bool has_parent_process = false;
         if (CommandLine::has("--parent-process", &parent_pid))


### PR DESCRIPTION
I don't know how to get the number of icons in advance, nor I can make proper animations, so for now the jump in size is like that. I will add more commits if I find out how.

---

I made this commit a few months ago, I remember nothing apart from description but maybe you find it useful enough

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
