### PR TITLE
Add a security lock in android/generate_assets.sh

### DIFF
--- a/android/generate_assets.sh
+++ b/android/generate_assets.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 #
 # (C) 2016-2017 Dawid Gan, under the GPLv3
+# Edited in 2026 by Gustavo Barreira (aka GustaLOLE)
 #
-# A script that generates data files for Android apk
+# A script that generates lighter data files for Android apk
 
 
 # Below you can find some simple configuration variables.
@@ -147,6 +148,13 @@ if command -v magick > /dev/null; then
     MAGICK='magick'
 else
     MAGICK='convert'
+fi
+
+# Ensure that don't exists the assets folder in case of a user error, like wrong typed command, etc...
+if [ -d "./assets" ]; then
+    echo "SECURITY MESSAGE: You might be trying to reset assets folder!"
+    echo "Delete or rename your assets folder to continue..."
+    exit 1
 fi
 
 # Clear previous assets directory
@@ -718,6 +726,6 @@ echo "has_assets" > "$OUTPUT_PATH/has_assets.txt"
 # It will be probably ignored by ant, but create it anyway...
 touch "$OUTPUT_PATH/.nomedia"
 
-
-echo "Done."
+# Just the finish message
+echo "Done ;)"
 exit 0

--- a/android/generate_assets.sh
+++ b/android/generate_assets.sh
@@ -150,10 +150,10 @@ else
     MAGICK='convert'
 fi
 
-# Ensure that don't exists the assets folder in case of a user error, like wrong typed command, etc...
+# Ensure that the assets doesn't exist, in case of a user error, like a wrongly typed command, etc...
 if [ -d "./assets" ]; then
     echo "SECURITY MESSAGE: You might be trying to reset assets folder!"
-    echo "Delete or rename your assets folder to continue..."
+    echo "Delete or rename your assets folder (inside the android folder) to continue..."
     exit 1
 fi
 
@@ -727,5 +727,5 @@ echo "has_assets" > "$OUTPUT_PATH/has_assets.txt"
 touch "$OUTPUT_PATH/.nomedia"
 
 # Just the finish message
-echo "Done ;)"
+echo "Done."
 exit 0


### PR DESCRIPTION
The title says all :)

I added this in case of someone type this command without wanting to when he already have the assets converted, and need to wait a long time to convert it again, as I talked in the Matrix chat.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
