### PR TITLE
Obfuscate Username on Windows, Linux and Mac in displayed Ghost Path

### DIFF
--- a/src/io/file_manager.cpp
+++ b/src/io/file_manager.cpp
@@ -858,6 +858,30 @@ std::string FileManager::getStdoutDir() const
 }   // getStdoutDir
 
 //-----------------------------------------------------------------------------
+/** Obfuscates system username for common paths.
+ */
+std::string FileManager::obfuscateUsername(const std::string &path)
+{
+    std::string obfuscated_path(path), asterisks("***");
+    if (obfuscated_path.size() > 6 && obfuscated_path.substr(0, 6) == "/home/") { // Linux usual Home Dir.
+        size_t next_delimiter_pos(obfuscated_path.find('/', 6));
+        if (next_delimiter_pos != std::string::npos)
+            obfuscated_path.replace(0, next_delimiter_pos, "~");
+    }
+    else if (obfuscated_path.size() > 9 && obfuscated_path.substr(0, 9) == "C:\\Users\\") { // Windows usual User Dir.
+        size_t next_delimiter_pos(obfuscated_path.find('\\', 9));
+        if (next_delimiter_pos != std::string::npos)
+            obfuscated_path.replace(9, next_delimiter_pos - 9, asterisks);
+    }
+    else if (obfuscated_path.size() > 7 && obfuscated_path.substr(0, 7) == "/Users/") { // Mac usual User Dir.
+        size_t next_delimiter_pos(obfuscated_path.find('/', 7));
+        if (next_delimiter_pos != std::string::npos)
+            obfuscated_path.replace(0, next_delimiter_pos, "~");
+    }
+    return obfuscated_path;
+}   // obfuscateUsername
+
+//-----------------------------------------------------------------------------
 /** Returns the full path of a texture file name by searching in all
  *  directories currently in the texture search path. The difference to
  *  a call getAsset(TEXTURE,...) is that the latter will only return

--- a/src/io/file_manager.hpp
+++ b/src/io/file_manager.hpp
@@ -156,6 +156,7 @@ public:
     std::string       getCachedTexturesDir() const;
     std::string       getGPDir() const;
     std::string       getStdoutDir() const;
+    static std::string obfuscateUsername(const std::string &path);
     bool              checkAndCreateDirectory(const std::string &path);
     bool              checkAndCreateDirectoryP(const std::string &path);
     const std::string &getAddonsDir() const;

--- a/src/replay/replay_recorder.cpp
+++ b/src/replay/replay_recorder.cpp
@@ -392,7 +392,7 @@ void ReplayRecorder::save()
     }
 
     core::stringw msg = _("Replay saved in \"%s\".",
-        StringUtils::utf8ToWide(file_manager->getReplayDir() + getReplayFilename()));
+        StringUtils::utf8ToWide(FileManager::obfuscateUsername(file_manager->getReplayDir()) + getReplayFilename()));
     MessageQueue::add(MessageQueue::MT_GENERIC, msg);
 
     fprintf(fd, "version: %d\n", getCurrentReplayVersion());


### PR DESCRIPTION
Often, people use a system username they do not wish to reveal, for example if it is linked to their real names, however it is displayed in the "Replay saved in ..." message when a race is finished with Ghost recording. It is easy to accidentally leak the username in a video if one does not notice the message, and I have seen lots of Speedrunners censoring it manually in submissions.

This Pull Request alleviates the issue by obfuscating the username when it recognizes the usual paths used on Windows (`C:\Users\...`), Linux (`/home/...`) and Mac (`/Users/...`), which already covers a great part of Players.
There does not seem to be a practical way to handle this generically for all systems or esoteric configurations, recognizing and hardcoding common paths seemed to be the best compromise.
More paths for other systems may be added in follow-up Pull Requests.

<img width="1280" height="720" alt="ObfuscateUsernameGhost" src="https://github.com/user-attachments/assets/16c032a5-f74c-403f-9259-448ef7352ce4" />

An alternative could be to just omit the first part of the path or even just showing only the Ghost Filename, and maybe have some practical way to open the Ghost Folder directly from the Ui.

## Agreement

By creating a pull request in stk-code, I hereby agree to dual-license my contribution as GNU General Public License version 3 or any later version and Mozilla Public License version 2 or any later version.

This includes my previous contribution(s) under the same name of contributor.