### PR TITLE
add new TV spectator mode

### DIFF
--- a/src/graphics/camera/camera.cpp
+++ b/src/graphics/camera/camera.cpp
@@ -234,7 +234,7 @@ Camera::Mode Camera::getPreviousMode()
  */
 bool Camera::isSpectatorMode()
 {
-    return ((m_mode == CM_SPECTATOR_TOP_VIEW) || (m_mode == CM_SPECTATOR_SOCCER));
+    return ((m_mode == CM_SPECTATOR_TOP_VIEW) || (m_mode == CM_SPECTATOR_SOCCER) || (m_mode == CM_SPECTATOR_TV));
 }   // isSpectatorMode
 
 // ----------------------------------------------------------------------------
@@ -243,7 +243,14 @@ bool Camera::isSpectatorMode()
 void Camera::setNextSpectatorMode()
 {
     if (m_mode == CM_SPECTATOR_SOCCER) m_mode = CM_SPECTATOR_TOP_VIEW;
-    else if (m_mode == CM_SPECTATOR_TOP_VIEW) m_mode = m_previous_mode;
+    else if (m_mode == CM_SPECTATOR_TOP_VIEW)
+    {
+        if (CameraNormal::hasTVCameras())
+            m_mode = CM_SPECTATOR_TV;
+        else
+            m_mode = m_previous_mode; 
+    }
+    else if (m_mode == CM_SPECTATOR_TV && m_previous_mode != CM_SPECTATOR_TV) m_mode = m_previous_mode;
     else setMode(CM_SPECTATOR_SOCCER);
 }   // setNextSpectatorMode
 

--- a/src/graphics/camera/camera.hpp
+++ b/src/graphics/camera/camera.hpp
@@ -66,6 +66,7 @@ public:
         CM_LEADER_MODE,       //!< for deleted player karts in follow the leader
         CM_SPECTATOR_SOCCER,   //!< for spectator (in soccer mode)
         CM_SPECTATOR_TOP_VIEW, //!< for spectator (top view on ball if soccer or top view on kart)
+        CM_SPECTATOR_TV,       //!< spectator TV cameras placed in scene (soccer), always follow ball
         CM_SIMPLE_REPLAY,
         CM_FALLING
     };   // Mode

--- a/src/graphics/camera/camera_normal.hpp
+++ b/src/graphics/camera/camera_normal.hpp
@@ -67,6 +67,15 @@ private:
     btVector3 m_kart_position;
     btQuaternion m_kart_rotation;
 
+    // TV spectator cameras defined by track designer (soccer). Always follow ball.
+    static std::vector<Vec3> m_tv_cameras;
+
+    // TV camera selection smoothing
+    int   m_tv_current_index = -1;
+    float m_tv_switch_cooldown = 0.0f; // seconds remaining before next switch
+    static float m_tv_min_delta2;       // required improvement (squared distance) to switch
+    static float m_tv_cooldown_default; // default cooldown after a switch (seconds)
+
     // Give a few classes access to the constructor (mostly for inheritance)
     friend class Camera;
     friend class CameraDebug;
@@ -93,6 +102,15 @@ public:
     // ------------------------------------------------------------------------
     /** Returns the current ambient light. */
     const video::SColor &getAmbientLight() const {return m_ambient_light; }
+
+    // Load TV cameras from XML section <tv-cameras> in scene.xml
+    static void readTVCameras(const XMLNode &root);
+
+    // clean all TV camera
+    static void clearTVCameras();
+    
+    // Returns true if at least one TV camera was loaded
+    static bool hasTVCameras();
 
 };   // class CameraNormal
 

--- a/src/modes/soccer_world.cpp
+++ b/src/modes/soccer_world.cpp
@@ -23,6 +23,7 @@
 #include "config/user_config.hpp"
 #include "io/file_manager.hpp"
 #include "graphics/irr_driver.hpp"
+#include "graphics/camera/camera_normal.hpp"
 #include "karts/abstract_kart_animation.hpp"
 #include "karts/kart_model.hpp"
 #include "karts/kart_properties.hpp"
@@ -264,6 +265,9 @@ SoccerWorld::~SoccerWorld()
 
     delete m_ball_track_sector;
     m_ball_track_sector = NULL;
+
+    // clear TV camera
+    CameraNormal::clearTVCameras();
 }   // ~SoccerWorld
 
 //-----------------------------------------------------------------------------

--- a/src/tracks/track.cpp
+++ b/src/tracks/track.cpp
@@ -28,6 +28,7 @@
 #include "config/stk_config.hpp"
 #include "config/user_config.hpp"
 #include "graphics/camera/camera_end.hpp"
+#include "graphics/camera/camera_normal.hpp"
 #include "graphics/CBatchingMesh.hpp"
 #include "graphics/central_settings.hpp"
 #include "graphics/cpu_particle_manager.hpp"
@@ -2495,6 +2496,10 @@ void Track::loadObjects(const XMLNode* root, const std::string& path,
         else if (name == "end-cameras")
         {
             CameraEnd::readEndCamera(*node);
+        }
+        else if (name == "tv-cameras")
+        {
+            CameraNormal::readTVCameras(*node);
         }
         else if (name == "light")
         {


### PR DESCRIPTION
## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
This is a third TV spectator view mode where you can watch soccer matches a bit like a TV program.
It can only be enabled if the game finds the <tv-camera> tag in the scene.xml file