### PR TITLE
Change mobile sensitivity X-axis to 30 for STK Evolution 

### DIFF
--- a/src/config/user_config.hpp
+++ b/src/config/user_config.hpp
@@ -566,7 +566,7 @@ namespace UserConfigParams
             "considered as centered in steering button."));
 
     PARAM_PREFIX FloatUserConfigParam         m_multitouch_sensitivity_x
-            PARAM_DEFAULT( FloatUserConfigParam(0.2f, "multitouch_sensitivity_x",
+            PARAM_DEFAULT( FloatUserConfigParam(0.3f, "multitouch_sensitivity_x",
             &m_multitouch_group,
             "A parameter in range [0, 1.0] that determines the sensitivity for x axis."));
 


### PR DESCRIPTION
After some tests, this level is very near of STK 1.x handling

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

You also confirm that this contribution is your own original work
and that it does not contain code generated by AI tools.

Keep the above statement in the pull request comment for agreement.

```
