### PR TITLE
Fix mouse wheel scrolling in lists without requiring click first

### DIFF
--- a/lib/irrlicht/source/Irrlicht/CGUIEnvironment.cpp
+++ b/lib/irrlicht/source/Irrlicht/CGUIEnvironment.cpp
@@ -544,6 +544,16 @@ bool CGUIEnvironment::postEventFromUser(const SEvent& event)
 		if (Focus && Focus->OnEvent(event))
 			return true;
 
+		// If the hovered element is different from the focused one,
+		// send mouse wheel events to the hovered element as well so
+		// that scrolling works without clicking the element first.
+		if (event.MouseInput.Event == EMIE_MOUSE_WHEEL &&
+			Hovered && Hovered != Focus)
+		{
+			if (Hovered->OnEvent(event))
+				return true;
+		}
+
 		// focus could have died in last call
 		if (!Focus && Hovered)
 		{


### PR DESCRIPTION
In CGUIEnvironment::postEventFromUser(), mouse wheel events were only dispatched to the focused element. Focus only changes on left-click, so hovering over a list and scrolling wouldn't work until the list was clicked.

Add a fallback: when a mouse wheel event isn't handled by the focused element, also try sending it to the hovered element.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
