### PR TITLE
Fix inverted gravity on track edges

### DIFF
--- a/src/karts/kart.cpp
+++ b/src/karts/kart.cpp
@@ -1632,7 +1632,13 @@ void Kart::update(int ticks)
         if (material && material->hasGravity())
         {
             Vec3 normal = m_terrain_info->getNormal();
-            gravity = normal * -g;
+            // Only apply surface gravity if normal has sufficient vertical
+            // component (|Y| > 0.3). Edge faces have near-horizontal normals
+            // that would incorrectly flip gravity direction.
+            if (fabsf(normal.getY()) > 0.3f)
+            {
+                gravity = normal * -g;
+            }
         }
 
         body->setGravity(gravity);

--- a/src/physics/btKart.cpp
+++ b/src/physics/btKart.cpp
@@ -119,6 +119,10 @@ void btKart::reset()
     m_ticks_additional_rotation  = 0;
     m_max_speed                  = -1.0f;
     m_min_speed                  = 0.0f;
+    // Initialize to default downward gravity - will be updated when grounded
+    m_last_grounded_gravity      = btVector3(0, -(Track::getCurrentTrack()
+                                              ? Track::getCurrentTrack()->getGravity()
+                                              : 9.80665f), 0);
 
     // Set the brakes so that karts don't slide downhill
     setAllBrakes(5.0f);
@@ -433,12 +437,22 @@ void btKart::updateVehicle( btScalar step )
         m_wheelInfo[i].m_was_on_ground = m_wheelInfo[i].m_raycastInfo.m_isInContact;
 
 
+    // Store gravity when grounded for use in flying mode.
+    // This prevents incorrect orientation when gravity was set by an edge
+    // surface with unusual normal just before the kart became airborne.
+    if(m_num_wheels_on_ground > 0)
+    {
+        m_last_grounded_gravity = m_chassisBody->getGravity();
+    }
+
     // If the kart is flying, try to keep it parallel to the ground.
     // -------------------------------------------------------------
     if(m_num_wheels_on_ground==0)
     {
         btVector3 kart_up    = getChassisWorldTransform().getBasis().getColumn(1);
-        btVector3 terrain_up = -m_chassisBody->getGravity();
+        // Use last grounded gravity instead of current gravity to prevent
+        // flipping when gravity was set incorrectly by an edge surface.
+        btVector3 terrain_up = -m_last_grounded_gravity;
         terrain_up = terrain_up.normalize();
         // Length of axis depends on the angle - i.e. the further awat
         // the kart is from being upright, the larger the applied impulse
@@ -449,7 +463,6 @@ void btKart::updateVehicle( btScalar step )
 
         // To avoid the kart going backwards/forwards (or rolling sideways),
         // set the pitch/roll to 0 before applying the 'straightening' impulse.
-        // TODO: make this works if gravity is changed.
         btVector3 av = m_chassisBody->getAngularVelocity();
         av.setX(0);
         av.setZ(0);

--- a/src/physics/btKart.hpp
+++ b/src/physics/btKart.hpp
@@ -98,6 +98,11 @@ private:
     /** Number of wheels that touch the ground. */
     int                 m_num_wheels_on_ground;
 
+    /** Last known gravity direction when wheels were on the ground.
+     *  Used in flying mode to prevent incorrect orientation when
+     *  gravity was set by an edge surface with unusual normal. */
+    btVector3           m_last_grounded_gravity;
+
     /** Index of the right axis. */
     int                 m_indexRightAxis;
     /** Index of the up axis. */


### PR DESCRIPTION
## Summary

Fixes #5584

When driving at high speed over track edges on Ravenbridge Mansion, the kart could become inverted with gravity also inverting. This occurred because edge faces with `hasGravity` textures have near-horizontal normals that were incorrectly being used to set gravity direction.

## Root Cause

1. Edge geometry on the track has textures with `hasGravity=true`
2. Edge faces have normals pointing sideways/diagonally instead of upward
3. When the kart's wheel raycasts hit these edge faces, gravity was set to align with the unusual normal
4. When the kart lost ground contact (fell into hole), flying mode tried to align the kart with this incorrect gravity direction
5. The torque impulse flipped the kart to match the wrong gravity vector

## Fix

Two-layer defense:

1. **Surface normal validation** (`kart.cpp`): Only apply gravity from `hasGravity` surfaces when the normal has sufficient vertical component (`|Y| > 0.3`). Edge faces with near-horizontal normals are rejected.

2. **Grounded gravity memory** (`btKart.cpp`): Store the last known gravity direction when wheels were on ground. Flying mode now uses this stored value instead of current gravity, preventing incorrect orientation when gravity was set by an edge surface just before becoming airborne.

## Test Plan

- [x] Tested 7 laps on Ravenbridge Mansion without reproducing the bug
- [x] Passed cppcheck static analysis
- [x] Follows STK coding style guidelines