### PR TITLE
allows moving the fps camera in artist debug 3x faster by pressing shift, as suggested in #5796

### DIFF
--- a/src/utils/debug.cpp
+++ b/src/utils/debug.cpp
@@ -1706,7 +1706,7 @@ void handleStaticAction(int key, int value, bool control_pressed, bool shift_pre
             if (cam)
             {
                 core::vector3df vel(cam->getLinearVelocity());
-                vel.Z = value ? cam->getMaximumVelocity() : 0;
+                vel.Z = value ? cam->getMaximumVelocity() * (shift_pressed ? 3.0f : 1.0f) : 0;
                 cam->setLinearVelocity(vel);
             }
             break;
@@ -1716,7 +1716,7 @@ void handleStaticAction(int key, int value, bool control_pressed, bool shift_pre
             if (cam)
             {
                 core::vector3df vel(cam->getLinearVelocity());
-                vel.Z = value ? -cam->getMaximumVelocity() : 0;
+                vel.Z = value ? -cam->getMaximumVelocity() * (shift_pressed ? 3.0f : 1.0f) : 0;
                 cam->setLinearVelocity(vel);
             }
             break;
@@ -1726,7 +1726,7 @@ void handleStaticAction(int key, int value, bool control_pressed, bool shift_pre
             if (cam)
             {
                 core::vector3df vel(cam->getLinearVelocity());
-                vel.X = value ? -cam->getMaximumVelocity() : 0;
+                vel.X = value ? -cam->getMaximumVelocity() * (shift_pressed ? 3.0f : 1.0f) : 0;
                 cam->setLinearVelocity(vel);
             }
             break;
@@ -1736,7 +1736,7 @@ void handleStaticAction(int key, int value, bool control_pressed, bool shift_pre
             if (cam)
             {
                 core::vector3df vel(cam->getLinearVelocity());
-                vel.X = value ? cam->getMaximumVelocity() : 0;
+                vel.X = value ? cam->getMaximumVelocity() * (shift_pressed ? 3.0f : 1.0f) : 0;
                 cam->setLinearVelocity(vel);
             }
             break;
@@ -1746,7 +1746,7 @@ void handleStaticAction(int key, int value, bool control_pressed, bool shift_pre
             if (cam)
             {
                 core::vector3df vel(cam->getLinearVelocity());
-                vel.Y = value ? cam->getMaximumVelocity() : 0;
+                vel.Y = value ? cam->getMaximumVelocity() * (shift_pressed ? 3.0f : 1.0f) : 0;
                 cam->setLinearVelocity(vel);
             }
             break;
@@ -1756,7 +1756,7 @@ void handleStaticAction(int key, int value, bool control_pressed, bool shift_pre
             if (cam)
             {
                 core::vector3df vel(cam->getLinearVelocity());
-                vel.Y = value ? -cam->getMaximumVelocity() : 0;
+                vel.Y = value ? -cam->getMaximumVelocity() * (shift_pressed ? 3.0f : 1.0f) : 0;
                 cam->setLinearVelocity(vel);
             }
             break;


### PR DESCRIPTION
Allows moving the first person view camera in artist debug mode 3 times as fast by pressing shift, as suggested in #5796 .

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

You also confirm that this contribution is your own original work
and that it does not contain code generated by AI tools.

Keep the above statement in the pull request comment for agreement.

```
