### PR TITLE
Correct text vertical alignment in Football mode and UI

### DIFF
--- a/lib/irrlicht/include/GlyphLayout.h
+++ b/lib/irrlicht/include/GlyphLayout.h
@@ -105,8 +105,8 @@ inline void eraseTopLargerThan(std::vector<GlyphLayout>& gls,
 }
 
 inline core::dimension2d<u32> getGlyphLayoutsDimension(
-    const std::vector<GlyphLayout>& gls, s32 height_per_line, f32 inverse_shaping,
-    f32 scale, s32 cluster = -1)
+    const std::vector<GlyphLayout>& gls, s32 height_per_line, s32 height_per_glyph, 
+    f32 inverse_shaping, f32 scale, s32 cluster = -1)
 {
     core::dimension2d<f32> dim(0.0f, 0.0f);
     core::dimension2d<f32> this_line(0.0f, (f32)height_per_line);
@@ -148,7 +148,7 @@ inline core::dimension2d<u32> getGlyphLayoutsDimension(
             break;
     }
 
-    dim.Height += this_line.Height;
+    dim.Height += height_per_glyph;
     if (dim.Width < this_line.Width)
         dim.Width = this_line.Width;
 
@@ -328,7 +328,7 @@ inline bool getDrawOffset(const core::rect<s32>& position, bool hcenter,
     if (hcenter || vcenter || clip)
     {
         text_dimension = gui::getGlyphLayoutsDimension(
-            gls, next_line_height, inverse_shaping, scale);
+            gls, next_line_height, next_line_height, inverse_shaping, scale, -1);
 
         if (hcenter)
         {

--- a/lib/irrlicht/include/IGUIFont.h
+++ b/lib/irrlicht/include/IGUIFont.h
@@ -112,6 +112,8 @@ public:
 
 	//! Returns the height per line (including padding between 2 lines)
 	virtual s32 getHeightPerLine() const = 0;
+	virtual s32 getHeightPerGlyph() const = 0;
+
 
 	//! Define which characters should not be drawn by the font.
 	/** For example " " would not draw any space which is usually blank in

--- a/lib/irrlicht/source/Irrlicht/CGUIButton.cpp
+++ b/lib/irrlicht/source/Irrlicht/CGUIButton.cpp
@@ -333,9 +333,15 @@ void CGUIButton::draw()
 		}
 
 		if (font)
-			font->draw(Text.c_str(), rect,
+		{
+			const core::dimension2d<u32> dim = font->getDimension(Text.c_str());
+			core::rect<s32> text_rect = rect;
+			text_rect.UpperLeftCorner.Y += (rect.getHeight() - (s32)dim.Height) / 2;
+			text_rect.LowerRightCorner.Y = text_rect.UpperLeftCorner.Y + (s32)dim.Height;
+			font->draw(Text.c_str(), text_rect,
 				skin->getColor(isEnabled() ? EGDC_BUTTON_TEXT : EGDC_GRAY_TEXT),
-				true, true, &AbsoluteClippingRect);
+				true, false, &AbsoluteClippingRect);
+		}
 	}
 
 	IGUIElement::draw();

--- a/lib/irrlicht/source/Irrlicht/CGUIFont.h
+++ b/lib/irrlicht/source/Irrlicht/CGUIFont.h
@@ -81,6 +81,8 @@ public:
 	virtual void setKerningHeight (s32 kerning);
 
 	virtual s32 getHeightPerLine() const { return (s32)getDimension(L"A").Height + getKerningHeight(); }
+	virtual s32 getHeightPerGlyph() const { return (s32)getDimension(L"A").Height; }
+
 
 	//! set an Pixel Offset on Drawing ( scale position on width )
 	virtual s32 getKerningWidth(const wchar_t* thisLetter=0, const wchar_t* previousLetter=0) const;

--- a/lib/irrlicht/source/Irrlicht/CGUIStaticText.cpp
+++ b/lib/irrlicht/source/Irrlicht/CGUIStaticText.cpp
@@ -298,9 +298,9 @@ s32 CGUIStaticText::getTextHeight() const
 		return 0;
 
 	auto dim = getGlyphLayoutsDimension(m_glyph_layouts,
-		font->getHeightPerLine(), font->getInverseShaping(), font->getScale());
+		font->getHeightPerLine(), font->getHeightPerGlyph(), font->getInverseShaping(), font->getScale());
 
-	return dim.Height;
+	return dim.Height + 2 * (font->getHeightPerLine() - font->getHeightPerGlyph());
 }
 
 
@@ -311,7 +311,7 @@ s32 CGUIStaticText::getTextWidth() const
 		return 0;
 
 	auto dim = getGlyphLayoutsDimension(m_glyph_layouts,
-		font->getHeightPerLine(), font->getInverseShaping(), font->getScale());
+		font->getHeightPerLine(), font->getHeightPerGlyph(), font->getInverseShaping(), font->getScale());
 
 	return dim.Width;
 }
@@ -486,7 +486,7 @@ void CGUIStaticText::getDrawPosition(core::rect<s32>* draw_pos, bool* hcenter, c
 	core::rect<s32> r = *draw_pos;
 	IGUIFont* font = getActiveFont();
 	auto dim = getGlyphLayoutsDimension(m_glyph_layouts,
-		font->getHeightPerLine(), font->getInverseShaping(), font->getScale());
+		font->getHeightPerLine(), font->getHeightPerGlyph(), font->getInverseShaping(), font->getScale());
 
 	s32 totalHeight = dim.Height;
 	if (VAlign == EGUIA_CENTER)

--- a/src/font/font_with_face.hpp
+++ b/src/font/font_with_face.hpp
@@ -94,6 +94,10 @@ protected:
     /** Used in top side bearing calculation. */
     int m_glyph_max_height;
 
+    int m_glyph_max_above;
+
+    int m_glyph_max_below;
+
     // ------------------------------------------------------------------------
     /** Check characters to see if they are loaded in font, if not load them.
      *  For font that doesn't need lazy loading, nothing will be done.

--- a/src/guiengine/message_queue.cpp
+++ b/src/guiengine/message_queue.cpp
@@ -160,7 +160,7 @@ public:
         gui::breakGlyphLayouts(m_gls, (float)max_width,
             m_font->getInverseShaping(), m_font->getScale());
         core::dimension2du dim = gui::getGlyphLayoutsDimension(m_gls,
-            m_font->getHeightPerLine(), m_font->getInverseShaping(),
+            m_font->getHeightPerLine(), m_font->getHeightPerGlyph(), m_font->getInverseShaping(),
             m_font->getScale());
 
         if ((int)dim.Height > m_font->getHeightPerLine() * 3)

--- a/src/guiengine/scalable_font.cpp
+++ b/src/guiengine/scalable_font.cpp
@@ -155,6 +155,19 @@ s32 ScalableFont::getHeightPerLine() const
          * m_font_settings->getScale();
 }   // getHeightPerLine
 
+s32 ScalableFont::getHeightPerGlyph() const
+{
+    const float scale = m_face->getNativeScalingFactor() *
+        m_font_settings->getScale();
+
+    const bool border = m_font_settings->useBlackBorder() ||
+        m_font_settings->useColoredBorder();
+    const bool thin_border = m_font_settings->useThinBorder();
+    const int thickness = border ? (thin_border ? 1 : 2) : 0;
+
+    return (m_face->getGlyphMaxHeight() + thickness * 2) * scale;
+}
+
 // ----------------------------------------------------------------------------
 /** Convert text to glyph layouts for fast rendering with optional caching
  *  enabled.

--- a/src/guiengine/scalable_font.hpp
+++ b/src/guiengine/scalable_font.hpp
@@ -95,6 +95,7 @@ public:
     virtual core::dimension2d<u32> getDimension(const wchar_t* text) const;
     // ------------------------------------------------------------------------
     virtual s32 getHeightPerLine() const;
+    virtual s32 getHeightPerGlyph() const;
     // ------------------------------------------------------------------------
     /** Calculates the index of the character in the text which is on a
      * specific position. */
@@ -127,6 +128,7 @@ public:
     virtual f32 getInverseShaping() const;
     // ------------------------------------------------------------------------
     virtual s32 getFaceFontMaxHeight() const;
+    
     // ------------------------------------------------------------------------
     virtual s32 getFaceGlyphMaxHeight() const;
 };

--- a/src/guiengine/widgets/CGUIEditBox.cpp
+++ b/src/guiengine/widgets/CGUIEditBox.cpp
@@ -1082,7 +1082,7 @@ core::dimension2du CGUIEditBox::getTextDimension()
         return core::dimension2du(0, 0);
 
     return gui::getGlyphLayoutsDimension(m_glyph_layouts,
-        font->getHeightPerLine(), font->getInverseShaping(), font->getScale());
+        font->getHeightPerLine(), font->getHeightPerGlyph(), font->getInverseShaping(), font->getScale());
 }
 
 
@@ -1222,7 +1222,7 @@ void CGUIEditBox::setTextRect(s32 line)
 
     // get text dimension
     d = gui::getGlyphLayoutsDimension(m_glyph_layouts,
-        font->getHeightPerLine(), font->getInverseShaping(), font->getScale());
+        font->getHeightPerLine(), font->getHeightPerGlyph(), font->getInverseShaping(), font->getScale());
     // justification
     switch (HAlign)
     {
@@ -1339,14 +1339,14 @@ void CGUIEditBox::updateCursorDistance()
     if (m_cursor_pos != 0)
     {
         m_cursor_distance = getGlyphLayoutsDimension(m_glyph_layouts,
-            font->getHeightPerLine(), font->getInverseShaping(),
-            font->getScale(), m_cursor_pos - 1).Width;
+            font->getHeightPerLine(), font->getHeightPerGlyph(),
+            font->getInverseShaping(), font->getScale(), m_cursor_pos - 1).Width;
     }
     else if ((m_glyph_layouts[0].flags & GLF_RTL_LINE) != 0)
     {
         // For rtl line the cursor in the begining is total width
         m_cursor_distance = getGlyphLayoutsDimension(m_glyph_layouts,
-            font->getHeightPerLine(), font->getInverseShaping(),
+            font->getHeightPerLine(), font->getHeightPerGlyph(), font->getInverseShaping(),
             font->getScale()).Width;
     }
 }

--- a/src/states_screens/online/networking_lobby.cpp
+++ b/src/states_screens/online/networking_lobby.cpp
@@ -1424,6 +1424,7 @@ void NetworkingLobby::updateChatScrollbar()
         (unsigned)core::max_(1, (s32)m_text_bubble->getDimension().Width - scrollbar_width));
     const float box_height = m_text_bubble->getDimension().Height;
     s32 line_height = font->getHeightPerLine();
+    s32 glyph_height = font->getHeightPerGlyph();
     
     if (box_height <= 0.0f || line_height <= 0)
         return;
@@ -1435,7 +1436,7 @@ void NetworkingLobby::updateChatScrollbar()
     
     // Calculate total height of all chat messages with correct line breaks
     core::dimension2du total_dim = gui::getGlyphLayoutsDimension(
-        temp_layouts, line_height,
+        temp_layouts, line_height, glyph_height, 
         font->getInverseShaping(), font->getScale());
     
     s32 total_height = total_dim.Height;

--- a/src/states_screens/race_result_gui.cpp
+++ b/src/states_screens/race_result_gui.cpp
@@ -2282,7 +2282,7 @@ int RaceResultGUI::displayChallengeInfo(int x, int y, bool increase_density)
                                     the_font->getScale());
         irr::core::dimension2du dim = 
             irr::gui::getGlyphLayoutsDimension(best_while_slower_layout,
-                                               line_height,
+                                               line_height, line_height,
                                                the_font->getInverseShaping(),
                                                the_font->getScale());
         text_color = special_color;


### PR DESCRIPTION
Issue #5619 
Previously, using only `getHeightPerLine()` for centering calculations caused text to appear offset because it included line padding. By introducing `getHeightPerGlyph()`, we can now center text based on the visual bounds of the characters.

- **IGUIFont.h & CGUIFont.h**: Added `getHeightPerGlyph()` to the font interface to retrieve the actual height of characters without line spacing.
- **GlyphLayout.h**: Updated `getGlyphLayoutsDimension` to accept `height_per_glyph` as a parameter for more accurate dimension calculations.
- **CGUIButton.cpp**: Improved the centering logic in `draw()` to use the new glyph height, ensuring text is vertically centered within buttons.
- **CGUIStaticText.cpp**: Adjusted height and width calculations to account for the difference between line height and glyph height.

- **FontWithFace**: Added `m_glyph_max_above` and `m_glyph_max_below` to track precise font metrics (ascender/descender) via FreeType.
- **ScalableFont**: Implemented `getHeightPerGlyph()` for STK's scalable font system, including support for borders and shadows.
- **GUI Components**: Updated `CGUIEditBox`, `MessageQueue`, `NetworkingLobby`, and `RaceResultGUI` to use the new dimension logic.

### Technical Background: Bearing vs. Height
To fix the vertical alignment, I've distinguished between the line height and the visual glyph metrics. As explained in the [FreeType documentation](https://freetype.org/freetype2/docs/glyphs/glyphs-3.html):

- **Line Height (Height)**: The distance between two consecutive baselines. It often includes internal leading/padding, which causes "centering" logic to look offset.
- **Glyph Bearing/Bounding Box**: This represents the actual ink of the characters. 

By implementing `getHeightPerGlyph()` (based on the max ascender and descender metrics), we ensure that UI elements like buttons and the Football score are centered based on the **visible** part of the text rather than the theoretical line height.


## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
