### PR TITLE
Allow GhostController to move backwards, make ghost(s) visible on rewind

### DIFF
--- a/src/karts/controller/ghost_controller.cpp
+++ b/src/karts/controller/ghost_controller.cpp
@@ -38,6 +38,19 @@ void GhostController::reset()
 void GhostController::update(int ticks)
 {
     m_current_time = World::getWorld()->getTime();
+
+    // This has been done to make the class keep the promise that was
+    // documented in the ghost_controller header.
+    // Consequently, this allows for replay seeking to be implemented.
+    // It is safe because it only triggers when a backwards clock
+    // movement occurs, which is impossible in regular play as forward
+    // playback only ever increases the clock.
+    while (m_current_index > 0 &&
+           m_all_times[m_current_index] > m_current_time)
+    {
+        m_current_index--;
+    }
+
     // Find (if necessary) the next index to use
     if (m_current_time != 0.0f)
     {

--- a/src/karts/ghost_kart.cpp
+++ b/src/karts/ghost_kart.cpp
@@ -138,11 +138,11 @@ void GhostKart::update(int ticks)
             // Start showing the ghost when it start racing
             m_node->setVisible(true);
         }
-	else
+        else
         {
             // When a replay ends, the node is hidden and nothing in
-	    // watch-replay mode restores it. GFX and sound recover
-	    // by themselves so there's no need to restore them.
+            // watch-replay mode restores it. GFX and sound recover
+            // by themselves so there's no need to restore them.
             m_node->setVisible(true);
         }
     }

--- a/src/karts/ghost_kart.cpp
+++ b/src/karts/ghost_kart.cpp
@@ -138,6 +138,13 @@ void GhostKart::update(int ticks)
             // Start showing the ghost when it start racing
             m_node->setVisible(true);
         }
+	else
+        {
+            // When a replay ends, the node is hidden and nothing in
+	    // watch-replay mode restores it. GFX and sound recover
+	    // by themselves so there's no need to restore them.
+            m_node->setVisible(true);
+        }
     }
 
     const float rd         = gc->getReplayDelta();


### PR DESCRIPTION
As of the current version, GhostController::update() only has the ability to advance it's frame index. Consequently, any backwards movement made by the world clock leaves ghosts at a specific pair of transforms without advancing any further, effectively rendering them frozen. This adds the functionality for a backwards walk which restores the invariant that is documented in the header ("the last index in m_all_times that is smaller than the current world time"). Regular forward playback remains untouched as the condition for a backward ghost movement:

m_all_times[m_current_index] > m_current_time

never fires under normal playback as there is (as of writing) no feature in the game that can move the clock back. In other words, this change is inert during normal playback.

A latch in GhostKart::update() has also been fixed. When the end of a replay is reached, the node is hidden and nothing shows it again. If you were to scrub back from the finish, the kart would be invisible. GFX and the sound engine recover by themselves from the replay data every frame and so only the scene node needs restoration.

These fixes do nothing under normal gameplay as there is no feature that drives the clock backwards. However, these fixes are required by any feature that would be implemented in the future that *would* drive the clock backwards, such as replay seeking.

Fixes #5834

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

You also confirm that this contribution is your own original work
and that it does not contain code generated by AI tools.

Keep the above statement in the pull request comment for agreement.

```
