### PR TITLE
For the nolok kart, use dedicated nitro textures

### DIFF
--- a/data/gfx/nitro-nolok.xml
+++ b/data/gfx/nitro-nolok.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<particles emitter="box" box_x="0.05" box_y="0.05" box_z="0.05">
+
+    <spreading angle="2"         />
+
+    <velocity  x="0.0"
+               y="0.0"
+               z="-0.003"         />
+
+    <material  file="nitro-particle-nolok.png"  />
+
+    <!-- Amount of particles emitted per second -->
+    <rate      min="600"
+               max="800"          />
+
+    <!-- Minimal and maximal lifetime of a particle, in milliseconds. -->
+    <lifetime  min="85"
+               max="120"           />
+
+    <!-- Size of the particles -->
+    <size      min="0.1"
+               max="0.25"
+               x-increase-factor="1.2"
+               y-increase-factor="1.2"
+               />
+
+    <color     min="255 255 255"
+               max="255 255 255"  />
+
+</particles>

--- a/data/gfx/nitro-smoke-nolok.xml
+++ b/data/gfx/nitro-smoke-nolok.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<particles emitter="box" box_x="0.35" box_y="0.2" box_z="0.2">
+
+    <spreading angle="30"         />
+
+    <velocity  x="0.0"
+               y="0.0"
+               z="-0.006"         />
+
+    <material  file="smoke_nitro_nolok.png"  />
+
+    <!-- Amount of particles emitted per second -->
+    <rate      min="500"
+               max="800"          />
+
+    <!-- Minimal and maximal lifetime of a particle, in milliseconds. -->
+    <lifetime  min="100"
+               max="150"          />
+
+    <!-- Size of the particles -->
+    <size      min="0.20"
+               max="0.40"         />
+
+    <color     min="255 255 255"
+               max="255 255 255"  />
+
+</particles>

--- a/src/karts/kart_gfx.cpp
+++ b/src/karts/kart_gfx.cpp
@@ -54,12 +54,25 @@ KartGFX::KartGFX(const AbstractKart *kart, bool is_day)
     scene::ISceneNode *node = m_kart->getNode();
     // Create nitro light
     core::vector3df location(0.0f, 0.5f, -0.5f*length - 0.05f);
+
+    bool is_nolok = m_kart->getIdent() == "nolok";
+
 #ifndef SERVER_ONLY
     if (!GUIEngine::isNoGraphics() && supportsLight())
     {
-        m_nitro_light = irr_driver->addLight(location, /*force*/ 0.4f,
-                                             /*radius*/ 5.0f, 0.0f, 0.4f, 1.0f,
-                                             false, node);
+        if (is_nolok)
+        {
+            m_nitro_light = irr_driver->addLight(location, /*force*/ 0.4f,
+                                                 /*radius*/ 5.0f, 1.0f, 0.0f, 0.4f,
+                                                 false, node);
+        }
+        else
+        {
+            m_nitro_light = irr_driver->addLight(location, /*force*/ 0.4f,
+                                                 /*radius*/ 5.0f, 0.0f, 0.4f, 1.0f,
+                                                 false, node);
+        }
+
         m_nitro_light->setVisible(false);
 #ifdef DEBUG
         m_nitro_light->setName( ("nitro emitter (" + m_kart->getIdent()
@@ -107,12 +120,15 @@ KartGFX::KartGFX(const AbstractKart *kart, bool is_day)
     if (!km->hasNitroEmitters())
         rear_nitro_right = rear_nitro_left = rear_nitro_center;
 
+    const char *nitro_xml = is_nolok ? "nitro-nolok.xml" : "nitro.xml";
+    const char *nitro_smoke_xml = is_nolok ? "nitro-smoke-nolok.xml" : "nitro-smoke.xml";
+
     // Create all effects. Note that they must be created
     // in the order of KartGFXType.
-    addEffect(KGFX_NITRO1,      "nitro.xml",       rear_nitro_right, true );
-    addEffect(KGFX_NITRO2,      "nitro.xml",       rear_nitro_left,  true );
-    addEffect(KGFX_NITROSMOKE1, "nitro-smoke.xml", rear_nitro_left,  false);
-    addEffect(KGFX_NITROSMOKE2, "nitro-smoke.xml", rear_nitro_right, false);
+    addEffect(KGFX_NITRO1,      nitro_xml,         rear_nitro_right, true );
+    addEffect(KGFX_NITRO2,      nitro_xml,         rear_nitro_left,  true );
+    addEffect(KGFX_NITROSMOKE1, nitro_smoke_xml,   rear_nitro_left,  false);
+    addEffect(KGFX_NITROSMOKE2, nitro_smoke_xml,   rear_nitro_right, false);
     addEffect(KGFX_ZIPPER,      "zipper_fire.xml", rear_center,      true );
     addEffect(KGFX_TERRAIN,     "smoke.xml",       Vec3(0, 0, 0),    false);
     addEffect(KGFX_SKID1L,      "skid1.xml",       rear_left,        true );


### PR DESCRIPTION
Had kind of a shower thought:

> Nolok already has special stuff such as the green gum bubble. But the nitro stream is still the regular (not to say: boring) blue. Why not to make it red - after all he's the evil guy!

Thought. Done.

[Bildschirmaufnahme_20260118_230213.webm](https://github.com/user-attachments/assets/89ef7f18-0547-4276-9a7d-a03beb1fecf0)

Admittedly, there's still some blue light below the kart during nitro usage. I'm new here and have not found the necessary texture, yet. Maybe someone can give me a hint.

Speaking of textures: To run this PR, you need to set SUPERTUXKART_ASSETS_DIR= to a copy of stk-assets with the following modifications:

```patch
--- ./textures/materials.xml.orig       2026-01-18 22:54:39.556897171 +0100
+++ ./textures/materials.xml    2026-01-18 22:01:02.779748332 +0100
@@ -123,2 +123,3 @@
   <material name="smoke_nitro.png"       shader="alphablend" ignore="Y" />
+  <material name="smoke_nitro_nolok.png" shader="alphablend" ignore="Y" />
   <material name="smoke_yellow.png"      shader="alphablend" ignore="Y"/>
@@ -133,2 +134,3 @@
   <material name="nitro-particle.png"    shader="additive" ignore="Y" />
+  <material name="nitro-particle-nolok.png" shader="additive" ignore="Y" />
   <material name="skid-particle1.png"    shader="additive" ignore="Y"/>
```

textures/nitro-particle-nolok.png:

<img width="128" height="128" alt="nitro-particle-nolok" src="https://github.com/user-attachments/assets/ae8fd329-b446-4655-ba10-e6568d609ee4" />

textures/smoke_nitro_nolok.png:

<img width="128" height="128" alt="smoke_nitro_nolok" src="https://github.com/user-attachments/assets/2c735d91-eeca-4b5d-87d2-5492d16a24cd" />

Apropos textures, this is how I've derived them:

<img width="1920" height="1080" alt="Bildschirmfoto_20260118_180816" src="https://github.com/user-attachments/assets/c996e77a-426c-42a2-9b8b-aaa38faa944d" />

I just thought that the regular nitro is, roughly speaking, blue. So I selected the "blue third" of the whole color spectre in GIMP for the input and the red one for the output. (In a browser, [I'd just use hue-rotate](https://github.com/Al2Klimov/icingaweb2-theme-apocalypse/blob/a4e558857e2ba5ad8e509ae0f1c8bd5cb77347a4/public/css/themes/virus.less#L4).)

What do you think?

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
