### PR TITLE
Fix tooltip overflow: Added dynamic margins and vertical flipping

### DIFF
--- a/src/guiengine/skin.cpp
+++ b/src/guiengine/skin.cpp
@@ -2446,7 +2446,9 @@ void Skin::drawTooltip(Widget* widget, bool atMouse)
     
     core::position2di pos(widget->m_x + 15, widget->m_y + widget->m_h);
     const core::dimension2d<u32> screen_size = irr_driver->getActualScreenSize();
-    const int margin = 10; // Space from screen edges so tooltip doesn't get cut off
+    const BoxRenderParams& params = SkinConfig::m_render_params["tooltip::neutral"];
+    const int margin = params.m_right_border; // Space from screen edges so tooltip doesn't get cut off
+    
 
     if (atMouse)
     {
@@ -2464,6 +2466,16 @@ void Skin::drawTooltip(Widget* widget, bool atMouse)
     if (pos.X < margin)
     {
         pos.X = margin;
+    }
+
+    if (pos.Y < margin) 
+    {
+        pos.Y = margin;
+    }
+
+    if (pos.Y + (int)size.Height > (int)screen_size.Height - margin)
+    {
+        pos.Y = (int)screen_size.Height - (int)size.Height - margin - 20;
     }
 
     core::recti r(pos, size);


### PR DESCRIPTION
### Description
This PR addresses the tooltip overflow issues described in #5589.
I took the opportunity to do the vertical overflow as well.

#### Key Changes
* **Dynamic Margin:** Following the maintainer's feedback, I replaced the fixed margin with a dynamic one using `params.m_right_border`. This ensures that the tooltip decoration (borders) remains inside the screen even at high resolutions.
* **Vertical Flip & Clamping:**
    * Added logic to handle the bottom of the screen. If a tooltip would overflow vertically, it now "flips" upwards to stay visible.
    * Included a safety offset (`- 20`) in the vertical clamping to prevent the tooltip from overlapping with the mouse cursor, ensuring better readability and interaction.

#### How to test
To verify the vertical overflow fix (especially for elements at the very bottom of the screen), you can temporarily replace the code in `src/states_screens/kart_selection.cpp` (line 342) with the following snippet:

```cpp
for (int n=0; n<group_amount; n++)
{
    if (groups[n] == "standard") { // Fix capitalization (#4622)
        tabs->addTextChild( _("Standard") , groups[n]);
        Widget* standard_tab = tabs->findWidgetNamed("standard");
        if (standard_tab != NULL)
            standard_tab->setTooltip(_("I have to be above !"));
    }
    else { // Try to translate group names
        tabs->addTextChild( _(groups[n].c_str()) , groups[n]);
    }
} // for n<group_amount
```

This displays a tooltip at the bottom of the screen for testing the code.

## Agreement

By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.