### PR TITLE
Prefil textbox for options and grand prix renaming

### DIFF
--- a/src/states_screens/grand_prix_editor_screen.cpp
+++ b/src/states_screens/grand_prix_editor_screen.cpp
@@ -114,9 +114,12 @@ void GrandPrixEditorScreen::eventCallback(Widget* widget, const std::string& nam
         }
         else if (m_action == "rename" && m_selection != NULL)
         {
-            new GeneralTextFieldDialog(_("Please enter the name of the grand prix"),
+            GeneralTextFieldDialog* dialog = new GeneralTextFieldDialog(_("Please enter the name of the grand prix"),
                 std::bind(&GrandPrixEditorScreen::setNewGPWithName,
                           this, std::placeholders::_1), validateName);
+            
+            // Prefill the textbox with the current grand prix name
+            dialog->getTextField()->setText(m_selection->getName());
         }
     }
     else if (name == "gpgroups")

--- a/src/states_screens/options/options_screen_device.cpp
+++ b/src/states_screens/options/options_screen_device.cpp
@@ -608,7 +608,7 @@ void OptionsScreenDevice::eventCallback(Widget* widget,
             _("Enter new configuration name, leave empty to revert default value.");
         DeviceConfig *the_config = m_config; //Can't give variable m_config directly
 
-        new GeneralTextFieldDialog(instruction, [] (const irr::core::stringw& text) {},
+        GeneralTextFieldDialog* dialog = new GeneralTextFieldDialog(instruction, [] (const irr::core::stringw& text) {},
             [the_config] (GUIEngine::LabelWidget* lw,
                 GUIEngine::TextBoxWidget* tb)->bool
             {
@@ -617,6 +617,9 @@ void OptionsScreenDevice::eventCallback(Widget* widget,
                 input_manager->getDeviceManager()->save();
                 return true;
             });
+        
+        // Prefill the textbox with the current configuration name
+        dialog->getTextField()->setText(the_config->getConfigName());
     }
     else if (name == "force_feedback")
     {


### PR DESCRIPTION
I made sure that when the text box opens to edit a name for the grand prix and configuration, the current name is already there.

Issue #5338 
## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
