### PR TITLE
Hide empty parent node of the attachable library node tool.

### DIFF
--- a/src/graphics/attachable_library_manager.cpp
+++ b/src/graphics/attachable_library_manager.cpp
@@ -70,7 +70,8 @@ void AttachableLibraryManager::loadLibraryNode(const std::string& folder_name,
     }
 
     m_attachable_lib_nodes[identifier] = irr_driver->getSceneManager()->addEmptySceneNode();
-
+    m_attachable_lib_nodes[identifier]->setVisible(false);
+    
     XMLNode* libroot;
     // During reloads, the folder map is preserved but the attachable nodes aren't
     if (m_folder_map.count(identifier) == 0)


### PR DESCRIPTION
This should hide the emitter visible in the kart selection screen and not break attachable library node functionality. Resolves https://github.com/supertuxkart/stk-code/issues/5730. 

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

You also confirm that this contribution is your own original work
and that it does not contain code generated by AI tools.

Keep the above statement in the pull request comment for agreement.

```
