### PR TITLE
Fix wrong powerup sound when using after a rewind/forced sync

### DIFF
--- a/src/items/powerup.cpp
+++ b/src/items/powerup.cpp
@@ -149,10 +149,6 @@ void Powerup::set(PowerupManager::PowerupType type, int n)
 
     m_number=n;
 
-    // Don't re-create sound sound during rewinding
-    if (RewindManager::get()->isRewinding())
-        return;
-
     if (m_sound_use != NULL)
     {
         m_sound_use->deleteSFX();


### PR DESCRIPTION
Known bug for years, happens most often when playing on a server with a custom powerup.xml or when one's internet connection is bad/has a lot of packet loss. This PR simply removes a check in `Powerup::set()` that made sure not to re-create the sound source when rewinding. This check was unnecessary and produced an audio bug where basically the client would decide on an item sound, and never change it regardless of whether the server corrected this item or not. The `Powerup::rewindTo()` function already makes sure not to invoke `Powerup::set()` for cases where the sound source would not need to be recreated (item of the same type), so as far as I know there are no concerns about unneeded memory accesses.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
