### PR TITLE
Set focus on username textbox when opening rename screen

### DIFF
--- a/src/states_screens/online/register_screen.cpp
+++ b/src/states_screens/online/register_screen.cpp
@@ -149,6 +149,7 @@ void RegisterScreen::init()
 
     TextBoxWidget* local_username = getWidget<TextBoxWidget>("local_username");
     local_username->setText(username);
+    local_username->setFocusForPlayer(PLAYER_ID_GAME_MASTER);
 
     m_password_widget->setPasswordBox(true, L'*');
     getWidget<TextBoxWidget>("password_confirm")->setPasswordBox(true, L'*');


### PR DESCRIPTION
Set focus on username textbox when opening rename screen.
It's a small add, but I thought it would be useful for users.
Issue #5338 

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
