### PR TITLE
arena_graph.hpp: include cstdint for int16_t

### DIFF
--- a/src/tracks/arena_graph.hpp
+++ b/src/tracks/arena_graph.hpp
@@ -22,6 +22,7 @@
 #include "tracks/graph.hpp"
 #include "utils/cpp2011.hpp"
 
+#include <cstdint>
 #include <set>
 
 class ArenaNode;


### PR DESCRIPTION
Allows to build successfully on musl:
```
/usr/bin/powerpc64le-unknown-linux-musl-g++ -DENABLE_CRYPTO_OPENSSL -DENABLE_SOUND -DNDEBUG -DSUPERTUXKART_DATADIR=\"/usr/share/supertuxkart\" -DSUPERTUXKART_VERSION=\"1.4\" -I/var/tmp/portage/games-action/supertuxkart-1.4-r1/work/SuperTuxKart-1.4-src/lib/sheenbidi/Headers -I/var/tmp/portage/games-action/supertuxkart-1.4-r1/work/SuperTuxKart-1.4-src/lib/irrlicht/include -I/var/tmp/portage/games-action/supertuxkart-1.4-r1/work/SuperTuxKart-1.4-src/lib/tinygettext/include -I/var/tmp/portage/games-action/supertuxkart-1.4-r1/work/SuperTuxKart-1.4-src/lib/graphics_utils -I/var/tmp/portage/games-action/supertuxkart-1.4-r1/work/SuperTuxKart-1.4-src/lib/graphics_engine/include -I/var/tmp/portage/games-action/supertuxkart-1.4-r1/work/SuperTuxKart-1.4-src/lib/libsquish -I/var/tmp/portage/games-action/supertuxkart-1.4-r1/work/SuperTuxKart-1.4-src/lib/bullet/src -I/usr/include/SDL2 -I/var/tmp/portage/games-action/supertuxkart-1.4-r1/work/SuperTuxKart-1.4-src/src -I/usr/include/AL -I/usr/include/freetype2 -I/usr/include/harfbuzz -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include  -O2 -pipe -mcpu=power9 -fgraphite-identity -floop-nest-optimize -ftrivial-auto-var-init=zero -Werror=odr -Werror=lto-type-mismatch -Werror=strict-aliasing -fno-strict-aliasing -std=gnu++0x -Wall -Wno-unused-function -MD -MT CMakeFiles/supertuxkart.dir/src/tracks/arena_graph.cpp.o -MF CMakeFiles/supertuxkart.dir/src/tracks/arena_graph.cpp.o.d -o CMakeFiles/supertuxkart.dir/src/tracks/arena_graph.cpp.o -c /var/tmp/portage/games-action/supertuxkart-1.4-r1/work/SuperTuxKart-1.4-src/src/tracks/arena_graph.cpp In file included from /var/tmp/portage/games-action/supertuxkart-1.4-r1/work/SuperTuxKart-1.4-src/src/tracks/arena_graph.cpp:19: /var/tmp/portage/games-action/supertuxkart-1.4-r1/work/SuperTuxKart-1.4-src/src/tracks/arena_graph.hpp:41:29: error: 'int16_t' was not declared in this scope
   41 |     std::vector<std::vector<int16_t>> m_parent_node;
      |                             ^~~~~~~
/var/tmp/portage/games-action/supertuxkart-1.4-r1/work/SuperTuxKart-1.4-src/src/tracks/arena_graph.hpp:26:1: note: 'int16_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
   25 | #include <set>
  +++ |+#include <cstdint>
   26 |
```

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
