### PR TITLE
Add a speedmeter on multitouch

### DIFF
--- a/src/states_screens/race_gui.cpp
+++ b/src/states_screens/race_gui.cpp
@@ -374,20 +374,16 @@ void RaceGUI::renderPlayerView(const Camera *camera, float dt)
 
     if (!isSpectatorCam) drawPlungerInFace(camera, dt);
 
-    // Scale race GUI along screen size
-    scaling *= sqrtf(float(viewport.getWidth()) / 800.0f);
-    scaling *= sqrtf(float(viewport.getHeight()) / 450.0f); 
-
-    // Scale X and Y separately in splitscreen for proper relative positioning
     if (viewport.getWidth() != (int)irr_driver->getActualScreenSize().Width ||
         viewport.getHeight() != (int)irr_driver->getActualScreenSize().Height)
     {
-        // This is tuned so that in 2-way splitscreen, the UI elements have a size
-        // close to the icons without splitscreen.
-        scaling.X *= 1.35f * float(viewport.getWidth()) / float(irr_driver->getActualScreenSize().Width);
-        scaling.Y *= 1.35f * float(viewport.getHeight()) / float(irr_driver->getActualScreenSize().Height);
+        scaling.X *= float(viewport.getWidth()) / float(irr_driver->getActualScreenSize().Width); // scale race GUI along screen size
+        scaling.Y *= float(viewport.getHeight()) / float(irr_driver->getActualScreenSize().Height); // scale race GUI along screen size
     }
-
+    else
+    {
+        scaling *= float(viewport.getWidth()) / 800.0f; // scale race GUI along screen size
+    }
     
     drawAllMessages(kart, viewport, scaling);
 
@@ -400,6 +396,10 @@ void RaceGUI::renderPlayerView(const Camera *camera, float dt)
         {
             drawPowerupIcons(kart, viewport, scaling);
             drawSpeedEnergyRank(kart, viewport, scaling, dt);
+        }
+        else
+        {
+           drawMultitouchSpeedEnergyRank(kart, viewport, scaling, dt);
         }
     }
 
@@ -1129,6 +1129,133 @@ void RaceGUI::drawSpeedEnergyRank(const AbstractKart* kart,
     drawMeterTexture(m_speed_bar_icon, vertices, count);
 #endif
 }   // drawSpeedEnergyRank
+
+//-----------------------------------------------------------------------------
+/** Draws a miltitouch speedometer and
+ *  the rank of the player (in the same local of always).
+ *  \param kart The kart for which to show the data.
+ *  \param viewport The viewport to use.
+ *  \param scaling Which scaling to apply to the speedometer.
+ *  \param dt Time step size.
+ */
+
+void RaceGUI::drawMultitouchSpeedRank(const AbstractKart* kart,
+                                 const core::recti &viewport,
+                                 const core::vector2df &scaling,
+                                 float dt)
+{
+#ifndef SERVER_ONLY
+    float min_ratio         = std::min(scaling.X, scaling.Y);
+    const int SPEEDWIDTH   = 128;
+    int meter_width        = (int)(SPEEDWIDTH*min_ratio);
+    int meter_height       = (int)(SPEEDWIDTH*min_ratio);
+
+    // First draw the meter (i.e. the background )
+    // -------------------------------------------------------------------------
+    core::vector2df offset;
+    offset.X = (float)(viewport.LowerRightCorner.X-meter_width) - 260.0f*scaling.X;
+    offset.Y = viewport.LowerRightCorner.Y-80.0f*scaling.Y;
+
+    const core::rect<s32> meter_pos((int)offset.X,
+                                    (int)(offset.Y-meter_height),
+                                    (int)(offset.X+meter_width),
+                                    (int)offset.Y);
+    const core::rect<s32> meter_texture_coords(core::position2d<s32>(0,0),
+                                               m_speed_meter_icon->getSize());
+    draw2DImage(m_speed_meter_icon, meter_pos, meter_texture_coords, NULL,
+                       NULL, true);
+    // TODO: temporary workaround, shouldn't have to use
+    // draw2DVertexPrimitiveList to render a simple rectangle
+
+    const float speed =  kart->getSpeed();
+
+    drawRank(kart, offset, min_ratio, meter_width, meter_height, dt);
+
+
+    if(speed <=0) return;  // Nothing to do if speed is negative.
+
+    // Draw the actual speed bar (if the speed is >0)
+    // ----------------------------------------------
+    float speed_ratio = speed/40.0f; //max displayed speed of 40
+    if(speed_ratio>1) speed_ratio = 1;
+
+    // see computeVerticesForMeter for the detail of the drawing
+    // If increasing this, update drawMeterTexture
+
+    const int vertices_count = 12;
+
+    video::S3DVertex vertices[vertices_count];
+
+    // The positions for A to J2 are defined here.
+
+    // They are calculated from speedometer.png
+    // A is the center of the speedometer's circle
+    // B2, C, D, E, F, G, H, I and J1 are points on the line
+    // from A to their respective 1/8th threshold division
+    // B2 is 36,9° clockwise from the vertical (on bottom-left)
+    // J1 s 70,7° clockwise from the vertical (on upper-right)
+    // B1 and J2 are used for correct display of the 3D effect
+    // They are 1,13* further than the speedometer farther position because
+    // the lines between them would otherwise cut through the outside circle.
+
+    core::vector2df position[vertices_count];
+
+    position[0].X = 0.546f;//A
+    position[0].Y = 0.566f;//A
+    position[1].X = 0.216f;//B1
+    position[1].Y = 1.036f;//B1
+    position[2].X = 0.201f;//B2
+    position[2].Y = 1.023f;//B2
+    position[3].X = 0.036f;//C
+    position[3].Y = 0.831f;//C
+    position[4].X = -0.029f;//D
+    position[4].Y = 0.589f;//D
+    position[5].X = 0.018f;//E
+    position[5].Y = 0.337f;//E
+    position[6].X = 0.169f;//F
+    position[6].Y = 0.134f;//F
+    position[7].X = 0.391f;//G
+    position[7].Y = 0.014f;//G
+    position[8].X = 0.642f;//H
+    position[8].Y = 0.0f;//H
+    position[9].X = 0.878f;//I
+    position[9].Y = 0.098f;//I
+    position[10].X = 1.046f;//J1
+    position[10].Y = 0.285f;//J1
+    position[11].X = 1.052f;//J2
+    position[11].Y = 0.297f;//J2
+
+    // The speed ratios at which different triangles must be used.
+
+    float threshold[vertices_count-2];
+    threshold[0] = 0.00001f;//for the 3D margin
+    threshold[1] = 0.125f;
+    threshold[2] = 0.25f;
+    threshold[3] = 0.375f;
+    threshold[4] = 0.50f;
+    threshold[5] = 0.625f;
+    threshold[6] = 0.750f;
+    threshold[7] = 0.875f;
+    threshold[8] = 0.99999f;//for the 3D margin
+    threshold[9] = 1.0f;
+
+    //3D effect : wait for the full border to appear before drawing
+    for (int i=0;i<8;i++)
+    {
+        if ((speed_ratio-0.125f*i < 0.00625f && speed_ratio-0.125f*i >= 0.0f) || (0.125f*i-speed_ratio < 0.0045f && 0.125f*i-speed_ratio >= 0.0f) )
+        {
+            speed_ratio = 0.125f*i-0.0045f;
+            break;
+        }
+    }
+
+    unsigned int count = computeVerticesForMeter(position, threshold, vertices, vertices_count, 
+                                                     speed_ratio, meter_width, meter_height, offset);
+
+
+    drawMeterTexture(m_speed_bar_icon, vertices, count);
+#endif // drawMultitouchSpeedRank
+} 
 
 void RaceGUI::drawMeterTexture(video::ITexture *meter_texture, video::S3DVertex vertices[], unsigned int count, bool reverse)
 {

--- a/src/states_screens/race_gui.hpp
+++ b/src/states_screens/race_gui.hpp
@@ -20,7 +20,6 @@
 #ifndef HEADER_RACE_GUI_HPP
 #define HEADER_RACE_GUI_HPP
 
-#include <map>
 #include <string>
 #include <vector>
 
@@ -108,30 +107,34 @@ private:
     /** Animation state: none, getting smaller (old value),
      *  getting bigger (new number). */
     enum AnimationState {AS_NONE, AS_SMALLER, AS_BIGGER};
-    std::map<int, AnimationState> m_animation_states;
+    std::vector<AnimationState> m_animation_states;
 
-    /** How long the speedometer digit animation has been shown for this number. */
-    std::map<int, float> m_animation_duration;
+    /** How long the rank animation has been shown. */
+    std::vector<float> m_rank_animation_duration;
 
-    /** Stores the previous digit on the center of the speedometer for each number. */
-    std::map<int, int> m_last_digit;
+    /** Stores the previous rank for each kart. Used for the rank animation. */
+    std::vector<int> m_last_ranks;
 
     bool m_is_tutorial;
 
     /* Display informat for one player on the screen. */
-    void drawEnergyMeter       (int x, int y, const AbstractKart *kart,
-                                const core::recti &viewport,
-                                const core::vector2df &scaling);
-    void drawSpeedEnergyRank   (const AbstractKart* kart,
-                                const core::recti &viewport,
-                                const core::vector2df &scaling, float dt);
-    void drawLap               (const AbstractKart* kart,
-                                const core::recti &viewport,
-                                const core::vector2df &scaling);
-    void drawRank              (const AbstractKart *kart,
-                                const core::vector2df &offset,
-                                float min_ratio, int meter_width,
-                                int meter_height, float dt);
+    void drawEnergyMeter                (int x, int y, const AbstractKart *kart,
+                                        const core::recti &viewport,
+                                        const core::vector2df &scaling);
+    void drawSpeedEnergyRank            (const AbstractKart* kart,
+                                        const core::recti &viewport,
+                                        const core::vector2df &scaling, float dt);
+    void drawMultitouchSpeedRank        (const AbstractKart* kart,
+                                        const core::recti &viewport,
+                                        const core::vector2df &scaling,
+                                        float dt);
+    void drawLap                        (const AbstractKart* kart,
+                                        const core::recti &viewport,
+                                        const core::vector2df &scaling);
+    void drawRank                       (const AbstractKart *kart,
+                                        const core::vector2df &offset,
+                                        float min_ratio, int meter_width,
+                                        int meter_height, float dt);
 
     /* Helper functions for drawing meters */
 


### PR DESCRIPTION
Finnally!!! A way to know your speed on Android (and iOS).

Anyway, this add the same speedmeter from PC to Android in left of the control buttons (skid, nitro, etc).

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
