### PR TITLE
Detect Linux touchscreens for multitouch auto mode

### DIFF
--- a/data/gui/dialogs/android/multitouch_settings.stkgui
+++ b/data/gui/dialogs/android/multitouch_settings.stkgui
@@ -3,7 +3,23 @@
     <div x="2%" y="2%" width="96%" height="96%" layout="vertical-row" >
         <header id="title" width="100%" height="fit" text_align="center" word_wrap="true" text="Touch Device Settings" />
 
-        <spacer height="35" width="10" />
+        <spacer height="20" width="10" />
+
+        <div width="90%" layout="horizontal-row" proportion="1">
+            <label proportion="1" align="center" text_align="right" I18N="In the multitouch settings screen" text="Touch controls"/>
+            <div proportion="1" align="center" height="fit" layout="horizontal-row" >
+                <spacer width="40" height="10" />
+                <spinner id="multitouch_active" proportion="1" min_value="0" max_value="2" wrap_around="false"/>
+            </div>
+        </div>
+
+        <div width="90%" layout="horizontal-row" proportion="1">
+            <label proportion="1" align="center" text_align="right" I18N="In the multitouch settings screen" text="Auto-detect touch-only devices"/>
+            <div proportion="1" align="center" height="fit" layout="horizontal-row" >
+                <spacer width="40" height="10" />
+                <checkbox id="touch_only"/>
+            </div>
+        </div>
 
         <div width="75%" layout="horizontal-row" proportion="1">
             <label proportion="1" align="center" text_align="right" I18N="In the multitouch settings screen" text="Device enabled"/>

--- a/lib/irrlicht/source/Irrlicht/CIrrDeviceSDL.cpp
+++ b/lib/irrlicht/source/Irrlicht/CIrrDeviceSDL.cpp
@@ -1560,8 +1560,10 @@ bool CIrrDeviceSDL::hasHardwareKeyboard() const
 {
 #if defined(ANDROID) || defined(IOS_STK)
 	return false;
-#else
+#elif defined(__linux__)
 	return LinuxTouchDetect::hasHardwareKeyboard();
+#else
+	return true;
 #endif
 }
 

--- a/lib/irrlicht/source/Irrlicht/CIrrDeviceSDL.cpp
+++ b/lib/irrlicht/source/Irrlicht/CIrrDeviceSDL.cpp
@@ -26,6 +26,7 @@
 #include "ge_vulkan_driver.hpp"
 #include "ge_vulkan_scene_manager.hpp"
 #include "MoltenVK.h"
+#include "input/linux_touch_detect.hpp"
 
 #include <SDL_vulkan.h>
 
@@ -1550,7 +1551,18 @@ void CIrrDeviceSDL::createKeyMap()
 
 bool CIrrDeviceSDL::supportsTouchDevice() const
 {
-	return SDL_GetNumTouchDevices() > 0;
+	if (SDL_GetNumTouchDevices() > 0)
+		return true;
+	return LinuxTouchDetect::hasTouchscreen();
+}
+
+bool CIrrDeviceSDL::hasHardwareKeyboard() const
+{
+#if defined(ANDROID) || defined(IOS_STK)
+	return false;
+#else
+	return LinuxTouchDetect::hasHardwareKeyboard();
+#endif
 }
 
 

--- a/lib/irrlicht/source/Irrlicht/CIrrDeviceSDL.h
+++ b/lib/irrlicht/source/Irrlicht/CIrrDeviceSDL.h
@@ -106,6 +106,8 @@ class MoltenVK;
 
 		virtual bool supportsTouchDevice() const;
 
+		virtual bool hasHardwareKeyboard() const;
+
 		//! Get the device type
 		virtual E_DEVICE_TYPE getType() const
 		{

--- a/src/config/user_config.hpp
+++ b/src/config/user_config.hpp
@@ -539,6 +539,11 @@ namespace UserConfigParams
             &m_multitouch_group,
             "Enable multitouch support: 0 = disabled, 1 = if available, 2 = enabled") );
 
+    PARAM_PREFIX BoolUserConfigParam         m_multitouch_touch_only
+            PARAM_DEFAULT( BoolUserConfigParam(false, "multitouch_touch_only",
+            &m_multitouch_group,
+            "When multitouch_active is 1 (auto), enable only on touch-only devices (touchscreen and no physical keyboard)"));
+
     PARAM_PREFIX BoolUserConfigParam         m_multitouch_draw_gui
             PARAM_DEFAULT( BoolUserConfigParam(false, "multitouch_draw_gui",
             &m_multitouch_group,

--- a/src/graphics/irr_driver.cpp
+++ b/src/graphics/irr_driver.cpp
@@ -20,6 +20,7 @@
 #include "challenges/story_mode_timer.hpp"
 #include "config/player_manager.hpp"
 #include "config/user_config.hpp"
+#include "input/linux_touch_detect.hpp"
 #include "font/bold_face.hpp"
 #include "font/digit_face.hpp"
 #include "font/font_manager.hpp"
@@ -402,6 +403,31 @@ void IrrDriver::createListOfVideoModes()
         }   // if depth >=24
     }   // for i < video modes count
 }   // createListOfVideoModes
+
+bool IrrDriver::isTouchOnlyDevice() const
+{
+#if defined(ANDROID) || defined(IOS_STK)
+    return true;
+#else
+    if (m_device && m_device->supportsTouchDevice() &&
+        !m_device->hasHardwareKeyboard())
+        return true;
+    return LinuxTouchDetect::isTouchOnly();
+#endif
+}
+
+bool IrrDriver::isMultitouchEnabled() const
+{
+    if (UserConfigParams::m_multitouch_active == 0)
+        return false;
+    if (UserConfigParams::m_multitouch_active > 1)
+        return true;
+    if (!m_device || !m_device->supportsTouchDevice())
+        return false;
+    if (UserConfigParams::m_multitouch_touch_only && !isTouchOnlyDevice())
+        return false;
+    return true;
+}
 
 // --------------------------------------------------------------------------------------------
 /** This creates the actualy OpenGL device. This is called

--- a/src/graphics/irr_driver.cpp
+++ b/src/graphics/irr_driver.cpp
@@ -408,11 +408,13 @@ bool IrrDriver::isTouchOnlyDevice() const
 {
 #if defined(ANDROID) || defined(IOS_STK)
     return true;
-#else
+#elif defined(__linux__)
     if (m_device && m_device->supportsTouchDevice() &&
         !m_device->hasHardwareKeyboard())
         return true;
     return LinuxTouchDetect::isTouchOnly();
+#else
+    return false;
 #endif
 }
 

--- a/src/graphics/irr_driver.hpp
+++ b/src/graphics/irr_driver.hpp
@@ -312,6 +312,8 @@ public:
     // ------------------------------------------------------------------------
     /** Returns the irrlicht device. */
     IrrlichtDevice       *getDevice()       const { return m_device;        }
+    bool                  isMultitouchEnabled() const;
+    bool                  isTouchOnlyDevice() const;
     // ------------------------------------------------------------------------
     /** Returns the irrlicht video driver. */
     video::IVideoDriver  *getVideoDriver()  const { return m_video_driver;  }

--- a/src/guiengine/widgets/dynamic_ribbon_widget.cpp
+++ b/src/guiengine/widgets/dynamic_ribbon_widget.cpp
@@ -713,9 +713,7 @@ EventPropagation DynamicRibbonWidget::mouseHovered(Widget* child, const int play
 
     updateLabel();
 
-    bool multitouch_enabled = (UserConfigParams::m_multitouch_active == 1 &&
-                               irr_driver->getDevice()->supportsTouchDevice()) ||
-                               UserConfigParams::m_multitouch_active > 1;
+    bool multitouch_enabled = irr_driver->isMultitouchEnabled();
     // For now disable it to fix the weird "triangle selection" for touch
     // screen
     if (!multitouch_enabled)

--- a/src/input/device_manager.cpp
+++ b/src/input/device_manager.cpp
@@ -91,9 +91,7 @@ bool DeviceManager::initialize()
         m_keyboards.push_back(new KeyboardDevice(m_keyboard_configs.get(n)));
     }
 
-    if ((UserConfigParams::m_multitouch_active == 1 &&
-        irr_driver->getDevice()->supportsTouchDevice()) ||
-        UserConfigParams::m_multitouch_active > 1)
+    if (irr_driver->isMultitouchEnabled())
     {
         m_multitouch_device = new MultitouchDevice();
     }
@@ -120,6 +118,15 @@ void DeviceManager::clearMultitouchDevices()
     delete m_multitouch_device;
     m_multitouch_device = NULL;
 }   // clearMultitouchDevices
+
+void DeviceManager::updateMultitouchAvailability()
+{
+    const bool want = irr_driver->isMultitouchEnabled();
+    if (want && m_multitouch_device == NULL)
+        m_multitouch_device = new MultitouchDevice();
+    else if (!want && m_multitouch_device != NULL)
+        clearMultitouchDevices();
+}   // updateMultitouchAvailability
 
 // -----------------------------------------------------------------------------
 void DeviceManager::setAssignMode(const PlayerAssignMode assignMode)

--- a/src/input/device_manager.hpp
+++ b/src/input/device_manager.hpp
@@ -141,6 +141,7 @@ public:
     MultitouchDevice*   getMultitouchDevice()    { return m_multitouch_device; }
     void                clearMultitouchDevices();
     void                updateMultitouchDevice();
+    void                updateMultitouchAvailability();
 
 
     /**

--- a/src/input/linux_touch_detect.hpp
+++ b/src/input/linux_touch_detect.hpp
@@ -1,0 +1,217 @@
+#ifndef HEADER_LINUX_TOUCH_DETECT_HPP
+#define HEADER_LINUX_TOUCH_DETECT_HPP
+
+#include <cctype>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+#ifndef _WIN32
+#include <unistd.h>
+#endif
+
+/** Linux /proc and DMI helpers for touchscreen vs keyboard.
+ *  Used by Irrlicht SDL (supportsTouchDevice) and STK (touch-only policy). */
+namespace LinuxTouchDetect
+{
+    const int KEY_A = 30;
+    const int ABS_MT_POSITION_X = 53;
+    const int INPUT_PROP_DIRECT = 1;
+
+    inline bool containsI(const char* hay, const char* needle)
+    {
+        if (!hay || !needle || !needle[0])
+            return false;
+        const size_t nlen = std::strlen(needle);
+        const size_t hlen = std::strlen(hay);
+        if (nlen > hlen)
+            return false;
+        for (size_t i = 0; i + nlen <= hlen; i++)
+        {
+            size_t j = 0;
+            for (; j < nlen; j++)
+            {
+                if (std::tolower((unsigned char)hay[i + j]) !=
+                    std::tolower((unsigned char)needle[j]))
+                    break;
+            }
+            if (j == nlen)
+                return true;
+        }
+        return false;
+    }
+
+    inline bool ignoredKeyboardName(const char* name)
+    {
+        if (!name || !name[0])
+            return true;
+        return containsI(name, "power button") ||
+               containsI(name, "sleep button") ||
+               containsI(name, "lid switch") ||
+               containsI(name, "video bus") ||
+               containsI(name, "gpio-keys") ||
+               containsI(name, "headset") ||
+               containsI(name, "hdmi") ||
+               containsI(name, "sof-hda") ||
+               containsI(name, "consumer control");
+    }
+
+    inline bool bitmapHasBit(const char* hex, unsigned bit)
+    {
+        unsigned long words[32];
+        int n = 0;
+        int word_bits = 32;
+        const char* p = hex;
+        std::memset(words, 0, sizeof(words));
+        while (p && *p && n < 32)
+        {
+            while (*p == ' ' || *p == '\t' || *p == '\n' || *p == '\r')
+                p++;
+            if (!*p)
+                break;
+            const char* start = p;
+            char* end = NULL;
+            words[n] = std::strtoul(p, &end, 16);
+            if (end == p)
+                break;
+            if ((int)(end - start) > 8)
+                word_bits = 64;
+            n++;
+            p = end;
+        }
+        if (n == 0)
+            return false;
+        const unsigned word_from_low = bit / (unsigned)word_bits;
+        const unsigned bit_in_word = bit % (unsigned)word_bits;
+        const int idx = n - 1 - (int)word_from_low;
+        if (idx < 0 || idx >= n)
+            return false;
+        return (words[idx] & (1UL << bit_in_word)) != 0;
+    }
+
+    inline void scanProcBusInput(bool* has_touch, bool* has_keyboard)
+    {
+        FILE* f = std::fopen("/proc/bus/input/devices", "r");
+        if (!f)
+            return;
+        char line[512];
+        char name[256];
+        unsigned prop = 0;
+        bool key_a = false;
+        bool abs_mt = false;
+        name[0] = 0;
+        while (std::fgets(line, sizeof(line), f))
+        {
+            if (std::strncmp(line, "N: Name=\"", 9) == 0)
+            {
+                name[0] = 0;
+                std::sscanf(line, "N: Name=\"%255[^\"]\"", name);
+            }
+            else if (std::strncmp(line, "B: PROP=", 8) == 0)
+                prop = (unsigned)std::strtoul(line + 8, NULL, 16);
+            else if (std::strncmp(line, "B: KEY=", 7) == 0)
+                key_a = bitmapHasBit(line + 7, KEY_A);
+            else if (std::strncmp(line, "B: ABS=", 7) == 0)
+                abs_mt = bitmapHasBit(line + 7, ABS_MT_POSITION_X);
+            else if (line[0] == '\n' || line[0] == '\r' || line[0] == 0)
+            {
+                if ((prop & (1u << INPUT_PROP_DIRECT)) ||
+                    containsI(name, "touchscreen"))
+                    *has_touch = true;
+                else if (abs_mt && !(prop & 1u) && containsI(name, "touch"))
+                    *has_touch = true;
+                if (key_a && !ignoredKeyboardName(name))
+                    *has_keyboard = true;
+                name[0] = 0;
+                prop = 0;
+                key_a = false;
+                abs_mt = false;
+            }
+        }
+        std::fclose(f);
+    }
+
+    inline int chassisType()
+    {
+        FILE* f = std::fopen("/sys/class/dmi/id/chassis_type", "r");
+        if (!f)
+            return -1;
+        int type = -1;
+        if (std::fscanf(f, "%d", &type) != 1)
+            type = -1;
+        std::fclose(f);
+        return type;
+    }
+
+    inline bool osReleaseHas(const char* needle)
+    {
+        FILE* f = std::fopen("/etc/os-release", "r");
+        if (!f)
+            return false;
+        char line[512];
+        while (std::fgets(line, sizeof(line), f))
+        {
+            if (containsI(line, needle))
+            {
+                std::fclose(f);
+                return true;
+            }
+        }
+        std::fclose(f);
+        return false;
+    }
+
+    inline bool isUbuntuTouch()
+    {
+        if (osReleaseHas("Ubuntu Touch") || osReleaseHas("UBUNTU_TOUCH") ||
+            osReleaseHas("VARIANT_ID=touch") || osReleaseHas("lomiri"))
+            return true;
+#ifndef _WIN32
+        if (access("/usr/share/ubports", F_OK) == 0)
+            return true;
+#endif
+        const char* desktop = std::getenv("XDG_CURRENT_DESKTOP");
+        if (desktop && (containsI(desktop, "Lomiri") || containsI(desktop, "Unity8")))
+            return true;
+        const char* click = std::getenv("CLICK_FRAMEWORK");
+        return click && click[0];
+    }
+
+    inline bool hasTouchscreen()
+    {
+        bool touch = false;
+        bool keyboard = false;
+        scanProcBusInput(&touch, &keyboard);
+        if (isUbuntuTouch())
+            touch = true;
+        return touch;
+    }
+
+    inline bool hasHardwareKeyboard()
+    {
+        bool touch = false;
+        bool keyboard = false;
+        scanProcBusInput(&touch, &keyboard);
+        if (isUbuntuTouch())
+            return false;
+        const int chassis = chassisType();
+        if (chassis == 11 || chassis == 30)
+            return false;
+        return keyboard;
+    }
+
+    inline bool isTouchOnly()
+    {
+        if (isUbuntuTouch())
+            return true;
+        const int chassis = chassisType();
+        bool touch = hasTouchscreen();
+        bool keyboard = hasHardwareKeyboard();
+        if ((chassis == 11 || chassis == 30) && touch)
+            return true;
+        return touch && !keyboard;
+    }
+}
+
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2476,7 +2476,7 @@ int main(int argc, char *argv[])
                 // doesn't have
                 android_tv = SDL_IsAndroidTV();
 #endif
-                if (!android_tv && irr_driver->getDevice()->supportsTouchDevice())
+                if (!android_tv && irr_driver->isMultitouchEnabled())
                 {
                     InitAndroidDialog* init_android = new InitAndroidDialog(
                                                                     0.8f, 0.8f);

--- a/src/states_screens/dialogs/multitouch_settings_dialog.cpp
+++ b/src/states_screens/dialogs/multitouch_settings_dialog.cpp
@@ -96,6 +96,20 @@ void MultitouchSettingsDialog::beforeAddingWidgets()
         buttons_en->setActive(false);
     }
 
+    SpinnerWidget* mode = getWidget<SpinnerWidget>("multitouch_active");
+    if (mode != NULL)
+    {
+        mode->clearLabels();
+        //I18N: In the multitouch settings screen
+        mode->addLabel(_("Off"));
+        //I18N: In the multitouch settings screen
+        mode->addLabel(_("Auto"));
+        //I18N: In the multitouch settings screen
+        mode->addLabel(_("Always"));
+        mode->m_properties[PROP_MIN_VALUE] = "0";
+        mode->m_properties[PROP_MAX_VALUE] = "2";
+    }
+
     updateValues();
 }
 
@@ -151,6 +165,14 @@ GUIEngine::EventPropagation MultitouchSettingsDialog::processEvent(
             assert(buttons_en != NULL);
             UserConfigParams::m_multitouch_draw_gui = buttons_en->getState();
 
+            SpinnerWidget* mode = getWidget<SpinnerWidget>("multitouch_active");
+            if (mode != NULL)
+                UserConfigParams::m_multitouch_active = mode->getValue();
+
+            CheckBoxWidget* touch_only = getWidget<CheckBoxWidget>("touch_only");
+            if (touch_only != NULL)
+                UserConfigParams::m_multitouch_touch_only = touch_only->getState();
+
             CheckBoxWidget* buttons_inv = getWidget<CheckBoxWidget>("buttons_inverted");
             assert(buttons_inv != NULL);
             UserConfigParams::m_multitouch_inverted = buttons_inv->getState();
@@ -187,6 +209,8 @@ GUIEngine::EventPropagation MultitouchSettingsDialog::processEvent(
                 touch_device->updateConfigParams();
             }
 
+            input_manager->getDeviceManager()->updateMultitouchAvailability();
+
             if (World::getWorld() && World::getWorld()->getRaceGUI())
             {
                 World::getWorld()->getRaceGUI()->recreateGUI();
@@ -205,6 +229,9 @@ GUIEngine::EventPropagation MultitouchSettingsDialog::processEvent(
             UserConfigParams::m_multitouch_controls.revertToDefaults();
             UserConfigParams::m_multitouch_scale.revertToDefaults();
             UserConfigParams::m_multitouch_sensitivity_x.revertToDefaults();
+
+            UserConfigParams::m_multitouch_active.revertToDefaults();
+            UserConfigParams::m_multitouch_touch_only.revertToDefaults();
 
             if (StateManager::get()->getGameState() != GUIEngine::INGAME_MENU)
             {
@@ -254,6 +281,14 @@ void MultitouchSettingsDialog::updateValues()
     CheckBoxWidget* buttons_inv = getWidget<CheckBoxWidget>("buttons_inverted");
     assert(buttons_inv != NULL);
     buttons_inv->setState(UserConfigParams::m_multitouch_inverted);
+
+    SpinnerWidget* mode = getWidget<SpinnerWidget>("multitouch_active");
+    if (mode != NULL)
+        mode->setValue(UserConfigParams::m_multitouch_active);
+
+    CheckBoxWidget* touch_only = getWidget<CheckBoxWidget>("touch_only");
+    if (touch_only != NULL)
+        touch_only->setState(UserConfigParams::m_multitouch_touch_only);
 
     RibbonWidget* control_type = getWidget<RibbonWidget>("control_type");
     assert(control_type != NULL);

--- a/src/states_screens/kart_selection.cpp
+++ b/src/states_screens/kart_selection.cpp
@@ -1646,9 +1646,7 @@ bool KartSelectionScreen::useContinueButton() const
 #ifdef MOBILE_STK
     if (m_multiplayer)
         return false;
-    bool multitouch_enabled = (UserConfigParams::m_multitouch_active == 1 &&
-        irr_driver->getDevice()->supportsTouchDevice()) ||
-        UserConfigParams::m_multitouch_active > 1;
+    bool multitouch_enabled = irr_driver->isMultitouchEnabled();
     return multitouch_enabled;
 #else
     return false;

--- a/src/states_screens/options/options_screen_input.cpp
+++ b/src/states_screens/options/options_screen_input.cpp
@@ -181,9 +181,7 @@ void OptionsScreenInput::init()
     getWidget<ButtonWidget>("add_device")->setActive(!in_game);
     OptionsCommon::updatePauseTooltip(getWidget<ButtonWidget>("add_device"), in_game);
 
-    bool multitouch_enabled = (UserConfigParams::m_multitouch_active == 1 &&
-        irr_driver->getDevice()->supportsTouchDevice()) ||
-        UserConfigParams::m_multitouch_active > 1;
+    bool multitouch_enabled = irr_driver->isMultitouchEnabled();
     if (multitouch_enabled)
     {
         // I18N: In the input configuration screen, help for touch device

--- a/src/states_screens/options/options_screen_ui.cpp
+++ b/src/states_screens/options/options_screen_ui.cpp
@@ -72,9 +72,7 @@ void OptionsScreenUI::loadedFromFile()
     minimap_options->addLabel( core::stringw(_("Centered")));
     minimap_options->m_properties[GUIEngine::PROP_MIN_VALUE] = "0";
 
-    bool multitouch_enabled = (UserConfigParams::m_multitouch_active == 1 &&
-                               irr_driver->getDevice()->supportsTouchDevice()) ||
-                               UserConfigParams::m_multitouch_active > 1;
+    bool multitouch_enabled = irr_driver->isMultitouchEnabled();
 
     if (multitouch_enabled && UserConfigParams::m_multitouch_draw_gui)
         minimap_options->m_properties[GUIEngine::PROP_MIN_VALUE] = "1";
@@ -207,9 +205,7 @@ void OptionsScreenUI::init()
     GUIEngine::SpinnerWidget* minimap_options = getWidget<GUIEngine::SpinnerWidget>("minimap");
     assert( minimap_options != NULL );
 
-    bool multitouch_enabled = (UserConfigParams::m_multitouch_active == 1 &&
-                               irr_driver->getDevice()->supportsTouchDevice()) ||
-                               UserConfigParams::m_multitouch_active > 1;
+    bool multitouch_enabled = irr_driver->isMultitouchEnabled();
 
     if (multitouch_enabled && UserConfigParams::m_multitouch_draw_gui &&
         UserConfigParams::m_minimap_display == 0)

--- a/src/states_screens/race_gui.cpp
+++ b/src/states_screens/race_gui.cpp
@@ -78,9 +78,7 @@ RaceGUI::RaceGUI()
         m_enabled = false;
 
     initSize();
-    bool multitouch_enabled = (UserConfigParams::m_multitouch_active == 1 &&
-                               irr_driver->getDevice()->supportsTouchDevice()) ||
-                               UserConfigParams::m_multitouch_active > 1;
+    bool multitouch_enabled = irr_driver->isMultitouchEnabled();
     
     if (multitouch_enabled && UserConfigParams::m_multitouch_draw_gui &&
         RaceManager::get()->getNumLocalPlayers() == 1)

--- a/src/states_screens/race_gui_overworld.cpp
+++ b/src/states_screens/race_gui_overworld.cpp
@@ -93,9 +93,7 @@ RaceGUIOverworld::RaceGUIOverworld()
     m_trophy[2] = irr_driver->getTexture(FileManager::GUI_ICON, "cup_gold.png"  );
     m_trophy[3] = irr_driver->getTexture(FileManager::GUI_ICON, "cup_platinum.png"  );
 
-    bool multitouch_enabled = (UserConfigParams::m_multitouch_active == 1 &&
-                               irr_driver->getDevice()->supportsTouchDevice()) ||
-                               UserConfigParams::m_multitouch_active > 1;
+    bool multitouch_enabled = irr_driver->isMultitouchEnabled();
     
     if (multitouch_enabled && UserConfigParams::m_multitouch_draw_gui &&
         RaceManager::get()->getNumLocalPlayers() == 1)

--- a/src/states_screens/soccer_setup_screen.cpp
+++ b/src/states_screens/soccer_setup_screen.cpp
@@ -19,6 +19,7 @@
 
 #include "audio/sfx_manager.hpp"
 #include "config/user_config.hpp"
+#include "graphics/irr_driver.hpp"
 #include <ge_render_info.hpp>
 #include "guiengine/widgets/bubble_widget.hpp"
 #include "guiengine/widgets/button_widget.hpp"
@@ -112,9 +113,7 @@ void SoccerSetupScreen::eventCallback(Widget* widget, const std::string& name,
 // -----------------------------------------------------------------------------
 void SoccerSetupScreen::beforeAddingWidget()
 {
-    bool multitouch_enabled = (UserConfigParams::m_multitouch_active == 1 &&
-        irr_driver->getDevice()->supportsTouchDevice()) ||
-        UserConfigParams::m_multitouch_active > 1;
+    bool multitouch_enabled = irr_driver->isMultitouchEnabled();
 
     // If a device doesn't use the multitouch GUI, it supports some form of left/right input
     // The original message is safer, as some devices are incorrectly reported as touch enabled.


### PR DESCRIPTION
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

## Summary
- `multitouch_active` 1 already meant "if available", but `SDL_GetNumTouchDevices()` is often 0 on Linux until the first finger.
- Scan `/proc/bus/input/devices` (and DMI chassis / Ubuntu Touch) so Auto works on Linux tablets.
- Add `multitouch_touch_only` (default **false**, so current "any touchscreen" behaviour is unchanged) and Off / Auto / Always in the touch settings dialog.
- One helper, `IrrDriver::isMultitouchEnabled()`, replaces the repeated 3-line check.

We ship a tablet build at [SuperTuxKart-Touch](https://github.com/dixonSolutions/SuperTuxKart-Touch) that turns the touch-only filter on by default. This PR is only the detection layer, not that product overlay.

## Test plan
- [ ] Android/iOS: Auto still enables the race GUI (touch-only is true on those platforms).
- [ ] Linux desktop, no touchscreen: Auto stays off.
- [ ] Linux tablet / Ubuntu Touch: Auto enables with `multitouch_touch_only` on.
- [ ] Laptop with a keyboard + touchscreen: Auto + touch-only off still matches old "if available"; touch-only on leaves mouse/keyboard.
- [ ] Touch settings: Off / Auto / Always and the touch-only checkbox persist after Apply.


Made with [Cursor](https://cursor.com)