### PR TITLE
Fix tooltip for horizontal overflow

### DIFF
--- a/src/guiengine/skin.cpp
+++ b/src/guiengine/skin.cpp
@@ -2443,12 +2443,27 @@ void Skin::drawTooltip(Widget* widget, bool atMouse)
     irr::gui::ScalableFont* font = GUIEngine::getSmallFont();
     core::dimension2d<u32> size =
         font->getDimension(widget->getTooltipText().c_str());
+    
     core::position2di pos(widget->m_x + 15, widget->m_y + widget->m_h);
+    const core::dimension2d<u32> screen_size = irr_driver->getActualScreenSize();
+    const int margin = 10; // Space from screen edges so tooltip doesn't get cut off
 
     if (atMouse)
     {
-        pos = irr_driver->getDevice()->getCursorControl()->getPosition()
-            + core::position2di(10 - size.Width / 2, 20);
+        pos = irr_driver->getDevice()->getCursorControl()->getPosition();
+        pos.X -= size.Width / 2;
+        pos.Y += 20;
+    }
+
+    // Fix horizontal position
+    if (pos.X + (int)size.Width > (int)screen_size.Width - margin)
+    {
+        pos.X = (int)screen_size.Width - size.Width - margin;
+    }
+
+    if (pos.X < margin)
+    {
+        pos.X = margin;
     }
 
     core::recti r(pos, size);


### PR DESCRIPTION
Fix the issue #5589

### Changes
- **Horizontal Clamping:** Added logic to detect if the tooltip exceeds the screen width (left or right).
- **Auto-adjustment:** If the tooltip goes out of bounds, its position is shifted to stay visible within the screen.
- **Safety Margin:** Added a 10px margin so the text doesn't touch the screen edges directly.

<img width="1905" height="1041" alt="image" src="https://github.com/user-attachments/assets/e613317a-95bf-4837-be3d-80065b375310" />



## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
