### PR TITLE
switch: update devkitpro version

### DIFF
--- a/.github/workflows/switch.yml
+++ b/.github/workflows/switch.yml
@@ -14,7 +14,7 @@ jobs:
     name: Build Switch
     runs-on: ubuntu-latest
     container:
-      image: 'devkitpro/devkita64:20241023'
+      image: 'devkitpro/devkita64'
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -472,7 +472,7 @@ if (NOT SERVER_ONLY)
 
     # Freetype
     find_package(Freetype)
-    if(FREETYPE_FOUND)
+    if(FREETYPE_FOUND OR TARGET Freetype::Freetype)
         include_directories(${FREETYPE_INCLUDE_DIRS})
     else()
         message(FATAL_ERROR "Freetype not found. "
@@ -739,6 +739,7 @@ if (USE_SWITCH)
   target_link_libraries(supertuxkart
     ${NX_LIBRARY}
     ${ZLIB_LIBRARY}
+    Freetype::Freetype
     ${FREETYPE_LIBRARIES}
     -logg
     -lvorbis


### PR DESCRIPTION
required tweaking some freetype stuff to use the target system, because the new devkitpro version came with an updated cmake config for freetype.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

You also confirm that this contribution is your own original work
and that it does not contain code generated by AI tools.

Keep the above statement in the pull request comment for agreement.

```
