### PR TITLE
Fix GLES sampler precision issue for advanced pipeline

### DIFF
--- a/src/graphics/shader_files_manager.cpp
+++ b/src/graphics/shader_files_manager.cpp
@@ -202,12 +202,14 @@ ShaderFilesManager::SharedShader ShaderFilesManager::loadShader
         code << "precision highp float;\n";
         code << "precision highp sampler2DArrayShadow;\n";
         code << "precision highp sampler2DArray;\n";
+        code << "precision highp sampler2D;\n";
     }
     else
     {
         code << "precision mediump float;\n";
         code << "precision mediump sampler2DArrayShadow;\n";
         code << "precision mediump sampler2DArray;\n";
+        code << "precision mediump sampler2D;\n";
     }
 #endif
     code << "#define MAX_BONES " << stk_config->m_max_skinning_bones << "\n";


### PR DESCRIPTION
Currently we do not add precision description to sampler2D's, and the default precision defined by ESSL spec is lowp.

Experimentation on an Imagination AXM-8-256 GPU shows that the advanced pipeline needs highp sampler2D, otherwise some distant objects will glitch (noticable at the start point of black_forest map).

Manually add precision modifiers for sampler2D to fix the glitch.

Tested on Eswin EIC7700 with X11+EGL+GLES with Imagination DDK 23.2 driver.

P.S. setting mediump instead of highp on sampler2D's seems to be not enough for resolving the glitch; maybe hardwares w/o highp support need to be forbidden from advanced pipeline or some shaders need to be rewritten to be mediump-safe.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
