### PR TITLE
Replace RegisterScreen with GeneralTextFieldDialog for player renaming

### DIFF
--- a/src/states_screens/options/user_screen.cpp
+++ b/src/states_screens/options/user_screen.cpp
@@ -30,6 +30,7 @@
 #include "states_screens/dialogs/message_dialog.hpp"
 #include "states_screens/dialogs/kart_color_slider_dialog.hpp"
 #include "states_screens/dialogs/recovery_dialog.hpp"
+#include "states_screens/dialogs/general_text_field_dialog.hpp"
 #include "states_screens/main_menu_screen.hpp"
 #include "states_screens/online/register_screen.hpp"
 
@@ -418,13 +419,35 @@ void BaseUserScreen::eventCallback(Widget* widget,
         else if (button == "rename")
         {
             PlayerProfile *cp = getSelectedPlayer();
-            RegisterScreen::getInstance()->setRename(cp);
-            RegisterScreen::getInstance()->push();
-            RegisterScreen::getInstance()->setParent(this);
-            m_new_registered_data = false;
-            m_auto_login          = false;
-            // Init will automatically be called, which
-            // refreshes the player list
+            core::stringw instruction = _("Enter the new name for this player");
+            
+            new GeneralTextFieldDialog(instruction,
+                [this] (const irr::core::stringw& new_name)
+                {
+                    if (new_name.size() > 0)
+                    {
+                        PlayerProfile *player = getSelectedPlayer();
+                        if (player)
+                        {
+                            player->setName(new_name);
+                            PlayerManager::get()->save();
+                            init(); // Refresh the player list
+                        }
+                    }
+                });
+            // Set the current name in the text field
+            if (cp)
+            {
+                GUIEngine::ModalDialog* dialog = GUIEngine::ModalDialog::getCurrent();
+                if (dialog)
+                {
+                    GeneralTextFieldDialog* text_dialog = dynamic_cast<GeneralTextFieldDialog*>(dialog);
+                    if (text_dialog)
+                    {
+                        text_dialog->getTextField()->setText(cp->getName());
+                    }
+                }
+            }
         }
         else if (button == "default_kart_color")
         {


### PR DESCRIPTION
Replace the full RegisterScreen with GeneralTextFieldDialog when renaming a player to match the UI used for grand prix and device configuration naming.
Issue #5338 

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
<img width="1912" height="1025" alt="image_2025-10-30_134208351" src="https://github.com/user-attachments/assets/0e88578e-fc6f-49ba-8311-c18b1fbfc7a1" />
