### PR TITLE
Remember player 1's last kart class filter (light/medium/heavy)

### DIFF
--- a/src/config/user_config.hpp
+++ b/src/config/user_config.hpp
@@ -481,6 +481,9 @@ namespace UserConfigParams
     PARAM_PREFIX StringUserConfigParam m_last_used_kart_group
             PARAM_DEFAULT( StringUserConfigParam("all", "last_kart_group",
                                                  "Last selected kart group") );
+    PARAM_PREFIX IntUserConfigParam m_last_used_kart_class
+            PARAM_DEFAULT(  IntUserConfigParam(-1, "last_kart_class",
+                                                 "Last selected kart class") );
     PARAM_PREFIX IntUserConfigParam          m_soccer_red_ai_num
             PARAM_DEFAULT(  IntUserConfigParam(0, "soccer-red-ai-num",
             &m_race_setup_group, "Number of red AI karts in soccer mode.") );

--- a/src/states_screens/kart_selection.cpp
+++ b/src/states_screens/kart_selection.cpp
@@ -311,7 +311,9 @@ void KartSelectionScreen::init()
     const std::vector<std::string> &classes = kart_properties_manager->getAllKartTypes();
     GUIEngine::SpinnerWidget* kart_class = getWidget<GUIEngine::SpinnerWidget>("kart_class");
     assert(kart_class != NULL);
-    kart_class->setValue(classes.size()); // All
+
+    const int last_class = UserConfigParams::m_last_used_kart_class;
+    kart_class->setValue(last_class < 0 ? classes.size() /* All */ : last_class);
 
     // Build kart list (it is built everytime, to account for .g. locking)
     setKartsFromCurrentGroup();
@@ -1242,6 +1244,18 @@ void KartSelectionScreen::allPlayersDone()
         if (n == PLAYER_ID_GAME_MASTER)
         {
             UserConfigParams::m_default_kart = selected_kart;
+
+            if (selected_kart == RANDOM_KART_ID)
+            {
+                SpinnerWidget* kart_class = getWidget<SpinnerWidget>("kart_class");
+                assert(kart_class != NULL);
+
+                UserConfigParams::m_last_used_kart_class = kart_class->getValue();
+            }
+            else
+            {
+                UserConfigParams::m_last_used_kart_class = -1;
+            }
         }
 
         if (selected_kart == RANDOM_KART_ID)


### PR DESCRIPTION
This is especially useful when player 1 plays random karts of a particular class all the time.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
