### PR TITLE
added random track button outside the track chooser

### DIFF
--- a/data/gui/screens/tracks_and_gp.stkgui
+++ b/data/gui/screens/tracks_and_gp.stkgui
@@ -25,7 +25,7 @@
             <header width="30%" I18N="In the track and grand prix selection screen" text="All Tracks"
                     align="center" text_align="center" />
             <textbox width="30%" id="search"/>
-            <icon-button id="random_track" width="fit" height="100%" icon="gui/icons/track_random.png" I18N="In the track and grand prix selection screen" text=""/>
+            <icon-button id="random_track" width="10%" height="100%" icon="gui/icons/track_random.png" I18N="In the track and grand prix selection screen" text=""/>
             <div width="fit" height="100%" layout="horizontal-row" align="center">
                 <checkbox id="favorite"/>
                 <tiny-header width="fit" height="100%" I18N="In the track and grand prix selection screen" text="Edit favorite tracks"/>

--- a/data/gui/screens/tracks_and_gp.stkgui
+++ b/data/gui/screens/tracks_and_gp.stkgui
@@ -24,8 +24,9 @@
         <div width="100%" height="fit" layout="horizontal-row" >
             <header width="30%" I18N="In the track and grand prix selection screen" text="All Tracks"
                     align="center" text_align="center" />
-            <textbox width="40%" id="search"/>
+            <textbox width="30%" id="search"/>
             <spacer width="3%"/>
+            <icon-button id="random_track" width="10%" height="50%" icon="gui/icons/track_random.png" I18N="In the track and grand prix selection screen" text="Random track"/>
             <div width="fit" height="100%" layout="horizontal-row" align="center">
                 <checkbox id="favorite"/>
                 <spacer width="5%"/>

--- a/data/gui/screens/tracks_and_gp.stkgui
+++ b/data/gui/screens/tracks_and_gp.stkgui
@@ -25,11 +25,9 @@
             <header width="30%" I18N="In the track and grand prix selection screen" text="All Tracks"
                     align="center" text_align="center" />
             <textbox width="30%" id="search"/>
-            <spacer width="3%"/>
-            <icon-button id="random_track" width="10%" height="50%" icon="gui/icons/track_random.png" I18N="In the track and grand prix selection screen" text="Random track"/>
+            <icon-button id="random_track" width="fit" height="100%" icon="gui/icons/track_random.png" I18N="In the track and grand prix selection screen" text=""/>
             <div width="fit" height="100%" layout="horizontal-row" align="center">
                 <checkbox id="favorite"/>
-                <spacer width="5%"/>
                 <tiny-header width="fit" height="100%" I18N="In the track and grand prix selection screen" text="Edit favorite tracks"/>
             </div>
         </div>

--- a/src/states_screens/tracks_and_gp_screen.cpp
+++ b/src/states_screens/tracks_and_gp_screen.cpp
@@ -51,48 +51,35 @@ static const char ALL_TRACK_GROUPS_ID[] = "all";
 void TracksAndGPScreen::eventCallback(Widget* widget, const std::string& name,
                                  const int playerID)
 {
-    // -- hacky solution for random_track button
-    if (name == "random_track") {
-        if (m_random_track_list.empty()) return;
-
-        std::string selection = m_random_track_list.front();
-        m_random_track_list.pop_front();
-        m_random_track_list.push_back(selection);
-
-        Track *track = track_manager->getTrack(selection);
-
-        if (track)
-        {
-            TrackInfoScreen::getInstance()->setTrack(track);
-            TrackInfoScreen::getInstance()->push();
-        }
-    }
-
-    // -- track selection screen
-    if (name == "tracks")
+    // -- track selection screen / random track button
+    if (name == "tracks" || name == "random_track")
     {
-        DynamicRibbonWidget* w2 = dynamic_cast<DynamicRibbonWidget*>(widget);
-        if(!w2) return;
-
-        std::string selection = w2->getSelectionIDString(PLAYER_ID_GAME_MASTER);
-        if (UserConfigParams::logGUI())
+        std::string selection;
+        if (name == "tracks")
         {
-            Log::info("TracksAndGPScreen", "Clicked on track '%s'.",
-                       selection.c_str());
+            DynamicRibbonWidget* w2 = dynamic_cast<DynamicRibbonWidget*>(widget);
+            if(!w2) return;
+
+            selection = w2->getSelectionIDString(PLAYER_ID_GAME_MASTER);
+            if (UserConfigParams::logGUI())
+            {
+                Log::info("TracksAndGPScreen", "Clicked on track '%s'.",
+                           selection.c_str());
+            }
+
+            UserConfigParams::m_last_track = selection;
+            if (selection == "locked" && RaceManager::get()->getNumLocalPlayers() == 1)
+            {
+                unlock_manager->playLockSound();
+                return;
+            }
+            else if (selection == RibbonWidget::NO_ITEM_ID)
+            {
+                return;
+            }
         }
 
-        UserConfigParams::m_last_track = selection;
-        if (selection == "locked" && RaceManager::get()->getNumLocalPlayers() == 1)
-        {
-            unlock_manager->playLockSound();
-            return;
-        }
-        else if (selection == RibbonWidget::NO_ITEM_ID)
-        {
-            return;
-        }
-
-        if (selection == "random_track")
+        if (selection == "random_track" || name == "random_track")
         {
             if (m_random_track_list.empty()) return;
 

--- a/src/states_screens/tracks_and_gp_screen.cpp
+++ b/src/states_screens/tracks_and_gp_screen.cpp
@@ -51,6 +51,23 @@ static const char ALL_TRACK_GROUPS_ID[] = "all";
 void TracksAndGPScreen::eventCallback(Widget* widget, const std::string& name,
                                  const int playerID)
 {
+    // -- hacky solution for random_track button
+    if (name == "random_track") {
+        if (m_random_track_list.empty()) return;
+
+        std::string selection = m_random_track_list.front();
+        m_random_track_list.pop_front();
+        m_random_track_list.push_back(selection);
+
+        Track *track = track_manager->getTrack(selection);
+
+        if (track)
+        {
+            TrackInfoScreen::getInstance()->setTrack(track);
+            TrackInfoScreen::getInstance()->push();
+        }
+    }
+
     // -- track selection screen
     if (name == "tracks")
     {


### PR DESCRIPTION
## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
##
Adds the "random track" button outside the track chooser, because once you have >100 tracks, then finding the "random track" button is very annoying. I can't count the amount of times I had to scrool through my whole "gallery" of maps, just to find the "random track" button.

The code must be cleaned up (the button functionality is very similar to the one in the track chooser and I didn't know what's the best way to make it good).
There must be work on UX, (the button "fits/feels" weirdly in its current place)