### PR TITLE
Fix some warnings in Gradle compiling (in Evolution branch)

### DIFF
--- a/src/karts/kart.hpp
+++ b/src/karts/kart.hpp
@@ -465,7 +465,7 @@ public:
     // ------------------------------------------------------------------------
     /** Returns a unique identifier for this kart (name of the directory the
      *  kart was loaded from). */
-    virtual const std::string& getIdent() const;
+    virtual const std::string& getIdent() const OVERRIDE;
     // ------------------------------------------------------------------------
     virtual void   updateGraphics(float dt) OVERRIDE;
     virtual void   createPhysics    ();
@@ -514,7 +514,7 @@ public:
     /** Returns the pitch of the terrain depending on the heading. */
     virtual float getTerrainPitch(float heading) const;
 
-    virtual void   reset            ();
+    virtual void   reset            () OVERRIDE;
     virtual void   partialReset     (bool affect_squash = true);
     // ------------------------------------------------------------------------
     /** Sets zipper time, and apply one time additional speed boost. It can be

--- a/src/modes/soccer_world.cpp
+++ b/src/modes/soccer_world.cpp
@@ -552,15 +552,12 @@ void SoccerWorld::onCheckGoalTriggered(bool first_goal)
        else
             sd.m_time = getTime();
 
-// Shut up GCC complaining incorrectly about sd.m_country_code
-#pragma GCC diagnostic push
         // First goal being true means that the ball entered the
         // blue goal, meaning that the red team scored.
         if (first_goal)
             m_red_scorers.push_back(sd);
         else
             m_blue_scorers.push_back(sd);
-#pragma GCC diagnostic pop
 
         if (NetworkConfig::get()->isNetworking() &&
             NetworkConfig::get()->isServer())
@@ -620,14 +617,11 @@ void SoccerWorld::handlePlayerGoalFromServer(const NetworkString& ns)
     ns.decodeString(&sd.m_country_code);
     sd.m_handicap_level = (HandicapLevel)ns.getUInt8();
 
-// Shut up GCC complaining incorrectly about sd.m_country_code
-#pragma GCC diagnostic push
     if (first_goal)
         m_red_scorers.push_back(sd);
     else
         m_blue_scorers.push_back(sd);
-#pragma GCC diagnostic pop
-
+	
     if (ticks_now >= ticks_back_to_own_goal && !isStartPhase())
     {
         Log::warn("SoccerWorld", "Server ticks %d is too close to client ticks "
@@ -1094,13 +1088,11 @@ void SoccerWorld::restoreCompleteState(const BareNetworkString& b)
         b.decodeStringW(&sd.m_player);
         b.decodeString(&sd.m_country_code);
         sd.m_handicap_level = (HandicapLevel)b.getUInt8();
-// Shut up GCC complaining incorrectly about sd.m_country_code
-#pragma GCC diagnostic push
+
         if (i < red_size)
             m_red_scorers.push_back(sd);
         else
             m_blue_scorers.push_back(sd);
-#pragma GCC diagnostic pop
     }
 
     m_reset_ball_ticks = b.getTime();

--- a/src/modes/soccer_world.cpp
+++ b/src/modes/soccer_world.cpp
@@ -554,7 +554,6 @@ void SoccerWorld::onCheckGoalTriggered(bool first_goal)
 
 // Shut up GCC complaining incorrectly about sd.m_country_code
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
         // First goal being true means that the ball entered the
         // blue goal, meaning that the red team scored.
         if (first_goal)
@@ -623,7 +622,6 @@ void SoccerWorld::handlePlayerGoalFromServer(const NetworkString& ns)
 
 // Shut up GCC complaining incorrectly about sd.m_country_code
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
     if (first_goal)
         m_red_scorers.push_back(sd);
     else
@@ -1098,7 +1096,6 @@ void SoccerWorld::restoreCompleteState(const BareNetworkString& b)
         sd.m_handicap_level = (HandicapLevel)b.getUInt8();
 // Shut up GCC complaining incorrectly about sd.m_country_code
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
         if (i < red_size)
             m_red_scorers.push_back(sd);
         else


### PR DESCRIPTION
- The warnings related in kart.hpp and movable.hpp (-Winconsistent-missing-override) are fixed now.

More warnings (of STK Evolution) gonna be fixed later by me also in another PRs.
## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

You also confirm that this contribution is your own original work
and that it does not contain code generated by AI tools.

Keep the above statement in the pull request comment for agreement.

```
