### PR TITLE
add tooltips for disabled options during a race

### DIFF
--- a/src/guiengine/skin.cpp
+++ b/src/guiengine/skin.cpp
@@ -1115,6 +1115,19 @@ void Skin::drawButton(Widget* w, const core::recti &rect,
                                 SkinConfig::m_render_params["button::neutral"],
                                 w->m_deactivated);
         }   // if not deactivated or focused
+        
+        // Check for tooltips even on deactivated widgets
+        if (w->hasTooltip())
+        {
+            const core::position2di mouse_position =
+                irr_driver->getDevice()->getCursorControl()->getPosition();
+
+            if (sized_rect.isPointInside(mouse_position))
+            {
+                m_tooltip_at_mouse.push_back(true);
+                m_tooltips.push_back(w);
+            }
+        }
     }
     else   // not within an appearing dialog
     {
@@ -1136,6 +1149,19 @@ void Skin::drawButton(Widget* w, const core::recti &rect,
                                 SkinConfig::m_render_params["button::neutral"],
                                 w->m_deactivated);
         }   // if not deactivated or focused
+        
+        // Check for tooltips even on deactivated widgets
+        if (w->hasTooltip())
+        {
+            const core::position2di mouse_position =
+                irr_driver->getDevice()->getCursorControl()->getPosition();
+
+            if (rect.isPointInside(mouse_position))
+            {
+                m_tooltip_at_mouse.push_back(true);
+                m_tooltips.push_back(w);
+            }
+        }
     }   // not within an appearing dialog
 }   // drawButton
 
@@ -1687,6 +1713,16 @@ void Skin::drawRibbonChild(const core::recti &rect, Widget* widget,
             m_tooltips.push_back(widget);
         }
     }
+    else if (widget->hasTooltip())
+    {
+        // Check tooltips for deactivated widgets too
+        if (rect.isPointInside(irr_driver->getDevice()->getCursorControl()
+                                                      ->getPosition()))
+        {
+            m_tooltip_at_mouse.push_back(true);
+            m_tooltips.push_back(widget);
+        }
+    }
 #endif
 }   // drawRibbonChild
 
@@ -1874,6 +1910,18 @@ void Skin::drawSpinnerBody(const core::recti &rect, Widget* widget,
     {
         m_tooltip_at_mouse.push_back(false);
         m_tooltips.push_back(widget);
+    }
+    else if (widget->hasTooltip())
+    {
+        // Check tooltips for deactivated widgets too
+        const core::position2di mouse_position =
+            irr_driver->getDevice()->getCursorControl()->getPosition();
+
+        if (sized_rect.isPointInside(mouse_position))
+        {
+            m_tooltip_at_mouse.push_back(true);
+            m_tooltips.push_back(widget);
+        }
     }
 }
 
@@ -2135,6 +2183,18 @@ void Skin::drawCheckBox(const core::recti &rect, Widget* widget, bool focused)
 
     if (focused && widget->hasTooltip())
     {
+        const core::position2di mouse_position =
+            irr_driver->getDevice()->getCursorControl()->getPosition();
+
+        if (rect.isPointInside(mouse_position))
+        {
+            m_tooltip_at_mouse.push_back(true);
+            m_tooltips.push_back(widget);
+        }
+    }
+    else if (widget->hasTooltip())
+    {
+        // Check tooltips for deactivated widgets too
         const core::position2di mouse_position =
             irr_driver->getDevice()->getCursorControl()->getPosition();
 

--- a/src/states_screens/options/options_common.cpp
+++ b/src/states_screens/options/options_common.cpp
@@ -52,7 +52,9 @@ namespace OptionsCommon
 		if (StateManager::get()->getGameState() == GUIEngine::INGAME_MENU)
 		{
 	    	GUIEngine::getWidget("tab_players")->setActive(false);
+	    	GUIEngine::getWidget("tab_players")->setTooltip(_("This option cannot be changed during a race."));
 	    	GUIEngine::getWidget("tab_language")->setActive(false);			
+	    	GUIEngine::getWidget("tab_language")->setTooltip(_("This option cannot be changed during a race."));			
 		}
 		else
 		{

--- a/src/states_screens/options/options_screen_display.cpp
+++ b/src/states_screens/options/options_screen_display.cpp
@@ -128,8 +128,23 @@ void OptionsScreenDisplay::init()
     bool in_game = StateManager::get()->getGameState() == GUIEngine::INGAME_MENU;
 
     res->setActive(!in_game || is_vulkan_fullscreen_desktop);
+    if (in_game && !is_vulkan_fullscreen_desktop)
+    {
+        res->setTooltip(_("This option cannot be changed during a race."));
+    }
+
     full->setActive(!in_game || is_vulkan_fullscreen_desktop);
+    if (in_game && !is_vulkan_fullscreen_desktop)
+    {
+        full->setTooltip(_("This option cannot be changed during a race."));
+    }
+
     applyBtn->setActive(!in_game);
+    if (in_game)
+    {
+        applyBtn->setTooltip(_("This option cannot be changed during a race."));
+    }
+
 
 #if defined(MOBILE_STK) || defined(__SWITCH__)
     applyBtn->setVisible(false);

--- a/src/states_screens/options/options_screen_input.cpp
+++ b/src/states_screens/options/options_screen_input.cpp
@@ -180,6 +180,9 @@ void OptionsScreenInput::init()
     // Disable adding keyboard configurations
     bool in_game = StateManager::get()->getGameState() == GUIEngine::INGAME_MENU;
     getWidget<ButtonWidget>("add_device")->setActive(!in_game);
+    if(in_game){
+        getWidget<ButtonWidget>("add_device")->setTooltip(_("This option cannot be changed during a race."));
+    }
 
     bool multitouch_enabled = (UserConfigParams::m_multitouch_active == 1 &&
         irr_driver->getDevice()->supportsTouchDevice()) ||

--- a/src/states_screens/options/options_screen_ui.cpp
+++ b/src/states_screens/options/options_screen_ui.cpp
@@ -175,7 +175,15 @@ void OptionsScreenUI::init()
     bool currSkinFound = false;
     const std::string& user_skin = UserConfigParams::m_skin_file;
     m_base_skin_selector ->setActive(!in_game);
+    if (in_game)
+    {
+        m_base_skin_selector->setTooltip(_("This option cannot be changed during a race."));
+    }
     m_variant_skin_selector->setActive(!in_game);
+    if (in_game)
+    {
+        m_variant_skin_selector->setTooltip(_("This option cannot be changed during a race."));
+    }
 
     for (unsigned int i = 0; i < m_skins.size(); i++)
     {
@@ -229,6 +237,10 @@ void OptionsScreenUI::init()
     font_size->setValue(size_int);
     UserConfigParams::m_font_size = font_size->getValue();
     font_size->setActive(!in_game);
+    if (in_game)
+    {
+        font_size->setTooltip(_("This option cannot be changed during a race."));
+    }
 
     CheckBoxWidget* karts_powerup_gui = getWidget<CheckBoxWidget>("karts_powerup_gui");
     assert(karts_powerup_gui != NULL);

--- a/src/states_screens/options/options_screen_video.cpp
+++ b/src/states_screens/options/options_screen_video.cpp
@@ -184,13 +184,29 @@ void OptionsScreenVideo::init()
     bool in_game = StateManager::get()->getGameState() == GUIEngine::INGAME_MENU;
 
     gfx->setActive(!in_game && CVS->isGLSL());
+    if (in_game && CVS->isGLSL())
+    {
+        gfx->setTooltip(_("This option cannot be changed during a race."));
+    }
     getWidget<ButtonWidget>("custom")->setActive(!in_game || !CVS->isGLSL());
+    if (in_game && CVS->isGLSL())
+    {
+        getWidget<ButtonWidget>("custom")->setTooltip(_("This option cannot be changed during a race."));
+    }
     if (getWidget<SpinnerWidget>("scale_rtts")->isActivated())
     {
         getWidget<SpinnerWidget>("scale_rtts")->setActive(!in_game ||
             GE::getDriver()->getDriverType() == video::EDT_VULKAN);
+        if (in_game && GE::getDriver()->getDriverType() != video::EDT_VULKAN)
+        {
+            getWidget<SpinnerWidget>("scale_rtts")->setTooltip(_("This option cannot be changed during a race."));
+        }
     }
     getWidget<ButtonWidget>("benchmarkCurrent")->setActive(!in_game);
+    if (in_game)
+    {
+        getWidget<ButtonWidget>("benchmarkCurrent")->setTooltip(_("This option cannot be changed during a race."));
+    }
 
     // If a benchmark was requested and the game had to reload
     // the graphics engine, start the benchmark when the


### PR DESCRIPTION
Issue #5468 
I added a tooltip for all parameters where the boolean “in_game” was true. I don't think I forgot any parameters, but it would still be worth checking. I hope you like it.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
