### PR TITLE
Use Wiimote accelerometer calibration offset

### DIFF
--- a/src/input/wiimote.cpp
+++ b/src/input/wiimote.cpp
@@ -78,7 +78,10 @@ void Wiimote::resetIrrEvent()
  */
 void Wiimote::update()
 {
-    float normalized_angle = -(m_wiimote_handle->accel.y-128)
+    int zero_y = m_wiimote_handle->accel_calib.cal_zero.y;
+    if (zero_y == 0) zero_y = 128; 
+
+    float normalized_angle = -(m_wiimote_handle->accel.y-zero_y)
                            /  UserConfigParams::m_wiimote_raw_max;
 
     if(normalized_angle<-1.0f)


### PR DESCRIPTION
Currently raw accelerometer readings are used and the EEPROM calibration offsets are ignored, meaning the kart will drift on almost all wiimotes.

This PR now subtracts the calibration constant from the reading (nicely provided by `wiiuse`).

I realize the wiimote driver is on the way out in favour of SDL, but I haven't had much success with it (incorrectly mapped buttons, no accelerometer support?).

Below is verbose output from 2 horizontal wiimotes - both have their calibration factor applied and are now zero, despite the raw value not being 128.
```
[verbose  ] wiimote: raw 119 normal 0.000000 result 0.000000
[verbose  ] wiimote: raw 125 normal 0.000000 result 0.000000
[verbose  ] wiimote: raw 125 normal 0.000000 result 0.000000
[verbose  ] wiimote: raw 125 normal 0.000000 result 0.000000
[verbose  ] wiimote: raw 125 normal 0.000000 result 0.000000
[verbose  ] wiimote: raw 125 normal 0.000000 result 0.000000
[verbose  ] wiimote: raw 119 normal 0.000000 result 0.000000
[verbose  ] wiimote: raw 125 normal 0.000000 result 0.000000
[verbose  ] wiimote: raw 119 normal 0.000000 result 0.000000
[verbose  ] wiimote: raw 119 normal 0.000000 result 0.000000
[verbose  ] wiimote: raw 119 normal 0.000000 result 0.000000
[verbose  ] wiimote: raw 119 normal 0.000000 result 0.000000
```

I believe this also fixes #4291

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
