### PR TITLE
Add a "Player finished the race" message in the race GUI

### DIFF
--- a/src/modes/linear_world.cpp
+++ b/src/modes/linear_world.cpp
@@ -67,6 +67,7 @@ LinearWorld::LinearWorld() : WorldWithRank()
     m_valid_reference_time = false;
     m_live_time_difference = 0.0f;
     m_fastest_lap_kart_name = "";
+    m_finished_kart_name    = "";
     m_check_structure_compatible = false;
 }   // LinearWorld
 
@@ -86,6 +87,7 @@ void LinearWorld::init()
     m_last_lap_sfx_playing          = false;
 
     m_fastest_lap_kart_name         = "";
+    m_finished_kart_name            = "";
 
     // The values are initialised in reset()
     m_kart_info.resize(m_karts.size());
@@ -523,6 +525,20 @@ void LinearWorld::newLap(unsigned int kart_index)
             }
             kart->finishedRace(finish_time);
         }
+
+        // Message when the player finishes the race
+
+        // Store the temporary string because clang would mess this up
+        // (remove the stringw before the wchar_t* is used).
+        const core::stringw &kart_name = kart->getController()->getName();
+        m_finished_kart_name = kart_name;
+
+        //I18N: as in "Wilber finished the race"
+        if (m_race_gui)
+        {
+            m_race_gui->addMessage(_("%s finished the race", kart_name), NULL, 6.0f,
+                                   video::SColor(255, 0, 0, 255), false);
+        }
     }
     int ticks_per_lap;
     if (kart_info.m_finished_laps == 1) // just completed first lap
@@ -543,7 +559,7 @@ void LinearWorld::newLap(unsigned int kart_index)
     }
 
     // if new fastest lap
-    if(ticks_per_lap < m_fastest_lap_ticks && raceHasLaps() &&
+    if (ticks_per_lap < m_fastest_lap_ticks && raceHasLaps() &&
         kart_info.m_finished_laps>0 && !isLiveJoinWorld())
     {
         m_fastest_lap_ticks = ticks_per_lap;
@@ -567,7 +583,6 @@ void LinearWorld::newLap(unsigned int kart_index)
                 video::SColor(255, 255, 255, 255), false);
         }
     } // end if new fastest lap
-
     kart_info.m_lap_start_ticks = getTimeTicks();
     kart->getController()->newLap(kart_info.m_finished_laps);
 }   // newLap

--- a/src/modes/linear_world.hpp
+++ b/src/modes/linear_world.hpp
@@ -51,6 +51,8 @@ private:
 
     core::stringw m_fastest_lap_kart_name;
 
+    core::stringw m_finished_kart_name;
+
     /** The track length returned by Track::getLength() only covers the
      *  distance from start line to finish line, i.e. it does not include
      *  the distance the karts actually start behind the start line (the


### PR DESCRIPTION
- This message is shown when a player finishes the race;
- This message appears in blue in the same place of the fastest lap message.

A issue that I've seen here happens when various players finish the race at the same time, and the screen are polluted with various messages.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
