### PR TITLE
Fix libjpeg in android compilation

### DIFF
--- a/android/Android.mk
+++ b/android/Android.mk
@@ -268,15 +268,16 @@ LOCAL_MODULE       := irrlicht
 LOCAL_PATH         := .
 LOCAL_CPP_FEATURES += rtti exceptions
 LOCAL_SRC_FILES    := $(wildcard ../lib/irrlicht/source/Irrlicht/*.cpp)
-LOCAL_CFLAGS       := -I../lib/irrlicht/source/Irrlicht/ \
-                      -I../lib/irrlicht/include/         \
-                      -I../src                           \
-                      -Ideps-$(TARGET_ARCH_ABI)/libjpeg/ \
-                      -Ideps-$(TARGET_ARCH_ABI)/libpng/  \
-                      -Ideps-$(TARGET_ARCH_ABI)/zlib/    \
-                      -I../lib/sdl2/include/             \
-                      -I../lib/graphics_engine/include   \
-                      -DMOBILE_STK                       \
+LOCAL_CFLAGS       := -I../lib/irrlicht/source/Irrlicht/    \
+                      -I../lib/irrlicht/include/            \
+                      -I../src                              \
+                      -Ideps-$(TARGET_ARCH_ABI)/libjpeg/    \
+                      -Ideps-$(TARGET_ARCH_ABI)/libjpeg/src \
+                      -Ideps-$(TARGET_ARCH_ABI)/libpng/     \
+                      -Ideps-$(TARGET_ARCH_ABI)/zlib/       \
+                      -I../lib/sdl2/include/                \
+                      -I../lib/graphics_engine/include      \
+                      -DMOBILE_STK                          \
                       -DANDROID_PACKAGE_CALLBACK_NAME=$(PACKAGE_CALLBACK_NAME)
 LOCAL_CPPFLAGS     := -std=gnu++0x
 LOCAL_STATIC_LIBRARIES := libjpeg png zlib


### PR DESCRIPTION
 - With the update of deps, libjpeg reorganized some source files to libjpeg/src, but the compiler doesn't recognize it.
 - So, the irrlicht build returns a fatal error: 'something.h' file not found in the source file that handles jpeg files.
 - To fix it, I put more one flag in irrlicht instructions (of Android.mk) linking this new folder to irr compiler.

The compiler now compiles sucessfully the game.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

You also confirm that this contribution is your own original work
and that it does not contain code generated by AI tools.

Keep the above statement in the pull request comment for agreement.

```
