### PR TITLE
Remove releases from AppStream metadata

### DIFF
--- a/data/net.supertuxkart.SuperTuxKart.metainfo.xml
+++ b/data/net.supertuxkart.SuperTuxKart.metainfo.xml
@@ -433,17 +433,6 @@
     <content_attribute id="violence-cartoon">mild</content_attribute>
     <content_attribute id="social-chat">intense</content_attribute>
   </content_rating>
-  <releases>
-    <release version="1.4" date="2022-10-31">
-      <url>https://blog.supertuxkart.net/2022/11/supertuxkart-14-release.html</url>
-    </release>
-    <release version="1.3" date="2021-09-28">
-      <url>https://blog.supertuxkart.net/2021/09/supertuxkart-13-release.html</url>
-    </release>
-    <release version="1.2" date="2020-08-27"/>
-    <release version="1.1" date="2020-01-05"/>
-    <release version="1.0" date="2019-04-21"/>
-  </releases>
   <languages>
     <lang percentage="98">ar</lang>
     <lang percentage="99">be</lang>


### PR DESCRIPTION
If there is no _releases_ section in the upstream metainfo file, the release version and release date are auto generated by downstream packaging tools. However, if there is a releases section but is outdated, the outdated data is used instead - and that is a problem. In other words, all downstream STK 1.5 packages will now appear as 1.4 because you forgot to update the releases section. And this is sadly not the first time this happened. 1.4 had the same problem if I remember correctly. So... Let's remove the whole section to prevent this from happening again.

/cc @Alayan-stk-2

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
