### PR TITLE
Sanitize illegal characters from download filename.

### DIFF
--- a/src/states_screens/dialogs/addons_pack.cpp
+++ b/src/states_screens/dialogs/addons_pack.cpp
@@ -82,6 +82,14 @@ public:
             url.find("http://") != std::string::npos)
         {
             setURL(url);
+            std::string illegal_chars = "/\\:*\"?<>|";
+            for(unsigned i = 0; i < m_filename.size(); i++)
+            {
+                if(illegal_chars.find(m_filename[i]) != std::string::npos)
+                {
+                    m_filename[i] = '-';
+                }
+            }
             setDownloadAssetsRequest(true);
         }
         else


### PR DESCRIPTION
## Bug
Currently, some addon downloads triggered with ``/installaddon`` fail.
```
[info   ] ClientLobby: nomagno: /installaddon https://dl.kimden.online/?m=3&c=20
[info   ] ClientLobby: matahina: link not working because windumb OS
[info   ] ClientLobby: Elrit: blame microslop
```

Surprisingly, Microsoft was not exactly to blame this time (rare event).
This failure is caused by the presence of the character ``?`` in the basename, which is illegal on NTFS and exFAT.
```
[info   ] HTTPRequest: Downloading https://dl.kimden.online/?t=what-a-great-game
[error  ] HTTPRequest: Can't open 'C:\Users\Legion\AppData\Roaming/supertuxkart/config-0.10/../addons/?t=what-a-great-game.part' for writing, ignored.
```
Additionally, links like ``https://dl.kimden.online/?t=what-a-great-game&/`` fail even on linux filesystems (tested on android) for a similar reason. Checkmate, windows haters!

# Fix
This PR prevents /installaddon failing (more commonly on windows) when basename contains characters that are illegal in popular filesystems by replacing those characters with hyphens.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
