### PR TITLE
Drop the repeated track operand in track object presentation guards

### DIFF
--- a/src/tracks/track_object_presentation.cpp
+++ b/src/tracks/track_object_presentation.cpp
@@ -546,7 +546,7 @@ void TrackObjectPresentationMesh::init(const XMLNode* xml_node,
             enabled = false;
             m_force_always_hidden = true;
             Track *track = Track::getCurrentTrack();
-            if (track && track && xml_node)
+            if (track && xml_node)
                 track->addPhysicsOnlyNode(m_node);
         }
     }
@@ -588,7 +588,7 @@ void TrackObjectPresentationMesh::init(const XMLNode* xml_node,
         node->useAnimationSet(0);
 
         Track *track = Track::getCurrentTrack();
-        if (track && track && xml_node)
+        if (track && xml_node)
             track->handleAnimatedTextures(m_node, *xml_node);
         Track::uploadNodeVertexBuffer(node);
     }


### PR DESCRIPTION
Both guards in `track_object_presentation.cpp` test `track` twice, so the middle operand adds nothing. Both call sites pass `m_node` into the call underneath, and at the first one `m_node` comes straight out of `addMesh` and can be null, so if the second operand was meant to be a check on that rather than a repeat, say so and I will change it to `m_node` instead of dropping it.
