### PR TITLE
Added batch downloading

### DIFF
--- a/data/gui/screens/addons_screen.stkgui
+++ b/data/gui/screens/addons_screen.stkgui
@@ -2,6 +2,8 @@
 <stkgui>
     <div x="1%" y="0" width="98%" layout="horizontal-row" height="9%">
         <icon-button id="back" height="100%" icon_align="left" icon="gui/icons/back.png"/>
+        <spacer proportion="0.1" height="1"/>
+        <icon-button id="download_all" height="100%" icon="gui/icons/package-update.png" icon_align="left"/>
         <spacer proportion="1" height="1"/>
         <icon-button id="reload" y="5%" height="90%" icon_align="right" icon="gui/icons/restart.png"/>
     </div>

--- a/src/states_screens/addons_screen.hpp
+++ b/src/states_screens/addons_screen.hpp
@@ -23,6 +23,8 @@
 #include "guiengine/widgets/list_widget.hpp"
 #include "guiengine/widgets/text_box_widget.hpp"
 
+#include <list>
+
 /* used for the installed/unsinstalled icons*/
 namespace irr { namespace gui { class STKModifiedSpriteBank; } }
 
@@ -58,6 +60,9 @@ private:
     int              m_icon_not_installed;
     /** Icon for 'loading' */
     int              m_icon_loading;
+
+    std::list<std::string> m_addon_queue;
+    AddonsLoading * m_addons_loading;
 
     irr::gui::STKModifiedSpriteBank
                     *m_icon_bank;

--- a/src/states_screens/dialogs/addons_loading.cpp
+++ b/src/states_screens/dialogs/addons_loading.cpp
@@ -62,6 +62,7 @@ AddonsLoading::AddonsLoading(const std::string &id)
              , m_addon(*(addons_manager->getAddon(id)) )
 #endif
 {
+    m_cancelled         = false;
     m_message_shown    = false;
     m_icon_shown       = false;
 #ifdef SERVER_ONLY
@@ -208,6 +209,17 @@ bool AddonsLoading::onEscapePressed()
     ModalDialog::dismiss();
     return true;
 }   // onEscapePressed
+
+bool AddonsLoading::isDone()
+{
+    if (!m_download_request)
+        return true;
+    return m_download_request->isDone();
+}
+bool AddonsLoading::wasCancelled()
+{
+    return m_cancelled;
+}
 
 // ----------------------------------------------------------------------------
 void AddonsLoading::tryInstall()
@@ -370,6 +382,7 @@ void AddonsLoading::stopDownload()
     if (m_download_request)
     {
         m_download_request->cancel();
+        m_cancelled = true;
         m_download_request = nullptr;
     }
 }   // startDownload

--- a/src/states_screens/dialogs/addons_loading.hpp
+++ b/src/states_screens/dialogs/addons_loading.hpp
@@ -49,6 +49,8 @@ private:
     void doInstall();
     void doUninstall();
 
+    bool m_cancelled;
+
     /** True if the icon is being displayed. */
     bool m_icon_shown;
     /** True if the error message has shown once. */
@@ -75,6 +77,8 @@ public:
     void onUpdate(float delta) OVERRIDE;
     void voteClicked();
     void tryInstall();
+    bool isDone();
+    bool wasCancelled();
     virtual bool onEscapePressed() OVERRIDE;
     
 };   // AddonsLoading


### PR DESCRIPTION
## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
This allow the user to automatically download all of the listed karts/tracks/arenas. This is useful with #5500 as the combination of this pr and that one allows the user to (for example) download all of the featured tracks, with just a single mouse press.

So far it seems to work, excluding the FIXME (mem-leak) and the icon-button doesn't working well with the mouse for some reason (high chance I messed up the .stkgui)
