### PR TITLE
Only create RaceGUIMultitouch buttons when isn't watching a ghost replay (mobile STK)

### DIFF
--- a/src/states_screens/race_gui_base.cpp
+++ b/src/states_screens/race_gui_base.cpp
@@ -584,7 +584,7 @@ void RaceGUIBase::renderPlayerView(const Camera *camera, float dt)
     
     if (m_multitouch_gui != NULL && !GUIEngine::ModalDialog::isADialogActive())
     {
-        m_multitouch_gui->draw(kart, viewport, scaling);
+        m_multitouch_gui->draw(kart, viewport, scaling, dt);
     }
 }   // renderPlayerView
 

--- a/src/states_screens/race_gui_base.hpp
+++ b/src/states_screens/race_gui_base.hpp
@@ -263,9 +263,12 @@ public:
     void drawPlayerIcon(AbstractKart *kart, int x, int y, int w,
                         bool is_local);
     
-    virtual void drawEnergyMeter(int x, int y, const AbstractKart *kart,
-                                 const core::recti &viewport,
-                                 const core::vector2df &scaling) {};
+    virtual void drawEnergyMeter    (int x, int y, const AbstractKart *kart,
+                                     const core::recti &viewport,
+                                     const core::vector2df &scaling) {};
+	virtual void drawSpeedEnergyRank(const AbstractKart* kart,
+									 const core::recti &viewport,
+								     const core::vector2df &scaling, float dt) {};
 
     void cleanupMessages(const float dt);
     void removeReferee();

--- a/src/states_screens/race_gui_multitouch.cpp
+++ b/src/states_screens/race_gui_multitouch.cpp
@@ -34,6 +34,7 @@ using namespace irr;
 #include "karts/abstract_kart.hpp"
 #include "karts/controller/kart_control.hpp"
 #include "network/protocols/client_lobby.hpp"
+#include "race/race_manager.hpp"
 #include "states_screens/race_gui_base.hpp"
 
 #include <IrrlichtDevice.h>
@@ -46,6 +47,7 @@ RaceGUIMultitouch::RaceGUIMultitouch(RaceGUIBase* race_gui)
     m_race_gui = race_gui;
     m_gui_action = false;
     m_is_spectator_mode = false;
+    m_is_watching_replay = false;
     m_height = 0;
     m_steering_wheel_tex = NULL;
     m_steering_wheel_tex_mask_up = NULL;
@@ -164,11 +166,17 @@ void RaceGUIMultitouch::init()
                                         "android/steering_wheel_mask_down.png");
 
     auto cl = LobbyProtocol::get<ClientLobby>();
-    
+    auto rm = RaceManager::get()->isWatchingReplay();
+
     if (cl && cl->isSpectator())
     {
         createSpectatorGUI();
         m_is_spectator_mode = true;
+    }
+    else if (rm)
+    {
+        m_is_watching_replay = true;
+        createRaceGUI();
     }
     else
     {
@@ -236,39 +244,44 @@ void RaceGUIMultitouch::createRaceGUI()
     }
 
     m_height = (unsigned int)(2 * col_size + margin / 2);
-    
-    if (UserConfigParams::m_multitouch_controls == MULTITOUCH_CONTROLS_ACCELEROMETER ||
-        UserConfigParams::m_multitouch_controls == MULTITOUCH_CONTROLS_GYROSCOPE)
+    if (!m_is_watching_replay)
     {
-        m_device->addButton(BUTTON_UP_DOWN,
-                    int(steering_accel_x), int(steering_accel_y),
-                    int(btn2_size / 2), int(btn2_size));
-    }
-    else
-    {
-        m_device->addButton(BUTTON_STEERING,
-                            int(steering_wheel_x), int(steering_wheel_y),
-                            int(btn2_size), int(btn2_size));
-    }
+        if (UserConfigParams::m_multitouch_controls == MULTITOUCH_CONTROLS_ACCELEROMETER ||
+            UserConfigParams::m_multitouch_controls == MULTITOUCH_CONTROLS_GYROSCOPE)
+        {
+            m_device->addButton(BUTTON_UP_DOWN,
+                        int(steering_accel_x), int(steering_accel_y),
+                        int(btn2_size / 2), int(btn2_size));
+        }
+        else
+        {
+            m_device->addButton(BUTTON_STEERING,
+                                int(steering_wheel_x), int(steering_wheel_y),
+                                int(btn2_size), int(btn2_size));
+        }
 
-    m_device->addButton(BUTTON_ESCAPE,
-                        int(margin_top), int(margin_small),
-                        int(btn_small_size), int(btn_small_size));
-    m_device->addButton(BUTTON_RESCUE,
-                        int(margin_top + col_small_size), int(margin_small),
-                        int(btn_small_size), int(btn_small_size));
-    m_device->addButton(BUTTON_NITRO,
-                        int(second_column_x), int(h - 2 * col_size),
-                        int(btn_size), int(btn_size));
-    m_device->addButton(BUTTON_SKIDDING,
-                        int(second_column_x), int(h - 1 * col_size),
-                        int(btn_size), int(btn_size));
-    m_device->addButton(BUTTON_FIRE,
-                        int(first_column_x),  int(h - 2 * col_size),
-                        int(btn_size), int(btn_size));
-    m_device->addButton(BUTTON_LOOK_BACKWARDS,
-                        int(first_column_x), int(h - 1 * col_size),
-                        int(btn_size), int(btn_size));
+        m_device->addButton(BUTTON_ESCAPE,
+                            int(margin_top), int(margin_small),
+                            int(btn_small_size), int(btn_small_size));
+        m_device->addButton(BUTTON_RESCUE,
+                            int(margin_top + col_small_size), int(margin_small),
+                            int(btn_small_size), int(btn_small_size));
+        m_device->addButton(BUTTON_NITRO,
+                            int(second_column_x), int(h - 2 * col_size),
+                            int(btn_size), int(btn_size));
+        m_device->addButton(BUTTON_SKIDDING,
+                            int(second_column_x), int(h - 1 * col_size),
+                            int(btn_size), int(btn_size));
+        m_device->addButton(BUTTON_FIRE,
+                            int(first_column_x),  int(h - 2 * col_size),
+                            int(btn_size), int(btn_size));
+        m_device->addButton(BUTTON_LOOK_BACKWARDS,
+                            int(first_column_x), int(h - 1 * col_size),
+                            int(btn_size), int(btn_size));
+        m_device->addButton(BUTTON_ESCAPE,
+                            int(margin_top), int(margin_small),
+                            int(btn_small_size), int(btn_small_size));
+    }
 } // createRaceGUI
 
 //-----------------------------------------------------------------------------

--- a/src/states_screens/race_gui_multitouch.cpp
+++ b/src/states_screens/race_gui_multitouch.cpp
@@ -175,8 +175,8 @@ void RaceGUIMultitouch::init()
     }
     else if (rm)
     {
+		createWatchingGUI();
         m_is_watching_replay = true;
-        createRaceGUI();
     }
     else
     {
@@ -244,45 +244,66 @@ void RaceGUIMultitouch::createRaceGUI()
     }
 
     m_height = (unsigned int)(2 * col_size + margin / 2);
-    if (!m_is_watching_replay)
+    
+    if (UserConfigParams::m_multitouch_controls == MULTITOUCH_CONTROLS_ACCELEROMETER ||
+        UserConfigParams::m_multitouch_controls == MULTITOUCH_CONTROLS_GYROSCOPE)
     {
-        if (UserConfigParams::m_multitouch_controls == MULTITOUCH_CONTROLS_ACCELEROMETER ||
-            UserConfigParams::m_multitouch_controls == MULTITOUCH_CONTROLS_GYROSCOPE)
-        {
-            m_device->addButton(BUTTON_UP_DOWN,
-                        int(steering_accel_x), int(steering_accel_y),
-                        int(btn2_size / 2), int(btn2_size));
-        }
-        else
-        {
-            m_device->addButton(BUTTON_STEERING,
-                                int(steering_wheel_x), int(steering_wheel_y),
-                                int(btn2_size), int(btn2_size));
-        }
-
-        m_device->addButton(BUTTON_ESCAPE,
-                            int(margin_top), int(margin_small),
-                            int(btn_small_size), int(btn_small_size));
-        m_device->addButton(BUTTON_RESCUE,
-                            int(margin_top + col_small_size), int(margin_small),
-                            int(btn_small_size), int(btn_small_size));
-        m_device->addButton(BUTTON_NITRO,
-                            int(second_column_x), int(h - 2 * col_size),
-                            int(btn_size), int(btn_size));
-        m_device->addButton(BUTTON_SKIDDING,
-                            int(second_column_x), int(h - 1 * col_size),
-                            int(btn_size), int(btn_size));
-        m_device->addButton(BUTTON_FIRE,
-                            int(first_column_x),  int(h - 2 * col_size),
-                            int(btn_size), int(btn_size));
-        m_device->addButton(BUTTON_LOOK_BACKWARDS,
-                            int(first_column_x), int(h - 1 * col_size),
-                            int(btn_size), int(btn_size));
-        m_device->addButton(BUTTON_ESCAPE,
-                            int(margin_top), int(margin_small),
-                            int(btn_small_size), int(btn_small_size));
+        m_device->addButton(BUTTON_UP_DOWN,
+                    int(steering_accel_x), int(steering_accel_y),
+                    int(btn2_size / 2), int(btn2_size));
     }
+    else
+    {
+        m_device->addButton(BUTTON_STEERING,
+                            int(steering_wheel_x), int(steering_wheel_y),
+                            int(btn2_size), int(btn2_size));
+    }
+
+    m_device->addButton(BUTTON_ESCAPE,
+                        int(margin_top), int(margin_small),
+                        int(btn_small_size), int(btn_small_size));
+    m_device->addButton(BUTTON_RESCUE,
+                        int(margin_top + col_small_size), int(margin_small),
+                        int(btn_small_size), int(btn_small_size));
+    m_device->addButton(BUTTON_NITRO,
+                        int(second_column_x), int(h - 2 * col_size),
+                        int(btn_size), int(btn_size));
+    m_device->addButton(BUTTON_SKIDDING,
+                        int(second_column_x), int(h - 1 * col_size),
+                        int(btn_size), int(btn_size));
+    m_device->addButton(BUTTON_FIRE,
+                        int(first_column_x),  int(h - 2 * col_size),
+                        int(btn_size), int(btn_size));
+    m_device->addButton(BUTTON_LOOK_BACKWARDS,
+                        int(first_column_x), int(h - 1 * col_size),
+                        int(btn_size), int(btn_size));
 } // createRaceGUI
+
+//-----------------------------------------------------------------------------
+/** Determines the look of multitouch watching GUI interface (for replay watching)
+ */
+void RaceGUIMultitouch::createWatchingGUI()
+{
+    if (m_device == NULL)
+        return;
+        
+    const float scale = UserConfigParams::m_multitouch_scale;
+
+    const int h = irr_driver->getActualScreenSize().Height;
+    const float btn_size = 0.125f * h * scale;
+    const float margin = 0.075f * h * scale;
+    const float margin_top = 0.3f * h;
+
+    const float small_ratio = 0.75f;
+    const float btn_small_size = small_ratio * btn_size;
+    const float margin_small = small_ratio * margin;
+    
+    m_height = (unsigned int)(btn_size + 2 * margin);
+    
+    m_device->addButton(BUTTON_ESCAPE,
+                        int(margin_top), int(margin_small),
+                        int(btn_small_size), int(btn_small_size));
+} // createWatchingGUI
 
 //-----------------------------------------------------------------------------
 /** Determines the look of spectator GUI interface
@@ -369,7 +390,8 @@ void RaceGUIMultitouch::onCustomButtonPress(unsigned int button_id,
  */
 void RaceGUIMultitouch::draw(const AbstractKart* kart,
                              const core::recti &viewport,
-                             const core::vector2df &scaling)
+                             const core::vector2df &scaling,
+                             float dt)
 {
 #ifndef SERVER_ONLY
     if (m_device == NULL)
@@ -563,6 +585,10 @@ void RaceGUIMultitouch::draw(const AbstractKart* kart,
                 font->setScale(1.0f);
                 font->setBlackBorder(false);
             }
+			if (m_is_watching_replay)
+			{
+				m_race_gui->drawSpeedEnergyRank(kart, viewport, scaling, dt);
+			}
         }
     }
 #endif

--- a/src/states_screens/race_gui_multitouch.hpp
+++ b/src/states_screens/race_gui_multitouch.hpp
@@ -33,6 +33,7 @@ using namespace irr;
 
 class AbstractKart;
 class MultitouchDevice;
+class RaceManager;
 class RaceGUIBase;
 
 class RaceGUIMultitouch
@@ -43,6 +44,7 @@ private:
     
     bool m_gui_action;
     bool m_is_spectator_mode;
+    bool m_is_watching_replay;
     unsigned int m_height;
     
     video::ITexture* m_steering_wheel_tex;

--- a/src/states_screens/race_gui_multitouch.hpp
+++ b/src/states_screens/race_gui_multitouch.hpp
@@ -67,6 +67,7 @@ private:
 
     void init();
     void createRaceGUI();
+	void createWatchingGUI();
     void createSpectatorGUI();
     void close();
     static void onCustomButtonPress(unsigned int button_id, bool pressed);
@@ -76,7 +77,7 @@ public:
     ~RaceGUIMultitouch();
 
     void draw(const AbstractKart* kart, const core::recti &viewport,
-              const core::vector2df &scaling);
+              const core::vector2df &scaling, float dt);
                                 
     unsigned int getHeight() {return m_height;}
     bool isSpectatorMode() {return m_is_spectator_mode;}


### PR DESCRIPTION
 - Now, the screen is clearer in this situation, allowing the mobile player to watch a replay with less annoying things on-screen.
 - The player can open ihe pause menu using ESC or pressing the Android back button.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

You also confirm that this contribution is your own original work
and that it does not contain code generated by AI tools.

Keep the above statement in the pull request comment for agreement.

```
