### PR TITLE
Fix incorrect argument count in plural friend-request message.

### DIFF
--- a/src/online/online_player_profile.cpp
+++ b/src/online/online_player_profile.cpp
@@ -590,7 +590,8 @@ namespace Online
             {
                 message = _P("You have %d new friend request!",
                              "You have %d new friend requests!",
-                             friend_request_count, friend_request_count);
+                            /* to pick the plural form */ friend_request_count,
+                            /* to insert in the final string */ friend_request_count);
             }
             else
             {


### PR DESCRIPTION
## Before
<img width="1920" height="206" alt="image" src="https://github.com/user-attachments/assets/dcd17953-4d01-4866-8176-f56743c5c2bd" />

```yml
[warn   ] StringUtils: insertValues: Invalid number of arguments in 'You have %d new friend requests!'
```

## After
<img width="1920" height="198" alt="image" src="https://github.com/user-attachments/assets/e7365dff-b6be-4c23-bb2a-ac6d4e505289" />


## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
