### PR TITLE
Add `StartupWMClass` to the desktop file

### DIFF
--- a/data/supertuxkart.desktop
+++ b/data/supertuxkart.desktop
@@ -1,6 +1,7 @@
 [Desktop Entry]
 Name=SuperTuxKart
 Icon=supertuxkart
+StartupWMClass=supertuxkart
 #I18N: Generic name in desktop file entry, summary in AppData and short description in Google Play
 GenericName[ar]=لعبة سباق سيارات ثلاثية الأبعاد مفتوحة المصدر
 GenericName[be]=3D-гульня для гонак на картах з адкрытым зыходным кодам


### PR DESCRIPTION
This resolves some edge-cases where desktop icon isn't shown, like in Gnome's dash panel for example.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
