### PR TITLE
Revert "Removed glow under main menu options"

### DIFF
--- a/src/guiengine/skin.cpp
+++ b/src/guiengine/skin.cpp
@@ -1424,11 +1424,10 @@ void Skin::drawRibbonChild(const core::recti &rect, Widget* widget,
         }
 
         const bool mark_focused =
-            (focused || (parent_focused && parentRibbonWidget != NULL &&
+            focused || (parent_focused && parentRibbonWidget != NULL &&
                           parentRibbonWidget->m_mouse_focus == widget) ||
                        (mark_selected && !always_show_selection &&
-                          parent_focused)) &&
-                        widget->m_properties[PROP_FOCUS_ICON].size() == 0;
+                          parent_focused);
 
         /* draw "selection bubble" if relevant */
         if (always_show_selection && mark_selected)


### PR DESCRIPTION
This complete breaks the Cartoon theme unfortunately, as the highlight effect is very subtle vs the classic theme.  Open for a better solution, but this should certainly be fixed before 1.5 is released as it's a pretty big usability issue.