### PR TITLE
Fix skip button hover not working in feature unlocked screen

### DIFF
--- a/src/states_screens/feature_unlocked.cpp
+++ b/src/states_screens/feature_unlocked.cpp
@@ -34,6 +34,7 @@
 #include "graphics/sp/sp_texture_manager.hpp"
 #include "guiengine/engine.hpp"
 #include "guiengine/scalable_font.hpp"
+#include "guiengine/widgets/button_widget.hpp"
 #include "io/file_manager.hpp"
 #include "karts/kart_model.hpp"
 #include "karts/kart_properties.hpp"
@@ -476,6 +477,8 @@ void FeatureUnlockedCutScene::init()
             Log::error("FeatureUnlockedCutScene::init", "Malformed unlocked goody");
         }
     }
+
+    getWidget<GUIEngine::ButtonWidget>("continue")->setFocusForPlayer(PLAYER_ID_GAME_MASTER);
 }   // init
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Fixes #5592 - Skip button after completing a challenge in story mode does not react on hover

## Problem
The skip/continue button in `FeatureUnlockedCutScene` (the screen shown after completing a challenge where the chest presents the trophy) was not reacting to hover because it was missing the `setFocusForPlayer()` call.

## Root Cause
Both `GrandPrixWin::init()` and `GrandPrixLose::init()` call `setFocusForPlayer(PLAYER_ID_GAME_MASTER)` on the continue button, which enables the GUI engine to track focus and apply hover visual effects. `FeatureUnlockedCutScene::init()` was missing this call.

## Fix
Added the missing `setFocusForPlayer()` call at the end of `FeatureUnlockedCutScene::init()`, matching the pattern used by the other cutscene screens.

## Testing
- Build compiles successfully
- Pattern matches working implementations in `grand_prix_win.cpp:220` and `grand_prix_lose.cpp:121`