### PR TITLE
Fix embedded irrlicht build failures on Debian big endian archs

### DIFF
--- a/lib/irrlicht/include/IrrCompileConfig.h
+++ b/lib/irrlicht/include/IrrCompileConfig.h
@@ -116,6 +116,10 @@
 #if !defined(_IRR_WINDOWS_API_) && !defined(_IRR_OSX_PLATFORM_) && !defined(_IRR_ANDROID_PLATFORM_) && !defined(_IRR_HAIKU_PLATFORM_)
 #ifndef _IRR_SOLARIS_PLATFORM_
 #define _IRR_LINUX_PLATFORM_
+#include <endian.h>
+ #if __BYTE_ORDER == __BIG_ENDIAN
+  #define __BIG_ENDIAN__
+ #endif
 #endif
 #define _IRR_POSIX_API_
 #endif
@@ -469,11 +473,7 @@ precision will be lower but speed higher. currently X86 only
     #undef _IRR_WCHAR_FILESYSTEM
 #endif
 
-#if defined(__sparc__) || defined(__sun__)
-#define __BIG_ENDIAN__
-#endif
-
-#if defined(_IRR_SOLARIS_PLATFORM_)
+#if defined(_IRR_SOLARIS_PLATFORM_) || defined(__FreeBSD_kernel__) || defined(__gnu_hurd__)
     #undef _IRR_COMPILE_WITH_JOYSTICK_EVENTS_
 #endif
 


### PR DESCRIPTION
## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```

Debian's supertuxkart package has carried these big-endian-specific changes to the embedded irrlicht copy for a while now, and I'd like to forward them upstream for inclusion ([patch included in Debian package here](https://salsa.debian.org/games-team/supertuxkart/-/blob/master/debian/patches/irrlicht/arch-support.diff?ref_type=heads)). This was included to fix build failures on Debian mips/powerpc/s390x/sparc, and should not affect building on any other architecture adversely. Thanks!

Patch header has some additional context:

```
Building on non-linux architectures currently fails with unpatched
irrlicht because irrlicht tries to create Joystick support using
linux-specific headers. However there's infrastructure to disable
Joystick support, we just need to activate that on non-linux
architectures.

Additionally if built on a sparc machine irrlicht assumes wrongly it's
a solaris system. We fix this wrong assumption as our sparc builds are
all on linux.
```