### PR TITLE
In local sessions, pause the race when the window leaves focus.

### DIFF
--- a/lib/irrlicht/source/Irrlicht/CIrrDeviceSDL.cpp
+++ b/lib/irrlicht/source/Irrlicht/CIrrDeviceSDL.cpp
@@ -987,10 +987,9 @@ bool CIrrDeviceSDL::run()
 				else if (SDL_event.window.event == SDL_WINDOWEVENT_FOCUS_LOST)
 				{
 					// During a local session, pause the race when the window loses focus.
-					WorldStatus::Phase phase;
 					if (World::getWorld())
 					{
-						phase = World::getWorld()->getPhase();
+						WorldStatus::Phase phase = World::getWorld()->getPhase();
 						if (!NetworkConfig::get()->isNetworking() && phase >= WorldStatus::READY_PHASE && phase <= WorldStatus::RACE_PHASE)
 							World::getWorld()->escapePressed();
 					}
@@ -1696,4 +1695,5 @@ const core::dimension2du& CIrrDeviceSDL::getRealScreenSize() const
 } // end namespace irr
 
 #endif // _IRR_COMPILE_WITH_SDL_DEVICE_
+
 


### PR DESCRIPTION
If you were ever in the middle of a game and you accidentally alt-tabbed out or an application suddenly popped up to steal the focus, chances are you have lost some progress by the time you returned in haste. This change adds a mechanism intended for non-networked sessions. The mechanism, which is triggered when the player is in a race, opens the pause menu and has the same effect as pressing <kbd>Esc</kbd> on the keyboard. I only tested the feature on Linux Mint, on which I report no regressions. Non-Linux versions may need testing.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.
```
