### PR TITLE
Fix build failure on Debian GNU/hurd

### DIFF
--- a/src/config/hardware_stats.cpp
+++ b/src/config/hardware_stats.cpp
@@ -42,7 +42,7 @@
 #      include <sys/utsname.h>
 #  endif
 #endif
-#if defined(__APPLE__) || defined(BSD)
+#if defined(__APPLE__) || (defined(BSD) && !defined(__gnu_hurd__))
 #  include <sys/sysctl.h>
 #endif
 


### PR DESCRIPTION
## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```

supertuxkart currently builds on every Debian arch except for hurd-{amd64,i386} due to the following build error ([full logs here](https://buildd.debian.org/status/fetch.php?pkg=supertuxkart&arch=hurd-i386&ver=1.5-1&stamp=1761394930&raw=0)). I'm unsure if anyone has actually tried (or wants to try) running supertuxkart on hurd but figured this is still worth fixing upstream. Thanks!

```
[ 45%] Building CXX object CMakeFiles/supertuxkart.dir/src/config/hardware_stats.cpp.o
/usr/bin/c++ -DENABLE_CRYPTO_MBEDTLS -DENABLE_IPV6 -DENABLE_SOUND -DENABLE_SQLITE3 -DNDEBUG -DSUPERTUXKART_DATADIR=\"/usr/share/games/supertuxkart\" -DSUPERTUXKART_VERSION=\"1.5\" -I/build/reproducible-path/supertuxkart-1.5/lib/sheenbidi/Headers -I/build/reproducible-path/supertuxkart-1.5/lib/irrlicht/include -I/build/reproducible-path/supertuxkart-1.5/lib/tinygettext/include -I/build/reproducible-path/supertuxkart-1.5/lib/graphics_utils -I/build/reproducible-path/supertuxkart-1.5/lib/graphics_engine/include -I/build/reproducible-path/supertuxkart-1.5/lib/enet/include -I/build/reproducible-path/supertuxkart-1.5/lib/bullet/src -I"/usr/include /usr/include" -I/usr/include/SDL2 -I/build/reproducible-path/supertuxkart-1.5/src -I/usr/include/AL -I/usr/include/freetype2 -I/usr/include/libpng16 -g -O2 -ffile-prefix-map=/build/reproducible-path/supertuxkart-1.5=. -flto=auto -ffat-lto-objects -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -std=gnu++0x -Wall -Wno-unused-function -O2 -DNDEBUG -MD -MT CMakeFiles/supertuxkart.dir/src/config/hardware_stats.cpp.o -MF CMakeFiles/supertuxkart.dir/src/config/hardware_stats.cpp.o.d -o CMakeFiles/supertuxkart.dir/src/config/hardware_stats.cpp.o -c /build/reproducible-path/supertuxkart-1.5/src/config/hardware_stats.cpp
/build/reproducible-path/supertuxkart-1.5/src/config/hardware_stats.cpp:46:12: fatal error: sys/sysctl.h: No such file or directory
   46 | #  include <sys/sysctl.h>
      |            ^~~~~~~~~~~~~~
compilation terminated.
make[3]: *** [CMakeFiles/supertuxkart.dir/build.make:418: CMakeFiles/supertuxkart.dir/src/config/hardware_stats.cpp.o] Error 1
```