### PR TITLE
Fix #5286 and remove a unused variable

### DIFF
--- a/src/states_screens/dialogs/kart_color_slider_dialog.cpp
+++ b/src/states_screens/dialogs/kart_color_slider_dialog.cpp
@@ -105,7 +105,17 @@ void KartColorSliderDialog::beforeAddingWidgets()
     core::matrix4 model_location;
 
     // scaling the view basing in the kart length
-    float scale = 40.0f / kart_model.getLength();
+    float scale = 35.0f / kart_model.getLength();
+
+    // if the kart is too short, use a predefined scale
+    if (kart_model.getLength() < 1.45f)
+    {
+        scale = 35.0f;
+    }
+    else if (kart_model.getLength() < 1.75f)
+    {
+        scale = 30.0f;
+    }
 
     model_location.setScale(core::vector3df(scale, scale, scale));
 

--- a/src/states_screens/dialogs/kart_color_slider_dialog.cpp
+++ b/src/states_screens/dialogs/kart_color_slider_dialog.cpp
@@ -105,17 +105,7 @@ void KartColorSliderDialog::beforeAddingWidgets()
     core::matrix4 model_location;
 
     // scaling the view basing in the kart length
-    float scale = 35.0f / kart_model.getLength();
-
-    // if the kart is too short, use a predefined scale
-    if (kart_model.getLength() < 1.45f)
-    {
-        scale = 35.0f;
-    }
-    else if (kart_model.getLength() < 1.75f)
-    {
-        scale = 30.0f;
-    }
+    float scale = 50.0f / kart_model.getLength();
 
     model_location.setScale(core::vector3df(scale, scale, scale));
 

--- a/src/states_screens/dialogs/kart_color_slider_dialog.cpp
+++ b/src/states_screens/dialogs/kart_color_slider_dialog.cpp
@@ -104,12 +104,8 @@ void KartColorSliderDialog::beforeAddingWidgets()
 
     core::matrix4 model_location;
 
-    float scale = 35.0f;
-    if (kart_model.getLength() > 1.45f)
-    {
-        // if kart is too long, size it down a bit so that it fits
-        scale = 30.0f;
-    }
+    // scaling the view basing in the kart length
+    float scale = 40.0f / kart_model.getLength();
 
     model_location.setScale(core::vector3df(scale, scale, scale));
 

--- a/src/states_screens/kart_selection.cpp
+++ b/src/states_screens/kart_selection.cpp
@@ -289,6 +289,11 @@ void KartSelectionScreen::init()
     tabs->select(UserConfigParams::m_last_used_kart_group,
                  PLAYER_ID_GAME_MASTER);
 
+#ifdef DEBUG
+    Widget* placeholder = getWidget("playerskarts");
+    assert(placeholder != NULL);
+#endif
+
     m_game_master_confirmed = false;
 
     tabs->setActive(true);

--- a/src/states_screens/kart_selection.cpp
+++ b/src/states_screens/kart_selection.cpp
@@ -289,9 +289,6 @@ void KartSelectionScreen::init()
     tabs->select(UserConfigParams::m_last_used_kart_group,
                  PLAYER_ID_GAME_MASTER);
 
-    Widget* placeholder = getWidget("playerskarts");
-    assert(placeholder != NULL);
-
     m_game_master_confirmed = false;
 
     tabs->setActive(true);
@@ -888,12 +885,8 @@ void KartSelectionScreen::updateKartWidgetModel(int widget_id,
         {
             const KartModel &kart_model = kp->getMasterKartModel();
 
-            float scale = 35.0f;
-            if (kart_model.getLength() > 1.45f)
-            {
-                // if kart is too long, size it down a bit so that it fits
-                scale = 30.0f;
-            }
+            // scaling the view basing in the kart length
+            float scale = 40.0f / kart_model.getLength();
 
             core::matrix4 model_location;
             model_location.setScale(core::vector3df(scale, scale, scale));

--- a/src/states_screens/kart_selection.cpp
+++ b/src/states_screens/kart_selection.cpp
@@ -886,7 +886,17 @@ void KartSelectionScreen::updateKartWidgetModel(int widget_id,
             const KartModel &kart_model = kp->getMasterKartModel();
 
             // scaling the view basing in the kart length
-            float scale = 40.0f / kart_model.getLength();
+            float scale = 35.0f / kart_model.getLength();
+
+            // if the kart is too short, use a predefined scale
+            if (kart_model.getLength() < 1.45f)
+            {
+                scale = 35.0f;
+            }
+            else if (kart_model.getLength() < 1.75f)
+            {
+                scale = 30.0f;
+            }
 
             core::matrix4 model_location;
             model_location.setScale(core::vector3df(scale, scale, scale));

--- a/src/states_screens/kart_selection.cpp
+++ b/src/states_screens/kart_selection.cpp
@@ -886,17 +886,7 @@ void KartSelectionScreen::updateKartWidgetModel(int widget_id,
             const KartModel &kart_model = kp->getMasterKartModel();
 
             // scaling the view basing in the kart length
-            float scale = 35.0f / kart_model.getLength();
-
-            // if the kart is too short, use a predefined scale
-            if (kart_model.getLength() < 1.45f)
-            {
-                scale = 35.0f;
-            }
-            else if (kart_model.getLength() < 1.75f)
-            {
-                scale = 30.0f;
-            }
+            float scale = 50.0f / kart_model.getLength();
 
             core::matrix4 model_location;
             model_location.setScale(core::vector3df(scale, scale, scale));

--- a/src/states_screens/soccer_setup_screen.cpp
+++ b/src/states_screens/soccer_setup_screen.cpp
@@ -167,8 +167,11 @@ void SoccerSetupScreen::beforeAddingWidget()
                 (info.team == KART_TEAM_BLUE ? 0.66f : 1.0f);
         }
 
+        // scaling the view basing in the kart length
+        float scale = 40.0f / kart_model.getLength();
+
         core::matrix4 model_location;
-        model_location.setScale(core::vector3df(35.0f, 35.0f, 35.0f));
+        model_location.setScale(core::vector3df(scale, scale, scale));
         // Add the kart model (including wheels and speed weight objects)
         kart_view->addModel(kart_model.getModel(), model_location,
             kart_model.getBaseFrame(), kart_model.getBaseFrame());

--- a/src/states_screens/soccer_setup_screen.cpp
+++ b/src/states_screens/soccer_setup_screen.cpp
@@ -168,7 +168,17 @@ void SoccerSetupScreen::beforeAddingWidget()
         }
 
         // scaling the view basing in the kart length
-        float scale = 40.0f / kart_model.getLength();
+        float scale = 35.0f / kart_model.getLength();
+
+        // if the kart is too short, use a predefined scale
+        if (kart_model.getLength() < 1.45f)
+        {
+            scale = 35.0f;
+        }
+        else if (kart_model.getLength() < 1.75f)
+        {
+            scale = 30.0f;
+        }
 
         core::matrix4 model_location;
         model_location.setScale(core::vector3df(scale, scale, scale));

--- a/src/states_screens/soccer_setup_screen.cpp
+++ b/src/states_screens/soccer_setup_screen.cpp
@@ -168,17 +168,7 @@ void SoccerSetupScreen::beforeAddingWidget()
         }
 
         // scaling the view basing in the kart length
-        float scale = 35.0f / kart_model.getLength();
-
-        // if the kart is too short, use a predefined scale
-        if (kart_model.getLength() < 1.45f)
-        {
-            scale = 35.0f;
-        }
-        else if (kart_model.getLength() < 1.75f)
-        {
-            scale = 30.0f;
-        }
+        float scale = 50.0f / kart_model.getLength();
 
         core::matrix4 model_location;
         model_location.setScale(core::vector3df(scale, scale, scale));


### PR DESCRIPTION
 - I've fixed the issue by using a inverse relationship in the "scale" variable (used also in kart_selection and kart_color_slider screens)
 - Was removed this warning also:

stk-code/src/states_screens/kart_selection.cpp:292:13: warning: unused variable ‘placeholder’ [-Wunused-variable]
  292 |     Widget* placeholder = getWidget("playerskarts");
      |             ^~~~~~~~~~~

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

You also confirm that this contribution is your own original work
and that it does not contain code generated by AI tools.

Keep the above statement in the pull request comment for agreement.

```
